### PR TITLE
Generate chatbot save intents

### DIFF
--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -17,7 +17,8 @@ export enum QueryParams {
   InputAmount = 'input_amount',
   Timestamp = 'timestamp',
   Network = 'network',
-  Chat = 'chat'
+  Chat = 'chat',
+  Tab = 'tab'
 }
 
 const isRestrictedBuild = import.meta.env.VITE_RESTRICTED_BUILD === 'true';

--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -93,7 +93,8 @@ export function MainApp() {
           rewardContracts,
           widgetParam || '',
           setSelectedRewardContract,
-          chainId
+          chainId,
+          chains
         );
         // Runs second validation for linked-action-specific criteria
         const validatedLinkedActionParams = validateLinkedActionSearchParams(validatedParams);

--- a/apps/webapp/src/modules/chat/components/ChatConfirmationModal.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogClose, DialogContent, DialogHeader } from '@/components/ui/dialog';
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Warning } from '@/modules/icons/Warning';
@@ -71,7 +71,9 @@ export const ChatConfirmationModal: React.FC = () => {
         <Warning boxSize={50} />
 
         <DialogHeader>
-          <Text className="text-text text-center text-[28px] md:text-[32px]">Confirm Action</Text>
+          <DialogTitle>
+            <Text className="text-text text-center text-[28px] md:text-[32px]">Confirm Action</Text>
+          </DialogTitle>
         </DialogHeader>
         <div className="flex w-full flex-col items-center justify-between gap-6">
           {selectedIntent && (

--- a/apps/webapp/src/modules/chat/hooks/__mocks__/mock-chat-endpoints.ts
+++ b/apps/webapp/src/modules/chat/hooks/__mocks__/mock-chat-endpoints.ts
@@ -1,4 +1,9 @@
-import { TRADE, TRADE_MAINNET, TRADE_BASE, TRADE_ARBITRUM } from '../../lib/intentClassificationOptions';
+import {
+  SAVINGS,
+  SAVINGS_MAINNET,
+  SAVINGS_BASE,
+  SAVINGS_ARBITRUM
+} from '../../lib/intentClassificationOptions';
 
 export const generateRandomResponse = () => {
   const responses = [
@@ -12,12 +17,15 @@ export const generateRandomResponse = () => {
 
 export const generateRandomIntent = () => {
   const intents = [
-    TRADE,
-    TRADE_MAINNET,
-    TRADE_BASE,
-    TRADE_ARBITRUM,
+    // TRADE,
+    // TRADE_MAINNET,
+    // TRADE_BASE,
+    // TRADE_ARBITRUM,
     // UPGRADE,
-    // SAVINGS,
+    SAVINGS,
+    SAVINGS_MAINNET,
+    SAVINGS_BASE,
+    SAVINGS_ARBITRUM,
     // REWARDS,
     'NONE'
   ];
@@ -46,84 +54,161 @@ type MockSlot = {
 
 export const generateRandomSlots = (intent?: string): MockSlot[] => {
   // If not a trade intent, return the original simple mock
-  if (!intent?.startsWith('TRADE')) {
-    const tokens = ['DAI', 'USDC', 'USDT', 'ETH', 'USDS'];
-    return [
-      {
-        field: 'token',
-        parsed_value: tokens[Math.floor(Math.random() * tokens.length)]
-      },
-      {
-        field: 'amount',
-        parsed_value: Math.floor(Math.random() * 1000).toString()
-      }
+  if (intent?.startsWith('SAVINGS')) {
+    // Token options depend on the network
+    const tokens = intent.startsWith('SAVINGS_') ? ['USDS', 'USDC'] : ['USDS'];
+    const amounts = ['0.1', '1', '10', '100', '1000', undefined];
+    const tabs = ['left', 'right', undefined]; // left=supply, right=withdraw
+
+    // Different combinations of slots for savings intents
+    const slotCombinations = [
+      // Complete savings info with amount and tab
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: tokens[Math.floor(Math.random() * tokens.length)]
+        },
+        {
+          field: 'input_amount',
+          parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
+        },
+        {
+          field: 'tab',
+          parsed_value: tabs[Math.floor(Math.random() * (tabs.length - 1))]!
+        }
+      ],
+      // Token and amount only
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: tokens[Math.floor(Math.random() * tokens.length)]
+        },
+        {
+          field: 'input_amount',
+          parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
+        }
+      ],
+      // Token and tab only
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: tokens[Math.floor(Math.random() * tokens.length)]
+        },
+        {
+          field: 'tab',
+          parsed_value: tabs[Math.floor(Math.random() * (tabs.length - 1))]!
+        }
+      ],
+      // Amount and tab only
+      () => [
+        {
+          field: 'input_amount',
+          parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
+        },
+        {
+          field: 'tab',
+          parsed_value: tabs[Math.floor(Math.random() * (tabs.length - 1))]!
+        }
+      ],
+      // Only token
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: tokens[Math.floor(Math.random() * tokens.length)]
+        }
+      ],
+      // Only tab
+      () => [
+        {
+          field: 'tab',
+          parsed_value: tabs[Math.floor(Math.random() * (tabs.length - 1))]!
+        }
+      ],
+      // Empty slots (generic savings)
+      () => []
     ];
+
+    const selectedCombination = slotCombinations[Math.floor(Math.random() * slotCombinations.length)];
+    return selectedCombination();
   }
 
-  // Trade-specific mock data
-  const sourceTokens = ['DAI', 'USDC', 'USDT', 'ETH', 'USDS', 'MKR', 'SKY'];
-  const targetTokens = ['DAI', 'USDC', 'USDT', 'ETH', 'USDS', 'MKR', 'SKY'];
-  const amounts = ['0.1', '1', '10', '100', '1000', undefined];
+  if (intent?.startsWith('TRADE')) {
+    // Trade-specific mock data
+    const sourceTokens = ['DAI', 'USDC', 'USDT', 'ETH', 'USDS', 'MKR', 'SKY'];
+    const targetTokens = ['DAI', 'USDC', 'USDT', 'ETH', 'USDS', 'MKR', 'SKY'];
+    const amounts = ['0.1', '1', '10', '100', '1000', undefined];
 
-  // Different combinations of slots for trade intents
-  const slotCombinations = [
-    // Complete trade info
-    () => [
-      {
-        field: 'source_token',
-        parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
-      },
-      {
-        field: 'target_token',
-        parsed_value: targetTokens[Math.floor(Math.random() * targetTokens.length)]
-      },
-      {
-        field: 'amount',
-        parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
-      }
-    ],
-    // Only source token
-    () => [
-      {
-        field: 'source_token',
-        parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
-      }
-    ],
-    // Only target token
-    () => [
-      {
-        field: 'target_token',
-        parsed_value: targetTokens[Math.floor(Math.random() * targetTokens.length)]
-      }
-    ],
-    // Source and target, no amount
-    () => [
-      {
-        field: 'source_token',
-        parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
-      },
-      {
-        field: 'target_token',
-        parsed_value: targetTokens[Math.floor(Math.random() * targetTokens.length)]
-      }
-    ],
-    // Source and amount
-    () => [
-      {
-        field: 'source_token',
-        parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
-      },
-      {
-        field: 'amount',
-        parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
-      }
-    ],
-    // Empty slots (generic trade)
-    () => []
+    // Different combinations of slots for trade intents
+    const slotCombinations = [
+      // Complete trade info
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
+        },
+        {
+          field: 'target_token',
+          parsed_value: targetTokens[Math.floor(Math.random() * targetTokens.length)]
+        },
+        {
+          field: 'input_amount',
+          parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
+        }
+      ],
+      // Only source token
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
+        }
+      ],
+      // Only target token
+      () => [
+        {
+          field: 'target_token',
+          parsed_value: targetTokens[Math.floor(Math.random() * targetTokens.length)]
+        }
+      ],
+      // Source and target, no amount
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
+        },
+        {
+          field: 'target_token',
+          parsed_value: targetTokens[Math.floor(Math.random() * targetTokens.length)]
+        }
+      ],
+      // Source and amount
+      () => [
+        {
+          field: 'source_token',
+          parsed_value: sourceTokens[Math.floor(Math.random() * sourceTokens.length)]
+        },
+        {
+          field: 'input_amount',
+          parsed_value: amounts[Math.floor(Math.random() * (amounts.length - 1))]!
+        }
+      ],
+      // Empty slots (generic trade)
+      () => []
+    ];
+    // Pick a random combination
+
+    const selectedCombination = slotCombinations[Math.floor(Math.random() * slotCombinations.length)];
+    return selectedCombination();
+  }
+
+  const tokens = ['DAI', 'USDC', 'USDT', 'ETH', 'USDS'];
+  return [
+    {
+      field: 'source_token',
+      parsed_value: tokens[Math.floor(Math.random() * tokens.length)]
+    },
+    {
+      field: 'input_amount',
+      parsed_value: Math.floor(Math.random() * 1000).toString()
+    }
   ];
