### PR TITLE
Add age restriction warning for the chatbot

### DIFF
--- a/apps/webapp/src/modules/app/components/ChatPane.tsx
+++ b/apps/webapp/src/modules/app/components/ChatPane.tsx
@@ -56,6 +56,7 @@ export const ChatPane = ({ sendMessage }: { sendMessage: (message: string) => vo
                   intents={intents}
                   sendMessage={sendMessage}
                   showModifierRow={!isFirstMessage && isLastMessage}
+                  isFirstMessage={isFirstMessage}
                 />
               );
             })}

--- a/apps/webapp/src/modules/chat/components/AgeWarningRow.tsx
+++ b/apps/webapp/src/modules/chat/components/AgeWarningRow.tsx
@@ -18,8 +18,8 @@ export const AgeWarningRow = () => {
         <Text variant="medium">You must be at least 18 years old to use this service.</Text>
       </div>
       <Text variant="terms" className="mt-2">
-        By clicking &quot;Continue&quot;, you confirm that you are at least 18 years old and agree to comply
-        with all applicable laws and regulations regarding age restrictions.
+        By clicking, you confirm that you are at least 18 years old and agree to comply with all applicable
+        laws and regulations regarding age restrictions.
       </Text>
       <div className="mt-3 flex gap-5">
         <Button variant="pill" size="xs" onClick={handleConfirm}>

--- a/apps/webapp/src/modules/chat/components/AgeWarningRow.tsx
+++ b/apps/webapp/src/modules/chat/components/AgeWarningRow.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@/components/ui/button';
+import { Text } from '@/modules/layout/components/Typography';
+import { useChatContext } from '../context/ChatContext';
+import { useCallback } from 'react';
+import { Warning } from '@/modules/icons/Warning';
+
+export const AgeWarningRow = () => {
+  const { setHasAcceptedAgeRestriction } = useChatContext();
+
+  const handleConfirm = useCallback(() => {
+    setHasAcceptedAgeRestriction(true);
+  }, [setHasAcceptedAgeRestriction]);
+
+  return (
+    <div className="text-text mt-5 rounded-xl bg-[#0b0b0c]/60 p-5">
+      <div className="flex items-center gap-2">
+        <Warning boxSize={20} viewBox="0 0 16 16" fill="#fdc134" />
+        <Text variant="medium">You must be at least 18 years old to use this service.</Text>
+      </div>
+      <Text variant="terms" className="mt-2">
+        By clicking &quot;Continue&quot;, you confirm that you are at least 18 years old and agree to comply
+        with all applicable laws and regulations regarding age restrictions.
+      </Text>
+      <div className="mt-3 flex gap-5">
+        <Button variant="pill" size="xs" onClick={handleConfirm}>
+          I am at least 18 years old
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/webapp/src/modules/chat/components/ChatBubble.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatBubble.tsx
@@ -16,12 +16,15 @@ import { ChatIntentsRow } from './ChatIntentsRow';
 import { StopGeneratingButton } from './StopGeneratingButton';
 import { ChatError } from '@/modules/icons';
 import { ChatMarkdownRenderer } from '@/modules/ui/components/markdown/ChatMarkdownRenderer';
+import { AgeWarningRow } from './AgeWarningRow';
+import { useChatContext } from '../context/ChatContext';
 
 type ChatBubbleProps = {
   user: UserType;
   message: string;
   type?: MessageType;
   isLastMessage?: boolean;
+  isFirstMessage?: boolean;
   suggestions?: string[];
   intents?: ChatIntent[];
   sendMessage: (message: string) => void;
@@ -70,11 +73,13 @@ export const ChatBubble = ({
   intents,
   sendMessage,
   showModifierRow = true,
-  isLastMessage
+  isLastMessage,
+  isFirstMessage
 }: ChatBubbleProps) => {
   const { address } = useAccount();
   const [searchParams] = useSearchParams();
   const { bpi } = useBreakpointIndex();
+  const { hasAcceptedAgeRestriction } = useChatContext();
   const shouldUseLargeAvatar = bpi >= BP.xl && searchParams.get(QueryParams.Details) !== 'true';
   const isError = type === MessageType.error;
   const isLoading = type === MessageType.loading;
@@ -127,6 +132,7 @@ export const ChatBubble = ({
                 <ChatMarkdownRenderer markdown={message} />
               </div>
             </HStack>
+            {isFirstMessage && !hasAcceptedAgeRestriction && <AgeWarningRow />}
             {user === UserType.bot && !isError && !isInternal && !isCanceled && (
               <div className="space-y-5">
                 {intents && intents?.length > 0 && isLastMessage && <ChatIntentsRow intents={intents} />}

--- a/apps/webapp/src/modules/chat/components/ChatInput.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatInput.tsx
@@ -7,7 +7,7 @@ import { useChatContext } from '../context/ChatContext';
 
 export const ChatInput = ({ sendMessage }: { sendMessage: (message: string) => void }) => {
   const [inputText, setInputText] = useState('');
-  const { isLoading } = useChatContext();
+  const { isLoading, hasAcceptedAgeRestriction, chatHistory } = useChatContext();
 
   const handleSubmit = () => {
     console.log('handleSubmit', inputText);
@@ -23,19 +23,27 @@ export const ChatInput = ({ sendMessage }: { sendMessage: (message: string) => v
     }
   };
 
+  const isFirstMessage = chatHistory.length === 1;
+  const placeholder = hasAcceptedAgeRestriction
+    ? isFirstMessage
+      ? t`Ask me anything`
+      : t`Ask another question`
+    : t`Please confirm you're at least 18`;
+
   return (
     <HStack className="bg-card justify-between rounded-xl p-4 hover:brightness-125">
       <input
-        placeholder={t`Ask another question`}
+        placeholder={placeholder}
         className="ring-offset-background grow bg-transparent text-sm leading-4 text-white placeholder:text-violet-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:placeholder:text-violet-200/20"
         value={inputText}
         onChange={e => setInputText(e.target.value)}
         onKeyUp={handleKeyPress}
+        disabled={!hasAcceptedAgeRestriction}
       />
       <Button
         variant="ghost"
         className="h-6 bg-transparent p-0 text-white hover:bg-transparent active:bg-transparent disabled:bg-transparent disabled:text-violet-200/50"
-        disabled={!inputText || isLoading}
+        disabled={!inputText || isLoading || !hasAcceptedAgeRestriction}
         onClick={handleSubmit}
       >
         <ChatbotSend />

--- a/apps/webapp/src/modules/chat/context/ChatContext.tsx
+++ b/apps/webapp/src/modules/chat/context/ChatContext.tsx
@@ -1,9 +1,12 @@
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { ChatHistory, ChatIntent } from '../types/Chat';
 import { generateUUID } from '../lib/generateUUID';
 import { t } from '@lingui/macro';
 import { CHATBOT_NAME, MessageType, UserType } from '../constants';
 import { intentModifiesState } from '../lib/intentUtils';
+
+// Key for localStorage
+const AGE_RESTRICTION_KEY = 'has-accepted-age-restriction';
 
 interface ChatContextType {
   isLoading: boolean;
@@ -14,12 +17,14 @@ interface ChatContextType {
   sessionId: string;
   shouldShowConfirmationWarning: boolean;
   shouldDisableActionButtons: boolean;
+  hasAcceptedAgeRestriction: boolean;
   setChatHistory: React.Dispatch<React.SetStateAction<ChatHistory[]>>;
   setConfirmationWarningOpened: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedIntent: React.Dispatch<React.SetStateAction<ChatIntent | undefined>>;
   setWarningShown: React.Dispatch<React.SetStateAction<ChatIntent[]>>;
   hasShownIntent: (intent?: ChatIntent) => boolean;
   setShouldDisableActionButtons: React.Dispatch<React.SetStateAction<boolean>>;
+  setHasAcceptedAgeRestriction: (accepted: boolean) => void;
 }
 
 const ChatContext = createContext<ChatContextType>({
@@ -36,7 +41,9 @@ const ChatContext = createContext<ChatContextType>({
   hasShownIntent: () => false,
   shouldShowConfirmationWarning: false,
   shouldDisableActionButtons: false,
-  setShouldDisableActionButtons: () => {}
+  setShouldDisableActionButtons: () => {},
+  hasAcceptedAgeRestriction: false,
+  setHasAcceptedAgeRestriction: () => {}
 });
 
 export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -55,7 +62,23 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [confirmationWarningOpened, setConfirmationWarningOpened] = useState<boolean>(false);
   const [warningShown, setWarningShown] = useState<ChatIntent[]>([]);
   const [shouldDisableActionButtons, setShouldDisableActionButtons] = useState<boolean>(false);
+  const [hasAcceptedAgeRestriction, setHasAcceptedAgeRestrictionState] = useState<boolean>(false);
   const isLoading = chatHistory[chatHistory.length - 1]?.type === MessageType.loading;
+
+  // Load age restriction acceptance from localStorage on initial render
+  useEffect(() => {
+    const storedValue = window.localStorage.getItem(AGE_RESTRICTION_KEY);
+    if (storedValue) {
+      setHasAcceptedAgeRestrictionState(storedValue === 'true');
+    }
+  }, []);
+
+  // Function to update both state and localStorage
+  const setHasAcceptedAgeRestriction = useCallback((accepted: boolean) => {
+    setHasAcceptedAgeRestrictionState(accepted);
+    window.localStorage.setItem(AGE_RESTRICTION_KEY, String(accepted));
+  }, []);
+
   const hasShownIntent = useCallback(
     (intent?: ChatIntent) => {
       if (!intent) return false;
@@ -85,7 +108,9 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
         hasShownIntent,
         shouldShowConfirmationWarning,
         shouldDisableActionButtons,
-        setShouldDisableActionButtons
+        setShouldDisableActionButtons,
+        hasAcceptedAgeRestriction,
+        setHasAcceptedAgeRestriction
       }}
     >
       {children}


### PR DESCRIPTION
- Add a warning message asking for the user's age. They need to be 18 or older to continue.
- Acceptance stored in localstorage.
- Input placeholder changes depending on the age confirmation, or if it's the first message:
  - _Please confirm you're at least 18_
  - _Ask me anything_
  - _Ask another question_
- Inputs are disabled until the user confirms age.

NOTE: Texts are not final and they serve the purpose of testing the layouts

https://github.com/user-attachments/assets/85a74330-dcd7-4b51-a22e-23e769037e2a


