### PR TITLE
Enable multi injected provider discovery

### DIFF
--- a/apps/integration-ui/src/modules/providers/wagmi.ts
+++ b/apps/integration-ui/src/modules/providers/wagmi.ts
@@ -81,7 +81,7 @@ export const getWagmiClientAndChains = (appName: string): Config => {
       [tenderlyBase.id]: http(import.meta.env.VITE_PUBLIC_RPC_PROVIDER_TENDERLY_BASE || ''),
       [tenderlyArbitrum.id]: http(import.meta.env.VITE_PUBLIC_RPC_PROVIDER_TENDERLY_ARBITRUM || '')
     },
-    multiInjectedProviderDiscovery: false
+    multiInjectedProviderDiscovery: true
   });
 
   return wagmiConfig;

--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -6,8 +6,7 @@ import {
   rainbowWallet,
   walletConnectWallet,
   metaMaskWallet,
-  coinbaseWallet,
-  injectedWallet
+  coinbaseWallet
 } from '@rainbow-me/rainbowkit/wallets';
 import {
   TENDERLY_CHAIN_ID,
@@ -83,14 +82,7 @@ const connectors = connectorsForWallets(
   [
     {
       groupName: 'Suggested',
-      wallets: [
-        metaMaskWallet,
-        coinbaseWallet,
-        walletConnectWallet,
-        rainbowWallet,
-        safeWallet,
-        injectedWallet
-      ]
+      wallets: [metaMaskWallet, coinbaseWallet, walletConnectWallet, rainbowWallet, safeWallet]
     }
   ],
   {
@@ -111,7 +103,7 @@ export const wagmiConfigDev = createConfig({
     [sepolia.id]: http(import.meta.env.VITE_RPC_PROVIDER_SEPOLIA || ''),
     [tenderlyArbitrum.id]: http(import.meta.env.VITE_RPC_PROVIDER_TENDERLY_ARBITRUM || '')
   },
-  multiInjectedProviderDiscovery: false,
+  multiInjectedProviderDiscovery: true,
   storage: createStorage({
     storage: typeof window !== 'undefined' && window.localStorage ? window.localStorage : noopStorage,
     key: 'wagmi-dev'
@@ -126,7 +118,7 @@ export const wagmiConfigMainnet = createConfig({
     [base.id]: http(import.meta.env.VITE_RPC_PROVIDER_BASE || ''),
     [arbitrum.id]: http(import.meta.env.VITE_RPC_PROVIDER_ARBITRUM || '')
   },
-  multiInjectedProviderDiscovery: false
+  multiInjectedProviderDiscovery: true
 });
 
 export const getSupportedChainIds = (chainId: number) => {

--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -103,6 +103,8 @@ export const wagmiConfigDev = createConfig({
     [sepolia.id]: http(import.meta.env.VITE_RPC_PROVIDER_SEPOLIA || ''),
     [tenderlyArbitrum.id]: http(import.meta.env.VITE_RPC_PROVIDER_TENDERLY_ARBITRUM || '')
   },
+  // This was causing issues in the past when users tried to connect to the Safe connector and had the Phantom wallet installed
+  // due to how Phantom handled `eth_accounts` requests, resulting in the Safe connector hanging in a reconnecting state
   multiInjectedProviderDiscovery: true,
   storage: createStorage({
     storage: typeof window !== 'undefined' && window.localStorage ? window.localStorage : noopStorage,


### PR DESCRIPTION
### What does this PR do?
- Since the issue with Phantom wallet seems to be fixed, we can enable back the `multiInjectedProviderDiscovery` functionality, to allow users to connect with any extension wallet installed

### Testing steps:
