### PR TITLE
Prevent loading states when no delegate or rewards are selected

### DIFF
--- a/packages/hooks/src/rewards/useRewardContractTokens.ts
+++ b/packages/hooks/src/rewards/useRewardContractTokens.ts
@@ -2,7 +2,7 @@ import { useChainId, useReadContracts } from 'wagmi';
 import { ReadHook } from '../hooks';
 import { usdsSkyRewardAbi } from '../generated';
 import { getEtherscanLink } from '@jetstreamgg/utils';
-import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
+import { TRUST_LEVELS, TrustLevelEnum, ZERO_ADDRESS } from '../constants';
 import { erc20Abi } from 'viem';
 import { Token } from '../tokens/types';
 
@@ -40,7 +40,7 @@ export const useRewardContractTokens = (
     ],
     allowFailure: false,
     query: {
-      enabled: !!rewardContractAddress
+      enabled: !!rewardContractAddress && rewardContractAddress !== ZERO_ADDRESS
     }
   });
 

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
@@ -370,7 +370,7 @@ export const PositionSummary = () => {
                 <JazziconComponent address={selectedDelegateOwner} diameter={20} />
               )
             ]
-          ) : isDelegateLoading || !delegateOwnerToDisplay ? (
+          ) : isDelegateLoading ? (
             <Skeleton className="w-30 h-5" />
           ) : (
             <JazziconComponent address={delegateOwnerToDisplay} diameter={20} />


### PR DESCRIPTION
### What does this PR do?
- When the selected reward contract is `zero_address`, disable the query to avoid running into errors
- Don't show the loading skeleton in the delegate row when there is no delegate selected