### PR TITLE
Filter not allowed actions

### DIFF
--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -1,7 +1,8 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { LinkedAction } from '@/modules/ui/hooks/useUserSuggestedActions';
-import { ALLOWED_EXTERNAL_DOMAINS } from './constants';
+import { ALLOWED_EXTERNAL_DOMAINS, CHAIN_WIDGET_MAP, restrictedIntents } from './constants';
+import { Intent } from './enums';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -63,4 +64,19 @@ export function sanitizeUrl(url: string | undefined) {
     console.error('Error parsing url: ', error);
     return undefined;
   }
+}
+
+export function isIntentAllowed(intent: Intent, chainId: number) {
+  const isRestrictedBuild = import.meta.env.VITE_RESTRICTED_BUILD === 'true';
+  const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
+  const isRestricted = isRestrictedBuild || isRestrictedMiCa;
+
+  // First check if restricted build
+  if (isRestricted && restrictedIntents.includes(intent)) {
+    return false;
+  }
+  // Then check if widget is supported on current chain
+  const supportedIntents = CHAIN_WIDGET_MAP[chainId] || [];
+
+  return supportedIntents.includes(intent);
 }

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -3,13 +3,7 @@ import { Intent } from '@/lib/enums';
 import { useLingui } from '@lingui/react';
 import { useCustomConnectModal } from '@/modules/ui/hooks/useCustomConnectModal';
 import { useAddRecentTransaction } from '@rainbow-me/rainbowkit';
-import {
-  CHAIN_WIDGET_MAP,
-  COMING_SOON_MAP,
-  mapIntentToQueryParam,
-  QueryParams,
-  restrictedIntents
-} from '@/lib/constants';
+import { COMING_SOON_MAP, mapIntentToQueryParam, QueryParams } from '@/lib/constants';
 import { WidgetNavigation } from '@/modules/app/components/WidgetNavigation';
 import { withErrorBoundary } from '@/modules/utils/withErrorBoundary';
 import { DualSwitcher } from '@/components/DualSwitcher';
@@ -32,6 +26,7 @@ import { getSupportedChainIds, getMainnetChainName } from '@/data/wagmi/config/c
 import { useSearchParams } from 'react-router-dom';
 import { useChains } from 'wagmi';
 import { useBalanceFilters } from '@/modules/ui/context/BalanceFiltersContext';
