### PR TITLE
Sanitize chat urls

### DIFF
--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -32,6 +32,7 @@ export function filterActionsByIntent(actions: LinkedAction[], intent: string) {
  */
 type SanitizeUrlOptions = {
   searchParamsOnly: boolean;
+  allowExternalLinks: boolean;
 };
 
 const URL_SAFE_CHARS_REGEX = /[^\w:/.?#&=-]/g;
@@ -43,7 +44,7 @@ function parseUrl(url: string, isSearchParamsOnly: boolean) {
 
 export function sanitizeUrl(
   url: string | undefined,
-  options: SanitizeUrlOptions = { searchParamsOnly: false }
+  options: SanitizeUrlOptions = { searchParamsOnly: false, allowExternalLinks: false }
 ) {
   if (!url) return undefined;
   try {
@@ -67,8 +68,10 @@ export function sanitizeUrl(
 
     const isValidExternalUrl =
       parsedUrl.protocol === 'https:' &&
-      ALLOWED_EXTERNAL_DOMAINS.some(
-        domain => parsedUrl.hostname === domain || parsedUrl.hostname.endsWith(`.${domain}`)
+      ALLOWED_EXTERNAL_DOMAINS.some(domain =>
+        options.allowExternalLinks
+          ? true
+          : parsedUrl.hostname === domain || parsedUrl.hostname.endsWith(`.${domain}`)
       );
 
     const sanitizedUrl = options.searchParamsOnly

--- a/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRetainedQueryParams } from '@/modules/ui/hooks/useRetainedQueryParams';
 import { intentSelectedMessage } from '../lib/intentSelectedMessage';
 import { QueryParams } from '@/lib/constants';
+import { sanitizeUrl } from '@/lib/utils';
 
 type ChatIntentsRowProps = {
   intents: ChatIntent[];
@@ -31,7 +32,11 @@ type IntentRowProps = {
 const IntentRow = ({ intent }: IntentRowProps) => {
   const { setConfirmationModalOpened, setSelectedIntent, hasShownIntent, setChatHistory } = useChatContext();
   const navigate = useNavigate();
-  const intentUrl = useRetainedQueryParams(intent?.url || '', [
+  const sanitizedIntentUrl = sanitizeUrl(intent?.url, { searchParamsOnly: true });
+
+  if (!sanitizedIntentUrl) return null;
+
+  const intentUrl = useRetainedQueryParams(sanitizedIntentUrl, [
     QueryParams.Locale,
     QueryParams.Details,
     QueryParams.Chat

--- a/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
@@ -32,7 +32,10 @@ type IntentRowProps = {
 const IntentRow = ({ intent }: IntentRowProps) => {
   const { setConfirmationModalOpened, setSelectedIntent, hasShownIntent, setChatHistory } = useChatContext();
   const navigate = useNavigate();
-  const sanitizedIntentUrl = sanitizeUrl(intent?.url, { searchParamsOnly: true });
+  const sanitizedIntentUrl = sanitizeUrl(intent?.url, {
+    searchParamsOnly: true,
+    allowExternalLinks: false
+  });
 
   if (!sanitizedIntentUrl) return null;
 

--- a/apps/webapp/src/modules/ui/components/markdown/ChatMarkdownRenderer.tsx
+++ b/apps/webapp/src/modules/ui/components/markdown/ChatMarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import { Text, Heading, List } from '@/modules/layout/components/Typography';
 import { SafeMarkdownRenderer } from './SafeMarkdownRenderer';
 import { ExternalLink } from '@/modules/layout/components/ExternalLink';
+import { sanitizeUrl } from '@/lib/utils';
 
 export const ChatMarkdownRenderer = ({ markdown }: { markdown: string }) => (
   <SafeMarkdownRenderer
@@ -36,11 +37,17 @@ export const ChatMarkdownRenderer = ({ markdown }: { markdown: string }) => (
           {children}
         </Text>
       ),
-      a: ({ children, ...props }) => (
-        <ExternalLink href={props.href || ''} className="text-blue-500 hover:underline" showIcon={false}>
-          {children}
-        </ExternalLink>
-      ),
+      a: ({ children, ...props }) => {
+        return (
+          <ExternalLink
+            href={sanitizeUrl(props.href, { allowExternalLinks: true, searchParamsOnly: false }) || ''}
+            className="text-blue-500 hover:underline"
+            showIcon={false}
+          >
+            {children}
+          </ExternalLink>
+        );
+      },
       ul: ({ children, ...props }) => (
         <List className="pb-3" {...props}>
           {children}

--- a/apps/webapp/src/modules/ui/components/markdown/ChatMarkdownRenderer.tsx
+++ b/apps/webapp/src/modules/ui/components/markdown/ChatMarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 import { Text, Heading, List } from '@/modules/layout/components/Typography';
 import { SafeMarkdownRenderer } from './SafeMarkdownRenderer';
+import { ExternalLink } from '@/modules/layout/components/ExternalLink';
 
 export const ChatMarkdownRenderer = ({ markdown }: { markdown: string }) => (
   <SafeMarkdownRenderer
@@ -36,9 +37,9 @@ export const ChatMarkdownRenderer = ({ markdown }: { markdown: string }) => (
         </Text>
       ),
       a: ({ children, ...props }) => (
-        <a className="text-blue-500 hover:underline" {...props}>
-          <Text tag="span">{children}</Text>
-        </a>
+        <ExternalLink href={props.href || ''} className="text-blue-500 hover:underline" showIcon={false}>
+          {children}
+        </ExternalLink>
       ),
       ul: ({ children, ...props }) => (
         <List className="pb-3" {...props}>


### PR DESCRIPTION
- Sanitizes urls or search params coming from the chatbot as suggested actions.
- Sanitizes urls coming in the chatbot markdown response and use ExternalLink component to render the link, allowing external links.

This is important in case the chatbot hallucinates or the endpoint is intercepted and the returned payload is modified by a malicious actor.