### PR TITLE
Add Coderabbit config file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -44,43 +44,42 @@ reviews:
     - '!**/*.min.js.css'
     - '!**/locales/**'
   path_instructions:
-    path_instructions:
-  # Instructions for the apps
-  - path: "apps/**/*.{ts,tsx,jsx,js}"
-    instructions: |
-      Confirm that the React applications adhere to the following guidelines:
-      - Use modern React practices (functional components, hooks, and context) for clarity and reusability.
-      - Leverage TypeScript to ensure strong type safety, including proper type definitions for props, state, and API responses.
-      - Maintain a clean component structure with efficient state management.
-      - Ensure accessibility, responsiveness, and performance optimizations.
-      - Provide thorough unit and integration testing, along with clear documentation.
-      
-  # Instructions for the hooks package
-  - path: "packages/hooks/**/*.{ts,tsx,jsx,js}"
-    instructions: |
-      Confirm that the Web3 React hooks package adheres to the following guidelines:
-      - Implement reusable and composable custom hooks for interacting with Web3 and smart contracts.
-      - Handle asynchronous operations and error states robustly.
-      - Use TypeScript effectively to ensure type safety and clarity.
-      - Include comprehensive tests and clear usage documentation.
-      
-  # Instructions for the widgets package
-  - path: "packages/widgets/**/*.{ts,tsx,jsx,js}"
-    instructions: |
-      Confirm that the Web3 React widgets package adheres to the following guidelines:
-      - Develop modular, reusable UI components that integrate smoothly with Web3 functionalities.
-      - Follow best practices for responsive design and accessibility.
-      - Optimize performance and manage state efficiently.
-      - Ensure consistency through proper TypeScript usage, testing, and documentation.
-      
-  # Instructions for the utils package
-  - path: "packages/utils/**/*.{ts,tsx,jsx,js}"
-    instructions: |
-      Confirm that the utils package adheres to the following guidelines:
-      - Create well-structured, modular utility functions that promote code reuse.
-      - Follow consistent naming conventions and coding standards.
-      - Implement robust error handling and performance optimizations.
-      - Provide comprehensive unit tests and clear documentation to support library consumers.
+    # Instructions for the apps
+    - path: 'apps/**/*.{ts,tsx,jsx,js}'
+      instructions: |
+        Confirm that the React applications adhere to the following guidelines:
+        - Use modern React practices (functional components, hooks, and context) for clarity and reusability.
+        - Leverage TypeScript to ensure strong type safety, including proper type definitions for props, state, and API responses.
+        - Maintain a clean component structure with efficient state management.
+        - Ensure accessibility, responsiveness, and performance optimizations.
+        - Provide thorough unit and integration testing, along with clear documentation.
+
+    # Instructions for the hooks package
+    - path: 'packages/hooks/**/*.{ts,tsx,jsx,js}'
+      instructions: |
+        Confirm that the Web3 React hooks package adheres to the following guidelines:
+        - Implement reusable and composable custom hooks for interacting with Web3 and smart contracts.
+        - Handle asynchronous operations and error states robustly.
+        - Use TypeScript effectively to ensure type safety and clarity.
+        - Include comprehensive tests and clear usage documentation.
+
+    # Instructions for the widgets package
+    - path: 'packages/widgets/**/*.{ts,tsx,jsx,js}'
+      instructions: |
+        Confirm that the Web3 React widgets package adheres to the following guidelines:
+        - Develop modular, reusable UI components that integrate smoothly with Web3 functionalities.
+        - Follow best practices for responsive design and accessibility.
+        - Optimize performance and manage state efficiently.
+        - Ensure consistency through proper TypeScript usage, testing, and documentation.
+
+    # Instructions for the utils package
+    - path: 'packages/utils/**/*.{ts,tsx,jsx,js}'
+      instructions: |
+        Confirm that the utils package adheres to the following guidelines:
+        - Create well-structured, modular utility functions that promote code reuse.
+        - Follow consistent naming conventions and coding standards.
+        - Implement robust error handling and performance optimizations.
+        - Provide comprehensive unit tests and clear documentation to support library consumers.
   abort_on_close: true
   auto_review:
     enabled: true
@@ -88,7 +87,7 @@ reviews:
     ignore_title_keywords: []
     labels:
       # Only review PRs containing the following labels
-      - "ready for review"
+      - 'ready for review'
     drafts: false
     base_branches: []
   finishing_touches:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,175 @@
