### PR TITLE
Add claim flow to rewards and seal

### DIFF
--- a/apps/webapp/src/modules/utils/validateSearchParams.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.ts
@@ -1,5 +1,5 @@
 import { RewardContract } from '@jetstreamgg/hooks';
-import { RewardsFlow, SUPPORTED_TOKEN_SYMBOLS, UpgradeFlow } from '@jetstreamgg/widgets';
+import { RewardsFlow, SealFlow, SUPPORTED_TOKEN_SYMBOLS, UpgradeFlow } from '@jetstreamgg/widgets';
 import {
   QueryParams,
   IntentMapping,
@@ -68,6 +68,13 @@ export const validateSearchParams = (
 
       // if the flow is claim, remove the flow param as it's only used by the chatbot
       if (searchParams.get(QueryParams.Flow) === RewardsFlow.CLAIM) {
+        searchParams.delete(QueryParams.Flow);
+      }
+    }
+
+    if (widget === IntentMapping[Intent.SEAL_INTENT]) {
+      // if the flow is claim, remove the flow param as it's only used by the chatbot
+      if (searchParams.get(QueryParams.Flow) === SealFlow.CLAIM) {
         searchParams.delete(QueryParams.Flow);
       }
     }

--- a/apps/webapp/src/modules/utils/validateSearchParams.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.ts
@@ -1,5 +1,5 @@
 import { RewardContract } from '@jetstreamgg/hooks';
-import { SUPPORTED_TOKEN_SYMBOLS, UpgradeFlow } from '@jetstreamgg/widgets';
+import { RewardsFlow, SUPPORTED_TOKEN_SYMBOLS, UpgradeFlow } from '@jetstreamgg/widgets';
 import {
   QueryParams,
   IntentMapping,
@@ -64,6 +64,11 @@ export const validateSearchParams = (
       if (!searchParams.get(QueryParams.Reward)) {
         setSelectedRewardContract(undefined);
         searchParams.delete(QueryParams.InputAmount);
+      }
+
+      // if the flow is claim, remove the flow param as it's only used by the chatbot
+      if (searchParams.get(QueryParams.Flow) === RewardsFlow.CLAIM) {
+        searchParams.delete(QueryParams.Flow);
       }
     }
 

--- a/packages/widgets/src/widgets/RewardsWidget/lib/constants.ts
+++ b/packages/widgets/src/widgets/RewardsWidget/lib/constants.ts
@@ -6,7 +6,8 @@ import { RewardContract } from '@jetstreamgg/hooks';
 
 export enum RewardsFlow {
   SUPPLY = 'supply',
-  WITHDRAW = 'withdraw'
+  WITHDRAW = 'withdraw',
+  CLAIM = 'claim'
 }
 
 export enum RewardsAction {

--- a/packages/widgets/src/widgets/SealModuleWidget/lib/constants.ts
+++ b/packages/widgets/src/widgets/SealModuleWidget/lib/constants.ts
@@ -6,7 +6,8 @@ import { TOKENS } from '@jetstreamgg/hooks';
 
 export enum SealFlow {
   OPEN = 'open',
-  MANAGE = 'manage'
+  MANAGE = 'manage',
+  CLAIM = 'claim'
 }
 
 export enum SealAction {


### PR DESCRIPTION
It adds a new "Claim" flow to Rewards and Seal so the chatbot can generate urls to take the user to the right widget. But they are ignored as is the user who needs to interact with the claim button.