-
-  // Pick a random combination
-
-  const selectedCombination = slotCombinations[Math.floor(Math.random() * slotCombinations.length)];
-  return selectedCombination();
 };

--- a/apps/webapp/src/modules/chat/hooks/useSendMessage.tsx
+++ b/apps/webapp/src/modules/chat/hooks/useSendMessage.tsx
@@ -48,7 +48,7 @@ const fetchEndpoints = async (messagePayload: Partial<SendMessageRequest>) => {
         recommendations: generateRandomRecommendations()
       },
       slotResponse: {
-        slots: generateRandomSlots('TRADE')
+        slots: generateRandomSlots('SAVINGS_')
       }
     };
 

--- a/apps/webapp/src/modules/chat/lib/generateRewardIntents.ts
+++ b/apps/webapp/src/modules/chat/lib/generateRewardIntents.ts
@@ -1,4 +1,4 @@
-import { ChatIntent, Slot } from '../types/Chat';
+import { ChatIntent, Slot, SlotType } from '../types/Chat';
 import { IntentMapping, QueryParams } from '@/lib/constants';
 import { RewardContract } from '@jetstreamgg/hooks';
 
@@ -6,10 +6,11 @@ export const generateRewardIntents = (slots: Slot[], rewards?: RewardContract[])
   const { REWARDS_INTENT: REWARDS } = IntentMapping;
   const intent_id = REWARDS;
   const { Widget, InputAmount, Chat } = QueryParams;
+  const { Amount, SourceToken, TargetToken } = SlotType;
 
-  const amountSlot = slots.find(slot => slot.field === 'amount');
-  const sourceTokenSlot = slots.find(slot => slot.field === 'source_token');
-  const targetTokenSlot = slots.find(slot => slot.field === 'target_token');
+  const amountSlot = slots.find(slot => slot.field === Amount);
+  const sourceTokenSlot = slots.find(slot => slot.field === SourceToken);
+  const targetTokenSlot = slots.find(slot => slot.field === TargetToken);
 
   let stakeReward;
   const intents = [];

