### PR TITLE
Multiple updates in Staking engine and Seal

### DIFF
--- a/apps/webapp/src/modules/stake/components/StakePositionOverview.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionOverview.tsx
@@ -3,7 +3,7 @@ import {
   getIlkName,
   RiskLevel,
   // TOKENS,
-  useSealPosition,
+  useStakePosition,
   useStakeUrnAddress,
   // useUrnAddress,
   useVault,
@@ -41,7 +41,7 @@ export function StakePositionOverview({
   positionIndex: number;
 }): React.ReactElement | null {
   const chainId = useChainId();
-  const { data, isLoading, error } = useSealPosition({ urnIndex: positionIndex });
+  const { data, isLoading, error } = useStakePosition({ urnIndex: positionIndex });
   const { data: urnAddress, isLoading: urnAddressLoading } = useStakeUrnAddress(BigInt(positionIndex));
   const {
     data: vault,

--- a/apps/webapp/src/modules/stake/components/StakeRewardsOverview.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeRewardsOverview.tsx
@@ -8,8 +8,8 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import {
   useRewardContractTokens,
   useRewardsChartInfo,
-  useSaRewardContracts,
-  useSealHistoricData
+  useStakeRewardContracts,
+  useSealHistoricData // TODO: This is being updated in a separate PR
 } from '@jetstreamgg/hooks';
 import { formatAddress, formatNumber } from '@jetstreamgg/utils';
 import { t } from '@lingui/core/macro';
@@ -99,7 +99,7 @@ const StakeRewardsOverviewRow = ({ contractAddress }: { contractAddress: `0x${st
 };
 
 export function StakeRewardsOverview() {
-  const { data, isLoading, error } = useSaRewardContracts();
+  const { data, isLoading, error } = useStakeRewardContracts();
 
   return (
     <LoadingErrorWrapper

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -148,6 +148,7 @@ export { useStakeSkyAllowance, useStakeUsdsAllowance } from './stake/useStakeAll
 export { useStakeSkyApprove, useStakeUsdsApprove } from './stake/useStakeApprove';
 export { useClaimRewards as useStakeClaimRewards } from './stake/useClaimRewards';
 export { useStakeRewardsData } from './stake/useStakeRewardsData';
+export { useStakePosition } from './stake/useStakePosition';
 export * from './stake/calldata';
 
 //Vaults

--- a/packages/hooks/src/stake/stakeModule.d.ts
+++ b/packages/hooks/src/stake/stakeModule.d.ts
@@ -102,7 +102,7 @@ export type Bark = {
 export type StakePosition = {
   owner: string;
   index: number;
-  mkrLocked: bigint;
+  skyLocked: bigint;
   usdsDebt: bigint;
   selectedDelegate: string | undefined;
   selectedReward: string | undefined;

--- a/packages/hooks/src/stake/useStakePosition.ts
+++ b/packages/hooks/src/stake/useStakePosition.ts
@@ -8,8 +8,8 @@ import { useAccount, useChainId } from 'wagmi';
 
 type StakePositionResponse = {
   // TODO: Update this to stakeUrns once the subgraph is updated
-  sealUrns: {
-    mkrLocked: string; // Update mkrLocked once the subgraph is updated
+  stakingUrns: {
+    skyLocked: string;
     usdsDebt: string;
     voteDelegate: {
       id: string;
@@ -30,8 +30,8 @@ async function fetchStakePosition(
   // TODO: Update this query once the subgraph is updated
   const query = gql`
     {
-      sealUrns(where: {owner: "${address}", index: "${urnIndex}"}) {
-        mkrLocked
+      stakingUrns(where: {owner: "${address}", index: "${urnIndex}"}) {
+        skyLocked
         usdsDebt
         voteDelegate {
           id
@@ -50,17 +50,17 @@ async function fetchStakePosition(
 
   const response: StakePositionResponse = await request(urlSubgraph, query);
 
-  if (!response.sealUrns || response.sealUrns.length === 0) return;
-  const { mkrLocked, usdsDebt, voteDelegate, reward } = response.sealUrns[0];
+  if (!response.stakingUrns || response.stakingUrns.length === 0) return;
+  const { skyLocked, usdsDebt, voteDelegate, reward } = response.stakingUrns[0];
 
   return {
     owner: address,
     index: urnIndex,
-    mkrLocked: BigInt(mkrLocked),
+    skyLocked: BigInt(skyLocked),
     usdsDebt: BigInt(usdsDebt),
     selectedDelegate: voteDelegate?.id,
     selectedReward: reward?.id,
-    barks: response.sealUrns[0].barks
+    barks: response.stakingUrns[0].barks
   };
 }
 

--- a/packages/widgets/src/widgets/SealModuleWidget/components/PositionDetail.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/PositionDetail.tsx
@@ -203,6 +203,7 @@ export function PositionDetail({
         onNavigateToMigratedUrn={onNavigateToMigratedUrn}
         sealedAmount={sealedAmount}
         onSealUrnChange={onSealUrnChange}
+        borrowedAmount={borrowedAmount}
       />
       <>
         {sealRewardContracts &&
@@ -227,13 +228,15 @@ const MigrateButton = ({
   index,
   // sealedAmount,
   onNavigateToMigratedUrn,
-  onSealUrnChange
+  onSealUrnChange,
+  borrowedAmount
 }: {
   isMigrated?: boolean;
   index: bigint;
   onNavigateToMigratedUrn?: (index?: bigint) => void;
   onSealUrnChange?: OnSealUrnChange;
   sealedAmount?: bigint;
+  borrowedAmount?: bigint;
 }) => {
   const { setWidgetState } = useContext(WidgetContext);
   const { setCurrentStep, setSelectedRewardContract, setSelectedDelegate, setActiveUrn } =
@@ -296,12 +299,20 @@ const MigrateButton = ({
   // }
 
   return (
-    <Button
-      variant="primaryAlt"
-      onClick={handleOnClick}
-      // disabled={!!rewardContractToClaim && indexToClaim !== undefined}
-    >
-      <Text>Migrate Position</Text>
-    </Button>
+    <VStack gap={3}>
+      {!borrowedAmount && (
+        <Text variant="captionSm" className="text-warning text-center">
+          Note: It will be more gas-efficient to manually close this position and open a new one in the
+          Staking Engine.
+        </Text>
+      )}
+      <Button
+        variant="primaryAlt"
+        onClick={handleOnClick}
+        // disabled={!!rewardContractToClaim && indexToClaim !== undefined}
+      >
+        <Text>Migrate Position</Text>
+      </Button>
+    </VStack>
   );
 };

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
@@ -187,15 +187,6 @@ export const PositionSummary = () => {
   const lineItems = useMemo(() => {
     return [
       {
-        label: t`Exit fee`,
-        updated: hasPositions && skyToFree > 0n,
-        value:
-          hasPositions && skyToFree > 0n && typeof exitFee === 'bigint'
-            ? [`${Number(formatUnits(skyToFree * exitFee, WAD_PRECISION * 2)).toFixed(2)} SKY`]
-            : '',
-        icon: <TokenIcon token={TOKENS.sky} className="h-5 w-5" />
-      },
-      {
         label: getStakeLabel(existingVault?.collateralAmount, updatedVault?.collateralAmount),
         updated:
           hasPositions && isUpdatedValue(existingVault?.collateralAmount, updatedVault?.collateralAmount),

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/Repay.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/Repay.tsx
@@ -129,24 +129,6 @@ const PositionManagerOverviewContainer = ({
               : `${formatBigInt(newCollateralAmount)}  SKY`
         },
         {
-          label: t`Exit fee`,
-          value:
-            hasPositions && typeof exitFee === 'bigint'
-              ? [
-                  `${formatBigInt((existingColAmount - newCollateralAmount) * exitFee, {
-                    unit: WAD_PRECISION * 2
-                  })} SKY`
-                ]
-              : ''
-        },
-        {
-          label: t`Exit fee percentage`,
-          value:
-            hasPositions && typeof exitFee === 'bigint'
-              ? [`${Number(formatUnits(exitFee * 100n, WAD_PRECISION)).toFixed(2)}%`]
-              : ''
-        },
-        {
           label: t`You borrowed`,
           value:
             hasPositions && newBorrowAmount !== existingBorrowAmount


### PR DESCRIPTION
- Removes reference of the exit fee in the Staking engine
- For positions with no debt, show a message re gas-efficiency
- Add "Staking Rewards overview" section to Staking details
- Add "Accrued staking rewards" to stake position details

### Removes reference of the exit fee in the Staking engine
<img width="405" alt="image" src="https://github.com/user-attachments/assets/5e3e0a51-2d56-4516-b704-608720f00d3c" />

### For positions with no debt, show a message re gas-efficiency
#### Without debt
<img width="392" alt="image" src="https://github.com/user-attachments/assets/3ce0b69f-323b-417d-8f43-45786078bd39" />

#### With debt
<img width="392" alt="image" src="https://github.com/user-attachments/assets/27204aaa-105b-47ef-85af-682c6a47140a" />


### Add "Staking Rewards overview" section to Staking details

<img width="897" alt="image" src="https://github.com/user-attachments/assets/9df5f4de-7580-436c-8f89-cd6625ac53d5" />

### Add "Accrued staking rewards" to stake position details
<img width="937" alt="image" src="https://github.com/user-attachments/assets/6326dcf1-5f04-4a63-a388-5fc38ad122fe" />

