### PR TITLE
Fix widget retry button handler

### DIFF
--- a/.changeset/nice-doors-act.md
+++ b/.changeset/nice-doors-act.md
@@ -1,0 +1,5 @@
+---
+'@jetstreamgg/widgets': patch
+---
+
+Fix retry button handler

--- a/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
@@ -614,11 +614,11 @@ const SavingsWidgetWrapped = ({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === SavingsAction.SUPPLY
-      ? supplyOnClick
+      ? supplyOnClick()
       : widgetState.action === SavingsAction.WITHDRAW
-        ? withdrawOnClick
+        ? withdrawOnClick()
         : widgetState.action === SavingsAction.APPROVE
-          ? approveOnClick
+          ? approveOnClick()
           : undefined;
   };
 
@@ -631,7 +631,7 @@ const SavingsWidgetWrapped = ({
       : txStatus === TxStatus.SUCCESS
         ? nextOnClick
         : txStatus === TxStatus.ERROR
-          ? errorOnClick()
+          ? errorOnClick
           : (widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.APPROVE) ||
               (widgetState.flow === SavingsFlow.WITHDRAW && widgetState.action === SavingsAction.APPROVE)
             ? approveOnClick

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -792,9 +792,9 @@ function TradeWidgetWrapped({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === TradeAction.TRADE
-      ? tradeOnClick
+      ? tradeOnClick()
       : widgetState.action === TradeAction.APPROVE
-        ? approveOnClick
+        ? approveOnClick()
         : undefined;
   };
 

--- a/packages/widgets/src/widgets/RewardsWidget/index.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/index.tsx
@@ -521,13 +521,13 @@ const RewardsWidgetWrapped = ({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === RewardsAction.SUPPLY
-      ? supplyOnClick
+      ? supplyOnClick()
       : widgetState.action === RewardsAction.WITHDRAW
-        ? withdrawOnClick
+        ? withdrawOnClick()
         : widgetState.action === RewardsAction.APPROVE
-          ? approveOnClick
+          ? approveOnClick()
           : widgetState.action === RewardsAction.CLAIM
-            ? onClaimClick
+            ? onClaimClick()
             : undefined;
   };
 
@@ -553,7 +553,7 @@ const RewardsWidgetWrapped = ({
       : txStatus === TxStatus.SUCCESS
         ? nextOnClick
         : txStatus === TxStatus.ERROR
-          ? errorOnClick()
+          ? errorOnClick
           : widgetState.flow === RewardsFlow.SUPPLY && widgetState.action === RewardsAction.APPROVE
             ? approveOnClick
             : widgetState.flow === RewardsFlow.SUPPLY && widgetState.action === RewardsAction.SUPPLY

--- a/packages/widgets/src/widgets/SavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/index.tsx
@@ -366,11 +366,11 @@ const SavingsWidgetWrapped = ({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === SavingsAction.SUPPLY
-      ? supplyOnClick
+      ? supplyOnClick()
       : widgetState.action === SavingsAction.WITHDRAW
-        ? withdrawOnClick
+        ? withdrawOnClick()
         : widgetState.action === SavingsAction.APPROVE
-          ? approveOnClick
+          ? approveOnClick()
           : undefined;
   };
 
@@ -383,7 +383,7 @@ const SavingsWidgetWrapped = ({
       : txStatus === TxStatus.SUCCESS
         ? nextOnClick
         : txStatus === TxStatus.ERROR
-          ? errorOnClick()
+          ? errorOnClick
           : widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.APPROVE
             ? approveOnClick
             : widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.SUPPLY

--- a/packages/widgets/src/widgets/SealModuleWidget/components/ClaimRewardsButton.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/ClaimRewardsButton.tsx
@@ -59,7 +59,11 @@ export function ClaimRewardsButton({
   if (!rewardsBalance || !rewardContractTokens) return null;
 
   return (
-    <Button onClick={handleClick} disabled={!!rewardContractToClaim && indexToClaim !== undefined}>
+    <Button
+      variant="primaryAlt"
+      onClick={handleClick}
+      disabled={!!rewardContractToClaim && indexToClaim !== undefined}
+    >
       <Text>
         {indexToClaim === index && rewardContractToClaim === rewardContract
           ? 'Preparing your claim transaction...'

--- a/packages/widgets/src/widgets/TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/index.tsx
@@ -1027,9 +1027,9 @@ function TradeWidgetWrapped({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === TradeAction.TRADE
-      ? tradeOnClick
+      ? tradeOnClick()
       : widgetState.action === TradeAction.APPROVE
-        ? approveOnClick
+        ? approveOnClick()
         : undefined;
   };
 
@@ -1045,7 +1045,7 @@ function TradeWidgetWrapped({
         : txStatus === TxStatus.SUCCESS
           ? nextOnClick
           : txStatus === TxStatus.ERROR
-            ? errorOnClick()
+            ? errorOnClick
             : txStatus === TxStatus.CANCELLED
               ? nextOnClick
               : widgetState.screen === TradeScreen.ACTION

--- a/packages/widgets/src/widgets/UpgradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/index.tsx
@@ -434,11 +434,11 @@ export function UpgradeWidgetWrapped({
   // Handle the error onClicks separately to keep it clear
   const errorOnClick = () => {
     return widgetState.action === UpgradeAction.UPGRADE
-      ? upgradeOnClick
+      ? upgradeOnClick()
       : widgetState.action === UpgradeAction.REVERT
-        ? revertOnClick
+        ? revertOnClick()
         : widgetState.action === UpgradeAction.APPROVE
-          ? approveOnClick
+          ? approveOnClick()
           : undefined;
   };
 
@@ -449,7 +449,7 @@ export function UpgradeWidgetWrapped({
       : txStatus === TxStatus.SUCCESS
         ? nextOnClick
         : txStatus === TxStatus.ERROR
-          ? errorOnClick()
+          ? errorOnClick
           : (widgetState.flow === UpgradeFlow.UPGRADE && widgetState.action === UpgradeAction.APPROVE) ||
               (widgetState.flow === UpgradeFlow.REVERT && widgetState.action === UpgradeAction.APPROVE)
             ? approveOnClick


### PR DESCRIPTION
### What does this PR do?
- Fix an issue where the retry button of some widgets didn't retrigger the transaction
- Also fixes the background color and states of the Seal widget claim button

### Testing steps:
- Attempt to perform a transaction in the trade L2 widget
- Cancel the tx in the wallet
- Click the 'Retry' button
- The transaction should be attempted again