+import { isIntentAllowed } from '@/lib/utils';
 
 export type WidgetContent = [
   Intent,
@@ -59,8 +54,6 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
   const locale = i18n.locale;
 
   const isRestrictedBuild = import.meta.env.VITE_RESTRICTED_BUILD === 'true';
-  const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
-  const isRestricted = isRestrictedBuild || isRestrictedMiCa;
   const referralCode = Number(import.meta.env.VITE_REFERRAL_CODE) || 0; // fallback to 0 if invalid
 
   const rightHeaderComponent = <DualSwitcher />;
@@ -152,15 +145,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
 
   return (
     <WidgetNavigation
-      widgetContent={widgetContent.filter(([widgetIntent]) => {
-        // First check if restricted build
-        if (isRestricted && restrictedIntents.includes(widgetIntent)) {
-          return false;
-        }
-        // Then check if widget is supported on current chain
-        const supportedIntents = CHAIN_WIDGET_MAP[chainId] || [];
-        return supportedIntents.includes(widgetIntent);
-      })}
+      widgetContent={widgetContent.filter(([widgetIntent]) => isIntentAllowed(widgetIntent, chainId))}
       intent={intent}
     >
       {children}

--- a/apps/webapp/src/modules/chat/hooks/useSendMessage.tsx
+++ b/apps/webapp/src/modules/chat/hooks/useSendMessage.tsx
@@ -5,7 +5,7 @@ import { useChatContext } from '../context/ChatContext';
 import { CHATBOT_NAME, MessageType, UserType } from '../constants';
 import { generateUUID } from '../lib/generateUUID';
 import { t } from '@lingui/macro';
-import { chainIdNameMapping } from '../lib/intentUtils';
+import { chainIdNameMapping, isChatIntentAllowed } from '../lib/intentUtils';
 
 interface ChatbotResponse {
   chatResponse: {
@@ -99,6 +99,8 @@ export const useSendMessage = () => {
       },
       {
         onSuccess: data => {
+          const intents = data.intents?.filter(chatIntent => isChatIntentAllowed(chatIntent, chainId));
+
           setChatHistory(prevHistory => {
             return prevHistory[prevHistory.length - 1].type === CANCELED
               ? prevHistory
@@ -108,7 +110,7 @@ export const useSendMessage = () => {
                     id: generateUUID(),
                     user: UserType.bot,
                     message: data.response,
-                    intents: data.intents
+                    intents
                   }
                 ];
           });
@@ -131,6 +133,7 @@ export const useSendMessage = () => {
         }
       }
     );
+
     setChatHistory(prevHistory => [
       ...prevHistory,
       { id: generateUUID(), user: UserType.user, message },

--- a/apps/webapp/src/modules/chat/lib/confirmationWarningMetadata.ts
+++ b/apps/webapp/src/modules/chat/lib/confirmationWarningMetadata.ts
@@ -32,7 +32,7 @@ export const getConfirmationWarningMetadata = (intent?: ChatIntent) => {
     CONFIRMATION_WARNING_METADATA[intent.intent_id] || {
       description: 'You are about to execute a transaction suggested by our AI chatbot.',
       disclaimer:
-        'Please be aware that while we strive to provide accurate and helpful suggestions, you&apos;re solely responsible for reviewing and implementing any recommended actions. We do not guarantee the accuracy or completeness of the AI&apos;s suggestions and disclaim any liability for consequences arising from your use of this feature.'
+        "Please be aware that while we strive to provide accurate and helpful suggestions, you're solely responsible for reviewing and implementing any recommended actions. We do not guarantee the accuracy or completeness of the AI's suggestions and disclaim any liability for consequences arising from your use of this feature."
     }
   );
 };

--- a/apps/webapp/src/modules/chat/lib/intentUtils.ts
+++ b/apps/webapp/src/modules/chat/lib/intentUtils.ts
@@ -1,5 +1,5 @@
 import { Chain } from 'wagmi/chains';
-import { QueryParams } from '@/lib/constants';
+import { COMING_SOON_MAP, QueryParams } from '@/lib/constants';
 import { ChatIntent } from '../types/Chat';
 import { Intent } from '@/lib/enums';
 import { isIntentAllowed } from '@/lib/utils';
@@ -112,19 +112,21 @@ export const isChatIntentAllowed = (intent: ChatIntent, currentChainId: number):
       return false; // Widget name is not recognized
     }
 
-    // If network parameter exists, validate and use it
+    // In case the network param is missing, we use the current chainId as fallback
+    let chainIdToCheck: number = currentChainId;
+
+    // If the network param is present and it's a valid network, we use the mapped chainId
     if (intentNetwork) {
       const mappedChainId = networkMapping[intentNetwork as keyof typeof networkMapping];
       if (mappedChainId === undefined) {
         // Invalid network param value, intent is not allowed
         return false;
       }
-      // Network is valid, check allowance using the mapped chainId
-      return isIntentAllowed(intentEnum, mappedChainId);
+      chainIdToCheck = mappedChainId;
     }
-
-    // Network parameter is missing, check allowance using the current chainId
-    return isIntentAllowed(intentEnum, currentChainId);
+    return (
+      isIntentAllowed(intentEnum, chainIdToCheck) && !COMING_SOON_MAP[chainIdToCheck]?.includes(intentEnum)
+    );
   } catch (error) {
     console.error('Failed to parse intent URL or check allowance:', error);
     return false;


### PR DESCRIPTION
The chatbot may return a list of suggested actions that aren't allowed either for the network or if we're in a restricted build. This PR filters those intents before presenting them to the user.

Examples: 

- Upgrade on base
- Trade on MiCa builds
- Rewards on L2s (from the coming soon map)
