### PR TITLE
Show selected reward and delegate in the Stake flow

### DIFF
--- a/packages/widgets/src/widgets/SealModuleWidget/components/PositionDetail.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/PositionDetail.tsx
@@ -248,12 +248,12 @@ const MigrateButton = ({
   const { data: vaultData } = useVault(urnAddress || ZERO_ADDRESS);
 
   const handleOnClick = useCallback(() => {
-    if (vaultData?.collateralAmount && urnSelectedRewardContract) {
+    if (urnAddress && urnAddress !== ZERO_ADDRESS && urnSelectedRewardContract) {
       setSelectedRewardContract(urnSelectedRewardContract);
     } else {
       setSelectedRewardContract(undefined);
     }
-    if (vaultData?.collateralAmount && urnSelectedVoteDelegate) {
+    if (urnAddress && urnAddress !== ZERO_ADDRESS && urnSelectedVoteDelegate) {
       setSelectedDelegate(urnSelectedVoteDelegate);
     } else {
       setSelectedDelegate(undefined);

--- a/packages/widgets/src/widgets/SealModuleWidget/components/UrnPosition.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/UrnPosition.tsx
@@ -87,12 +87,12 @@ export const UrnPosition: React.FC<UrnPositionProps> = ({
   };
 
   const handleOnClick = useCallback(() => {
-    if (vaultData?.collateralAmount && urnSelectedRewardContract) {
+    if (urnAddress && urnAddress !== ZERO_ADDRESS && urnSelectedRewardContract) {
       setSelectedRewardContract(urnSelectedRewardContract);
     } else {
       setSelectedRewardContract(undefined);
     }
-    if (vaultData?.collateralAmount && urnSelectedVoteDelegate) {
+    if (urnAddress && urnAddress !== ZERO_ADDRESS && urnSelectedVoteDelegate) {
       setSelectedDelegate(urnSelectedVoteDelegate);
     } else {
       setSelectedDelegate(undefined);

--- a/packages/widgets/src/widgets/SealModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/index.tsx
@@ -919,12 +919,12 @@ function SealModuleWidgetWrapped({
       !!externalParamUrnAddress
     ) {
       // Navigate to the Urn
-      if (externalParamVaultData?.collateralAmount && externalUrnRewardContract) {
+      if (!!externalParamVaultData && externalUrnRewardContract) {
         setSelectedRewardContract(externalUrnRewardContract);
       } else {
         setSelectedRewardContract(undefined);
       }
-      if (externalParamVaultData?.collateralAmount && externalUrnVoteDelegate) {
+      if (!!externalParamVaultData && externalUrnVoteDelegate) {
         setSelectedDelegate(externalUrnVoteDelegate);
       } else {
         setSelectedDelegate(undefined);

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/UrnPosition.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/UrnPosition.tsx
@@ -87,12 +87,12 @@ export const UrnPosition: React.FC<UrnPositionProps> = ({
   };
 
   const handleOnClick = useCallback(() => {
-    if (vaultData?.collateralAmount && urnSelectedRewardContract) {
+    if (urnAddress && urnAddress !== ZERO_ADDRESS && urnSelectedRewardContract) {
       setSelectedRewardContract(urnSelectedRewardContract);
     } else {
       setSelectedRewardContract(undefined);
     }
-    if (vaultData?.collateralAmount && urnSelectedVoteDelegate) {
+    if (urnAddress && urnAddress !== ZERO_ADDRESS && urnSelectedVoteDelegate) {
       setSelectedDelegate(urnSelectedVoteDelegate);
     } else {
       setSelectedDelegate(undefined);

--- a/packages/widgets/src/widgets/StakeModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/index.tsx
@@ -629,13 +629,13 @@ function StakeModuleWidgetWrapped({
     }
 
     // Set up the urn state
-    if (externalParamVaultData?.collateralAmount && externalUrnRewardContract) {
+    if (!!externalParamVaultData && externalUrnRewardContract) {
       setSelectedRewardContract(externalUrnRewardContract);
     } else {
       setSelectedRewardContract(undefined);
     }
 
-    if (externalParamVaultData?.collateralAmount && externalUrnVoteDelegate) {
+    if (!!externalParamVaultData && externalUrnVoteDelegate) {
       setSelectedDelegate(externalUrnVoteDelegate);
     } else {
       setSelectedDelegate(undefined);


### PR DESCRIPTION
Display the already selected reward and delegate in the Stake widget during the wizard flow
Apply the same change to Seal