### PR TITLE
Fix: Clear input state when switching from Stake to Unstake tab

### DIFF
--- a/apps/webapp/src/modules/stake/components/StakeWidgetPane.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeWidgetPane.tsx
@@ -64,36 +64,44 @@ export function StakeWidgetPane(sharedProps: SharedProps) {
     stakeTab,
     originAmount
   }: WidgetStateChangeParams) => {
-    if (widgetState.flow) {
-      setSearchParams(prev => {
-        prev.set(QueryParams.Flow, widgetState.flow);
-        return prev;
-      });
-    }
+    const currentStakeTabParam = searchParams.get(QueryParams.StakeTab);
 
-    if (stakeTab) {
-      setSearchParams(prev => {
-        prev.set(QueryParams.StakeTab, stakeTab === StakeAction.FREE ? 'free' : 'lock'); // Example mapping
-        return prev;
-      });
-    } else if (stakeTab === '') {
-      setSearchParams(prev => {
-        prev.delete(QueryParams.StakeTab);
-        return prev;
-      });
-    }
+    setSearchParams(prev => {
+      const params = new URLSearchParams(prev);
+      if (widgetState.flow) {
+        params.set(QueryParams.Flow, widgetState.flow);
+      }
 
-    if (originAmount && originAmount !== '0') {
-      setSearchParams(prev => {
-        prev.set(QueryParams.InputAmount, originAmount);
-        return prev;
-      });
-    } else if (originAmount === '') {
-      setSearchParams(prev => {
-        prev.delete(QueryParams.InputAmount);
-        return prev;
-      });
-    }
+      const newStakeTabValue =
+        stakeTab === StakeAction.FREE ? 'free' : stakeTab === StakeAction.LOCK ? 'lock' : undefined;
+      let tabDidChange = false;
+
+      if (newStakeTabValue) {
+        if (currentStakeTabParam !== newStakeTabValue) {
+          params.delete(QueryParams.InputAmount); // Tab changed, remove input amount
+          tabDidChange = true;
+        }
+        params.set(QueryParams.StakeTab, newStakeTabValue);
+      } else if (stakeTab === '') {
+        // Explicitly clearing the tab
+        params.delete(QueryParams.StakeTab);
+        params.delete(QueryParams.InputAmount); // Tab cleared, remove input amount
+        tabDidChange = true; // Treat as a change for amount handling logic
+      }
+
+      // Update InputAmount based on originAmount, only if the tab didn't *just* change in this event
+      if (!tabDidChange) {
+        if (originAmount && originAmount !== '0') {
+          params.set(QueryParams.InputAmount, originAmount);
+        } else if (originAmount === '') {
+          // Explicitly empty string means clear
+          params.delete(QueryParams.InputAmount);
+        }
+        // If originAmount is undefined (not part of this event), InputAmount remains untouched unless tabDidChange was true
+      }
+
+      return params;
+    });
 
     // After a successful linked action open flow, set the final step to "success"
     if (


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where selecting 100% on the **Stake and Borrow** tab causes the same amount to persist when navigating to the **Unstake** tab. As a result, the Unstake tab is incorrectly prefilled with the previous amount, which can lead to unintended actions.

**Fix summary:**
- Refactored `StakeWidgetPane` to improve URL parameter handling for the stake tab and input amount  
- Consolidated state updates into a single `setSearchParams` call to prevent unintended state persistence

### Testing steps:

1. Navigate to an open Stake position  
2. Input an amount to borrow  
3. Switch to the **Unstake** tab  
4. Verify that the previous amount is no longer present
