### PR TITLE
Add migration toast

### DIFF
--- a/apps/webapp/src/modules/app/hooks/useGovernanceMigrationToast.tsx
+++ b/apps/webapp/src/modules/app/hooks/useGovernanceMigrationToast.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { toast } from '@/components/ui/use-toast';
+import { Text } from '@/modules/layout/components/Typography';
+import { VStack } from '@/modules/layout/components/VStack';
+import { Button } from '@/components/ui/button';
+import { ExternalLink } from '@/modules/layout/components/ExternalLink';
+
+const TOAST_STORAGE_KEY = 'governance-migration-notice-shown';
+
+export const useGovernanceMigrationToast = () => {
+  useEffect(() => {
+    const hasSeenToast = localStorage.getItem(TOAST_STORAGE_KEY);
+
+    if (!hasSeenToast) {
+      localStorage.setItem(TOAST_STORAGE_KEY, 'true');
+
+      toast({
+        title: (
+          <Text variant="medium" className="text-selectActive">
+            MKR to SKY Migration
+          </Text>
+        ),
+        description: (
+          <VStack className="mt-4 gap-4">
+            <Text variant="medium">
+              Sky Ecosystem Governance has voted to make SKY the sole governance token of the Sky Protocol.
+              MKR holders are encouraged to upgrade to SKY promptly to maintain access to Staking Rewards,
+              maintain the ability to participate in governance, and avoid the Delayed Upgrade Penalty.
+            </Text>
+            <Button className="place-self-start" variant="pill" size="xs">
+              <ExternalLink href="https://upgrademkrtosky.sky.money" showIcon={false}>
+                Visit MKR to SKY Upgrade Hub
+              </ExternalLink>
+            </Button>
+          </VStack>
+        ),
+        variant: 'info',
+        duration: 15000
+      });
+    }
+  }, []);
+};

--- a/apps/webapp/src/pages/App.tsx
+++ b/apps/webapp/src/pages/App.tsx
@@ -14,6 +14,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { ConnectedProvider } from '@/modules/ui/context/ConnectedContext';
 import { TermsModalProvider } from '@/modules/ui/context/TermsModalContext';
 import { BalanceFiltersProvider } from '@/modules/ui/context/BalanceFiltersContext';
+import { useGovernanceMigrationToast } from '@/modules/app/hooks/useGovernanceMigrationToast';
 
 import '@rainbow-me/rainbowkit/styles.css';
 import { ExternalLinkModal } from '@/modules/layout/components/ExternalLinkModal';
@@ -29,22 +30,30 @@ const config = useMock ? mockWagmiConfig : useTestnetConfig ? wagmiConfigDev : w
 
 const queryClient = new QueryClient();
 
+const AppContent = () => {
+  useGovernanceMigrationToast();
+
+  return (
+    <ConnectedProvider>
+      <TermsModalProvider>
+        <BalanceFiltersProvider>
+          <TooltipProvider delayDuration={300}>
+            <ExternalLinkModal />
+            <Toaster />
+            <RouterProvider router={router} />
+          </TooltipProvider>
+        </BalanceFiltersProvider>
+      </TermsModalProvider>
+    </ConnectedProvider>
+  );
+};
+
 export const App = () => (
   <I18nProvider i18n={i18n}>
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
         <RainbowKitProvider theme={rainbowTheme} avatar={CustomAvatar} showRecentTransactions={true}>
-          <ConnectedProvider>
-            <TermsModalProvider>
-              <BalanceFiltersProvider>
-                <TooltipProvider delayDuration={300}>
-                  <ExternalLinkModal />
-                  <Toaster />
-                  <RouterProvider router={router} />
-                </TooltipProvider>
-              </BalanceFiltersProvider>
-            </TermsModalProvider>
-          </ConnectedProvider>
+          <AppContent />
         </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>


### PR DESCRIPTION
### What does this PR do?

- Adds a migration toast notification
- Automatically closes after 15 seconds if not manually dismissed
- Persists a flag in `localStorage` to prevent showing it again to the same user

### Testing steps:

1. Navigate to the site
2. Confirm that the toast appears
3. Verify the content and check for any type errors
4. Refresh the page and confirm the toast does not appear again

