### PR TITLE
Prevent chat pane closing when navigating between modules

### DIFF
--- a/apps/webapp/src/modules/app/hooks/useActionForToken.tsx
+++ b/apps/webapp/src/modules/app/hooks/useActionForToken.tsx
@@ -22,14 +22,15 @@ export const useActionForToken = () => {
 
   const actionForToken = useCallback(
     (symbol: string, balance: string) => {
-      const { LinkedAction, InputAmount, SourceToken, TargetToken, Widget, Locale, Details } = QueryParams;
+      const { LinkedAction, InputAmount, SourceToken, TargetToken, Widget, Locale, Details, Chat } =
+        QueryParams;
       const {
         REWARDS_INTENT: REWARD,
         UPGRADE_INTENT: UPGRADE,
         TRADE_INTENT: TRADE,
         SAVINGS_INTENT: SAVINGS
       } = IntentMapping;
-      const retainedParams = [Locale, Details];
+      const retainedParams = [Locale, Details, Chat];
 
       const lowerSymbol = symbol.toLowerCase();
       const upperSymbol = symbol.toUpperCase();

--- a/apps/webapp/src/modules/ui/hooks/useRetainedQueryParams.tsx
+++ b/apps/webapp/src/modules/ui/hooks/useRetainedQueryParams.tsx
@@ -24,7 +24,12 @@ export const getRetainedQueryParams = (
 
 export const useRetainedQueryParams = (
   url: string,
-  retainedParams: QueryParams[] = [QueryParams.Locale, QueryParams.Details, QueryParams.Network]
+  retainedParams: QueryParams[] = [
+    QueryParams.Locale,
+    QueryParams.Details,
+    QueryParams.Network,
+    QueryParams.Chat
+  ]
 ) => {
   const [searchParams] = useSearchParams();
 

--- a/apps/webapp/src/modules/utils/deleteSearchParams.ts
+++ b/apps/webapp/src/modules/utils/deleteSearchParams.ts
@@ -5,7 +5,12 @@ export const deleteSearchParams = (searchParams: URLSearchParams): URLSearchPara
 
   searchParams.forEach((_, key) => {
     // Collect keys to delete after iteration to avoid potential issues during modification
-    if (QueryParams.Details !== key && QueryParams.Widget !== key && QueryParams.Network !== key) {
+    if (
+      QueryParams.Details !== key &&
+      QueryParams.Widget !== key &&
+      QueryParams.Network !== key &&
+      QueryParams.Chat !== key
+    ) {
       keysToDelete.push(key);
     }
   });


### PR DESCRIPTION
Prevent chat panel from closing when:

- Navigating modules
- Click on balance cards
- Click on balance token actions