### PR TITLE
Add log error when execute is called with no simulation data

### DIFF
--- a/.changeset/fresh-eyes-dress.md
+++ b/.changeset/fresh-eyes-dress.md
@@ -1,0 +1,5 @@
+---
+'@jetstreamgg/hooks': patch
+---
+
+Add log error when useWriteContractFlow.execute() is called before the simulation is ready

--- a/packages/hooks/src/shared/useWriteContractFlow.ts
+++ b/packages/hooks/src/shared/useWriteContractFlow.ts
@@ -125,6 +125,13 @@ export function useWriteContractFlow<
     execute: () => {
       if (simulationData?.request) {
         writeContract(simulationData.request);
+      } else {
+        console.log(`ERROR: the contract interaction was triggered before the call was ready.
+          contract address: ${useSimulateContractParamters.address}
+          function name: ${useSimulateContractParamters.functionName}
+          function arguments: ${useSimulateContractParamters.args}
+          isSimulationLoading: ${isSimulationLoading}
+          simulationError: ${simulationError}`);
       }
     },
     data: txHash,

--- a/packages/hooks/src/shared/useWriteContractFlow.ts
+++ b/packages/hooks/src/shared/useWriteContractFlow.ts
@@ -131,7 +131,8 @@ export function useWriteContractFlow<
           function name: ${useSimulateContractParamters.functionName}
           function arguments: ${useSimulateContractParamters.args}
           isSimulationLoading: ${isSimulationLoading}
-          simulationError: ${simulationError}`);
+          simulationError: ${simulationError}
+          enabled: ${enabled}`);
       }
     },
     data: txHash,


### PR DESCRIPTION
### What does this PR do?
Previously we checked if the `simulationData.request` was defined in order to call `writeContract()`, but if it wasn't defined, the function would return silently, making debugging errors more difficult. This PR adds an error log when `useWriteContractFlow.execute()` is called while `simulationData.request` is undefined