--- a/apps/webapp/src/modules/chat/lib/generateSavingsIntents.ts
+++ b/apps/webapp/src/modules/chat/lib/generateSavingsIntents.ts
@@ -1,27 +1,158 @@
-import { ChatIntent, Slot } from '../types/Chat';
+import { Chain } from 'viem';
+import { ChatIntent, Slot, SlotType } from '../types/Chat';
 import { IntentMapping, QueryParams } from '@/lib/constants';
 
-export const generateSavingsIntents = (slots: Slot[]): ChatIntent[] => {
-  const { SAVINGS_INTENT: SAVINGS } = IntentMapping;
-  const intent_id = SAVINGS;
-  const { Widget, InputAmount, Chat } = QueryParams;
+const networkMapping = {
+  mainnet: 1,
+  ethereum: 1,
+  base: 8453,
+  arbitrum: 42161
+};
 
-  const amountSlot = slots.find(slot => slot.field === 'amount');
+const chainIdNameMapping = {
+  1: 'ethereum',
+  8453: 'base',
+  42161: 'arbitrum'
+};
 
-  const intents = [];
+// TODO: This should come from a config or API
+const supportedTokensByNetwork: Record<number, string[]> = {
+  1: ['USDS'],
+  8453: ['USDS', 'USDC'],
+  42161: ['USDS', 'USDC']
+};
 
-  if (amountSlot && !Number.isNaN(Number(amountSlot.parsed_value))) {
-    intents.push({
-      intent_id,
-      intent_description: `Deposit ${amountSlot.parsed_value} USDS into Savings`,
-      url: `?${Widget}=${SAVINGS}&${InputAmount}=${amountSlot.parsed_value}&${Chat}=true`
+const isTokenSupportedOnNetwork = (token: string, chainId: number): boolean => {
+  const networkTokens = supportedTokensByNetwork[chainId];
+  if (!networkTokens) return false;
+  return networkTokens.some(t => t.toLowerCase() === token.toLowerCase());
+};
+
+const generateIntentDescription = (
+  amount: string | undefined,
+  token: string | undefined,
+  network?: Chain,
+  tab?: 'left' | 'right'
+): string => {
+  const networkSuffix = network ? ` on ${network.name}` : '';
+  const action = tab === 'right' ? 'Withdraw' : 'Supply';
+
+  // Case 1: Complete info (amount + token + tab)
+  if (amount && token && tab) {
+    return `${action} ${amount} ${token} ${tab === 'right' ? 'from' : 'to'} Savings${networkSuffix}`;
+  }
+
+  // Case 2: Amount + token (no tab)
+  if (amount && token) {
+    return `Supply or withdraw ${amount} ${token} ${networkSuffix}`;
+  }
+
+  // Case 3: Amount + tab (no token)
+  if (amount && tab) {
+    return `${action} ${amount} ${tab === 'right' ? 'from' : 'to'} Savings${networkSuffix}`;
+  }
+
+  // Case 4: Token + tab (no amount)
+  if (token && tab) {
+    return `${action} ${token} ${tab === 'right' ? 'from' : 'to'} Savings${networkSuffix}`;
+  }
+
+  // Case 5: Only token
+  if (token) {
+    return `Supply or withdraw ${token}${networkSuffix}`;
+  }
+
+  // Case 6: Only tab
+  if (tab) {
+    return `${action} ${tab === 'right' ? 'from' : 'to'} Savings${networkSuffix}`;
+  }
+
+  // Case 7: No slots (generic)
+  return `Go to Savings${networkSuffix}`;
+};
+
+const generateIntentUrl = (
+  amount: string | undefined,
+  token: string | undefined,
+  network?: Chain,
+  tab?: 'left' | 'right'
+): string => {
+  const { Widget, InputAmount, SourceToken, Chat } = QueryParams;
+  const urlParams = new URLSearchParams();
+
+  urlParams.append(Widget, IntentMapping.SAVINGS_INTENT);
+  urlParams.append(Chat, 'true');
+
+  // Only add parameters if they are defined
+  if (amount) urlParams.append(InputAmount, amount);
+  if (token) urlParams.append(SourceToken, token);
+  if (network) urlParams.append('network', chainIdNameMapping[network.id as keyof typeof chainIdNameMapping]);
+  if (tab) urlParams.append('tab', tab);
+
+  return `?${urlParams.toString()}`;
+};
+
+export const generateSavingsIntents = (
+  slots: Slot[],
+  chains: Chain[],
+  tab?: 'left' | 'right',
+  detectedNetwork?: string
+): ChatIntent[] => {
+  if (import.meta.env.VITE_RESTRICTED_BUILD === 'true') {
+    return [];
+  }
+
+  const { Amount, SourceToken } = SlotType;
+
+  const amountSlot = slots.find(slot => slot.field === Amount);
+  const tokenSlot = slots.find(slot => slot.field === SourceToken);
+
+  const amount = amountSlot?.parsed_value || undefined;
+  const token = tokenSlot?.parsed_value || 'USDS'; // Default to USDS if not specified
+
+  const allIntents: ChatIntent[] = [];
+
+  // If we have a detected network, prioritize that network's intents
+  if (detectedNetwork) {
+    const targetChain = chains.find(
+      c => c.id === networkMapping[detectedNetwork.toLowerCase() as keyof typeof networkMapping]
+    );
+
+    if (targetChain && isTokenSupportedOnNetwork(token, targetChain.id)) {
+      allIntents.push({
+        intent_id: IntentMapping.SAVINGS_INTENT,
+        intent_description: generateIntentDescription(amount, token, targetChain, tab),
+        url: generateIntentUrl(amount, token, targetChain, tab)
+      });
+    }
+  }
+
+  // If no network was detected, generate intents for all supported networks
+  if (!detectedNetwork) {
+    chains.forEach(chain => {
+      if (isTokenSupportedOnNetwork(token, chain.id)) {
+        allIntents.push({
+          intent_id: IntentMapping.SAVINGS_INTENT,
+          intent_description: generateIntentDescription(amount, token, chain, tab),
+          url: generateIntentUrl(amount, token, chain, tab)
+        });
+      }
     });
   }
-  intents.push({
-    intent_id,
-    intent_description: 'Go to Savings',
-    url: `?${Widget}=${SAVINGS}&${Chat}=true`
-  });
 
-  return intents;
+  // Always add a fallback intent if no valid intents were generated
+  if (allIntents.length === 0) {
+    allIntents.push({
+      intent_id: IntentMapping.SAVINGS_INTENT,
+      intent_description: generateIntentDescription(undefined, undefined, undefined, tab),
+      url: generateIntentUrl(undefined, undefined, undefined, tab)
+    });
+  }
+
+  // Sort intents - prioritize those with amounts
+  return allIntents.sort((a, b) => {
+    const aHasAmount = a.url.includes(QueryParams.InputAmount);
+    const bHasAmount = b.url.includes(QueryParams.InputAmount);
+    return aHasAmount === bHasAmount ? 0 : aHasAmount ? -1 : 1;
+  });
 };

--- a/apps/webapp/src/modules/chat/lib/generateTradeIntents.ts
+++ b/apps/webapp/src/modules/chat/lib/generateTradeIntents.ts
@@ -1,5 +1,5 @@
 import { Chain } from 'wagmi/chains';
-import { ChatIntent, Slot } from '../types/Chat';
+import { ChatIntent, Slot, SlotType } from '../types/Chat';
 import { IntentMapping, QueryParams } from '@/lib/constants';
 import { defaultConfig } from '@/modules/config/default-config';
 import { Token } from '@jetstreamgg/hooks';
@@ -186,9 +186,11 @@ export const generateTradeIntents = (
     return [];
   }
 
-  const amountSlot = slots.find(slot => slot.field === 'amount');
-  const sourceTokenSlot = slots.find(slot => slot.field === 'source_token');
-  const targetTokenSlot = slots.find(slot => slot.field === 'target_token');
+  const { Amount, SourceToken, TargetToken } = SlotType;
+
+  const amountSlot = slots.find(slot => slot.field === Amount);
+  const sourceTokenSlot = slots.find(slot => slot.field === SourceToken);
+  const targetTokenSlot = slots.find(slot => slot.field === TargetToken);
 
   const amount = amountSlot?.parsed_value;
   const sourceToken = sourceTokenSlot?.parsed_value;

--- a/apps/webapp/src/modules/chat/lib/generateTradeIntents.ts
+++ b/apps/webapp/src/modules/chat/lib/generateTradeIntents.ts
@@ -3,19 +3,15 @@ import { ChatIntent, Slot, SlotType } from '../types/Chat';
 import { IntentMapping, QueryParams } from '@/lib/constants';
 import { defaultConfig } from '@/modules/config/default-config';
 import { Token } from '@jetstreamgg/hooks';
-
-const networkMapping = {
-  mainnet: 1,
-  ethereum: 1,
-  base: 8453,
-  arbitrum: 42161
-};
-
-const chainIdNameMapping = {
-  1: 'ethereum',
-  8453: 'base',
-  42161: 'arbitrum'
-};
+import {
+  networkMapping,
+  chainIdNameMapping,
+  generateBaseUrl,
+  addNetworkToDescription,
+  sortIntentsByPriority,
+  getChainFromNetwork,
+  generateFallbackIntent
+} from './intentUtils';
 
 type TokenPair = {
   sourceToken: string;
@@ -24,7 +20,7 @@ type TokenPair = {
 
 type DisallowedPairs = Record<number, TokenPair[]>;
 
-type IntentParams = {
+type TradeIntentParams = {
   sourceToken?: string | null;
   targetToken?: string | null;
   amount?: string | null;
@@ -44,7 +40,6 @@ const isTokenSupportedOnNetwork = (
     // Use Base token list for now for Arbitrum
     return tokenList[networkMapping.base].some(t => t.symbol.toLowerCase() === token.toLowerCase());
   }
-  // ^^^^^^^
 
   const networkTokens = tokenList[chainId];
   if (!networkTokens) return false;
@@ -64,7 +59,6 @@ const isPairAllowedOnNetwork = (
 
   // TODO: Remove this once we have a token list for Arbitrum vvvvvv
   if (chainId === networkMapping.arbitrum) {
-    // Use Base token list for now for Arbitrum. Remove this once we have a token list for Arbitrum
     const pairs = disallowedPairs[networkMapping.base];
     if (!pairs) return true;
 
@@ -74,7 +68,6 @@ const isPairAllowedOnNetwork = (
         p.targetToken.toLowerCase() === pair.targetToken.toLowerCase()
     );
   }
-  // ^^^^^^^
 
   const networkDisallowedPairs = disallowedPairs[chainId];
   if (!networkDisallowedPairs) return true;
@@ -89,90 +82,42 @@ const isPairAllowedOnNetwork = (
 /**
  * Generate intent description with optional network name
  */
-const generateIntentDescription = (params: IntentParams): string => {
+const generateTradeDescription = (params: TradeIntentParams): string => {
   const { sourceToken, targetToken, amount, network } = params;
-  const networkSuffix = network ? ` on ${network.name}` : '';
+  let description = '';
+
   if (sourceToken && targetToken) {
-    if (amount) {
-      return `Trade ${amount} ${sourceToken} for ${targetToken}${networkSuffix}`;
-    }
-    return `Trade ${sourceToken} for ${targetToken}${networkSuffix}`;
+    description = amount
+      ? `Trade ${amount} ${sourceToken} for ${targetToken}`
+      : `Trade ${sourceToken} for ${targetToken}`;
+  } else if (sourceToken) {
+    description = amount ? `Trade ${amount} ${sourceToken}` : `Trade ${sourceToken}`;
+  } else if (targetToken) {
+    description = `Trade to ${targetToken}`;
+  } else {
+    description = 'Go to Trade';
   }
 
-  if (sourceToken) {
-    if (amount) {
-      return `Trade ${amount} ${sourceToken}${networkSuffix}`;
-    }
-    return `Trade ${sourceToken}${networkSuffix}`;
-  }
-
-  if (targetToken) {
-    return `Trade to ${targetToken}${networkSuffix}`;
-  }
-
-  return `Go to Trade${networkSuffix}`;
-};
-
-/**
- * Generate URL with intent parameters
- */
-const generateIntentUrl = (params: IntentParams): string => {
-  const { Widget, InputAmount, SourceToken, TargetToken, Chat } = QueryParams;
-  const { sourceToken, targetToken, amount, network } = params;
-
-  const urlParams = new URLSearchParams();
-  urlParams.append(Widget, IntentMapping.TRADE_INTENT);
-  urlParams.append(Chat, 'true');
-
-  if (sourceToken) urlParams.append(SourceToken, sourceToken);
-  if (targetToken) urlParams.append(TargetToken, targetToken);
-  if (amount) urlParams.append(InputAmount, amount);
-  if (network) urlParams.append('network', chainIdNameMapping[network.id as keyof typeof chainIdNameMapping]);
-
-  return `?${urlParams.toString()}`;
+  return addNetworkToDescription(description, network || undefined);
 };
 
 /**
  * Generate a single trade intent
  */
-const generateSingleIntent = (params: IntentParams): ChatIntent => {
+const generateSingleIntent = (params: TradeIntentParams): ChatIntent => {
+  const { sourceToken, targetToken, amount, network } = params;
+  const urlParams: Record<string, string | undefined> = {
+    [QueryParams.SourceToken]: sourceToken ?? undefined,
+    [QueryParams.TargetToken]: targetToken ?? undefined,
+    [QueryParams.InputAmount]: amount ?? undefined,
+    network: network ? chainIdNameMapping[network.id as keyof typeof chainIdNameMapping] : undefined
+  };
+
   return {
     intent_id: IntentMapping.TRADE_INTENT,
-    intent_description: generateIntentDescription(params),
-    url: generateIntentUrl(params)
+    intent_description: generateTradeDescription(params),
+    url: generateBaseUrl(IntentMapping.TRADE_INTENT, urlParams)
   };
-};
-
-/**
- * Sort intents by relevance/priority
- * Priority order:
- * 1. Intents with amount and both tokens
- * 2. Intents with both tokens but no amount
- * 3. Intents with source token only
- * 4. Intents with target token only
- * 5. Generic trade intent
- */
-const sortIntentsByPriority = (intents: ChatIntent[]): ChatIntent[] => {
-  return [...intents].sort((a, b) => {
-    const aHasAmount = a.url.includes(QueryParams.InputAmount);
-    const bHasAmount = b.url.includes(QueryParams.InputAmount);
-    const aHasSourceToken = a.url.includes(QueryParams.SourceToken);
-    const bHasSourceToken = b.url.includes(QueryParams.SourceToken);
-    const aHasTargetToken = a.url.includes(QueryParams.TargetToken);
-    const bHasTargetToken = b.url.includes(QueryParams.TargetToken);
-    const aHasNetwork = a.url.includes('network=');
-    const bHasNetwork = b.url.includes('network=');
-
-    // Prioritize network-specific intents
-    if (aHasNetwork !== bHasNetwork) return aHasNetwork ? -1 : 1;
-    if (aHasAmount !== bHasAmount) return aHasAmount ? -1 : 1;
-    if ((aHasSourceToken && aHasTargetToken) !== (bHasSourceToken && bHasTargetToken)) {
-      return aHasSourceToken && aHasTargetToken ? -1 : 1;
-    }
-    if (aHasSourceToken !== bHasSourceToken) return aHasSourceToken ? -1 : 1;
-    if (aHasTargetToken !== bHasTargetToken) return aHasTargetToken ? -1 : 1;
-    return 0;
-  });
 };
 
 export const generateTradeIntents = (
@@ -182,6 +127,7 @@ export const generateTradeIntents = (
 ): ChatIntent[] => {
   const disallowedPairs = defaultConfig.tradeDisallowedPairs;
   const tradeTokens = defaultConfig.tradeTokenList;
+
   if (import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true') {
     return [];
   }
@@ -199,19 +145,10 @@ export const generateTradeIntents = (
   const allIntents: ChatIntent[] = [];
 
   // If we have a detected network, prioritize that network's intents
-  if (detectedNetwork) {
-    const targetChain = chains.find(
-      c => c.id === networkMapping[detectedNetwork.toLowerCase() as keyof typeof networkMapping]
-    );
-
-    if (targetChain) {
-      // Generate network-specific intent
-      allIntents.push(generateSingleIntent({ sourceToken, targetToken, amount, network: targetChain }));
-    }
+  const targetChain = getChainFromNetwork(detectedNetwork, chains);
+  if (targetChain) {
+    allIntents.push(generateSingleIntent({ sourceToken, targetToken, amount, network: targetChain }));
   }
-
-  // Always add network-agnostic intent as a fallback
-  // allIntents.push(generateSingleIntent({ sourceToken, targetToken, amount }));
 
   // If no network was detected, generate intents for all supported networks
   if (!detectedNetwork) {
@@ -268,14 +205,9 @@ export const generateTradeIntents = (
 
   // Always add generic trade intent as fallback if no valid intents
   if (validIntents.length === 0) {
-    validIntents.push({
-      intent_id: IntentMapping.TRADE_INTENT,
-      intent_description: 'Go to Trade',
-      url: `?${QueryParams.Widget}=${IntentMapping.TRADE_INTENT}&${QueryParams.Chat}=true`
-    });
+    validIntents.push(generateFallbackIntent(IntentMapping.TRADE_INTENT, 'Go to Trade'));
   }
 
-  // Sort intents by priority
   return sortIntentsByPriority(validIntents);
 };
 

--- a/apps/webapp/src/modules/chat/lib/generateUpgradeIntents.ts
+++ b/apps/webapp/src/modules/chat/lib/generateUpgradeIntents.ts
@@ -1,14 +1,15 @@
-import { ChatIntent, Slot } from '../types/Chat';
+import { ChatIntent, Slot, SlotType } from '../types/Chat';
 import { IntentMapping, QueryParams } from '@/lib/constants';
 
 export const generateUpgradeIntents = (slots: Slot[]): ChatIntent[] => {
   const { UPGRADE_INTENT: UPGRADE } = IntentMapping;
   const intent_id = UPGRADE;
   const { Widget, InputAmount, Chat, SourceToken } = QueryParams;
+  const { Amount, SourceToken: SourceTokenSlot, TargetToken: TargetTokenSlot } = SlotType;
 
-  const amountSlot = slots.find(slot => slot.field === 'amount');
-  const sourceTokenSlot = slots.find(slot => slot.field === 'source_token');
-  const targetTokenSlot = slots.find(slot => slot.field === 'target_token');
+  const amountSlot = slots.find(slot => slot.field === Amount);
+  const sourceTokenSlot = slots.find(slot => slot.field === SourceTokenSlot);
+  const targetTokenSlot = slots.find(slot => slot.field === TargetTokenSlot);
 
   const intents = [];
 

--- a/apps/webapp/src/modules/chat/lib/handleActionIntent.ts
+++ b/apps/webapp/src/modules/chat/lib/handleActionIntent.ts
@@ -5,7 +5,10 @@ import {
   SAVINGS,
   TRADE_MAINNET,
   TRADE_ARBITRUM,
-  TRADE_BASE
+  TRADE_BASE,
+  SAVINGS_MAINNET,
+  SAVINGS_ARBITRUM,
+  SAVINGS_BASE
 } from './intentClassificationOptions';
 import { ChatIntent, Slot } from '../types/Chat';
 import { generateRewardIntents } from './generateRewardIntents';
@@ -29,6 +32,9 @@ export const handleActionIntent = ({
   const parts = classification.split('_');
   const detectedNetwork = parts.length > 1 ? parts[1] : undefined;
 
+  // TODO: We don't know yet where we're going to get the tab from (slots or intent), so we're just going to presume it comes from the slots
+  const tab = slots.find(slot => slot.field === 'tab')?.parsed_value as 'left' | 'right' | undefined;
+
   switch (classification) {
     case TRADE:
     case TRADE_MAINNET:
@@ -40,7 +46,10 @@ export const handleActionIntent = ({
     case UPGRADE:
       return generateUpgradeIntents(slots);
     case SAVINGS:
-      return generateSavingsIntents(slots);
+    case SAVINGS_MAINNET:
+    case SAVINGS_BASE:
+    case SAVINGS_ARBITRUM:
+      return generateSavingsIntents(slots, chains, tab, detectedNetwork);
     // TODO: add Seal
     default:
       return [];

--- a/apps/webapp/src/modules/chat/lib/intentUtils.ts
+++ b/apps/webapp/src/modules/chat/lib/intentUtils.ts
@@ -1,0 +1,69 @@
+import { Chain } from 'wagmi/chains';
+import { QueryParams } from '@/lib/constants';
+import { ChatIntent } from '../types/Chat';
+
+export const networkMapping = {
+  mainnet: 1,
+  ethereum: 1,
+  base: 8453,
+  arbitrum: 42161
+} as const;
+
+export const chainIdNameMapping = {
+  1: 'ethereum',
+  8453: 'base',
+  42161: 'arbitrum'
+} as const;
+
+export type NetworkName = keyof typeof networkMapping;
+export type ChainId = (typeof networkMapping)[NetworkName];
+
+export type BaseIntentParams = {
+  amount?: string | null;
+  network?: Chain | null;
+};
+
+export const generateBaseUrl = (intentId: string, params: Record<string, string | undefined>): string => {
+  const urlParams = new URLSearchParams();
+  urlParams.append(QueryParams.Widget, intentId);
+  urlParams.append(QueryParams.Chat, 'true');
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) urlParams.append(key, value);
+  });
+
+  return `?${urlParams.toString()}`;
+};
+
+export const addNetworkToDescription = (description: string, network?: Chain): string => {
+  return network ? `${description} on ${network.name}` : description;
+};
+
+export const sortIntentsByPriority = (intents: ChatIntent[]): ChatIntent[] => {
+  return [...intents].sort((a, b) => {
+    const aHasAmount = a.url.includes(QueryParams.InputAmount);
+    const bHasAmount = b.url.includes(QueryParams.InputAmount);
+    const aHasNetwork = a.url.includes('network=');
+    const bHasNetwork = b.url.includes('network=');
+
+    // Prioritize network-specific intents
+    if (aHasNetwork !== bHasNetwork) return aHasNetwork ? -1 : 1;
+    if (aHasAmount !== bHasAmount) return aHasAmount ? -1 : 1;
+    return 0;
+  });
+};
+
+export const getChainFromNetwork = (
+  detectedNetwork: string | undefined,
+  chains: Chain[]
+): Chain | undefined => {
+  if (!detectedNetwork) return undefined;
+
+  return chains.find(c => c.id === networkMapping[detectedNetwork.toLowerCase() as NetworkName]);
+};
+
+export const generateFallbackIntent = (intentId: string, description: string): ChatIntent => ({
+  intent_id: intentId,
+  intent_description: description,
+  url: generateBaseUrl(intentId, {})
+});

--- a/apps/webapp/src/modules/chat/types/Chat.ts
+++ b/apps/webapp/src/modules/chat/types/Chat.ts
@@ -1,3 +1,5 @@
+import { MessageType, UserType } from '../constants';
+
 export interface SendMessageRequest {
   api_key: string;
   chatbot_id: string;
@@ -31,9 +33,16 @@ export interface ChatIntent {
   intent_id: string;
 }
 
+export enum SlotType {
+  Amount = 'input_amount',
+  SourceToken = 'source_token',
+  TargetToken = 'target_token',
+  Tab = 'tab'
+}
+
 export interface Slot {
   description: string;
-  field: string;
+  field: SlotType;
   slot_type: string;
   valid: boolean;
   raw_value?: string | null;

--- a/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
@@ -7,7 +7,7 @@ import {
 } from '@jetstreamgg/widgets';
 import { TOKENS, useSavingsHistory } from '@jetstreamgg/hooks';
 import { isBaseChainId } from '@jetstreamgg/utils';
-import { REFRESH_DELAY } from '@/lib/constants';
+import { QueryParams, REFRESH_DELAY } from '@/lib/constants';
 import { SharedProps } from '@/modules/app/types/Widgets';
 import { LinkedActionSteps } from '@/modules/config/context/ConfigContext';
 import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
@@ -20,13 +20,14 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
   const subgraphUrl = useSubgraphUrl();
   const { linkedActionConfig, updateLinkedActionConfig, exitLinkedActionMode } = useConfigContext();
   const { mutate: refreshSavingsHistory } = useSavingsHistory(subgraphUrl);
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const chainId = useChainId();
 
   const isBaseChain = isBaseChainId(chainId);
   const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
   const disallowedTokens =
     isRestrictedMiCa && isBaseChain ? { supply: [TOKENS.usdc], withdraw: [TOKENS.usdc] } : undefined;
+  const tab = searchParams.get(QueryParams.Tab) as 'left' | 'right' | undefined;
 
   const onSavingsWidgetStateChange = ({ hash, txStatus, widgetState }: WidgetStateChangeParams) => {
     // After a successful linked action sUPPLY, set the final step to "success"
@@ -66,7 +67,8 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
       onWidgetStateChange={onSavingsWidgetStateChange}
       externalWidgetState={{
         amount: linkedActionConfig?.inputAmount,
-        token: isBaseChain ? linkedActionConfig?.sourceToken : undefined
+        token: isBaseChain ? linkedActionConfig?.sourceToken : undefined,
+        tab
       }}
       disallowedTokens={disallowedTokens}
     />

--- a/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
@@ -28,7 +28,7 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
   const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
   const disallowedTokens =
     isRestrictedMiCa && isBaseChain ? { supply: [TOKENS.usdc], withdraw: [TOKENS.usdc] } : undefined;
-  const tab = searchParams.get(QueryParams.Tab) as 'left' | 'right' | undefined;
+  const tab = (searchParams.get(QueryParams.Tab) || undefined) as 'left' | 'right' | undefined;
 
   const onSavingsWidgetStateChange = ({
     hash,

--- a/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
@@ -3,7 +3,8 @@ import {
   BaseSavingsWidget,
   TxStatus,
   SavingsAction,
-  WidgetStateChangeParams
+  WidgetStateChangeParams,
+  SavingsFlow
 } from '@jetstreamgg/widgets';
 import { TOKENS, useSavingsHistory } from '@jetstreamgg/hooks';
 import { isBaseChainId } from '@jetstreamgg/utils';
@@ -29,7 +30,34 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
     isRestrictedMiCa && isBaseChain ? { supply: [TOKENS.usdc], withdraw: [TOKENS.usdc] } : undefined;
   const tab = searchParams.get(QueryParams.Tab) as 'left' | 'right' | undefined;
 
-  const onSavingsWidgetStateChange = ({ hash, txStatus, widgetState }: WidgetStateChangeParams) => {
+  const onSavingsWidgetStateChange = ({
+    hash,
+    txStatus,
+    widgetState,
+    originToken
+  }: WidgetStateChangeParams) => {
+    // Set tab search param based on widgetState.flow
+    if (widgetState.flow) {
+      setSearchParams(prevParams => {
+        const params = new URLSearchParams(prevParams);
+        // only set tab if it was set already
+        if (params.get(QueryParams.Tab)) {
+          params.set(QueryParams.Tab, widgetState.flow === SavingsFlow.SUPPLY ? 'left' : 'right');
+        }
+        return params;
+      });
+    }
+
+    if (originToken) {
+      setSearchParams(prevParams => {
+        const params = new URLSearchParams(prevParams);
+        if (params.get(QueryParams.SourceToken)) {
+          params.set(QueryParams.SourceToken, originToken);
+        }
+        return params;
+      });
+    }
+
     // After a successful linked action sUPPLY, set the final step to "success"
     if (
       widgetState.action === SavingsAction.SUPPLY &&

--- a/apps/webapp/src/modules/utils/validateSearchParams.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.ts
@@ -11,15 +11,18 @@ import {
 import { Intent } from '@/lib/enums';
 import { defaultConfig } from '../config/default-config';
 import { isBaseChainId } from '@jetstreamgg/utils';
+import { Chain } from 'viem';
 
 export const validateSearchParams = (
   searchParams: URLSearchParams,
   rewardContracts: RewardContract[],
   widget: string,
   setSelectedRewardContract: (rewardContract?: RewardContract) => void,
-  chainId: number
+  chainId: number,
+  chains: readonly [Chain, ...Chain[]]
 ) => {
-  const isBaseChain = isBaseChainId(chainId);
+  const chainInUrl = chains.find(c => c.name.toLowerCase() === searchParams.get(QueryParams.Network));
+  const isBaseChain = isBaseChainId(chainInUrl?.id || chainId);
 
   searchParams.forEach((value, key) => {
     // removes any query param not found in QueryParams
@@ -36,8 +39,8 @@ export const validateSearchParams = (
     if (
       key === QueryParams.Widget &&
       (!Object.values(IntentMapping).includes(value.toLowerCase()) ||
-        !CHAIN_WIDGET_MAP[chainId].includes(mapQueryParamToIntent(value)) ||
-        COMING_SOON_MAP[chainId]?.includes(mapQueryParamToIntent(value)))
+        !CHAIN_WIDGET_MAP[chainInUrl?.id || chainId].includes(mapQueryParamToIntent(value)) ||
+        COMING_SOON_MAP[chainInUrl?.id || chainId]?.includes(mapQueryParamToIntent(value)))
     ) {
       searchParams.delete(key);
     }

--- a/packages/widgets/src/shared/types/widgetState.d.ts
+++ b/packages/widgets/src/shared/types/widgetState.d.ts
@@ -62,6 +62,7 @@ export type WidgetStateChangeParams = {
   hash?: string;
   txStatus: TxStatus;
   widgetState: WidgetState;
+  originToken?: string;
   targetToken?: string;
   executedBuyAmount?: string;
   executedSellAmount?: string;

--- a/packages/widgets/src/widgets/BaseSavingsWidget/components/BaseSavingsSupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/BaseSavingsWidget/components/BaseSavingsSupplyWithdraw.tsx
@@ -65,7 +65,7 @@ export function BaseSavingsSupplyWithdraw({
 
   return (
     <VStack className="w-full items-center justify-center">
-      <Tabs defaultValue={tabIndex === 0 ? 'left' : 'right'} className="w-full">
+      <Tabs value={tabIndex === 0 ? 'left' : 'right'} className="w-full">
         <motion.div variants={positionAnimations}>
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger

--- a/packages/widgets/src/widgets/BaseSavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/BaseSavingsWidget/index.tsx
@@ -184,6 +184,14 @@ const SavingsWidgetWrapped = ({
   const [updatedChiForDeposit, setUpdatedChiForDeposit] = useState(0n);
 
   useEffect(() => {
+    setTabIndex(initialTabIndex);
+  }, [initialTabIndex]);
+
+  useEffect(() => {
+    setOriginToken(tokenForSymbol(validatedExternalState?.token || 'USDS'));
+  }, [validatedExternalState?.token]);
+
+  useEffect(() => {
     if (rho && dsr && chi) {
       const timestamp = Math.floor(Date.now() / 1000);
       const elapsedTimeWithEpoch = BigInt(timestamp) + BigInt(EPOCH_LENGTH) - rho;
@@ -792,6 +800,7 @@ const SavingsWidgetWrapped = ({
               onMenuItemChange={(op: Token | null) => {
                 if (op) {
                   setOriginToken(op as Token);
+                  onWidgetStateChange?.({ originToken: op.symbol, txStatus, widgetState });
                 }
               }}
               error={widgetState.flow === SavingsFlow.SUPPLY ? isSupplyBalanceError : isWithdrawBalanceError}

--- a/packages/widgets/src/widgets/SavingsWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SupplyWithdraw.tsx
@@ -73,7 +73,7 @@ export const SupplyWithdraw = ({
 
   return (
     <MotionVStack gap={0} className="w-full" variants={positionAnimations}>
-      <Tabs defaultValue={tabIndex === 0 ? 'left' : 'right'}>
+      <Tabs value={tabIndex === 0 ? 'left' : 'right'}>
         <motion.div variants={positionAnimations}>
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger position="left" value="left" onClick={() => onToggle(0)}>

--- a/packages/widgets/src/widgets/SavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/index.tsx
@@ -98,6 +98,10 @@ const SavingsWidgetWrapped = ({
     setAmount(initialAmount);
   }, [initialAmount]);
 
+  useEffect(() => {
+    setTabIndex(initialTabIndex);
+  }, [initialTabIndex]);
+
   const {
     setButtonText,
     setIsDisabled,


### PR DESCRIPTION
- Generates Savings intents based on the detected intent and slots
- Add tab support to the Savings widgets
- Fixes input_amount and source_token detection in the Savings widgets as they'd only work during the first render
- Fixes url params validation when switching networks. Update the checks to match the network in the url instead of the current chain id.
- Move common logic to a separate file utils


### Known issues
- [ ] the following url doesn't work well `'?widget=trade&chat=true&source_token=USDT&target_token=ETH&input_amount=100&network=ethereum'`