### PR TITLE
Fix issue with Trade widget

### DIFF
--- a/.changeset/shaggy-peas-speak.md
+++ b/.changeset/shaggy-peas-speak.md
@@ -1,0 +1,6 @@
+---
+'@jetstreamgg/hooks': patch
+'@jetstreamgg/widgets': patch
+---
+
+Fix issue that when BA Labs prices weren't present the Trade widget on mainnet would crash

--- a/packages/hooks/src/trade/useTradeCosts.tsx
+++ b/packages/hooks/src/trade/useTradeCosts.tsx
@@ -110,11 +110,10 @@ export const useTradeCosts = ({
 
   const sellTokenPrice = sellToken
     ? baPricesData?.[sellToken.symbol]?.price ||
-      (nativeCowSellTokenPrice ? formatUnits(BigInt(nativeCowSellTokenPrice), WAD_PRECISION) : undefined)
+      (nativeCowSellTokenPrice ? nativeCowSellTokenPrice : undefined)
     : undefined;
   const buyTokenPrice = buyToken
-    ? baPricesData?.[buyToken.symbol]?.price ||
-      (nativeCowBuyTokenPrice ? formatUnits(BigInt(nativeCowBuyTokenPrice), WAD_PRECISION) : undefined)
+    ? baPricesData?.[buyToken.symbol]?.price || (nativeCowBuyTokenPrice ? nativeCowBuyTokenPrice : undefined)
     : undefined;
 
   const sellAmountBeforeFeeUsd =


### PR DESCRIPTION
Fix crash in the trade widget.

Cow prices were strings like "0.9996915791616805" and when we tried to convert to a BigInt the hook would crash.

![image](https://github.com/user-attachments/assets/dd45bc6c-29a9-4d89-8002-30b2953a0287)
![image](https://github.com/user-attachments/assets/ad96acdc-043c-412f-be22-82cb5d747b37)

### How to test it
Since the error is triggered when BA Labs prices endpoint fails or return undefined for the sell or buy price, the best way to replicate the issue is by blocking that endpoint in your browser. You can test this in prod and compare with the deployment with the fix.

![image](https://github.com/user-attachments/assets/5ae9d407-8f4b-477a-b90b-475048603a58)
