### PR TITLE
Add app.safe.global to the allowed domains in CORS

### DIFF
--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -80,7 +80,14 @@ export default ({ mode }: { mode: modeEnum }) => {
   return defineConfig({
     server: {
       // vite default is 5173
-      port: 3000
+      port: 3000,
+      cors: {
+        origin: [
+          // Default option, allows localhost, 127.0.0.1 and ::1
+          /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
+          'https://app.safe.global'
+        ]
+      }
     },
     preview: {
       port: 3000


### PR DESCRIPTION
### What does this PR do?
Set up the CORS option for the dev server by using the default, but adding `app.safe.global` to enable compatibility with the safe app

Fixes the issue where the safe app was failing to load the manifest due to CORS errors
