### PR TITLE
Add ExternalLink to Chatbot markdown renderer

### DIFF
--- a/apps/webapp/src/modules/ui/components/markdown/ChatMarkdownRenderer.tsx
+++ b/apps/webapp/src/modules/ui/components/markdown/ChatMarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 import { Text, Heading, List } from '@/modules/layout/components/Typography';
 import { SafeMarkdownRenderer } from './SafeMarkdownRenderer';
+import { ExternalLink } from '@/modules/layout/components/ExternalLink';
 
 export const ChatMarkdownRenderer = ({ markdown }: { markdown: string }) => (
   <SafeMarkdownRenderer
@@ -35,11 +36,13 @@ export const ChatMarkdownRenderer = ({ markdown }: { markdown: string }) => (
           {children}
         </Text>
       ),
-      a: ({ children, ...props }) => (
-        <a className="text-blue-500 hover:underline" {...props}>
-          <Text tag="span">{children}</Text>
-        </a>
-      ),
+      a: ({ children, ...props }) => {
+        return (
+          <ExternalLink href={props.href} className="text-blue-500 hover:underline" showIcon={false}>
+            {children}
+          </ExternalLink>
+        );
+      },
       ul: ({ children, ...props }) => (
         <List className="pb-3" {...props}>
           {children}


### PR DESCRIPTION
It simply adds the ExternalLink component to the chatbot markdown

It's a subset from this other PR that is still open and sanitizes the urls for the chatbot https://github.com/jetstreamgg/tarmac/pull/70

<img width="1584" alt="image" src="https://github.com/user-attachments/assets/5766df92-c518-47a1-bc8a-0732000f272c" />
