### PR TITLE
Update mainnet staking ilk name to `LSEV2-SKY-A`

### DIFF
--- a/apps/webapp/src/modules/stake/components/StakeOverview.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeOverview.tsx
@@ -1,4 +1,4 @@
-import { useStakeHistoricData, useCollateralData, SupportedCollateralTypes } from '@jetstreamgg/hooks';
+import { useStakeHistoricData, useCollateralData, getIlkName } from '@jetstreamgg/hooks';
 import { formatDecimalPercentage, formatNumber, formatBigInt } from '@jetstreamgg/utils';
 import { DetailSectionRow } from '@/modules/ui/components/DetailSectionRow';
 import { DetailSectionWrapper } from '@/modules/ui/components/DetailSectionWrapper';
@@ -18,8 +18,10 @@ import { StakeChart } from './StakeChart';
 import { PopoverRateInfo } from '@/modules/ui/components/PopoverRateInfo';
 import { useMemo } from 'react';
 import { StakeToken } from '../constants';
+import { useChainId } from 'wagmi';
 
 export function StakeOverview() {
+  const chainId = useChainId();
   const { isConnectedAndAcceptedTerms } = useConnectedContext();
   const { data, isLoading, error } = useStakeHistoricData();
   const mostRecentData = data?.sort(
@@ -34,11 +36,13 @@ export function StakeOverview() {
   const tvl = mostRecentData?.tvl ?? 0;
   const numberOfUrns = mostRecentData?.numberOfUrns ?? 0;
 
+  const ilkName = getIlkName(chainId, 2);
+
   const {
     data: collateralData,
     isLoading: collateralDataLoading,
     error: collateralDataError
-  } = useCollateralData(SupportedCollateralTypes.LSEV2_A);
+  } = useCollateralData(ilkName);
   const debtCeiling = collateralData?.debtCeiling ?? 0n;
   const totalDebt = collateralData?.totalDaiDebt ?? 0n;
 

--- a/packages/hooks/src/seal/nextMigrationUrnIndex.test.tsx
+++ b/packages/hooks/src/seal/nextMigrationUrnIndex.test.tsx
@@ -5,8 +5,9 @@ import { useCurrentUrnIndex } from '../stake/useCurrentUrnIndex';
 import { useUrnAddress } from '../stake/useUrnAddress';
 import { useVault } from '../vaults/useVault';
 import { useNextMigrationUrnIndex } from './useNextMigrationUrnIndex';
-import { ZERO_ADDRESS } from '../constants';
+import { TENDERLY_CHAIN_ID, ZERO_ADDRESS } from '../constants';
 import { SupportedCollateralTypes } from '../vaults/vaults.constants';
+import { getIlkName } from '../vaults/helpers';
 
 // Mock wagmi hooks
 vi.mock('wagmi', async () => {
@@ -68,6 +69,7 @@ describe('useNextMigrationUrnIndex - Determining the next URN for migration', ()
   const candidateUrnAddr = '0xCandidateUrnAddress';
   const otherUrnAddr = '0xOtherUrnAddress';
   const chainId = 1;
+  const ilkName = getIlkName(TENDERLY_CHAIN_ID, 2);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -124,7 +126,7 @@ describe('useNextMigrationUrnIndex - Determining the next URN for migration', ()
       data: {
         debtValue: 0n,
         collateralAmount: 0n,
-        collateralType: SupportedCollateralTypes.LSEV2_A
+        collateralType: ilkName
         // Add other necessary fields from VaultData if the hook uses them
       },
       isLoading: false,
@@ -135,7 +137,7 @@ describe('useNextMigrationUrnIndex - Determining the next URN for migration', ()
     // Default mock for candidateUrnAddr
     mockUseVault.mockImplementation(
       (urnAddress: `0x${string}` | undefined, collateralType: SupportedCollateralTypes) => {
-        if (urnAddress === candidateUrnAddr && collateralType === SupportedCollateralTypes.LSEV2_A) {
+        if (urnAddress === candidateUrnAddr && collateralType === ilkName) {
           return mockVaultReturn;
         }
         // Return default/empty for others
@@ -258,7 +260,7 @@ describe('useNextMigrationUrnIndex - Determining the next URN for migration', ()
     // Arrange
     mockVaultReturn.data = {
       ...mockVaultReturn.data,
-      collateralType: SupportedCollateralTypes.LSEV2_A,
+      collateralType: ilkName,
       debtValue: 100n
     };
 
@@ -274,7 +276,7 @@ describe('useNextMigrationUrnIndex - Determining the next URN for migration', ()
     // Arrange
     mockVaultReturn.data = {
       ...mockVaultReturn.data,
-      collateralType: SupportedCollateralTypes.LSEV2_A,
+      collateralType: ilkName,
       collateralAmount: 50n
     };
 

--- a/packages/hooks/src/seal/useMigrationUrnIndexValid.ts
+++ b/packages/hooks/src/seal/useMigrationUrnIndexValid.ts
@@ -5,8 +5,8 @@ import { stakeDataSource } from '../stake/datasources';
 import { useUrnAddress } from '../stake/useUrnAddress';
 import { ZERO_ADDRESS } from '../constants';
 import { useVault } from '../vaults/useVault';
-import { SupportedCollateralTypes } from '../vaults/vaults.constants';
 import { useCurrentUrnIndex } from '../stake/useCurrentUrnIndex';
+import { getIlkName } from '../vaults/helpers';
 
 type UseMigrationUrnIndexValidResponse = ReadHook & {
   data: bigint | undefined;
@@ -54,13 +54,15 @@ export function useMigrationUrnIndexValid(urnIndex?: bigint): UseMigrationUrnInd
   // Check if the currently connected address is the urn owner
   const isCandidateUrnOwner = recordedAddress?.toLocaleLowerCase() === address?.toLocaleLowerCase();
 
+  const ilkName = getIlkName(chainId, 2);
+
   const {
     data: vaultData,
     isLoading: isVaultLoading,
     error: isVaultError,
     mutate: refetchVault,
     dataSources: vaultDataSources
-  } = useVault(candidateUrnAddress, SupportedCollateralTypes.LSEV2_A);
+  } = useVault(candidateUrnAddress, ilkName);
 
   // Check that there is no collateral locked or debt drawn
   const isUrnEmpty = vaultData?.debtValue === 0n && vaultData?.collateralAmount === 0n;

--- a/packages/hooks/src/seal/useNextMigrationUrnIndex.ts
+++ b/packages/hooks/src/seal/useNextMigrationUrnIndex.ts
@@ -6,7 +6,7 @@ import { useCurrentUrnIndex } from '../stake/useCurrentUrnIndex';
 import { useUrnAddress } from '../stake/useUrnAddress';
 import { ZERO_ADDRESS } from '../constants';
 import { useVault } from '../vaults/useVault';
-import { SupportedCollateralTypes } from '../vaults/vaults.constants';
+import { getIlkName } from '../vaults/helpers';
 
 type UseNextMigrationUrnIndexResponse = ReadHook & {
   data: bigint | undefined;
@@ -54,13 +54,15 @@ export function useNextMigrationUrnIndex(): UseNextMigrationUrnIndexResponse {
   // Check if the currently connected address is the urn owner
   const isCandidateUrnOwner = recordedAddress?.toLocaleLowerCase() === address?.toLocaleLowerCase();
 
+  const ilkName = getIlkName(chainId, 2);
+
   const {
     data: vaultData,
     isLoading: isVaultLoading,
     error: isVaultError,
     mutate: refetchVault,
     dataSources: vaultDataSources
-  } = useVault(candidateUrnAddress, SupportedCollateralTypes.LSEV2_A);
+  } = useVault(candidateUrnAddress, ilkName);
 
   // Check that there is no collateral locked or debt drawn
   const isUrnEmpty = vaultData?.debtValue === 0n && vaultData?.collateralAmount === 0n;

--- a/packages/hooks/src/vaults/helpers.ts
+++ b/packages/hooks/src/vaults/helpers.ts
@@ -2,13 +2,13 @@ import { mainnet } from 'viem/chains';
 import { SupportedCollateralTypes } from './vaults.constants';
 import { TENDERLY_CHAIN_ID } from '../constants';
 
-// SupportedCollateralTypes.LOCKSTAKE_SKY correspond to the current ilkName used in the Tenderly testnet
+// SupportedCollateralTypes.LSEV2_SKY_A correspond to the current ilkName used in the Tenderly testnet
 // `Copy of mainnet_2025_apr_15_0`, https://virtual.mainnet.rpc.tenderly.co/9ccec3fd-557a-4e67-9566-71d969dd3ec4;
-// TODO: Update the value when we switch to a new testnet
+// TODO: Update the value to `LSEV2_SKY_A` when we switch to a new testnet
 export const getIlkName = (chainId: number, version: number = 1): SupportedCollateralTypes => {
   switch (chainId) {
     case mainnet.id:
-      return version === 1 ? SupportedCollateralTypes.LSE_MKR_A : SupportedCollateralTypes.LSEV2_A;
+      return version === 1 ? SupportedCollateralTypes.LSE_MKR_A : SupportedCollateralTypes.LSEV2_SKY_A;
     case TENDERLY_CHAIN_ID:
     default:
       return version === 1 ? SupportedCollateralTypes.LSE_MKR_A : SupportedCollateralTypes.LSEV2_A;

--- a/packages/hooks/src/vaults/vaults.constants.ts
+++ b/packages/hooks/src/vaults/vaults.constants.ts
@@ -1,8 +1,7 @@
 export enum SupportedCollateralTypes {
-  LOCKSTAKE = 'LOCKSTAKE',
-  LSE_MKR_A = 'LSE-MKR-A',
-  LOCKSTAKE_SKY = 'LockstakeSky', // not sure if this is needed
-  LSEV2_A = 'LSEV2-A'
+  LSE_MKR_A = 'LSE-MKR-A', // Seal Engine ilk name
+  LSEV2_A = 'LSEV2-A', // Staking engine ilk name in Tenderly. TODO: remove it and replace it for `LSEV2_SKY_A` once we have new testnet
+  LSEV2_SKY_A = 'LSEV2-SKY-A' // Staking engine ilk name in Mainnet
 }
 
 export enum RiskLevel {

--- a/packages/widgets/src/widgets/SealModuleWidget/components/MigratePositionSummary.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/MigratePositionSummary.tsx
@@ -15,8 +15,7 @@ import {
   useSealExitFee,
   useDelegateName,
   useDelegateOwner,
-  useCollateralData,
-  SupportedCollateralTypes
+  useCollateralData
 } from '@jetstreamgg/hooks';
 import { useChainId } from 'wagmi';
 import { Card, CardContent } from '@widgets/components/ui/card';
@@ -52,6 +51,7 @@ const isUpdatedValue = (prev: any, next: any) => prev !== undefined && next !== 
 export const MigratePositionSummary = () => {
   const chainId = useChainId();
   const ilkName = getIlkName(chainId);
+  const stakingEngineIlkName = getIlkName(chainId, 2);
 
   const {
     activeUrn,
@@ -150,7 +150,7 @@ export const MigratePositionSummary = () => {
       : math.calculateMKRtoSKYPrice(updatedVault?.liquidationPrice || 0n);
 
   // collateral data will be for lockstake sky
-  const { data: collateralData } = useCollateralData(SupportedCollateralTypes.LOCKSTAKE_SKY);
+  const { data: collateralData } = useCollateralData(stakingEngineIlkName);
 
   // If the contract is ZERO_ADDRESS, we need to treat it as undefined
   const validatedExistingRewardsContract =

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/Borrow.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/Borrow.tsx
@@ -9,8 +9,7 @@ import {
   useVault,
   Vault,
   CollateralRiskParameters,
-  useSealExitFee,
-  SupportedCollateralTypes
+  useSealExitFee
 } from '@jetstreamgg/hooks';
 import { t } from '@lingui/core/macro';
 import { useContext, useEffect, useMemo } from 'react';
@@ -294,7 +293,7 @@ export const Borrow = ({ isConnectedAndEnabled }: { isConnectedAndEnabled: boole
   // Calculated total amount user will have locked based on existing collateral locked plus user input
   const newCollateralAmount = skyToLock + (existingVault?.collateralAmount || 0n);
 
-  const { data: collateralData } = useCollateralData(SupportedCollateralTypes.LSEV2_A);
+  const { data: collateralData } = useCollateralData(ilkName);
 
   const {
     data: simulatedVault,

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionDetailsAccordion.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionDetailsAccordion.tsx
@@ -10,7 +10,7 @@ import { Text } from '@widgets/shared/components/ui/Typography';
 import { captitalizeFirstLetter, formatBigInt, formatPercent } from '@jetstreamgg/utils';
 import { motion } from 'framer-motion';
 import { getRiskTextColor } from '../lib/utils';
-import { RiskLevel, SupportedCollateralTypes, useCollateralData } from '@jetstreamgg/hooks';
+import { getIlkName, RiskLevel, useCollateralData } from '@jetstreamgg/hooks';
 import { cn } from '@widgets/lib/utils';
 import {
   collateralizationRatioTooltipText,
@@ -18,6 +18,7 @@ import {
   liquidationPriceTooltipText,
   riskLevelTooltipText
 } from '../lib/constants';
+import { useChainId } from 'wagmi';
 
 type Props = {
   collateralizationRatio?: bigint;
@@ -41,8 +42,10 @@ export function PositionDetailAccordion({
   delayedPrice,
   liquidationPrice
 }: Props) {
+  const chainId = useChainId();
+  const ilkName = getIlkName(chainId, 2);
   const riskTextColor = getRiskTextColor(riskLevel as RiskLevel);
-  const { data: collateralData } = useCollateralData(SupportedCollateralTypes.LSEV2_A);
+  const { data: collateralData } = useCollateralData(ilkName);
 
   return (
     <Accordion type="single" collapsible>

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
@@ -15,8 +15,7 @@ import {
   useSealExitFee,
   useDelegateName,
   useDelegateOwner,
-  useCollateralData,
-  SupportedCollateralTypes
+  useCollateralData
 } from '@jetstreamgg/hooks';
 import { useChainId } from 'wagmi';
 import { Card, CardContent } from '@widgets/components/ui/card';
@@ -182,7 +181,7 @@ export const PositionSummary = () => {
   const existingLiquidationPrice = existingVault?.liquidationPrice || 0n;
   const updatedLiquidationPrice = updatedVault?.liquidationPrice || 0n;
 
-  const { data: collateralData } = useCollateralData(SupportedCollateralTypes.LSEV2_A);
+  const { data: collateralData } = useCollateralData(ilkName);
 
   const lineItems = useMemo(() => {
     return [


### PR DESCRIPTION
### What does this PR do?
- Update the Staking Engine ilk name value for mainnet
- Update references to the ilkNames so they all use the `getIlkName` function. This way it will be easier to update once we update the testnet
