### PR TITLE
Ind/404 page

### DIFF
--- a/apps/webapp/src/modules/app/Landing.tsx
+++ b/apps/webapp/src/modules/app/Landing.tsx
@@ -1,5 +1,0 @@
-import { MainApp } from './components/MainApp';
-
-export function Landing(): React.ReactElement {
-  return <MainApp />;
-}

--- a/apps/webapp/src/modules/layout/components/NotFound.tsx
+++ b/apps/webapp/src/modules/layout/components/NotFound.tsx
@@ -1,8 +1,9 @@
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { Layout } from './Layout';
 import { Heading, Text } from './Typography';
 import { Button } from '@/components/ui/button';
+import { NoResults } from '@jetstreamgg/widgets';
 
 export function NotFound() {
   const navigate = useNavigate();
@@ -15,17 +16,23 @@ export function NotFound() {
 
   return (
     <Layout>
-      <div className="my-6 text-center">
-        <Heading variant="large">404</Heading>
-        <Text>Page not found</Text>
-        <Text>
-          You will be redirected back to the homepage after 5 seconds or you can use the button below
-        </Text>
-        <Link to="/">
-          <Button variant="secondary" className="mt-4">
-            Back to homepage
+      <div className="-mt-16 flex w-full grow flex-col items-center justify-center text-center">
+        <div className="bg-container flex max-w-[650px] flex-col items-center gap-3 rounded-3xl border p-12 bg-blend-overlay backdrop-blur-[50px]">
+          <NoResults />
+          <Heading tag="h3" variant="large" className="text-[32px] leading-9">
+            Page not found
+          </Heading>
+          <Heading tag="h1" variant="large" className="text-[82px] leading-[96px]">
+            Lost in the Sky?
+          </Heading>
+          <Text variant="large" className="text-text">
+            Seems like you&apos;ve ventured into the unknown. Click the button to find your way back (you will
+            be redirected to the homepage in 5 seconds)
+          </Text>
+          <Button variant="primary" className="mt-1 self-center" onClick={() => navigate('/')}>
+            Homepage
           </Button>
-        </Link>
+        </div>
       </div>
     </Layout>
   );

--- a/apps/webapp/src/pages/Home.tsx
+++ b/apps/webapp/src/pages/Home.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Layout } from '../modules/layout/components/Layout';
-import { Landing } from '../modules/app/Landing';
+import { MainApp } from '@/modules/app/components/MainApp';
 
 function Home(): React.ReactElement {
   return (
     <Layout>
-      <Landing />
+      <MainApp />
     </Layout>
   );
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vnet:delete": "node --env-file=.env ./scripts/deleteVnet.ts",
     "vnet:delete:all": "node --env-file=.env ./scripts/deleteAllVnets.ts",
     "vnet:delete:ci": "node ./scripts/deleteVnet.ts",
-    "prepare": "husky install",
+    "prepare": "husky",
     "typecheck": "pnpm --filter './packages/**' --filter './apps/**' typecheck",
     "messages:extract": "lingui extract --clean",
     "messages:compile": "lingui compile",

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -27,3 +27,4 @@ export * from './widgets/SealModuleWidget/lib/constants';
 export { formatUrnIndex } from './widgets/SealModuleWidget/lib/utils';
 export { defaultConfig } from './config/default-config';
 export type { WidgetsConfig } from './config/types/widgets-config';
+export { NoResults } from './shared/components/icons/NoResults';


### PR DESCRIPTION
### What does this PR do?
Improve the style of the 404 page by implementing the layout and copy from the marketing site, using the styles of the webapp

Misc:
- Fix deprecation notice by replacing `husky install` comment for just `husky`
- Remove an unnecessary intermediary component (`Landing`) in the homepage tree of the webapp

After:
![image](https://github.com/user-attachments/assets/5ef6bac7-6cfd-433d-a8b2-2e763b5a5543)

Before:
![image](https://github.com/user-attachments/assets/a5d884db-a088-4d32-abfe-65f1cf4cfc4d)


### Testing steps:
Go to an invalid route in the webapp, e.g. `/test`