### PR TITLE
Add dynamic content to the chat confirmation modal

### DIFF
--- a/apps/webapp/src/modules/chat/components/ChatConfirmationModal.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatConfirmationModal.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { ChatIntent } from '../types/Chat';
 import { useRetainedQueryParams } from '@/modules/ui/hooks/useRetainedQueryParams';
 import { intentSelectedMessage } from '../lib/intentSelectedMessage';
+import { getConfirmationModalMetadata } from '../lib/confirmationModalMetadata';
 
 export const ChatConfirmationModal: React.FC = () => {
   const {
@@ -55,6 +56,10 @@ export const ChatConfirmationModal: React.FC = () => {
     hasShownIntent
   ]);
 
+  const disclaimerMetadata = getConfirmationModalMetadata(selectedIntent);
+  const defaultDisclaimer =
+    'You are about to execute an action suggested by our AI chatbot. Please be aware that while we strive to provide accurate and helpful suggestions, you&apos;re solely responsible for reviewing and implementing any recommended actions. We do not guarantee the accuracy or completeness of the AI&apos;s suggestions and disclaim any liability for consequences arising from your use of this feature.';
+
   return (
     <Dialog open={!hasShownIntent(selectedIntent) && confirmationModalOpened} onOpenChange={handleCancel}>
       <DialogContent className="bg-containerDark flex w-full flex-col items-center justify-center rounded-none p-5 md:w-[480px] md:rounded-2xl md:p-10">
@@ -70,11 +75,9 @@ export const ChatConfirmationModal: React.FC = () => {
             </Text>
           )}
           <Text className="font-custom-450 text-text text-center">
-            You are about to execute an action suggested by our AI chatbot. Please be aware that while we
-            strive to provide accurate and helpful suggestions, you&apos;re solely responsible for reviewing
-            and implementing any recommended actions. We do not guarantee the accuracy or completeness of the
-            AI&apos;s suggestions and disclaim any liability for consequences arising from your use of this
-            feature.
+            {disclaimerMetadata
+              ? `${disclaimerMetadata.description} ${disclaimerMetadata.disclaimer}`
+              : defaultDisclaimer}
           </Text>
           <Text className="font-custom-450 text-text text-center">
             If you wish to proceed, click &quot;Continue.&quot; If not, click &quot;Cancel&quot; to return to

--- a/apps/webapp/src/modules/chat/lib/confirmationModalMetadata.ts
+++ b/apps/webapp/src/modules/chat/lib/confirmationModalMetadata.ts
@@ -1,0 +1,32 @@
+import { Intent } from '@/lib/enums';
+import { ChatIntent } from '../types/Chat';
+import { IntentMapping } from '@/lib/constants';
+
+// TODO: The structure is yet tbd. Using this structure and values as a placeholder for now.
+const disclaimer =
+  "Please be aware that while we strive to provide accurate and helpful suggestions, you're solely responsible for reviewing and implementing any recommended actions. We do not guarantee the accuracy or completeness of the AI's suggestions and disclaim any liability for consequences arising from your use of this feature.";
+
+export const CONFIRMATION_MODAL_METADATA: Record<string, { description: string; disclaimer: string }> = {
+  [IntentMapping[Intent.TRADE_INTENT]]: {
+    description: 'You are about to execute a trade suggested by our AI chatbot.',
+    disclaimer
+  },
+  [IntentMapping[Intent.UPGRADE_INTENT]]: {
+    description: 'You are about to upgrade your tokens based on our AI chatbot&apos;s suggestion.',
+    disclaimer
+  },
+  [IntentMapping[Intent.SAVINGS_INTENT]]: {
+    description: 'You are about to deposit into savings based on our AI chatbot&apos;s suggestion.',
+    disclaimer
+  },
+  [IntentMapping[Intent.REWARDS_INTENT]]: {
+    description: 'You are about to access rewards based on our AI chatbot&apos;s suggestion.',
+    disclaimer
+  }
+};
+
+export const getConfirmationModalMetadata = (intent?: ChatIntent) => {
+  if (!intent?.intent_id) return undefined;
+
+  return CONFIRMATION_MODAL_METADATA[intent.intent_id];
+};

--- a/apps/webapp/src/modules/chat/lib/confirmationModalMetadata.ts
+++ b/apps/webapp/src/modules/chat/lib/confirmationModalMetadata.ts
@@ -12,15 +12,15 @@ export const CONFIRMATION_MODAL_METADATA: Record<string, { description: string; 
     disclaimer
   },
   [IntentMapping[Intent.UPGRADE_INTENT]]: {
-    description: 'You are about to upgrade your tokens based on our AI chatbot&apos;s suggestion.',
+    description: "You are about to upgrade your tokens based on our AI chatbot's suggestion.",
     disclaimer
   },
   [IntentMapping[Intent.SAVINGS_INTENT]]: {
-    description: 'You are about to deposit into savings based on our AI chatbot&apos;s suggestion.',
+    description: "You are about to deposit into savings based on our AI chatbot's suggestion.",
     disclaimer
   },
   [IntentMapping[Intent.REWARDS_INTENT]]: {
-    description: 'You are about to access rewards based on our AI chatbot&apos;s suggestion.',
+    description: "You are about to access rewards based on our AI chatbot's suggestion.",
     disclaimer
   }
 };


### PR DESCRIPTION
### Note: 
The `&apos;` you can see in the screenshots is fixed already in the pr.

![image](https://github.com/user-attachments/assets/a1ba7b76-7b3b-407e-8ce8-9eef9bfd3263)

![image](https://github.com/user-attachments/assets/03016e45-282a-4e0c-99d6-792d501dc9ef)
