### PR TITLE
Update etherscan v2 api key

### DIFF
--- a/packages/hooks/.env.example
+++ b/packages/hooks/.env.example
@@ -1,5 +1,4 @@
 VITE_HOOKS_TEST_RPC_PROVIDER_MAINNET=https://mainnet.infura.io/v3/your-api-key
 VITE_BA_LABS_API_KEY=YourApiKeyToken
-ETHERSCAN_API_KEY=YourApiKeyToken
-BASESCAN_API_KEY=YourApiKeyToken
+ETHERSCAN_V2_API_KEY=YourApiKeyToken
 TENDERLY_API_KEY=YourApiKeyToken

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -273,7 +273,7 @@ npm install -g @wagmi/cli
 
 ```
 
-Please, add the environment variable: `ETHERSCAN_API_KEY` with your Etherscan API key and `BASESCAN_API_KEY` with your Basescan API key.
+Please, add the environment variable: `ETHERSCAN_V2_API_KEY` with your Etherscan v2 API key.
 This is used to fetch the latest ABI from Etherscan and create the contracts file.
 
 To generate the contracts file, run:

--- a/packages/hooks/src/contracts.ts
+++ b/packages/hooks/src/contracts.ts
@@ -270,7 +270,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
     address: {
       [base.id]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
       [TENDERLY_BASE_CHAIN_ID]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      [TENDERLY_ARBITRUM_CHAIN_ID]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
       [arbitrum.id]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' //TODO: confirm address
     }
   },
@@ -279,7 +279,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
     address: {
       [base.id]: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc',
       [TENDERLY_BASE_CHAIN_ID]: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc',
-      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc', // TODO: update to Arbitrum address once we fork Arbitrum
+      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x6491c05A82219b8D1479057361ff1654749b876b',
       [arbitrum.id]: '0x6491c05A82219b8D1479057361ff1654749b876b'
     }
   },
@@ -288,7 +288,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
     address: {
       [base.id]: '0x5875eEE11Cf8398102FdAd704C9E96607675467a',
       [TENDERLY_BASE_CHAIN_ID]: '0x5875eEE11Cf8398102FdAd704C9E96607675467a',
-      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x5875eEE11Cf8398102FdAd704C9E96607675467a', // TODO: update to Arbitrum address once we fork Arbitrum
+      [TENDERLY_ARBITRUM_CHAIN_ID]: '0xdDb46999F8891663a8F2828d25298f70416d7610',
       [arbitrum.id]: '0xdDb46999F8891663a8F2828d25298f70416d7610'
     }
   },
@@ -297,7 +297,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
     address: {
       [base.id]: '0x60e3c701e65DEE30c23c9Fb78c3866479cc0944a',
       [TENDERLY_BASE_CHAIN_ID]: '0x60e3c701e65DEE30c23c9Fb78c3866479cc0944a',
-      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x60e3c701e65DEE30c23c9Fb78c3866479cc0944a',
+      [TENDERLY_ARBITRUM_CHAIN_ID]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
       [arbitrum.id]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' //TODO: placeholder address
     }
   },
@@ -306,7 +306,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
     address: {
       [base.id]: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
       [TENDERLY_BASE_CHAIN_ID]: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
-      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
+      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266',
       [arbitrum.id]: '0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266'
     }
   },
@@ -315,7 +315,7 @@ export const l2Contracts: { name: string; address: Record<L2ChainId, `0x${string
     address: {
       [base.id]: '0x65d946e533748A998B1f0E430803e39A6388f7a1',
       [TENDERLY_BASE_CHAIN_ID]: '0x65d946e533748A998B1f0E430803e39A6388f7a1',
-      [TENDERLY_ARBITRUM_CHAIN_ID]: '0x65d946e533748A998B1f0E430803e39A6388f7a1',
+      [TENDERLY_ARBITRUM_CHAIN_ID]: '0xEE2816c1E1eed14d444552654Ed3027abC033A36',
       [arbitrum.id]: '0xEE2816c1E1eed14d444552654Ed3027abC033A36'
     }
   }

