### PR TITLE
Add test in seal migration flow for when the old engine is already hoped

### DIFF
--- a/apps/webapp/src/test/e2e/tests/seal-migration.spec.ts
+++ b/apps/webapp/src/test/e2e/tests/seal-migration.spec.ts
@@ -160,3 +160,72 @@ test('Resume migration flow with a Staking position already created', async ({ p
   await expect(page.getByText('2,400,000 SKY')).toBeVisible(); // 100 MKR * 24,000 = 2,400,000
   await expect(page.getByText('38,000 USDS')).toBeVisible();
 });
+
+test('Resume migration flow with a Staking position already created and OldEngine already hoped', async ({
+  page
+}) => {
+  /*
+   * Set up new Staking position
+   */
+  // Migrate about
+  await page.getByRole('button', { name: 'Migrate Position' }).click();
+  await page.getByRole('checkbox').click();
+  await page.getByTestId('widget-button').first().click();
+
+  // select rewards
+  await expect(page.getByText('Choose your reward token')).toBeVisible();
+  await page.getByRole('button', { name: 'USDS' }).click();
+  await expect(page.getByTestId('widget-button').first()).toBeEnabled();
+  await page.getByTestId('widget-button').first().click();
+
+  // select delegate
+  await expect(page.getByText('Choose your delegate')).toBeVisible();
+  await page.getByRole('button', { name: '0x8779' }).click();
+  await expect(page.getByTestId('widget-button').first()).toBeEnabled();
+  await page.getByTestId('widget-button').first().click();
+
+  // Open staking position
+  await approveOrPerformAction(page, 'Submit');
+  await expect(page.getByText('Your staking position is now active. Next, start migration.')).toBeVisible();
+
+  // Approve migration contract
+  await approveOrPerformAction(page, "Let's now start the migration process");
+  await expect(page.getByText('In progress')).toBeVisible();
+  await expect(page.getByText('Migration contract approved')).toBeVisible();
+
+  /*
+   * Now reload page and attempt to resume the migration flow with the already created staking position
+   */
+  await page.goto('/seal-engine');
+  await connectMockWalletAndAcceptTerms(page);
+
+  // Migrate about
+  await page.getByRole('button', { name: 'Migrate Position' }).click();
+
+  await expect(page.getByTestId('migrate-from-card').getByText('Seal Position 1')).toBeVisible();
+  await expect(page.getByTestId('migrate-from-card').getByText('100 MKR')).toBeVisible();
+  await expect(page.getByTestId('migrate-from-card').getByText('38,000 USDS')).toBeVisible();
+  // The data about the previously created staking position is visible
+  await expect(page.getByTestId('migrate-to-card').getByText('Staking Position 1')).toBeVisible();
+  await expect(page.getByTestId('migrate-to-card').getByText('100 MKR')).toBeVisible();
+  await expect(page.getByTestId('migrate-to-card').getByText('2,400,000 SKY')).toBeVisible();
+  await expect(page.getByTestId('migrate-to-card').getByText('38,000 USDS')).toBeVisible();
+
+  await page.getByRole('checkbox').click();
+
+  // Continue - Approve migration contract should be skipped, we already approved it
+  // Execute migration
+  await approveOrPerformAction(page, 'Continue to migrate');
+  await expect(page.getByText('Confirm your migration')).toBeVisible();
+  await expect(page.getByText('In progress')).toBeVisible();
+  await expect(page.getByText('Success!')).toBeVisible();
+
+  // Successful migration, now go to check position
+  await page.goto('/?widget=stake');
+  await connectMockWalletAndAcceptTerms(page);
+
+  // Check that position 1 exists in stake module, and check the balances are the same than in the old seal position
+  await expect(page.getByText('Position 1')).toBeVisible();
+  await expect(page.getByText('2,400,000 SKY')).toBeVisible(); // 100 MKR * 24,000 = 2,400,000
+  await expect(page.getByText('38,000 USDS')).toBeVisible();
+});

--- a/apps/webapp/src/test/e2e/utils/approveOrPerformAction.ts
+++ b/apps/webapp/src/test/e2e/utils/approveOrPerformAction.ts
@@ -16,7 +16,8 @@ export type Action =
   | 'Confirm'
   | 'Submit'
   | "Let's now start the migration process"
-  | 'Migrate';
+  | 'Migrate'
+  | 'Continue to migrate';
 
 type approveOrPerformActionOptions = {
   reject?: boolean;

--- a/packages/widgets/src/widgets/SealModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/index.tsx
@@ -330,7 +330,7 @@ function SealModuleWidgetWrapped({
       console.log(error);
     },
     // TODO: criteria should be old hope, new hope and new index
-    enabled: !!newStakeUrn?.urnIndex
+    enabled: newStakeUrn?.urnIndex !== undefined
   });
 
   const lockMkrApprove = useSaMkrApprove({
@@ -750,6 +750,13 @@ function SealModuleWidgetWrapped({
         (widgetState.flow === SealFlow.MIGRATE &&
           currentStep === SealStep.HOPE_OLD &&
           txStatus === TxStatus.SUCCESS &&
+          !migrate.prepared) ||
+        // Disable next button if `migrate` is not prepared where resuming migration after approving migration contract
+        (widgetState.flow === SealFlow.MIGRATE &&
+          currentStep === SealStep.ABOUT &&
+          txStatus === TxStatus.IDLE &&
+          !needsNewUrnAuth &&
+          !needsOldUrnAuth &&
           !migrate.prepared) ||
         (currentStep === SealStep.OPEN_BORROW && (!isLockCompleted || !isBorrowCompleted)) ||
         (currentStep === SealStep.REWARDS && !isSelectRewardContractCompleted) ||

--- a/packages/widgets/src/widgets/SealModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/index.tsx
@@ -785,7 +785,9 @@ function SealModuleWidgetWrapped({
     txStatus,
     newStakeUrn?.urnIndex,
     hope.prepared,
-    migrate.prepared
+    migrate.prepared,
+    needsNewUrnAuth,
+    needsOldUrnAuth
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
- Disable next button if `migrate` is not prepared where resuming migration after approving migration contract
- Add test in seal migration flow for when the old engine is already hoped, so it starts directly in the migration step, skipping the approval.  
