### PR TITLE
Cwtf/chatbot panes poc

### DIFF
--- a/apps/webapp/src/components/ChatSwitcher.tsx
+++ b/apps/webapp/src/components/ChatSwitcher.tsx
@@ -17,14 +17,14 @@ export function ChatSwitcher(): JSX.Element {
   const { bpi } = useBreakpointIndex();
   const [searchParams, setSearchParams] = useSearchParams();
   const showingChat =
-    bpi >= BP.xl
+    bpi >= BP['3xl']
       ? !(searchParams.get(QueryParams.Chat) === 'false')
       : searchParams.get(QueryParams.Chat) === 'true';
 
   const handleSwitch = (pressed: boolean) => {
     const queryParam = pressed ? 'true' : 'false';
     searchParams.set(QueryParams.Chat, queryParam);
-    if (bpi < BP.xl && queryParam) searchParams.set(QueryParams.Details, 'false');
+    if (bpi < BP['3xl'] && queryParam) searchParams.set(QueryParams.Details, 'false');
     setSearchParams(searchParams);
   };
 

--- a/apps/webapp/src/components/ChatSwitcher.tsx
+++ b/apps/webapp/src/components/ChatSwitcher.tsx
@@ -16,7 +16,11 @@ import { BP, useBreakpointIndex } from '@/modules/ui/hooks/useBreakpointIndex';
 export function ChatSwitcher(): JSX.Element {
   const { bpi } = useBreakpointIndex();
   const [searchParams, setSearchParams] = useSearchParams();
-  const showingChat = searchParams.get(QueryParams.Chat) === 'true';
+  const showingChat =
+    bpi >= BP.xl
+      ? !(searchParams.get(QueryParams.Chat) === 'false')
+      : searchParams.get(QueryParams.Chat) === 'true';
+
   const handleSwitch = (pressed: boolean) => {
     const queryParam = pressed ? 'true' : 'false';
     searchParams.set(QueryParams.Chat, queryParam);

--- a/apps/webapp/src/components/DetailsSwitcher.tsx
+++ b/apps/webapp/src/components/DetailsSwitcher.tsx
@@ -21,7 +21,8 @@ export function DetailsSwitcher(): JSX.Element {
   const handleSwitch = (pressed: boolean) => {
     const queryParam = pressed ? 'true' : 'false';
     searchParams.set(QueryParams.Details, queryParam);
-    if ([BP.md, BP.lg].includes(bpi) && queryParam) searchParams.set(QueryParams.Chat, 'false');
+    if ([BP.md, BP.lg, BP.xl, BP['2xl']].includes(bpi) && queryParam)
+      searchParams.set(QueryParams.Chat, 'false');
     setSearchParams(searchParams);
   };
 

--- a/apps/webapp/src/modules/app/components/AppContainer.tsx
+++ b/apps/webapp/src/modules/app/components/AppContainer.tsx
@@ -8,7 +8,9 @@ export function AppContainer({ children }: { children: React.ReactNode }): React
 
   return (
     <motion.main
-      className="scrollbar-hidden md:scrollbar-thin bg-container 3xl:max-w-[1392px] group flex h-screen min-w-[375px] max-w-[480px] flex-col gap-3 overflow-y-auto overflow-x-hidden rounded-t-3xl border bg-blend-overlay backdrop-blur-[50px] has-[.chat-pane]:w-full has-[.details-pane]:w-full md:my-auto md:max-h-[1080px] md:max-w-[1150px] md:flex-row md:overflow-hidden md:rounded-3xl md:p-3 md:pr-0.5 xl:max-w-[calc(100vw-128px)] 2xl:max-w-[1270px]"
+      className="scrollbar-hidden md:scrollbar-thin bg-container group flex h-screen min-w-[375px] max-w-[480px] flex-col gap-3 overflow-y-auto overflow-x-hidden 
+      rounded-t-3xl border bg-blend-overlay backdrop-blur-[50px] has-[.chat-pane]:w-full has-[.details-pane]:w-full md:my-auto md:max-h-[1080px] md:max-w-[1150px] 
+      md:flex-row md:overflow-hidden md:rounded-3xl md:p-3 md:pr-0.5 xl:max-w-[calc(100vw-128px)] 2xl:max-w-[1570px]"
       layout
       // This style block is needed so the border radius is not distorted when applying the layout transition
       style={

--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -13,6 +13,7 @@ import { BP, useBreakpointIndex } from '@/modules/ui/hooks/useBreakpointIndex';
 import { LinkedActionSteps } from '@/modules/config/context/ConfigContext';
 import { useSendMessage } from '@/modules/chat/hooks/useSendMessage';
 import { ChatPane } from './ChatPane';
+import { useChatNotification } from '../hooks/useChatNotification';
 
 export function MainApp() {
   const {
@@ -73,12 +74,14 @@ export function MainApp() {
   const network = searchParams.get(QueryParams.Network) || undefined;
   const chatParam =
     chatEnabled &&
-    (bpi >= BP.xl
+    (bpi >= BP['3xl']
       ? !(searchParams.get(QueryParams.Chat) === 'false')
       : searchParams.get(QueryParams.Chat) === 'true');
 
   // step is initialized as 0 and will evaluate to false, setting the first step to 1
   const step = linkedAction ? linkedActionConfig.step || 1 : 0;
+
+  useChatNotification({ isAuthorized: chatEnabled });
 
   // Run validation on search params whenever search params change
   useEffect(() => {

--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -71,7 +71,11 @@ export function MainApp() {
   const inputAmount = searchParams.get(QueryParams.InputAmount) || undefined;
   const timestamp = searchParams.get(QueryParams.Timestamp) || undefined;
   const network = searchParams.get(QueryParams.Network) || undefined;
-  const chatParam = chatEnabled && searchParams.get(QueryParams.Chat) === 'true';
+  const chatParam =
+    chatEnabled &&
+    (bpi >= BP.xl
+      ? !(searchParams.get(QueryParams.Chat) === 'false')
+      : searchParams.get(QueryParams.Chat) === 'true');
 
   // step is initialized as 0 and will evaluate to false, setting the first step to 1
   const step = linkedAction ? linkedActionConfig.step || 1 : 0;

--- a/apps/webapp/src/modules/app/hooks/useChatNotification.tsx
+++ b/apps/webapp/src/modules/app/hooks/useChatNotification.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from 'react-router-dom';
 import { BP, useBreakpointIndex } from '@/modules/ui/hooks/useBreakpointIndex';
 import { QueryParams } from '@/lib/constants';
 import { CHATBOT_NAME } from '@/modules/chat/constants';
+import { Chat } from '@/modules/icons';
 
 export const useChatNotification = ({ isAuthorized }: { isAuthorized: boolean }) => {
   const { userConfig, updateUserConfig } = useConfigContext();
@@ -23,7 +24,7 @@ export const useChatNotification = ({ isAuthorized }: { isAuthorized: boolean })
 
   const onClickChat = useCallback(() => {
     searchParams.set(QueryParams.Chat, 'true');
-    if (bpi < BP.xl) searchParams.set(QueryParams.Details, 'false');
+    if (bpi < BP['3xl']) searchParams.set(QueryParams.Details, 'false');
     setSearchParams(searchParams);
     setTimeout(() => {
       dismiss();
@@ -42,9 +43,16 @@ export const useChatNotification = ({ isAuthorized }: { isAuthorized: boolean })
         if (!userConfig.chatSuggested && searchParams.get(QueryParams.Chat) !== 'true') {
           toast({
             title: (
-              <Text variant="medium" className="text-selectActive ml-1">
-                {CHATBOT_NAME}
-              </Text>
+              <HStack>
+                <img
+                  src="/images/chatbot_logo.svg"
+                  alt={`${CHATBOT_NAME} avatar`}
+                  className="@2xl/chat:h-8 @2xl/chat:w-8 h-5 w-5"
+                />
+                <Text variant="medium" className="text-selectActive ml-1">
+                  {CHATBOT_NAME}
+                </Text>
+              </HStack>
             ),
             description: (
               <HStack className="ml-1 w-full justify-between">
@@ -57,6 +65,7 @@ export const useChatNotification = ({ isAuthorized }: { isAuthorized: boolean })
                   </Text>
                 </VStack>
                 <Button className="place-self-end" variant="pill" size="xs" onClick={onClickChat}>
+                  <Chat width={16} height={16} className="mr-1" />
                   <Trans>Start Chatting</Trans>
                 </Button>
               </HStack>

--- a/apps/webapp/src/modules/chat/components/ChatHeader.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatHeader.tsx
@@ -4,6 +4,7 @@ import { Heading } from '@/modules/layout/components/Typography';
 import { ChevronLeft } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { CHATBOT_NAME } from '../constants';
+import { Close } from '@/modules/icons';
 
 export const ChatHeader = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -14,16 +15,23 @@ export const ChatHeader = () => {
   };
 
   return (
-    <div className="border-b-brandMiddle/55 block w-full border-b p-4 px-5 md:hidden">
-      <div className="flex items-center gap-3">
-        <Button variant="ghost" className="h-6 p-0" onClick={handleBack}>
-          <ChevronLeft className="text-textSecondary" />
-        </Button>
-        <img src="/images/chatbot_logo.svg" alt={`${CHATBOT_NAME} avatar`} width={32} height={32} />
-        <Heading variant="extraSmall" className="leading-5 tracking-normal">
-          {CHATBOT_NAME}
-        </Heading>
+    <>
+      <div className="border-b-brandMiddle/55 block w-full border-b p-4 px-5 md:hidden">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" className="h-6 p-0" onClick={handleBack}>
+            <ChevronLeft className="text-textSecondary" />
+          </Button>
+          <img src="/images/chatbot_logo.svg" alt={`${CHATBOT_NAME} avatar`} width={32} height={32} />
+          <Heading variant="extraSmall" className="leading-5 tracking-normal">
+            {CHATBOT_NAME}
+          </Heading>
+        </div>
       </div>
-    </div>
+      <div id="pepe" className="relative hidden md:block">
+        <Button variant="ghost" className="absolute right-4 top-4 h-10 w-10 p-0" onClick={handleBack}>
+          <Close boxSize={18} />
+        </Button>
+      </div>
+    </>
   );
 };

--- a/apps/webapp/src/modules/ui/hooks/useBreakpointIndex.ts
+++ b/apps/webapp/src/modules/ui/hooks/useBreakpointIndex.ts
@@ -5,7 +5,8 @@ export enum BP {
   md = 1,
   lg = 2,
   xl = 3,
-  '2xl' = 4
+  '2xl' = 4,
+  '3xl' = 5
 }
 
 enum BPValue {
@@ -13,7 +14,8 @@ enum BPValue {
   md = 768,
   lg = 912,
   xl = 1280,
-  '2xl' = 1400
+  '2xl' = 1400,
+  '3xl' = 1680
 }
 
 const getBreakpointIndex = (width: number) => {
@@ -26,7 +28,9 @@ const getBreakpointIndex = (width: number) => {
   // xl
   else if (width < BPValue['2xl']) return 3;
   // 2xl
-  else return 4;
+  else if (width < BPValue['3xl']) return 4;
+  // 3xl
+  else return 5;
 };
 
 export const useBreakpointIndex = () => {


### PR DESCRIPTION
- Shows 2 panes for breakpoints under 3xl. [Widget and Details] or [Widget and Chat]
- Shows 3 panes for 3xl breakpoints and wider
- Add close button to Chat pane
- Improve Chat notification UI

In order to test it remember to set the user-setting `chatSuggested` to false to show the notification when the page loads.
