### PR TITLE
Show chat pane open by default on big breakpoints

### DIFF
--- a/apps/webapp/src/components/ChatSwitcher.tsx
+++ b/apps/webapp/src/components/ChatSwitcher.tsx
@@ -16,7 +16,11 @@ import { BP, useBreakpointIndex } from '@/modules/ui/hooks/useBreakpointIndex';
 export function ChatSwitcher(): JSX.Element {
   const { bpi } = useBreakpointIndex();
   const [searchParams, setSearchParams] = useSearchParams();
-  const showingChat = searchParams.get(QueryParams.Chat) === 'true';
+  const showingChat =
+    bpi >= BP.xl
+      ? !(searchParams.get(QueryParams.Chat) === 'false')
+      : searchParams.get(QueryParams.Chat) === 'true';
+
   const handleSwitch = (pressed: boolean) => {
     const queryParam = pressed ? 'true' : 'false';
     searchParams.set(QueryParams.Chat, queryParam);

--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -71,7 +71,11 @@ export function MainApp() {
   const inputAmount = searchParams.get(QueryParams.InputAmount) || undefined;
   const timestamp = searchParams.get(QueryParams.Timestamp) || undefined;
   const network = searchParams.get(QueryParams.Network) || undefined;
-  const chatParam = chatEnabled && searchParams.get(QueryParams.Chat) === 'true';
+  const chatParam =
+    chatEnabled &&
+    (bpi >= BP.xl
+      ? !(searchParams.get(QueryParams.Chat) === 'false')
+      : searchParams.get(QueryParams.Chat) === 'true');
 
   // step is initialized as 0 and will evaluate to false, setting the first step to 1
   const step = linkedAction ? linkedActionConfig.step || 1 : 0;


### PR DESCRIPTION
When visiting the app without search params in the url, the Chat pane will be open on big breakpoints by default. This is the same behavior as the Details pane.