+language: en-US
+tone_instructions: ''
+early_access: false
+enable_free_tier: true
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: false
+  high_level_summary_placeholder: '@coderabbitai summary'
+  high_level_summary_in_walkthrough: false
+  auto_title_placeholder: '@coderabbitai'
+  auto_title_instructions: ''
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: false
+  changed_files_summary: true
+  sequence_diagrams: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  poem: false
+  labeling_instructions: []
+  path_filters:
+    - '!dist/**'
+    - '!**/*.yaml'
+    - '!**/*.yml'
+    - '!**/*.json'
+    - '!**/*.svg'
+    - '!**/*.jpeg'
+    - '!**/*.jpg'
+    - '!**/*.png'
+    - '!**/*.gif'
+    - '!**/*.bmp'
+    - '!**/*.tiff'
+    - '!**/*.webm'
+    - '!**/*.woff'
+    - '!**/*.woff2'
+    - '!**/*.min.js'
+    - '!**/*.min.js.map'
+    - '!**/*.min.js.css'
+    - '!**/locales/**'
+  path_instructions:
+    path_instructions:
+  # Instructions for the apps
+  - path: "apps/**/*.{ts,tsx,jsx,js}"
+    instructions: |
+      Confirm that the React applications adhere to the following guidelines:
+      - Use modern React practices (functional components, hooks, and context) for clarity and reusability.
+      - Leverage TypeScript to ensure strong type safety, including proper type definitions for props, state, and API responses.
+      - Maintain a clean component structure with efficient state management.
+      - Ensure accessibility, responsiveness, and performance optimizations.
+      - Provide thorough unit and integration testing, along with clear documentation.
+      
+  # Instructions for the hooks package
+  - path: "packages/hooks/**/*.{ts,tsx,jsx,js}"
+    instructions: |
+      Confirm that the Web3 React hooks package adheres to the following guidelines:
+      - Implement reusable and composable custom hooks for interacting with Web3 and smart contracts.
+      - Handle asynchronous operations and error states robustly.
+      - Use TypeScript effectively to ensure type safety and clarity.
+      - Include comprehensive tests and clear usage documentation.
+      
+  # Instructions for the widgets package
+  - path: "packages/widgets/**/*.{ts,tsx,jsx,js}"
+    instructions: |
+      Confirm that the Web3 React widgets package adheres to the following guidelines:
+      - Develop modular, reusable UI components that integrate smoothly with Web3 functionalities.
+      - Follow best practices for responsive design and accessibility.
+      - Optimize performance and manage state efficiently.
+      - Ensure consistency through proper TypeScript usage, testing, and documentation.
+      
+  # Instructions for the utils package
+  - path: "packages/utils/**/*.{ts,tsx,jsx,js}"
+    instructions: |
+      Confirm that the utils package adheres to the following guidelines:
+      - Create well-structured, modular utility functions that promote code reuse.
+      - Follow consistent naming conventions and coding standards.
+      - Implement robust error handling and performance optimizations.
+      - Provide comprehensive unit tests and clear documentation to support library consumers.
+  abort_on_close: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords: []
+    labels:
+      # Only review PRs containing the following labels
+      - "ready for review"
+    drafts: false
+    base_branches: []
+  finishing_touches:
+    docstrings:
+      enabled: true
+  tools:
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: true
+      enabled_only: false
+      level: default
+    biome:
+      enabled: true
+    hadolint:
+      enabled: true
+    swiftlint:
+      enabled: true
+    phpstan:
+      enabled: true
+      level: default
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    checkov:
+      enabled: true
+    detekt:
+      enabled: true
+    eslint:
+      enabled: true
+    rubocop:
+      enabled: true
+    buf:
+      enabled: true
+    regal:
+      enabled: true
+    actionlint:
+      enabled: true
+    pmd:
+      enabled: true
+    cppcheck:
+      enabled: true
+    semgrep:
+      enabled: true
+    circleci:
+      enabled: true
+    ast-grep:
+      packages: []
+      rule_dirs: []
+      util_dirs: []
+      essential_rules: true
+chat:
+  auto_reply: true
+  integrations:
+    jira:
+      usage: auto
+    linear:
+      usage: auto
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  jira:
+    usage: auto
+    project_keys: []
+  linear:
+    usage: auto
+    team_keys: []
+  pull_requests:
+    scope: auto


### PR DESCRIPTION
### What does this PR do?
- Extend CodeRabbit's current config set up through the UI and specify the same rules in the config file
- Limit reviews to only PRs containing the `ready for review` label
- Specify a set of path instructions for the different apps and packages in the monorepo, suggested by ChatGPT for our current architecture (Web3 React apps, web3 hooks, widgets and utils packages) and using as an input sample rule files provided by CodeRabbit
- Reduce the list of path filters to only those applicable to our repo to reduce noise
