### PR TITLE
Add new Tenderly Arbitrum forked chain with PSM3 contracts funded

### DIFF
--- a/apps/integration-ui/src/modules/providers/wagmi.ts
+++ b/apps/integration-ui/src/modules/providers/wagmi.ts
@@ -4,7 +4,7 @@ import { mainnet, sepolia, base, arbitrum } from 'wagmi/chains';
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
 
 export const tenderly = {
   id: TENDERLY_CHAIN_ID,

--- a/apps/integration-ui/src/modules/providers/wagmi.ts
+++ b/apps/integration-ui/src/modules/providers/wagmi.ts
@@ -4,7 +4,7 @@ import { mainnet, sepolia, base, arbitrum } from 'wagmi/chains';
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
 
 export const tenderly = {
   id: TENDERLY_CHAIN_ID,
@@ -44,7 +44,7 @@ export const tenderlyBase = {
 
 export const tenderlyArbitrum = {
   id: TENDERLY_ARBITRUM_CHAIN_ID,
-  name: 'arbitrum_testnet_base_fork_jan',
+  name: 'arbitrum_fork_feb_7',
   network: 'tenderly arbitrum',
   nativeCurrency: {
     decimals: 18,

--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -60,7 +60,7 @@ export const tenderlyBase = {
 
 export const tenderlyArbitrum = {
   id: TENDERLY_ARBITRUM_CHAIN_ID,
-  name: 'arbitrum_testnet_base_fork_jan',
+  name: 'arbitrum_fork_feb_7',
   network: 'tenderly arbitrum',
   // This is used by RainbowKit to display a chain icon for small screens. TODO: update to Arbitrum icon once available
   iconUrl: 'tokens/weth.svg',

--- a/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
+++ b/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
@@ -13,9 +13,9 @@ export const TENDERLY_RPC_URL =
 export const TENDERLY_BASE_RPC_URL =
   'https://virtual.base.rpc.tenderly.co/376e4980-c2de-48b9-bf76-c25bd6d1c324';
 
-// only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `arbitrum_testnet_base_fork_jan`
+// only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `Arbitrum-fork-feb-5`
 export const TENDERLY_ARBITRUM_RPC_URL =
-  'https://virtual.base.rpc.tenderly.co/17eaddcc-2f8a-433d-a5dc-7382eb7755d1';
+  'https://virtual.arbitrum.rpc.tenderly.co/c67d99b5-9c23-429b-87f6-2e5e71326d53';
 
 export const getTestTenderlyChains = () => {
   const [mainnetData, baseData, arbitrumData] = tenderlyTestnetData;

--- a/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
+++ b/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
@@ -3,7 +3,7 @@ import tenderlyTestnetData from '../../../../../../tenderlyTestnetData.json' wit
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
 
 // only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `mainnet_sep_30_0`
 export const TENDERLY_RPC_URL =

--- a/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
+++ b/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
@@ -3,7 +3,7 @@ import tenderlyTestnetData from '../../../../../../tenderlyTestnetData.json' wit
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
 
 // only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `mainnet_sep_30_0`
 export const TENDERLY_RPC_URL =
@@ -13,9 +13,9 @@ export const TENDERLY_RPC_URL =
 export const TENDERLY_BASE_RPC_URL =
   'https://virtual.base.rpc.tenderly.co/376e4980-c2de-48b9-bf76-c25bd6d1c324';
 
-// only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `Arbitrum-fork-feb-5`
+// only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `Arbitrum-fork-feb-7`
 export const TENDERLY_ARBITRUM_RPC_URL =
-  'https://virtual.arbitrum.rpc.tenderly.co/c67d99b5-9c23-429b-87f6-2e5e71326d53';
+  'https://virtual.arbitrum.rpc.tenderly.co/5a2a28a6-322f-4506-acf8-1151a13b5ccf';
 
 export const getTestTenderlyChains = () => {
   const [mainnetData, baseData, arbitrumData] = tenderlyTestnetData;

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -38,6 +38,7 @@ export default ({ mode }: { mode: string }) => {
       ${VITE_RPC_PROVIDER_TENDERLY_ARBITRUM}
       https://virtual.mainnet.rpc.tenderly.co
       https://virtual.base.rpc.tenderly.co
+      https://virtual.arbitrum.rpc.tenderly.co
       https://rpc.sepolia.org
       https://mainnet.base.org
       https://safe-transaction-mainnet.safe.global

--- a/packages/hooks/src/constants.ts
+++ b/packages/hooks/src/constants.ts
@@ -64,7 +64,7 @@ export const ARBITRUM_CHAIN_ID = 42161;
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
 
 export enum ModuleEnum {
   SAVINGS = 'SAVINGS',

--- a/packages/hooks/src/constants.ts
+++ b/packages/hooks/src/constants.ts
@@ -64,7 +64,7 @@ export const ARBITRUM_CHAIN_ID = 42161;
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
 
 export enum ModuleEnum {
   SAVINGS = 'SAVINGS',

--- a/packages/hooks/src/contracts.ts
+++ b/packages/hooks/src/contracts.ts
@@ -271,7 +271,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
       [base.id]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
       [TENDERLY_BASE_CHAIN_ID]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
       [TENDERLY_ARBITRUM_CHAIN_ID]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-      [arbitrum.id]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' //TODO: confirm address
+      [arbitrum.id]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
     }
   },
   {

--- a/packages/hooks/src/tokens/tokens.constants.ts
+++ b/packages/hooks/src/tokens/tokens.constants.ts
@@ -77,8 +77,8 @@ export const TOKENS: TokenMapping = {
       ...skyConfig.address,
       [base.id]: skyL2Address[base.id],
       [arbitrum.id]: skyL2Address[arbitrum.id],
-      [TENDERLY_BASE_CHAIN_ID]: skyL2Address[base.id],
-      [TENDERLY_ARBITRUM_CHAIN_ID]: skyL2Address[base.id]
+      [TENDERLY_BASE_CHAIN_ID]: skyL2Address[TENDERLY_BASE_CHAIN_ID],
+      [TENDERLY_ARBITRUM_CHAIN_ID]: skyL2Address[TENDERLY_ARBITRUM_CHAIN_ID]
     },
     name: 'SKY',
     symbol: 'SKY',
@@ -90,8 +90,8 @@ export const TOKENS: TokenMapping = {
       ...usdsConfig.address,
       [base.id]: usdsL2Address[base.id],
       [arbitrum.id]: usdsL2Address[arbitrum.id],
-      [TENDERLY_BASE_CHAIN_ID]: usdsL2Address[base.id],
-      [TENDERLY_ARBITRUM_CHAIN_ID]: usdsL2Address[base.id]
+      [TENDERLY_BASE_CHAIN_ID]: usdsL2Address[TENDERLY_BASE_CHAIN_ID],
+      [TENDERLY_ARBITRUM_CHAIN_ID]: usdsL2Address[TENDERLY_ARBITRUM_CHAIN_ID]
     },
     name: 'USDS',
     symbol: 'USDS',
@@ -112,8 +112,8 @@ export const TOKENS: TokenMapping = {
       ...usdcConfig.address,
       [base.id]: usdcL2Address[base.id],
       [arbitrum.id]: usdcL2Address[arbitrum.id],
-      [TENDERLY_BASE_CHAIN_ID]: usdcL2Address[base.id],
-      [TENDERLY_ARBITRUM_CHAIN_ID]: usdcL2Address[base.id]
+      [TENDERLY_BASE_CHAIN_ID]: usdcL2Address[TENDERLY_BASE_CHAIN_ID],
+      [TENDERLY_ARBITRUM_CHAIN_ID]: usdcL2Address[TENDERLY_ARBITRUM_CHAIN_ID]
     },
     name: 'USDC',
     symbol: 'USDC',
@@ -155,8 +155,8 @@ export const TOKENS: TokenMapping = {
       ...sUsdsConfig.address,
       [base.id]: sUsdsL2Address[base.id],
       [arbitrum.id]: sUsdsL2Address[arbitrum.id],
-      [TENDERLY_BASE_CHAIN_ID]: sUsdsL2Address[base.id],
-      [TENDERLY_ARBITRUM_CHAIN_ID]: sUsdsL2Address[base.id]
+      [TENDERLY_BASE_CHAIN_ID]: sUsdsL2Address[TENDERLY_BASE_CHAIN_ID],
+      [TENDERLY_ARBITRUM_CHAIN_ID]: sUsdsL2Address[TENDERLY_ARBITRUM_CHAIN_ID]
     },
     name: 'sUSDS',
     symbol: 'sUSDS',

--- a/packages/utils/src/chainId.ts
+++ b/packages/utils/src/chainId.ts
@@ -5,5 +5,5 @@ export const chainId = {
   base: 8453,
   arbitrum: 42161,
   tenderlyBase: 8555,
-  tenderlyArbitrum: 42161
+  tenderlyArbitrum: 42012
 };

--- a/packages/utils/src/chainId.ts
+++ b/packages/utils/src/chainId.ts
@@ -5,5 +5,5 @@ export const chainId = {
   base: 8453,
   arbitrum: 42161,
   tenderlyBase: 8555,
-  tenderlyArbitrum: 42012
+  tenderlyArbitrum: 42161
 };

--- a/packages/utils/src/getEtherscanLink.ts
+++ b/packages/utils/src/getEtherscanLink.ts
@@ -20,7 +20,7 @@ function getEtherscanPrefix(id: number) {
     case chainId.tenderlyBase:
       return 'dashboard.tenderly.co/explorer/vnet/376e4980-c2de-48b9-bf76-c25bd6d1c324';
     case chainId.tenderlyArbitrum:
-      return 'dashboard.tenderly.co/explorer/vnet/c67d99b5-9c23-429b-87f6-2e5e71326d53';
+      return 'dashboard.tenderly.co/explorer/vnet/5a2a28a6-322f-4506-acf8-1151a13b5ccf';
     default:
       return 'etherscan.io';
   }

--- a/packages/utils/src/getEtherscanLink.ts
+++ b/packages/utils/src/getEtherscanLink.ts
@@ -20,7 +20,7 @@ function getEtherscanPrefix(id: number) {
     case chainId.tenderlyBase:
       return 'dashboard.tenderly.co/explorer/vnet/376e4980-c2de-48b9-bf76-c25bd6d1c324';
     case chainId.tenderlyArbitrum:
-      return 'dashboard.tenderly.co/explorer/vnet/f60eedf8-6aa3-45a5-86c3-f001eab2da50';
+      return 'dashboard.tenderly.co/explorer/vnet/c67d99b5-9c23-429b-87f6-2e5e71326d53';
     default:
       return 'etherscan.io';
   }

--- a/packages/widgets/src/shared/constants.ts
+++ b/packages/widgets/src/shared/constants.ts
@@ -32,7 +32,7 @@ export const approveLoadingButtonText: TxCardCopyText = {
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
 
 export const tokenColors = [
   { symbol: 'ETH', color: '#6d7ce3' },

--- a/packages/widgets/src/shared/constants.ts
+++ b/packages/widgets/src/shared/constants.ts
@@ -32,7 +32,7 @@ export const approveLoadingButtonText: TxCardCopyText = {
 
 export const TENDERLY_CHAIN_ID = 314310;
 export const TENDERLY_BASE_CHAIN_ID = 8555;
-export const TENDERLY_ARBITRUM_CHAIN_ID = 42161;
+export const TENDERLY_ARBITRUM_CHAIN_ID = 42012;
 
 export const tokenColors = [
   { symbol: 'ETH', color: '#6d7ce3' },

--- a/scripts/forkVnet.ts
+++ b/scripts/forkVnet.ts
@@ -4,8 +4,8 @@ const { writeFile } = require('fs/promises');
 const MAINNET_FORK_CONTAINER_ID = '0f6b2f0e-98ca-4a7e-abaf-f2405dadf063';
 // corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/d382d976-02a4-4fc2-a9ba-db43a1602719
 const BASE_FORK_CONTAINER_ID = 'd382d976-02a4-4fc2-a9ba-db43a1602719';
-// corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/7edf678f-280c-4893-af29-a8551998e292
-const ARBITRUM_FORK_CONTAINER_ID = '7edf678f-280c-4893-af29-a8551998e292';
+// corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/c69c31b7-0f5b-4a2f-bb1b-7e72ad6f08bb
+const ARBITRUM_FORK_CONTAINER_ID = 'c69c31b7-0f5b-4a2f-bb1b-7e72ad6f08bb';
 
 const forkVnets = async () => {
   const responses = await Promise.all(

--- a/scripts/forkVnet.ts
+++ b/scripts/forkVnet.ts
@@ -4,8 +4,8 @@ const { writeFile } = require('fs/promises');
 const MAINNET_FORK_CONTAINER_ID = '0f6b2f0e-98ca-4a7e-abaf-f2405dadf063';
 // corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/d382d976-02a4-4fc2-a9ba-db43a1602719
 const BASE_FORK_CONTAINER_ID = 'd382d976-02a4-4fc2-a9ba-db43a1602719';
-// corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/c69c31b7-0f5b-4a2f-bb1b-7e72ad6f08bb
-const ARBITRUM_FORK_CONTAINER_ID = 'c69c31b7-0f5b-4a2f-bb1b-7e72ad6f08bb';
+// corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/e4895ee3-5d3d-4674-9e5c-fcabdba59870
+const ARBITRUM_FORK_CONTAINER_ID = 'e4895ee3-5d3d-4674-9e5c-fcabdba59870';
 
 const forkVnets = async () => {
   const responses = await Promise.all(

--- a/scripts/forkVnet.ts
+++ b/scripts/forkVnet.ts
@@ -4,8 +4,8 @@ const { writeFile } = require('fs/promises');
 const MAINNET_FORK_CONTAINER_ID = '0f6b2f0e-98ca-4a7e-abaf-f2405dadf063';
 // corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/d382d976-02a4-4fc2-a9ba-db43a1602719
 const BASE_FORK_CONTAINER_ID = 'd382d976-02a4-4fc2-a9ba-db43a1602719';
-// corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/e4895ee3-5d3d-4674-9e5c-fcabdba59870
-const ARBITRUM_FORK_CONTAINER_ID = 'e4895ee3-5d3d-4674-9e5c-fcabdba59870';
+// corresponds to https://dashboard.tenderly.co/jetstreamgg/jetstream/testnet/d720e619-0124-4c51-aae9-f32dcba6de2a
+const ARBITRUM_FORK_CONTAINER_ID = 'd720e619-0124-4c51-aae9-f32dcba6de2a';
 
 const forkVnets = async () => {
   const responses = await Promise.all(


### PR DESCRIPTION
### What does this PR do?
update with a new arbitrum fork
- [x] update the fork vnet script with new endpoint
- [x] update the etherscan v2 API key
- [x] update the tenderly arbitrum chain contract addresses
- [x] update the `testTenderlyChain` with the new endpoint
- [x] update the `getEtherscanLink` with the new endpoint
- [x] update the `TOKENS` mapping to use the right Tenderly Base and Tenderly arbitrum contract addresses for these chains 
