### PR TITLE
Handle query params in the Trade widget for mainnet

### DIFF
--- a/apps/webapp/src/modules/chat/components/ChatBubble.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatBubble.tsx
@@ -69,8 +69,8 @@ export const ChatBubble = ({
   suggestions,
   intents,
   sendMessage,
-  showModifierRow = true,
-  isLastMessage
+  showModifierRow = true
+  // isLastMessage
 }: ChatBubbleProps) => {
   const { address } = useAccount();
   const [searchParams] = useSearchParams();
@@ -127,9 +127,10 @@ export const ChatBubble = ({
                 <ChatMarkdownRenderer markdown={message} />
               </div>
             </HStack>
+            <ChatIntentsRow intents={[]} />
             {user === UserType.bot && !isError && !isInternal && !isCanceled && (
               <div className="space-y-5">
-                {intents && intents?.length > 0 && isLastMessage && <ChatIntentsRow intents={intents} />}
+                {/* {intents && intents?.length > 0 && isLastMessage && <ChatIntentsRow intents={intents} />} */}
                 {(!intents || intents.length === 0) && suggestions && (
                   <ChatSuggestionsRow suggestions={suggestions} sendMessage={sendMessage} />
                 )}

--- a/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
@@ -11,12 +11,158 @@ type ChatIntentsRowProps = {
   intents: ChatIntent[];
 };
 
+// TEST PURPOSES ONLY
+const network = 'ethereum';
+const testTradeIntents: ChatIntent[] = [
+  // Simple "Trade (token)" variants - allowed tokens
+  {
+    intent_id: 'trade',
+    intent_description: 'Go to Trade',
+    url: `?widget=trade&chat=true&details=false&network=${network}`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade USDC',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDC`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade ETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=ETH`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade WETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=WETH`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade USDT',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDT`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade DAI',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=DAI`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade USDS',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDS`
+  },
+
+  // "Trade to Token" variants
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade to USDC',
+    url: `?widget=trade&chat=true&details=false&network=${network}&target_token=USDC`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade to ETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&target_token=ETH`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade to WETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&target_token=WETH`
+  },
+
+  // Valid "Trade TokenA for TokenB" combinations
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade USDC for DAI',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDC&target_token=DAI`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade USDT for USDC',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDT&target_token=USDC`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade DAI for USDS',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=DAI&target_token=USDS`
+  },
+
+  // Not allowed combinations (ETH/WETH) - good for testing restrictions
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade ETH for WETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=ETH&target_token=WETH`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade WETH for ETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=WETH&target_token=ETH`
+  },
+
+  // "Trade N Amount Token" variants
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 100 USDC',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDC&input_amount=100`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 1 ETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=ETH&input_amount=1`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 2 WETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=WETH&input_amount=2`
+  },
+
+  // "Trade N Amount TokenA for TokenB" variants - valid combinations
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 1000 USDC for DAI',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDC&target_token=DAI&input_amount=1000`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 500 USDT for USDC',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDT&target_token=USDC&input_amount=500`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 200 DAI for USDS',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=DAI&target_token=USDS&input_amount=200`
+  },
+
+  // Not allowed combinations with amounts (ETH/WETH) - good for testing restrictions
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 1 ETH for WETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=ETH&target_token=WETH&input_amount=1`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade 2 WETH for ETH',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=WETH&target_token=ETH&input_amount=2`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade DAI for DAI',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=DAI&target_token=DAI`
+  },
+  {
+    intent_id: 'trade',
+    intent_description: 'Trade USDC for USDC',
+    url: `?widget=trade&chat=true&details=false&network=${network}&source_token=USDC&target_token=USDC`
+  }
+];
+// TODO: remove this ^^^^
+
 export const ChatIntentsRow = ({ intents }: ChatIntentsRowProps) => {
+  console.log('🚀 ~ intents:', intents);
   return (
     <div>
       <Text className="text-xs italic text-gray-500">Try a suggested action</Text>
       <div className="mt-2 flex flex-wrap gap-2">
-        {intents.map((intent, index) => (
+        {/* {intents.map((intent, index) => ( */}
+        {testTradeIntents.map((intent, index) => (
           <IntentRow key={index} intent={intent} />
         ))}
       </div>
@@ -29,7 +175,8 @@ type IntentRowProps = {
 };
 
 const IntentRow = ({ intent }: IntentRowProps) => {
-  const { setConfirmationModalOpened, setSelectedIntent, hasShownIntent, setChatHistory } = useChatContext();
+  // const { setConfirmationModalOpened, setSelectedIntent, hasShownIntent, setChatHistory } = useChatContext();
+  const { setChatHistory } = useChatContext();
   const navigate = useNavigate();
   const intentUrl = useRetainedQueryParams(intent?.url || '', [
     QueryParams.Locale,
@@ -41,13 +188,16 @@ const IntentRow = ({ intent }: IntentRowProps) => {
     <Button
       variant="suggest"
       onClick={() => {
-        if (!hasShownIntent(intent)) {
-          setConfirmationModalOpened(true);
-          setSelectedIntent(intent);
-        } else {
-          setChatHistory(prev => [...prev, intentSelectedMessage(intent)]);
-          navigate(intentUrl);
-        }
+        // if (!hasShownIntent(intent)) {
+        //   setConfirmationModalOpened(true);
+        //   setSelectedIntent(intent);
+        // } else {
+        //   setChatHistory(prev => [...prev, intentSelectedMessage(intent)]);
+        //   navigate(intentUrl);
+        // }
+        setChatHistory(prev => [...prev, intentSelectedMessage(intent)]);
+        // navigate('?widget=trade&chat=true&target_token=USDC&network=sepolia&details=false');
+        navigate(intentUrl);
       }}
       onMouseEnter={() => {
         console.log('🚀 ~ onMouseEnter ~ intent:', intent);

--- a/apps/webapp/src/modules/chat/hooks/__mocks__/mock-chat-endpoints.ts
+++ b/apps/webapp/src/modules/chat/hooks/__mocks__/mock-chat-endpoints.ts
@@ -1,31 +1,28 @@
-import {
-  SAVINGS,
-  SAVINGS_MAINNET,
-  SAVINGS_BASE,
-  SAVINGS_ARBITRUM
-} from '../../lib/intentClassificationOptions';
+import { TRADE_MAINNET } from '../../lib/intentClassificationOptions';
 
 export const generateRandomResponse = () => {
+  // ... existing code ...
   const responses = [
-    'I can help you with that! What would you like to know?',
-    "Here's what I found about your request.",
-    'Let me assist you with that.',
-    'I understand you want to know more about this topic.'
+    'I can help you with that! Learn more at [sky.money](https://sky.money)',
+    "Here's what I found about your request. Visit [sky.money](https://sky.money) for more details",
+    'Let me assist you with that. Check out [sky.money](https://sky.money)',
+    'I understand you want to know more. Explore [sky.money](https://sky.money) for additional information'
   ];
+  // ... existing code ...
   return responses[Math.floor(Math.random() * responses.length)];
 };
 
 export const generateRandomIntent = () => {
   const intents = [
     // TRADE,
-    // TRADE_MAINNET,
+    TRADE_MAINNET,
     // TRADE_BASE,
     // TRADE_ARBITRUM,
     // UPGRADE,
-    SAVINGS,
-    SAVINGS_MAINNET,
-    SAVINGS_BASE,
-    SAVINGS_ARBITRUM,
+    // SAVINGS,
+    // SAVINGS_MAINNET,
+    // SAVINGS_BASE,
+    // SAVINGS_ARBITRUM,
     // REWARDS,
     'NONE'
   ];

--- a/apps/webapp/src/modules/chat/hooks/useSendMessage.tsx
+++ b/apps/webapp/src/modules/chat/hooks/useSendMessage.tsx
@@ -48,7 +48,7 @@ const fetchEndpoints = async (messagePayload: Partial<SendMessageRequest>) => {
         recommendations: generateRandomRecommendations()
       },
       slotResponse: {
-        slots: generateRandomSlots('SAVINGS_')
+        slots: generateRandomSlots('TRADE')
       }
     };
 

--- a/apps/webapp/src/modules/chat/lib/generateTradeIntents.ts
+++ b/apps/webapp/src/modules/chat/lib/generateTradeIntents.ts
@@ -109,7 +109,7 @@ const generateSingleIntent = (params: TradeIntentParams): ChatIntent => {
   const urlParams: Record<string, string | undefined> = {
     [QueryParams.SourceToken]: sourceToken ?? undefined,
     [QueryParams.TargetToken]: targetToken ?? undefined,
-    [QueryParams.InputAmount]: amount ?? undefined,
+    [QueryParams.InputAmount]: amount && sourceToken ? amount : undefined,
     network: network ? chainIdNameMapping[network.id as keyof typeof chainIdNameMapping] : undefined
   };
 

--- a/apps/webapp/src/modules/trade/components/TradeWidgetPane.tsx
+++ b/apps/webapp/src/modules/trade/components/TradeWidgetPane.tsx
@@ -36,8 +36,43 @@ export function TradeWidgetPane(sharedProps: SharedProps) {
     hash,
     txStatus,
     widgetState,
-    executedBuyAmount
+    originToken,
+    targetToken,
+    executedBuyAmount,
+    originAmount
   }: WidgetStateChangeParams) => {
+    // Update search params
+    if (originAmount) {
+      setSearchParams(prev => {
+        prev.set(QueryParams.InputAmount, originAmount);
+        return prev;
+      });
+    } else if (originAmount === '') {
+      setSearchParams(prev => {
+        prev.delete(QueryParams.InputAmount);
+        return prev;
+      });
+    }
+
+    if (originToken) {
+      setSearchParams(prev => {
+        prev.set(QueryParams.SourceToken, originToken);
+        return prev;
+      });
+    }
+
+    if (targetToken) {
+      setSearchParams(prev => {
+        prev.set(QueryParams.TargetToken, targetToken);
+        return prev;
+      });
+    } else if (targetToken === '') {
+      setSearchParams(prev => {
+        prev.delete(QueryParams.TargetToken);
+        return prev;
+      });
+    }
+
     // After a successful trade, set the linked action step to "success"
     if (
       widgetState.action === TradeAction.TRADE &&

--- a/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
+++ b/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
@@ -27,7 +27,10 @@ export interface TokenInputProps {
   placeholder?: string;
   token?: Token;
   onTokenSelected?: (token: Token) => void;
-  onChange: (val: bigint) => void;
+  onChange: (
+    val: bigint,
+    e?: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>
+  ) => void;
   onInput?: () => void;
   tokenList: Token[];
   balance?: bigint;
@@ -90,7 +93,10 @@ export function TokenInput({
   const [errorInvalidFormat, setErrorInvalidFormat] = useState(false);
   const shownError = errorInvalidFormat ? 'Invalid amount. Please enter a valid amount.' : error;
 
-  const updateValue = (val: `${number}`) => {
+  const updateValue = (
+    val: `${number}`,
+    event?: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>
+  ) => {
     //prevent exponential notation
     if (val.includes('e')) return;
 
@@ -118,10 +124,10 @@ export function TokenInput({
 
       setErrorInvalidFormat(false);
 
-      onChange(newValue);
+      onChange(newValue, event);
     } catch (e) {
       setErrorInvalidFormat(true);
-      onChange(0n);
+      onChange(0n, event);
       return;
     }
   };
@@ -173,13 +179,13 @@ export function TokenInput({
 
     if (max) {
       const maxValue = balance - gasBufferAmount > 0n ? balance - gasBufferAmount : 0n;
-      updateValue(formatUnits(maxValue, decimals) as `${number}`);
+      updateValue(formatUnits(maxValue, decimals) as `${number}`, e);
       if (typeof onSetMax === 'function') onSetMax(true);
     } else {
       // Truncate the string to two decimal places
       const truncatedValue = truncateStringToFourDecimals(formattedValue);
       // Update the value
-      updateValue(truncatedValue as `${number}`);
+      updateValue(truncatedValue as `${number}`, e);
       if (typeof onSetMax === 'function') onSetMax(false);
     }
   };
@@ -259,7 +265,7 @@ export function TokenInput({
                       className="hideSpinButton"
                       value={inputValue !== '00' ? inputValue : '0'}
                       onChange={e => {
-                        updateValue(e.target.value as `${number}`);
+                        updateValue(e.target.value as `${number}`, e);
                         if (typeof onSetMax === 'function') onSetMax(false);
                       }}
                       onInput={() => {

--- a/packages/widgets/src/shared/types/widgetState.d.ts
+++ b/packages/widgets/src/shared/types/widgetState.d.ts
@@ -67,6 +67,7 @@ export type WidgetStateChangeParams = {
   executedBuyAmount?: string;
   executedSellAmount?: string;
   displayToken?: Token;
+  originAmount?: string;
 };
 
 export type WidgetProps = {

--- a/packages/widgets/src/widgets/TradeWidget/components/TradeInputs.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeInputs.tsx
@@ -44,6 +44,9 @@ type TradeInputsProps = {
   onUserSwitchTokens?: (originToken?: string, targetToken?: string) => void;
   tradeAnyway: boolean;
   setTradeAnyway: (tradeAnyway: boolean) => void;
+  onOriginTokenChange?: (token: TokenForChain) => void;
+  onTargetTokenChange?: (token: TokenForChain) => void;
+  onOriginInputChange?: (val: bigint, userTriggered?: boolean) => void;
 };
 
 export function TradeInput(props: TokenInputProps) {
@@ -78,7 +81,10 @@ export function TradeInputs({
   isConnectedAndEnabled = true,
   onUserSwitchTokens,
   tradeAnyway,
-  setTradeAnyway
+  setTradeAnyway,
+  onOriginTokenChange,
+  onTargetTokenChange,
+  onOriginInputChange
 }: TradeInputsProps) {
   const separationPx = 12;
   const separationMb = 'mb-[12px]';
@@ -180,9 +186,10 @@ export function TradeInputs({
           label={t`Choose a token to trade, and enter an amount`}
           token={originToken as Token}
           balance={originBalance?.value}
-          onChange={newValue => {
+          onChange={(newValue, event) => {
             setLastUpdated(TradeSide.IN);
             setOriginAmount(BigInt(newValue));
+            onOriginInputChange?.(BigInt(newValue), !!event);
           }}
           value={originAmount}
           dataTestId="trade-input-origin"
@@ -199,6 +206,7 @@ export function TradeInputs({
             }
 
             setOriginToken(option as TokenForChain);
+            onOriginTokenChange?.(option as TokenForChain);
           }}
           error={
             isBalanceError
@@ -264,6 +272,7 @@ export function TradeInputs({
           onTokenSelected={option => {
             setTargetAmount(0n);
             setTargetToken(option as TokenForChain);
+            onTargetTokenChange?.(option as TokenForChain);
           }}
           showPercentageButtons={false}
           enabled={isConnectedAndEnabled}

--- a/packages/widgets/src/widgets/TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/index.tsx
@@ -899,20 +899,23 @@ function TradeWidgetWrapped({
           const tokenChanged = newOriginToken.symbol !== originToken?.symbol;
           setOriginToken(newOriginToken);
 
-          // Always clear target token if it matches the origin token
-          // This handles both direct matches and new origin matching existing target
-          if (
-            targetToken?.symbol.toLowerCase() === newOriginToken.symbol.toLowerCase() ||
-            externalWidgetState?.targetToken?.toLowerCase() === newOriginToken.symbol.toLowerCase()
-          ) {
-            setTargetToken(undefined);
-          } else if (externalWidgetState?.targetToken) {
+          // Handle target token changes
+          if (externalWidgetState?.targetToken) {
             // Get allowed target tokens for this origin
             const newTargetList = getAllowedTargetTokens(newOriginToken.symbol, tokenList, disallowedPairs);
             const newTargetToken = newTargetList.find(
               token => token.symbol.toLowerCase() === externalWidgetState.targetToken?.toLowerCase()
             );
-            setTargetToken(newTargetToken || undefined);
+
+            // Only clear target if it's the same as origin, otherwise set the new target
+            if (newOriginToken.symbol.toLowerCase() === externalWidgetState.targetToken?.toLowerCase()) {
+              setTargetToken(undefined);
+            } else {
+              setTargetToken(newTargetToken || undefined);
+            }
+          } else {
+            // If no target token in external state, clear it
+            setTargetToken(undefined);
           }
 
           // Handle amount updates


### PR DESCRIPTION
It handles different search param combinations in the mainnet Trade widget. 

During my testing I found that certain combinations of actions could lead to unexpected results.

**Note:** The code includes a temporarily set of buttons to test the functionality that will be remove later before the PR is merged. This is intentionally and will help the tester with this task.
<img width="676" alt="image" src="https://github.com/user-attachments/assets/f8359d62-ea1d-4496-a6b3-9adedde6bbe4" />
