### PR TITLE
Validate source token in Savings L2

### DIFF
--- a/apps/webapp/src/modules/utils/validateSearchParams.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.ts
@@ -24,6 +24,7 @@ export const validateSearchParams = (
 ) => {
   const chainInUrl = chains.find(c => normalizeUrlParam(c.name) === searchParams.get(QueryParams.Network));
   const isL2Chain = isL2ChainId(chainInUrl?.id || chainId);
+  const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
 
   searchParams.forEach((value, key) => {
     // removes any query param not found in QueryParams
@@ -104,6 +105,16 @@ export const validateSearchParams = (
           isL2Chain)
       ) {
         searchParams.delete(key);
+      }
+
+      // Add check for disallowed tokens in Savings on L2
+      if (widgetParam?.toLowerCase() === IntentMapping[Intent.SAVINGS_INTENT] && isL2Chain) {
+        if (isRestrictedMiCa) {
+          // Currently, USDS is the only allowed token in this scenario
+          if (value.toLowerCase() !== 'usds') {
+            searchParams.delete(key);
+          }
+        }
       }
 
       // if widget is upgrade, only valid source token is MKR or DAI

--- a/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
@@ -54,7 +54,6 @@ function calculateOriginOptions(
 ) {
   const options = action === 'deposit' ? [...depositOptions] : [...withdrawOptions];
   const disallowed = disallowedTokens[flow];
-  console.log('🚀 ~ disallowedTokens:', disallowedTokens);
   const allowedOptions = options.filter(option => !disallowed.includes(option));
 
   // Sort the array so that the selected token is first

--- a/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
@@ -54,6 +54,7 @@ function calculateOriginOptions(
 ) {
   const options = action === 'deposit' ? [...depositOptions] : [...withdrawOptions];
   const disallowed = disallowedTokens[flow];
+  console.log('🚀 ~ disallowedTokens:', disallowedTokens);
   const allowedOptions = options.filter(option => !disallowed.includes(option));
 
   // Sort the array so that the selected token is first
@@ -133,7 +134,28 @@ const SavingsWidgetWrapped = ({
   referralCode,
   disallowedTokens
 }: SavingsWidgetProps) => {
-  const validatedExternalState = getValidatedState(externalWidgetState, ['USDS', 'USDC']);
+  const {
+    setButtonText,
+    setIsDisabled,
+    setIsLoading,
+    txStatus,
+    setTxStatus,
+    setExternalLink,
+    widgetState,
+    setWidgetState,
+    setShowStepIndicator
+  } = useContext(WidgetContext);
+
+  const disallowedForFlow =
+    disallowedTokens?.[SavingsFlow.WITHDRAW ? SavingsFlow.WITHDRAW : SavingsFlow.SUPPLY] || [];
+  const allowedSymbolsForValidation = ['USDS', 'USDC'].filter(
+    symbol =>
+      !disallowedForFlow.some(
+        disallowedToken => disallowedToken.symbol.toLowerCase() === symbol.toLowerCase()
+      )
+  );
+
+  const validatedExternalState = getValidatedState(externalWidgetState, allowedSymbolsForValidation);
 
   useEffect(() => {
     onStateValidated?.(validatedExternalState);
@@ -158,18 +180,6 @@ const SavingsWidgetWrapped = ({
   );
   const [amount, setAmount] = useState(initialAmount);
   const debouncedAmount = useDebounce(amount);
-
-  const {
-    setButtonText,
-    setIsDisabled,
-    setIsLoading,
-    txStatus,
-    setTxStatus,
-    setExternalLink,
-    widgetState,
-    setWidgetState,
-    setShowStepIndicator
-  } = useContext(WidgetContext);
 
   const {
     data: allowance,


### PR DESCRIPTION
- Delete Source Token query param for Savings L2 if not valid (webapp)
- Validate source token in the widget external state based on the disallowed tokens

### How to test it

Try setting `source_token=usdc` or other token symbol as a query param for a mica build, it should remove it from the url and the widget should show only `USDS`

`USDS` should be allowed