### PR TITLE
Fix missing terms link empty render

### DIFF
--- a/apps/webapp/src/modules/seal/components/SealWidgetPane.tsx
+++ b/apps/webapp/src/modules/seal/components/SealWidgetPane.tsx
@@ -7,7 +7,7 @@ import { useSearchParams } from 'react-router-dom';
 import { deleteSearchParams } from '@/modules/utils/deleteSearchParams';
 import { Intent } from '@/lib/enums';
 import { useEffect } from 'react';
-
+import { Error } from '@/modules/layout/components/Error';
 export function SealWidgetPane(sharedProps: SharedProps) {
   let termsLink: any[] = [];
   try {
@@ -99,6 +99,7 @@ export function SealWidgetPane(sharedProps: SharedProps) {
   const hasTermsLink = Array.isArray(termsLink) && termsLink.length > 0;
   if (!hasTermsLink) {
     console.error('No terms link found');
+    return <Error />;
   }
 
   return (

--- a/apps/webapp/src/modules/seal/components/SealWidgetPane.tsx
+++ b/apps/webapp/src/modules/seal/components/SealWidgetPane.tsx
@@ -99,7 +99,6 @@ export function SealWidgetPane(sharedProps: SharedProps) {
   const hasTermsLink = Array.isArray(termsLink) && termsLink.length > 0;
   if (!hasTermsLink) {
     console.error('No terms link found');
-    return null;
   }
 
   return (
@@ -108,7 +107,7 @@ export function SealWidgetPane(sharedProps: SharedProps) {
       onSealUrnChange={onSealUrnChange}
       onWidgetStateChange={onSealWidgetStateChange}
       externalWidgetState={{ amount: linkedActionConfig?.inputAmount, urnIndex: selectedSealUrnIndex }}
-      termsLink={termsLink[0]}
+      termsLink={Array.isArray(termsLink) && termsLink.length > 0 ? termsLink[0] : undefined}
     />
   );
 }


### PR DESCRIPTION
### What does this PR do?

Show a better message if terms are missing instead of empty render

Before:
![Screenshot 2025-03-12 at 1 17 06 PM](https://github.com/user-attachments/assets/561d964a-a48a-4de9-8422-ad959a8e274b)

After: 
![Screenshot 2025-03-12 at 1 36 24 PM](https://github.com/user-attachments/assets/3f91bc51-a972-417b-ae42-bfc1a58faadd)
