### PR TITLE
Add hooks to retrieve seal migrations

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -125,6 +125,9 @@ export { usePositionsAtRisk } from './seal/usePositionsAtRisk';
 export { useTotalUserSealed } from './seal/useTotalUserSealed';
 export { useSealRewardsData } from './seal/useSealRewardsData';
 export { useSealHistoricData } from './seal/useSealHistoricData';
+export { useIsUrnMigrated } from './seal/useIsUrnMigrated';
+export { useSealMigrations } from './seal/useSealMigrations';
+export { checkUrnMigrationStatus } from './seal/checkUrnMigrationStatus';
 
 //Vaults
 export { useVault } from './vaults/useVault';

--- a/packages/hooks/src/seal/checkUrnMigrationStatus.ts
+++ b/packages/hooks/src/seal/checkUrnMigrationStatus.ts
@@ -1,0 +1,17 @@
+import { SealMigration } from './sealModule';
+
+export function checkUrnMigrationStatus(
+  migrations: SealMigration[] | undefined | null,
+  oldUrnIndex: number
+): { isMigrated: boolean; migrationDetails: SealMigration | undefined } {
+  if (!migrations || migrations.length === 0) {
+    return { isMigrated: false, migrationDetails: undefined };
+  }
+
+  const migration = migrations.find(m => m.oldIndex === oldUrnIndex.toString());
+
+  return {
+    isMigrated: !!migration,
+    migrationDetails: migration
+  };
+}

--- a/packages/hooks/src/seal/sealModule.d.ts
+++ b/packages/hooks/src/seal/sealModule.d.ts
@@ -108,3 +108,21 @@ export type SealPosition = {
   selectedReward: string | undefined;
   barks: Bark[];
 };
+
+export type SealMigrationRaw = {
+  id: `0x${string}`;
+  oldOwner: `0x${string}`;
+  newOwner: `0x${string}`;
+  oldIndex: string;
+  newIndex: string;
+  ink: string;
+  debt: string;
+  blockNumber: string;
+  blockTimestamp: string;
+  transactionHash: `0x${string}`;
+};
+
+export type SealMigration = SealMigrationRaw & {
+  ink: bigint;
+  debt: bigint;
+};

--- a/packages/hooks/src/seal/useIsUrnMigrated.ts
+++ b/packages/hooks/src/seal/useIsUrnMigrated.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { ReadHook } from '../hooks';
+import { SealMigration } from './sealModule';
+import { useSealMigrations } from './useSealMigrations';
+
+export function useIsUrnMigrated({
+  owner,
+  oldUrnIndex,
+  subgraphUrl
+}: {
+  owner: `0x${string}`;
+  oldUrnIndex: number;
+  subgraphUrl?: string;
+}): ReadHook & { isMigrated: boolean; migrationDetails: SealMigration | undefined } {
+  const {
+    data: migrations,
+    isLoading,
+    error,
+    mutate,
+    dataSources
+  } = useSealMigrations({ owner, subgraphUrl });
+
+  const { isMigrated, migrationDetails } = useMemo(() => {
+    if (!migrations || migrations.length === 0) {
+      return { isMigrated: false, migrationDetails: undefined };
+    }
+
+    const migration = migrations.find(m => m.oldIndex === oldUrnIndex.toString());
+
+    return {
+      isMigrated: !!migration,
+      migrationDetails: migration
+    };
+  }, [migrations, oldUrnIndex]);
+
+  return {
+    isLoading,
+    isMigrated,
+    migrationDetails,
+    error,
+    mutate,
+    dataSources
+  };
+}

--- a/packages/hooks/src/seal/useIsUrnMigrated.ts
+++ b/packages/hooks/src/seal/useIsUrnMigrated.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { ReadHook } from '../hooks';
 import { SealMigration } from './sealModule';
 import { useSealMigrations } from './useSealMigrations';
+import { checkUrnMigrationStatus } from './checkUrnMigrationStatus';
 
 export function useIsUrnMigrated({
   owner,
@@ -20,18 +21,10 @@ export function useIsUrnMigrated({
     dataSources
   } = useSealMigrations({ owner, subgraphUrl });
 
-  const { isMigrated, migrationDetails } = useMemo(() => {
-    if (!migrations || migrations.length === 0) {
-      return { isMigrated: false, migrationDetails: undefined };
-    }
-
-    const migration = migrations.find(m => m.oldIndex === oldUrnIndex.toString());
-
-    return {
-      isMigrated: !!migration,
-      migrationDetails: migration
-    };
-  }, [migrations, oldUrnIndex]);
+  const { isMigrated, migrationDetails } = useMemo(
+    () => checkUrnMigrationStatus(migrations, oldUrnIndex),
+    [migrations, oldUrnIndex]
+  );
 
   return {
     isLoading,

--- a/packages/hooks/src/seal/useSealMigrations.ts
+++ b/packages/hooks/src/seal/useSealMigrations.ts
@@ -1,0 +1,77 @@
+import request, { gql } from 'graphql-request';
+import { useChainId } from 'wagmi';
+import { getMakerSubgraphUrl } from '../helpers/getSubgraphUrl';
+import { useQuery } from '@tanstack/react-query';
+import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
+import { ReadHook } from '../hooks';
+import { SealMigrationRaw, SealMigration } from './sealModule';
+
+async function fetchSealMigrations(urlSubgraph: string, owner: `0x${string}`) {
+  const query = gql`
+    {
+      lockstakeMigrates(where: { oldOwner: "${owner}" }, orderBy: oldIndex, orderDirection: asc) {
+        id
+        oldOwner
+        newOwner
+        oldIndex
+        newIndex
+        ink
+        debt
+        blockNumber
+        blockTimestamp
+        transactionHash
+      }
+    }
+  `;
+
+  const response = await request<{
+    lockstakeMigrates: SealMigrationRaw[];
+  }>(urlSubgraph, query);
+  const parsedSealMigrations = response.lockstakeMigrates;
+  if (!parsedSealMigrations) {
+    return undefined;
+  }
+
+  return parsedSealMigrations.map(migration => ({
+    ...migration,
+    ink: BigInt(migration.ink || 0),
+    debt: BigInt(migration.debt || 0)
+  })) as SealMigration[];
+}
+
+export function useSealMigrations({
+  owner,
+  subgraphUrl
+}: {
+  owner: `0x${string}`;
+  subgraphUrl?: string;
+}): ReadHook & { data: SealMigration[] | undefined } {
+  const chainId = useChainId();
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getMakerSubgraphUrl(chainId) || '';
+
+  const {
+    data,
+    error,
+    refetch: mutate,
+    isLoading
+  } = useQuery({
+    queryKey: ['sealMigrations', urlSubgraph, owner],
+    queryFn: () => fetchSealMigrations(urlSubgraph, owner),
+    enabled: !!urlSubgraph && !!owner
+  });
+
+  return {
+    isLoading,
+    data,
+    error,
+    mutate,
+    dataSources: [
+      {
+        title: 'Sky Ecosystem subgraph',
+        href: urlSubgraph,
+        onChain: false,
+        trustLevel: TRUST_LEVELS[TrustLevelEnum.ONE]
+      }
+    ]
+  };
+}


### PR DESCRIPTION
There are some assumption that might need to be updated in the future.

- useSealMigrations: Returns all migrations from the same owner
- useIsUrnMigrated: Check if a urn index has been migrated