--- a/packages/hooks/src/generated.ts
+++ b/packages/hooks/src/generated.ts
@@ -4748,7 +4748,7 @@ export const proxyRegistryConfig = { address: proxyRegistryAddress, abi: proxyRe
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const psm3L2Abi = [
   {
@@ -5040,18 +5040,18 @@ export const psm3L2Abi = [
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const psm3L2Address = {
   8453: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
   8555: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
-  42012: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
-  42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+  42012: '0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266',
+  42161: '0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266'
 } as const;
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const psm3L2Config = { address: psm3L2Address, abi: psm3L2Abi } as const;
 
@@ -5660,7 +5660,7 @@ export const sUsdsImplementationConfig = {
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x5875eEE11Cf8398102FdAd704C9E96607675467a)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xdDb46999F8891663a8F2828d25298f70416d7610)
  */
 export const sUsdsL2Abi = [
   {
@@ -5694,18 +5694,18 @@ export const sUsdsL2Abi = [
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x5875eEE11Cf8398102FdAd704C9E96607675467a)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xdDb46999F8891663a8F2828d25298f70416d7610)
  */
 export const sUsdsL2Address = {
   8453: '0x5875eEE11Cf8398102FdAd704C9E96607675467a',
   8555: '0x5875eEE11Cf8398102FdAd704C9E96607675467a',
-  42012: '0x5875eEE11Cf8398102FdAd704C9E96607675467a',
-  42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+  42012: '0xdDb46999F8891663a8F2828d25298f70416d7610',
+  42161: '0xdDb46999F8891663a8F2828d25298f70416d7610'
 } as const;
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x5875eEE11Cf8398102FdAd704C9E96607675467a)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xdDb46999F8891663a8F2828d25298f70416d7610)
  */
 export const sUsdsL2Config = { address: sUsdsL2Address, abi: sUsdsL2Abi } as const;
 
@@ -6838,7 +6838,7 @@ export const skyL2Abi = [
 export const skyL2Address = {
   8453: '0x60e3c701e65DEE30c23c9Fb78c3866479cc0944a',
   8555: '0x60e3c701e65DEE30c23c9Fb78c3866479cc0944a',
-  42012: '0x60e3c701e65DEE30c23c9Fb78c3866479cc0944a',
+  42012: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
 } as const;
 
@@ -6854,7 +6854,7 @@ export const skyL2Config = { address: skyL2Address, abi: skyL2Abi } as const;
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const ssrAuthOracleAbi = [
   { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
@@ -7113,18 +7113,18 @@ export const ssrAuthOracleAbi = [
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const ssrAuthOracleAddress = {
   8453: '0x65d946e533748A998B1f0E430803e39A6388f7a1',
   8555: '0x65d946e533748A998B1f0E430803e39A6388f7a1',
-  42012: '0x65d946e533748A998B1f0E430803e39A6388f7a1',
-  42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+  42012: '0xEE2816c1E1eed14d444552654Ed3027abC033A36',
+  42161: '0xEE2816c1E1eed14d444552654Ed3027abC033A36'
 } as const;
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const ssrAuthOracleConfig = { address: ssrAuthOracleAddress, abi: ssrAuthOracleAbi } as const;
 
@@ -7298,7 +7298,7 @@ export const usdcL2Abi = [
 export const usdcL2Address = {
   8453: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   8555: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-  42012: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  42012: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
 } as const;
 
@@ -7659,7 +7659,7 @@ export const usdsConfig = { address: usdsAddress, abi: usdsAbi } as const;
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x820C137fa70C8691f0e44Dc420a5e53c168921Dc)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x6491c05A82219b8D1479057361ff1654749b876b)
  */
 export const usdsL2Abi = [
   {
@@ -7693,18 +7693,18 @@ export const usdsL2Abi = [
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x820C137fa70C8691f0e44Dc420a5e53c168921Dc)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x6491c05A82219b8D1479057361ff1654749b876b)
  */
 export const usdsL2Address = {
   8453: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc',
   8555: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc',
-  42012: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc',
-  42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+  42012: '0x6491c05A82219b8D1479057361ff1654749b876b',
+  42161: '0x6491c05A82219b8D1479057361ff1654749b876b'
 } as const;
 
 /**
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x820C137fa70C8691f0e44Dc420a5e53c168921Dc)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x6491c05A82219b8D1479057361ff1654749b876b)
  */
 export const usdsL2Config = { address: usdsL2Address, abi: usdsL2Abi } as const;
 
@@ -16212,7 +16212,7 @@ export const useSimulateProxyRegistryBuild = /*#__PURE__*/ createUseSimulateCont
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2 = /*#__PURE__*/ createUseReadContract({ abi: psm3L2Abi, address: psm3L2Address });
 
@@ -16220,7 +16220,7 @@ export const useReadPsm3L2 = /*#__PURE__*/ createUseReadContract({ abi: psm3L2Ab
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"convertToAssetValue"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2ConvertToAssetValue = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16232,7 +16232,7 @@ export const useReadPsm3L2ConvertToAssetValue = /*#__PURE__*/ createUseReadContr
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"convertToAssets"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2ConvertToAssets = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16244,7 +16244,7 @@ export const useReadPsm3L2ConvertToAssets = /*#__PURE__*/ createUseReadContract(
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"convertToShares"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2ConvertToShares = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16256,7 +16256,7 @@ export const useReadPsm3L2ConvertToShares = /*#__PURE__*/ createUseReadContract(
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"owner"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2Owner = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16268,7 +16268,7 @@ export const useReadPsm3L2Owner = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"pocket"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2Pocket = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16280,7 +16280,7 @@ export const useReadPsm3L2Pocket = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"previewDeposit"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2PreviewDeposit = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16292,7 +16292,7 @@ export const useReadPsm3L2PreviewDeposit = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"previewSwapExactIn"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2PreviewSwapExactIn = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16304,7 +16304,7 @@ export const useReadPsm3L2PreviewSwapExactIn = /*#__PURE__*/ createUseReadContra
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"previewSwapExactOut"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2PreviewSwapExactOut = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16316,7 +16316,7 @@ export const useReadPsm3L2PreviewSwapExactOut = /*#__PURE__*/ createUseReadContr
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"previewWithdraw"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2PreviewWithdraw = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16328,7 +16328,7 @@ export const useReadPsm3L2PreviewWithdraw = /*#__PURE__*/ createUseReadContract(
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"rateProvider"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2RateProvider = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16340,7 +16340,7 @@ export const useReadPsm3L2RateProvider = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"shares"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2Shares = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16352,7 +16352,7 @@ export const useReadPsm3L2Shares = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"susds"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2Susds = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16364,7 +16364,7 @@ export const useReadPsm3L2Susds = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"totalAssets"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2TotalAssets = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16376,7 +16376,7 @@ export const useReadPsm3L2TotalAssets = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"totalShares"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2TotalShares = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16388,7 +16388,7 @@ export const useReadPsm3L2TotalShares = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"usdc"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2Usdc = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16400,7 +16400,7 @@ export const useReadPsm3L2Usdc = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"usds"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useReadPsm3L2Usds = /*#__PURE__*/ createUseReadContract({
   abi: psm3L2Abi,
@@ -16412,7 +16412,7 @@ export const useReadPsm3L2Usds = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2 = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16423,7 +16423,7 @@ export const useWritePsm3L2 = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"deposit"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2Deposit = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16435,7 +16435,7 @@ export const useWritePsm3L2Deposit = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"renounceOwnership"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2RenounceOwnership = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16447,7 +16447,7 @@ export const useWritePsm3L2RenounceOwnership = /*#__PURE__*/ createUseWriteContr
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"setPocket"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2SetPocket = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16459,7 +16459,7 @@ export const useWritePsm3L2SetPocket = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"swapExactIn"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2SwapExactIn = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16471,7 +16471,7 @@ export const useWritePsm3L2SwapExactIn = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"swapExactOut"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2SwapExactOut = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16483,7 +16483,7 @@ export const useWritePsm3L2SwapExactOut = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"transferOwnership"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2TransferOwnership = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16495,7 +16495,7 @@ export const useWritePsm3L2TransferOwnership = /*#__PURE__*/ createUseWriteContr
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"withdraw"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWritePsm3L2Withdraw = /*#__PURE__*/ createUseWriteContract({
   abi: psm3L2Abi,
@@ -16507,7 +16507,7 @@ export const useWritePsm3L2Withdraw = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2 = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16518,7 +16518,7 @@ export const useSimulatePsm3L2 = /*#__PURE__*/ createUseSimulateContract({
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"deposit"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2Deposit = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16530,7 +16530,7 @@ export const useSimulatePsm3L2Deposit = /*#__PURE__*/ createUseSimulateContract(
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"renounceOwnership"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2RenounceOwnership = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16542,7 +16542,7 @@ export const useSimulatePsm3L2RenounceOwnership = /*#__PURE__*/ createUseSimulat
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"setPocket"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2SetPocket = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16554,7 +16554,7 @@ export const useSimulatePsm3L2SetPocket = /*#__PURE__*/ createUseSimulateContrac
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"swapExactIn"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2SwapExactIn = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16566,7 +16566,7 @@ export const useSimulatePsm3L2SwapExactIn = /*#__PURE__*/ createUseSimulateContr
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"swapExactOut"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2SwapExactOut = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16578,7 +16578,7 @@ export const useSimulatePsm3L2SwapExactOut = /*#__PURE__*/ createUseSimulateCont
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"transferOwnership"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2TransferOwnership = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16590,7 +16590,7 @@ export const useSimulatePsm3L2TransferOwnership = /*#__PURE__*/ createUseSimulat
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link psm3L2Abi}__ and `functionName` set to `"withdraw"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useSimulatePsm3L2Withdraw = /*#__PURE__*/ createUseSimulateContract({
   abi: psm3L2Abi,
@@ -16602,7 +16602,7 @@ export const useSimulatePsm3L2Withdraw = /*#__PURE__*/ createUseSimulateContract
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link psm3L2Abi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWatchPsm3L2 = /*#__PURE__*/ createUseWatchContractEvent({
   abi: psm3L2Abi,
@@ -16613,7 +16613,7 @@ export const useWatchPsm3L2 = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link psm3L2Abi}__ and `eventName` set to `"Deposit"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWatchPsm3L2Deposit = /*#__PURE__*/ createUseWatchContractEvent({
   abi: psm3L2Abi,
@@ -16625,7 +16625,7 @@ export const useWatchPsm3L2Deposit = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link psm3L2Abi}__ and `eventName` set to `"OwnershipTransferred"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWatchPsm3L2OwnershipTransferred = /*#__PURE__*/ createUseWatchContractEvent({
   abi: psm3L2Abi,
@@ -16637,7 +16637,7 @@ export const useWatchPsm3L2OwnershipTransferred = /*#__PURE__*/ createUseWatchCo
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link psm3L2Abi}__ and `eventName` set to `"PocketSet"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWatchPsm3L2PocketSet = /*#__PURE__*/ createUseWatchContractEvent({
   abi: psm3L2Abi,
@@ -16649,7 +16649,7 @@ export const useWatchPsm3L2PocketSet = /*#__PURE__*/ createUseWatchContractEvent
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link psm3L2Abi}__ and `eventName` set to `"Swap"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWatchPsm3L2Swap = /*#__PURE__*/ createUseWatchContractEvent({
   abi: psm3L2Abi,
@@ -16661,7 +16661,7 @@ export const useWatchPsm3L2Swap = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link psm3L2Abi}__ and `eventName` set to `"Withdraw"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x1601843c5E9bC251A3272907010AFa41Fa18347E)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x2B05F8e1cACC6974fD79A673a341Fe1f58d27266)
  */
 export const useWatchPsm3L2Withdraw = /*#__PURE__*/ createUseWatchContractEvent({
   abi: psm3L2Abi,
@@ -17526,7 +17526,7 @@ export const useWatchSUsdsImplementationWithdraw = /*#__PURE__*/ createUseWatchC
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link sUsdsL2Abi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x5875eEE11Cf8398102FdAd704C9E96607675467a)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xdDb46999F8891663a8F2828d25298f70416d7610)
  */
 export const useWatchSUsdsL2 = /*#__PURE__*/ createUseWatchContractEvent({
   abi: sUsdsL2Abi,
@@ -17537,7 +17537,7 @@ export const useWatchSUsdsL2 = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link sUsdsL2Abi}__ and `eventName` set to `"Upgraded"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x5875eEE11Cf8398102FdAd704C9E96607675467a)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xdDb46999F8891663a8F2828d25298f70416d7610)
  */
 export const useWatchSUsdsL2Upgraded = /*#__PURE__*/ createUseWatchContractEvent({
   abi: sUsdsL2Abi,
@@ -19381,7 +19381,7 @@ export const useWatchSkyL2Transfer = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracle = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19392,7 +19392,7 @@ export const useReadSsrAuthOracle = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"DATA_PROVIDER_ROLE"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleDataProviderRole = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19404,7 +19404,7 @@ export const useReadSsrAuthOracleDataProviderRole = /*#__PURE__*/ createUseReadC
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"DEFAULT_ADMIN_ROLE"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleDefaultAdminRole = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19416,7 +19416,7 @@ export const useReadSsrAuthOracleDefaultAdminRole = /*#__PURE__*/ createUseReadC
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getAPR"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetApr = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19428,7 +19428,7 @@ export const useReadSsrAuthOracleGetApr = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getChi"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetChi = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19440,7 +19440,7 @@ export const useReadSsrAuthOracleGetChi = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getConversionRate"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetConversionRate = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19452,7 +19452,7 @@ export const useReadSsrAuthOracleGetConversionRate = /*#__PURE__*/ createUseRead
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getConversionRateBinomialApprox"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetConversionRateBinomialApprox = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19464,7 +19464,7 @@ export const useReadSsrAuthOracleGetConversionRateBinomialApprox = /*#__PURE__*/
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getConversionRateLinearApprox"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetConversionRateLinearApprox = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19476,7 +19476,7 @@ export const useReadSsrAuthOracleGetConversionRateLinearApprox = /*#__PURE__*/ c
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getRho"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetRho = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19488,7 +19488,7 @@ export const useReadSsrAuthOracleGetRho = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getRoleAdmin"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetRoleAdmin = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19500,7 +19500,7 @@ export const useReadSsrAuthOracleGetRoleAdmin = /*#__PURE__*/ createUseReadContr
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getSSR"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetSsr = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19512,7 +19512,7 @@ export const useReadSsrAuthOracleGetSsr = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"getSUSDSData"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleGetSusdsData = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19524,7 +19524,7 @@ export const useReadSsrAuthOracleGetSusdsData = /*#__PURE__*/ createUseReadContr
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"hasRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleHasRole = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19536,7 +19536,7 @@ export const useReadSsrAuthOracleHasRole = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"maxSSR"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleMaxSsr = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19548,7 +19548,7 @@ export const useReadSsrAuthOracleMaxSsr = /*#__PURE__*/ createUseReadContract({
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"supportsInterface"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useReadSsrAuthOracleSupportsInterface = /*#__PURE__*/ createUseReadContract({
   abi: ssrAuthOracleAbi,
@@ -19560,7 +19560,7 @@ export const useReadSsrAuthOracleSupportsInterface = /*#__PURE__*/ createUseRead
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWriteSsrAuthOracle = /*#__PURE__*/ createUseWriteContract({
   abi: ssrAuthOracleAbi,
@@ -19571,7 +19571,7 @@ export const useWriteSsrAuthOracle = /*#__PURE__*/ createUseWriteContract({
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"grantRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWriteSsrAuthOracleGrantRole = /*#__PURE__*/ createUseWriteContract({
   abi: ssrAuthOracleAbi,
@@ -19583,7 +19583,7 @@ export const useWriteSsrAuthOracleGrantRole = /*#__PURE__*/ createUseWriteContra
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"renounceRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWriteSsrAuthOracleRenounceRole = /*#__PURE__*/ createUseWriteContract({
   abi: ssrAuthOracleAbi,
@@ -19595,7 +19595,7 @@ export const useWriteSsrAuthOracleRenounceRole = /*#__PURE__*/ createUseWriteCon
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"revokeRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWriteSsrAuthOracleRevokeRole = /*#__PURE__*/ createUseWriteContract({
   abi: ssrAuthOracleAbi,
@@ -19607,7 +19607,7 @@ export const useWriteSsrAuthOracleRevokeRole = /*#__PURE__*/ createUseWriteContr
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"setMaxSSR"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWriteSsrAuthOracleSetMaxSsr = /*#__PURE__*/ createUseWriteContract({
   abi: ssrAuthOracleAbi,
@@ -19619,7 +19619,7 @@ export const useWriteSsrAuthOracleSetMaxSsr = /*#__PURE__*/ createUseWriteContra
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"setSUSDSData"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWriteSsrAuthOracleSetSusdsData = /*#__PURE__*/ createUseWriteContract({
   abi: ssrAuthOracleAbi,
@@ -19631,7 +19631,7 @@ export const useWriteSsrAuthOracleSetSusdsData = /*#__PURE__*/ createUseWriteCon
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useSimulateSsrAuthOracle = /*#__PURE__*/ createUseSimulateContract({
   abi: ssrAuthOracleAbi,
@@ -19642,7 +19642,7 @@ export const useSimulateSsrAuthOracle = /*#__PURE__*/ createUseSimulateContract(
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"grantRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useSimulateSsrAuthOracleGrantRole = /*#__PURE__*/ createUseSimulateContract({
   abi: ssrAuthOracleAbi,
@@ -19654,7 +19654,7 @@ export const useSimulateSsrAuthOracleGrantRole = /*#__PURE__*/ createUseSimulate
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"renounceRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useSimulateSsrAuthOracleRenounceRole = /*#__PURE__*/ createUseSimulateContract({
   abi: ssrAuthOracleAbi,
@@ -19666,7 +19666,7 @@ export const useSimulateSsrAuthOracleRenounceRole = /*#__PURE__*/ createUseSimul
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"revokeRole"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useSimulateSsrAuthOracleRevokeRole = /*#__PURE__*/ createUseSimulateContract({
   abi: ssrAuthOracleAbi,
@@ -19678,7 +19678,7 @@ export const useSimulateSsrAuthOracleRevokeRole = /*#__PURE__*/ createUseSimulat
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"setMaxSSR"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useSimulateSsrAuthOracleSetMaxSsr = /*#__PURE__*/ createUseSimulateContract({
   abi: ssrAuthOracleAbi,
@@ -19690,7 +19690,7 @@ export const useSimulateSsrAuthOracleSetMaxSsr = /*#__PURE__*/ createUseSimulate
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `functionName` set to `"setSUSDSData"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useSimulateSsrAuthOracleSetSusdsData = /*#__PURE__*/ createUseSimulateContract({
   abi: ssrAuthOracleAbi,
@@ -19702,7 +19702,7 @@ export const useSimulateSsrAuthOracleSetSusdsData = /*#__PURE__*/ createUseSimul
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link ssrAuthOracleAbi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWatchSsrAuthOracle = /*#__PURE__*/ createUseWatchContractEvent({
   abi: ssrAuthOracleAbi,
@@ -19713,7 +19713,7 @@ export const useWatchSsrAuthOracle = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `eventName` set to `"RoleAdminChanged"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWatchSsrAuthOracleRoleAdminChanged = /*#__PURE__*/ createUseWatchContractEvent({
   abi: ssrAuthOracleAbi,
@@ -19725,7 +19725,7 @@ export const useWatchSsrAuthOracleRoleAdminChanged = /*#__PURE__*/ createUseWatc
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `eventName` set to `"RoleGranted"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWatchSsrAuthOracleRoleGranted = /*#__PURE__*/ createUseWatchContractEvent({
   abi: ssrAuthOracleAbi,
@@ -19737,7 +19737,7 @@ export const useWatchSsrAuthOracleRoleGranted = /*#__PURE__*/ createUseWatchCont
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `eventName` set to `"RoleRevoked"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWatchSsrAuthOracleRoleRevoked = /*#__PURE__*/ createUseWatchContractEvent({
   abi: ssrAuthOracleAbi,
@@ -19749,7 +19749,7 @@ export const useWatchSsrAuthOracleRoleRevoked = /*#__PURE__*/ createUseWatchCont
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `eventName` set to `"SetMaxSSR"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWatchSsrAuthOracleSetMaxSsr = /*#__PURE__*/ createUseWatchContractEvent({
   abi: ssrAuthOracleAbi,
@@ -19761,7 +19761,7 @@ export const useWatchSsrAuthOracleSetMaxSsr = /*#__PURE__*/ createUseWatchContra
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link ssrAuthOracleAbi}__ and `eventName` set to `"SetSUSDSData"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x65d946e533748A998B1f0E430803e39A6388f7a1)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xEE2816c1E1eed14d444552654Ed3027abC033A36)
  */
 export const useWatchSsrAuthOracleSetSusdsData = /*#__PURE__*/ createUseWatchContractEvent({
   abi: ssrAuthOracleAbi,
@@ -20573,7 +20573,7 @@ export const useWatchUsdsUpgraded = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link usdsL2Abi}__
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x820C137fa70C8691f0e44Dc420a5e53c168921Dc)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x6491c05A82219b8D1479057361ff1654749b876b)
  */
 export const useWatchUsdsL2 = /*#__PURE__*/ createUseWatchContractEvent({
   abi: usdsL2Abi,
@@ -20584,7 +20584,7 @@ export const useWatchUsdsL2 = /*#__PURE__*/ createUseWatchContractEvent({
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link usdsL2Abi}__ and `eventName` set to `"Upgraded"`
  *
  * - [__View Contract on Base Basescan__](https://basescan.org/address/0x820C137fa70C8691f0e44Dc420a5e53c168921Dc)
- * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
+ * - [__View Contract on Arbitrum One Arbiscan__](https://arbiscan.io/address/0x6491c05A82219b8D1479057361ff1654749b876b)
  */
 export const useWatchUsdsL2Upgraded = /*#__PURE__*/ createUseWatchContractEvent({
   abi: usdsL2Abi,

--- a/packages/hooks/wagmi.config.ts
+++ b/packages/hooks/wagmi.config.ts
@@ -30,23 +30,23 @@ export default defineConfig(() => {
       }),
       // The etherscan plugin fetches ABIs for contracts which have a mainnet deployment
       etherscan({
-        apiKey: env.ETHERSCAN_API_KEY,
+        apiKey: env.ETHERSCAN_V2_API_KEY,
         chainId: mainnet.id,
         contracts: contracts
       }),
       // This etherscan plugin fetches ABIs for contracts which have a sepolia deployment
       etherscan({
-        apiKey: env.ETHERSCAN_API_KEY,
+        apiKey: env.ETHERSCAN_V2_API_KEY,
         chainId: sepolia.id,
         contracts: sepoliaContracts
       }),
-      // This etherscan plugin fetches ABIs for contracts which have a base deployment
+      // This etherscan plugin fetches ABIs for L2 contracts which have a base deployment
       etherscan({
-        apiKey: env.BASESCAN_API_KEY,
+        apiKey: env.ETHERSCAN_V2_API_KEY,
         chainId: base.id,
         contracts: l2Contracts
       }),
-      // The fetch plugin fetches ABIs for contracts deployed on the tenderly testnet
+      // This fetch plugin fetches ABIs for contracts deployed on the tenderly testnet
       fetchPlugin({
         contracts: tenderlyContracts,
         request(contract) {


### PR DESCRIPTION
### What does this PR do?
- Update block explorers API keys to use the single Etherscan v2 key
- Update Tenderly Arbitrum contracts addresses to use the same as Arbitrum One

### Testing steps:
