### PR TITLE
Update colors of the RainbowKit modal

### DIFF
--- a/apps/webapp/src/themes/rainbowTheme.ts
+++ b/apps/webapp/src/themes/rainbowTheme.ts
@@ -1,14 +1,28 @@
-import { lightTheme, Theme } from '@rainbow-me/rainbowkit';
+import { midnightTheme, Theme } from '@rainbow-me/rainbowkit';
 
 export const rainbowTheme: Theme = {
-  ...lightTheme(),
-  radii: { ...lightTheme().radii, menuButton: '12px', connectButton: '12px' },
+  ...midnightTheme(),
+  radii: { ...midnightTheme().radii, menuButton: '12px', connectButton: '12px' },
   colors: {
-    ...lightTheme().colors,
+    ...midnightTheme().colors,
     connectButtonBackground: 'rgb(97, 67, 246)',
-    connectButtonText: 'white'
+    connectButtonText: 'white',
+    modalBackdrop: 'rgba(0, 0, 0, 0.5)',
+    modalBackground: '#0c0c0dd9',
+    modalBorder: 'transparent',
+    closeButtonBackground: 'transparent',
+    accentColor: 'rgba(102, 72, 246)',
+    menuItemBackground: 'rgb(43, 36, 90)',
+    profileForeground: '#2E2E2E59'
+  },
+  blurs: {
+    modalOverlay: 'blur(12.5px)'
   },
   fonts: {
     body: 'CircularStd, sans-serif'
+  },
+  shadows: {
+    ...midnightTheme().shadows,
+    dialog: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
   }
 };


### PR DESCRIPTION
### What does this PR do?
Update the colors of the RainbowKit modals to better match the styles of the other modals in the webapp.

### After:
![image](https://github.com/user-attachments/assets/bcfd5561-b45e-4296-96c8-835813bc9ff9)
![image](https://github.com/user-attachments/assets/2e22af9f-b6ea-47fd-9f04-91a2bb1a9d4e)

### Before:
![image](https://github.com/user-attachments/assets/3c1cff60-226d-415b-bfe8-b3e6c62e07a8)
![image](https://github.com/user-attachments/assets/380595a5-6962-450a-a728-0df7032e66fe)

