### PR TITLE
Use dynamic lockstake migrator address for hope calldata generation

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -257,6 +257,7 @@ export {
   useReadPsm3L2Pocket,
   useReadPsm3L2PreviewSwapExactIn,
   useReadPsm3L2PreviewSwapExactOut,
-  lsMkrUsdsRewardAddress
+  lsMkrUsdsRewardAddress,
+  lsMigratorAddress
 } from './generated';
 export { contracts, /*tenderlyContracts,*/ sepoliaContracts, l2Contracts } from './contracts';

--- a/packages/widgets/src/widgets/SealModuleWidget/context/context.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/context/context.tsx
@@ -14,7 +14,8 @@ import {
   TOKENS,
   useUrnSelectedRewardContract,
   useUrnSelectedVoteDelegate,
-  ZERO_ADDRESS
+  ZERO_ADDRESS,
+  lsMigratorAddress
 } from '@jetstreamgg/hooks';
 import {
   Dispatch,
@@ -30,11 +31,6 @@ import { SealFlow, SealStep } from '../lib/constants';
 import { OnSealUrnChange } from '../lib/types';
 import { WidgetContext } from '@widgets/context/WidgetContext';
 import { needsDelegateUpdate, needsRewardUpdate } from '../lib/utils';
-
-// TODO: need to import this from generated file
-const lsMigratorAddress = {
-  314310: '0xf4c5C29b14f0237131F7510A51684c8191f98E06'
-} as const;
 
 export interface SealModuleWidgetContextProps {
   isLockCompleted: boolean;
@@ -94,6 +90,7 @@ export interface SealModuleWidgetContextProps {
   generateAllCalldata: (
     ownerAddress: `0x${string}`,
     urnIndex: bigint,
+    chainId: number,
     referralCode?: number,
     newStakeUrnIndex?: bigint,
     newStakeUrnIndexAddress?: `0x${string}`
@@ -253,6 +250,7 @@ export const SealModuleWidgetProvider = ({ children }: { children: ReactNode }):
     (
       ownerAddress: `0x${string}`,
       urnIndex: bigint,
+      chainId: number,
       referralCode: number = 0,
       newStakeUrnIndex?: bigint,
       newStakeUrnIndexAddress?: `0x${string}`
@@ -341,8 +339,7 @@ export const SealModuleWidgetProvider = ({ children }: { children: ReactNode }):
           ? getSaHopeCalldata({
               ownerAddress,
               urnIndex: newStakeUrnIndex,
-              // TODO: make the address dynamic
-              usrAddress: lsMigratorAddress[314310]
+              usrAddress: lsMigratorAddress[chainId as keyof typeof lsMigratorAddress]
             })
           : undefined;
 

--- a/packages/widgets/src/widgets/SealModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/index.tsx
@@ -594,6 +594,7 @@ function SealModuleWidgetWrapped({
       const cd = generateAllCalldata(
         address,
         urnIndexForTransaction,
+        chainId,
         referralCode,
         newStakeUrn?.urnIndex,
         newStakeUrn?.urnAddress
@@ -607,7 +608,8 @@ function SealModuleWidgetWrapped({
     generateAllCalldata,
     referralCode,
     newStakeUrn?.urnIndex,
-    widgetState?.flow
+    widgetState?.flow,
+    chainId
   ]);
 
   // Update button state according to action and tx


### PR DESCRIPTION
Fixes a bug where attempting to migrate a position in mainnet would call hope with the Tenderly migrator address, causing the flow to get stuck in the first step