### PR TITLE
Add new chains to combined history hooks

### DIFF
--- a/packages/hooks/src/shared/useAllNetworksCombinedHistory.ts
+++ b/packages/hooks/src/shared/useAllNetworksCombinedHistory.ts
@@ -12,22 +12,45 @@ export function useAllNetworksCombinedHistory() {
   const arbitrumHistory = useL2CombinedHistory(
     isTestnetId(chainId) ? chainIdMap.tenderlyArbitrum : chainIdMap.arbitrum
   );
+  const optimismHistory = useL2CombinedHistory(chainIdMap.optimism);
+  const unichainHistory = useL2CombinedHistory(chainIdMap.unichain);
+
   const combinedData = useMemo(() => {
     return [
       ...(baseHistory.data || []),
       ...(ethereumHistory.data || []),
-      ...(arbitrumHistory.data || [])
+      ...(arbitrumHistory.data || []),
+      ...(optimismHistory.data || []),
+      ...(unichainHistory.data || [])
     ].sort((a: CombinedHistoryItem, b: CombinedHistoryItem) => b.blockTimestamp - a.blockTimestamp);
-  }, [baseHistory.data, ethereumHistory.data, arbitrumHistory.data]);
+  }, [
+    baseHistory.data,
+    ethereumHistory.data,
+    arbitrumHistory.data,
+    optimismHistory.data,
+    unichainHistory.data
+  ]);
 
   return {
     data: combinedData,
-    isLoading: baseHistory.isLoading || ethereumHistory.isLoading || arbitrumHistory.isLoading,
-    error: baseHistory.error || ethereumHistory.error || arbitrumHistory.error,
+    isLoading:
+      baseHistory.isLoading ||
+      ethereumHistory.isLoading ||
+      arbitrumHistory.isLoading ||
+      optimismHistory.isLoading ||
+      unichainHistory.isLoading,
+    error:
+      baseHistory.error ||
+      ethereumHistory.error ||
+      arbitrumHistory.error ||
+      optimismHistory.error ||
+      unichainHistory.error,
     mutate: () => {
       baseHistory.mutate();
       ethereumHistory.mutate();
       arbitrumHistory.mutate();
+      optimismHistory.mutate();
+      unichainHistory.mutate();
     }
   };
 }

--- a/packages/utils/src/getExplorerName.ts
+++ b/packages/utils/src/getExplorerName.ts
@@ -6,7 +6,7 @@ export enum ExplorerName {
   BASESCAN = 'Basescan',
   ARBITRUM_EXPLORER = 'Arbiscan',
   SAFE = 'Safe Wallet',
-  OPTIMISTIC_ETHERSCAN = 'OP Mainnet Explorer',
+  OPTIMISTIC_ETHERSCAN = 'OP Explorer',
   UNISCAN = 'Uniscan'
 }
 

--- a/packages/widgets/src/widgets/BalancesWidget/components/BalancesHeader.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/BalancesHeader.tsx
@@ -52,7 +52,7 @@ export const BalancesHeader = ({
     <Skeleton className="bg-card h-8" />
   ) : (
     <Card variant="address" className="mb-3">
-      <div className="flex justify-between">
+      <div className="flex items-center justify-between">
         <div className="flex">
           {jazziconComponent}
           <Text className="ml-3">{truncatedAddress}</Text>


### PR DESCRIPTION
### What does this PR do?
- Add Optimism and Unichain chains all networks combined history hooks
- Shorten Optimism block explorer name to prevent layout shifts

Misc:
- Fix vertical alignment in balances widget header between the user address and the copy to clipboard icon
