### PR TITLE
Prevent executing hopeOnClick when old seal urn doesn't need approval

### DIFF
--- a/packages/widgets/src/widgets/SealModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/index.tsx
@@ -490,6 +490,7 @@ function SealModuleWidgetWrapped({
       setTxStatus(TxStatus.SUCCESS);
       refetchNewUrnAuth();
       hope.retryPrepare();
+      migrate.retryPrepare();
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.SUCCESS });
     },
     onError: (error, hash) => {
@@ -1199,11 +1200,13 @@ function SealModuleWidgetWrapped({
               currentStep === SealStep.SUMMARY &&
               widgetState.flow === SealFlow.MIGRATE)
           ? submitOnClick
-          : // After successful open, we now hope the new urn
+          : // After successful open, we now hope the old urn if required, if not we migrate
             txStatus === TxStatus.SUCCESS &&
               currentStep === SealStep.SUMMARY &&
               widgetState.flow === SealFlow.MIGRATE
-            ? hopeOnClick
+            ? needsOldUrnAuth
+              ? hopeOnClick
+              : migrateOnClick
             : txStatus === TxStatus.SUCCESS &&
                 currentStep === SealStep.HOPE_OLD &&
                 widgetState.flow === SealFlow.MIGRATE


### PR DESCRIPTION
### How to test

1) Migrate position → Create New → Needs approval → Approve → Migrate ✅
2) Migrate position → Create New → Needs approval → Don't Approve → Refresh → Start migration flow again → Select last position → Approve → Migrate ✅
3) Migrate position → Create New → Needs approval → Approve → Refresh → Start migration flow again → Select last position → Skips Approve step → Jumps directly to Migrate ✅
4) Migrate position → Create New → Needs approval → Approve → Refresh → Start migration flow again → CREATE NEW → Should Skip Approve step → Jumps directly to Migrate ❌  (it goes to the approve step, when you cancel the transaction in MM and retry it takes you to the manage step)

Number 4 was failing, it should go directly to the migrate step.