### PR TITLE
Add batch transactions to L2 savings widget

### DIFF
--- a/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsWidgetPane.tsx
@@ -15,6 +15,7 @@ import { useSearchParams } from 'react-router-dom';
 import { deleteSearchParams } from '@/modules/utils/deleteSearchParams';
 import { useSubgraphUrl } from '@/modules/app/hooks/useSubgraphUrl';
 import { useChainId } from 'wagmi';
+import { useIsBatchEnabled } from '@/modules/ui/hooks/useIsBatchEnabled';
 
 export function SavingsWidgetPane(sharedProps: SharedProps) {
   const subgraphUrl = useSubgraphUrl();
@@ -27,6 +28,8 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
   const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
   const disallowedTokens =
     isRestrictedMiCa && isL2 ? { supply: [TOKENS.usdc], withdraw: [TOKENS.usdc] } : undefined;
+
+  const batchEnabled = useIsBatchEnabled();
 
   const onSavingsWidgetStateChange = ({ hash, txStatus, widgetState }: WidgetStateChangeParams) => {
     // After a successful linked action sUPPLY, set the final step to "success"
@@ -69,6 +72,7 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
         token: isL2 ? linkedActionConfig?.sourceToken : undefined
       }}
       disallowedTokens={disallowedTokens}
+      batchEnabled={batchEnabled}
     />
   );
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -170,6 +170,8 @@ export { useDelegateOwner } from './delegates/useDelegateOwner';
 // PSM
 export { usePsmSwapExactIn } from './psm/usePsmSwapExactIn';
 export { usePsmSwapExactOut } from './psm/usePsmSwapExactOut';
+export { useBatchPsmSwapExactIn } from './psm/useBatchPsmSwapExactIn';
+export { useBatchPsmSwapExactOut } from './psm/useBatchPsmSwapExactOut';
 export { useL2SavingsHistory } from './psm/useL2SavingsHistory';
 export { useL2TradeHistory } from './psm/useL2TradeHistory';
 export { usePsmLiquidity } from './psm/usePsmLiquidity';

--- a/packages/hooks/src/psm/useBatchPsmSwapExactIn.ts
+++ b/packages/hooks/src/psm/useBatchPsmSwapExactIn.ts
@@ -1,0 +1,74 @@
+import { useAccount, useChainId } from 'wagmi';
+import { BatchWriteHook, BatchWriteHookParams } from '../hooks';
+import { psm3L2Abi, psm3L2Address } from '../generated';
+import { useTokenAllowance } from '../tokens/useTokenAllowance';
+import { useSendBatchTransactionFlow } from '../shared/useSendBatchTransactionFlow';
+import { getWriteContractCall } from '../shared/getWriteContractCall';
+import { Call, erc20Abi } from 'viem';
+
+export function useBatchPsmSwapExactIn({
+  assetIn,
+  assetOut,
+  amountIn,
+  minAmountOut,
+  referralCode = 0n,
+  enabled: paramEnabled = true,
+  onSuccess = () => null,
+  onError = () => null,
+  onStart = () => null
+}: BatchWriteHookParams & {
+  assetIn: `0x${string}`;
+  assetOut: `0x${string}`;
+  amountIn: bigint;
+  minAmountOut: bigint;
+  referralCode?: bigint;
+}): BatchWriteHook {
+  const chainId = useChainId();
+  const { address, isConnected } = useAccount();
+  const psmAddress = psm3L2Address[chainId as keyof typeof psm3L2Address];
+
+  // Get the allowance of the input asset to be used by the PSM contract
+  const { data: allowance, error: allowanceError } = useTokenAllowance({
+    chainId,
+    contractAddress: assetIn,
+    owner: address,
+    spender: psmAddress
+  });
+
+  const hasAllowance = !!allowance && allowance >= amountIn;
+
+  // Calls for the batch transaction
+  const approveCall = getWriteContractCall({
+    to: assetIn,
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [psmAddress, amountIn]
+  });
+
+  const swapExactInCall = getWriteContractCall({
+    to: psmAddress,
+    abi: psm3L2Abi,
+    functionName: 'swapExactIn',
+    args: [assetIn, assetOut, amountIn, minAmountOut, address!, referralCode]
+  });
+
+  const calls: Call[] = [];
+  if (!hasAllowance) calls.push(approveCall);
+  calls.push(swapExactInCall);
+
+  const enabled = paramEnabled && isConnected && allowance !== undefined && amountIn !== 0n && !!address;
+
+  const sendBatchTransactionFlowResults = useSendBatchTransactionFlow({
+    calls,
+    chainId,
+    enabled,
+    onSuccess,
+    onError,
+    onStart
+  });
+
+  return {
+    ...sendBatchTransactionFlowResults,
+    error: sendBatchTransactionFlowResults.error || allowanceError
+  };
+}

--- a/packages/hooks/src/psm/useBatchPsmSwapExactOut.ts
+++ b/packages/hooks/src/psm/useBatchPsmSwapExactOut.ts
@@ -1,0 +1,74 @@
+import { useAccount, useChainId } from 'wagmi';
+import { BatchWriteHook, BatchWriteHookParams } from '../hooks';
+import { psm3L2Abi, psm3L2Address } from '../generated';
+import { useTokenAllowance } from '../tokens/useTokenAllowance';
+import { useSendBatchTransactionFlow } from '../shared/useSendBatchTransactionFlow';
+import { getWriteContractCall } from '../shared/getWriteContractCall';
+import { Call, erc20Abi } from 'viem';
+
+export function useBatchPsmSwapExactOut({
+  assetIn,
+  assetOut,
+  amountOut,
+  maxAmountIn,
+  referralCode = 0n,
+  enabled: paramEnabled = true,
+  onSuccess = () => null,
+  onError = () => null,
+  onStart = () => null
+}: BatchWriteHookParams & {
+  assetIn: `0x${string}`;
+  assetOut: `0x${string}`;
+  amountOut: bigint;
+  maxAmountIn: bigint;
+  referralCode?: bigint;
+}): BatchWriteHook {
+  const chainId = useChainId();
+  const { address, isConnected } = useAccount();
+  const psmAddress = psm3L2Address[chainId as keyof typeof psm3L2Address];
+
+  // Get the allowance of the input asset to be used by the PSM contract
+  const { data: allowance, error: allowanceError } = useTokenAllowance({
+    chainId,
+    contractAddress: assetIn,
+    owner: address,
+    spender: psmAddress
+  });
+
+  const hasAllowance = !!allowance && allowance >= maxAmountIn;
+
+  // Calls for the batch transaction
+  const approveCall = getWriteContractCall({
+    to: assetIn,
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [psmAddress, maxAmountIn]
+  });
+
+  const swapExactOutCall = getWriteContractCall({
+    to: psmAddress,
+    abi: psm3L2Abi,
+    functionName: 'swapExactOut',
+    args: [assetIn, assetOut, amountOut, maxAmountIn, address!, referralCode]
+  });
+
+  const calls: Call[] = [];
+  if (!hasAllowance) calls.push(approveCall);
+  calls.push(swapExactOutCall);
+
+  const enabled = paramEnabled && isConnected && allowance !== undefined && maxAmountIn !== 0n && !!address;
+
+  const sendBatchTransactionFlowResults = useSendBatchTransactionFlow({
+    calls,
+    chainId,
+    enabled,
+    onSuccess,
+    onError,
+    onStart
+  });
+
+  return {
+    ...sendBatchTransactionFlowResults,
+    error: sendBatchTransactionFlowResults.error || allowanceError
+  };
+}

--- a/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2SavingsWidget/index.tsx
@@ -6,6 +6,9 @@ import {
   useApproveToken,
   usePsmSwapExactIn,
   usePsmSwapExactOut,
+  useBatchPsmSwapExactIn,
+  useBatchPsmSwapExactOut,
+  useIsBatchSupported,
   useTokenAllowance,
   useTokenBalance,
   getTokenDecimals
@@ -77,6 +80,7 @@ const tokenForSymbol = (symbol: keyof typeof TOKENS) => {
 export type SavingsWidgetProps = WidgetProps & {
   disallowedTokens?: { [key in SavingsFlow]: Token[] };
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+  batchEnabled?: boolean;
 };
 
 export const L2SavingsWidget = ({
@@ -91,7 +95,8 @@ export const L2SavingsWidget = ({
   onExternalLinkClicked,
   enabled = true,
   referralCode,
-  disallowedTokens
+  disallowedTokens,
+  batchEnabled
 }: SavingsWidgetProps) => {
   return (
     <ErrorBoundary componentName="SavingsWidget">
@@ -109,6 +114,7 @@ export const L2SavingsWidget = ({
           enabled={enabled}
           referralCode={referralCode}
           disallowedTokens={disallowedTokens}
+          batchEnabled={batchEnabled}
         />
       </WidgetProvider>
     </ErrorBoundary>
@@ -128,7 +134,8 @@ const SavingsWidgetWrapped = ({
   locale,
   enabled = true,
   referralCode,
-  disallowedTokens
+  disallowedTokens,
+  batchEnabled
 }: SavingsWidgetProps) => {
   const validatedExternalState = getValidatedState(externalWidgetState);
 
@@ -157,6 +164,8 @@ const SavingsWidgetWrapped = ({
   const [amount, setAmount] = useState(initialAmount);
   const debouncedAmount = useDebounce(amount);
 
+  const { data: batchSupported } = useIsBatchSupported();
+
   const {
     setButtonText,
     setIsDisabled,
@@ -180,6 +189,9 @@ const SavingsWidgetWrapped = ({
     owner: address,
     spender: psm3L2Address[chainId as keyof typeof psm3L2Address]
   });
+
+  const hasAllowance = !!(allowance && debouncedAmount !== 0n && allowance >= debouncedAmount);
+  const shouldUseBatch = !!batchEnabled && !!batchSupported && !hasAllowance;
 
   const { data: chi } = useReadSsrAuthOracleGetChi();
   const { data: rho } = useReadSsrAuthOracleGetRho();
@@ -296,24 +308,26 @@ const SavingsWidgetWrapped = ({
   const shares = math.calculateSharesFromAssets(debouncedWadAmount, updatedChiForDeposit);
   const supplyMinAmountOut = originToken.symbol === 'USDC' ? math.roundDownLastTwelveDigits(shares) : shares;
 
-  const savingsSupply = usePsmSwapExactIn({
+  const savingsSupplyParams = {
     amountIn: debouncedAmount,
     assetIn: originToken.address[chainId],
     assetOut: TOKENS.susds.address[chainId],
     minAmountOut: supplyMinAmountOut,
-    onStart: (hash: string) => {
-      addRecentTransaction?.({
-        hash,
-        description: t`Supplying ${formatBigInt(debouncedAmount, {
-          locale,
-          unit: originToken && getTokenDecimals(originToken, chainId)
-        })} ${originToken.symbol}`
-      });
-      setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+    onStart: (hash?: string) => {
+      if (hash) {
+        addRecentTransaction?.({
+          hash,
+          description: t`Supplying ${formatBigInt(debouncedAmount, {
+            locale,
+            unit: originToken && getTokenDecimals(originToken, chainId)
+          })} ${originToken.symbol}`
+        });
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
       setTxStatus(TxStatus.LOADING);
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.LOADING });
     },
-    onSuccess: hash => {
+    onSuccess: (hash: string | undefined) => {
       onNotification?.({
         title: t`Supply successful`,
         description: t`You supplied ${formatBigInt(debouncedAmount, {
@@ -322,13 +336,16 @@ const SavingsWidgetWrapped = ({
         })} ${originToken.symbol}`,
         status: TxStatus.SUCCESS
       });
+      if (hash) {
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
       setTxStatus(TxStatus.SUCCESS);
       mutateAllowance();
       mutateOriginBalance();
       mutateSUsdsBalance();
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.SUCCESS });
     },
-    onError: (error, hash) => {
+    onError: (error: Error, hash: string | undefined) => {
       onNotification?.({
         title: t`Supply failed`,
         description: t`Something went wrong with your transaction. Please try again.`,
@@ -341,29 +358,41 @@ const SavingsWidgetWrapped = ({
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.ERROR });
       console.log(error);
     },
-    referralCode: referralCode ? BigInt(referralCode) : undefined,
+    referralCode: referralCode ? BigInt(referralCode) : undefined
+  };
+
+  const savingsSupply = usePsmSwapExactIn({
+    ...savingsSupplyParams,
     enabled: widgetState.action === SavingsAction.SUPPLY && allowance !== undefined && supplyMinAmountOut > 0n
   });
 
-  // use this to withdraw all from savings
-  const savingsWithdrawAll = usePsmSwapExactIn({
+  const batchSavingsSupply = useBatchPsmSwapExactIn({
+    ...savingsSupplyParams,
+    enabled:
+      (widgetState.action === SavingsAction.SUPPLY || widgetState.action === SavingsAction.APPROVE) &&
+      supplyMinAmountOut > 0n
+  });
+
+  const savingsWithdrawAllParams = {
     amountIn: sUsdsBalance?.value || 0n,
     assetIn: TOKENS.susds.address[chainId],
     assetOut: originToken.address[chainId],
     minAmountOut: minAmountOutForWithdrawAll,
-    onStart: (hash: string) => {
-      addRecentTransaction?.({
-        hash,
-        description: t`Withdrawing ${formatBigInt(debouncedAmount, {
-          locale,
-          unit: originToken && getTokenDecimals(originToken, chainId)
-        })} ${originToken.symbol}`
-      });
-      setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+    onStart: (hash?: string) => {
+      if (hash) {
+        addRecentTransaction?.({
+          hash,
+          description: t`Withdrawing ${formatBigInt(debouncedAmount, {
+            locale,
+            unit: originToken && getTokenDecimals(originToken, chainId)
+          })} ${originToken.symbol}`
+        });
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
       setTxStatus(TxStatus.LOADING);
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.LOADING });
     },
-    onSuccess: hash => {
+    onSuccess: (hash: string | undefined) => {
       onNotification?.({
         title: t`Withdraw successful`,
         description: t`You withdrew ${formatBigInt(debouncedAmount, {
@@ -372,13 +401,16 @@ const SavingsWidgetWrapped = ({
         })} ${originToken.symbol}`,
         status: TxStatus.SUCCESS
       });
+      if (hash) {
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
       setTxStatus(TxStatus.SUCCESS);
       mutateAllowance();
       mutateOriginBalance();
       mutateSUsdsBalance();
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.SUCCESS });
     },
-    onError: (error, hash) => {
+    onError: (error: Error, hash: string | undefined) => {
       onNotification?.({
         title: t`Withdraw failed`,
         description: t`Something went wrong with your withdraw. Please try again.`,
@@ -391,7 +423,12 @@ const SavingsWidgetWrapped = ({
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.ERROR });
       console.log(error);
     },
-    referralCode: referralCode ? BigInt(referralCode) : undefined,
+    referralCode: referralCode ? BigInt(referralCode) : undefined
+  };
+
+  // use this to withdraw all from savings
+  const savingsWithdrawAll = usePsmSwapExactIn({
+    ...savingsWithdrawAllParams,
     enabled:
       (widgetState.action === SavingsAction.WITHDRAW ||
         (widgetState.action === SavingsAction.APPROVE && txStatus === TxStatus.SUCCESS)) &&
@@ -399,25 +436,33 @@ const SavingsWidgetWrapped = ({
       allowance !== undefined
   });
 
-  // use this to withdraw a specific amount from savings
-  const savingsWithdraw = usePsmSwapExactOut({
+  const batchSavingsWithdrawAll = useBatchPsmSwapExactIn({
+    ...savingsWithdrawAllParams,
+    enabled:
+      (widgetState.action === SavingsAction.WITHDRAW || widgetState.action === SavingsAction.APPROVE) &&
+      isMaxWithdraw
+  });
+
+  const savingsWithdrawParams = {
     amountOut: debouncedAmount,
     assetOut: originToken.address[chainId],
     assetIn: TOKENS.susds.address[chainId],
     maxAmountIn: maxAmountInForWithdraw,
-    onStart: (hash: string) => {
-      addRecentTransaction?.({
-        hash,
-        description: t`Withdrawing ${formatBigInt(debouncedAmount, {
-          locale,
-          unit: originToken && getTokenDecimals(originToken, chainId)
-        })} ${originToken.symbol}`
-      });
-      setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+    onStart: (hash?: string) => {
+      if (hash) {
+        addRecentTransaction?.({
+          hash,
+          description: t`Withdrawing ${formatBigInt(debouncedAmount, {
+            locale,
+            unit: originToken && getTokenDecimals(originToken, chainId)
+          })} ${originToken.symbol}`
+        });
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
       setTxStatus(TxStatus.LOADING);
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.LOADING });
     },
-    onSuccess: hash => {
+    onSuccess: (hash: string | undefined) => {
       onNotification?.({
         title: t`Withdraw successful`,
         description: t`You withdrew ${formatBigInt(debouncedAmount, {
@@ -426,13 +471,16 @@ const SavingsWidgetWrapped = ({
         })} ${originToken.symbol}`,
         status: TxStatus.SUCCESS
       });
+      if (hash) {
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
       setTxStatus(TxStatus.SUCCESS);
       mutateAllowance();
       mutateOriginBalance();
       mutateSUsdsBalance();
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.SUCCESS });
     },
-    onError: (error, hash) => {
+    onError: (error: Error, hash: string | undefined) => {
       onNotification?.({
         title: t`Withdraw failed`,
         description: t`Something went wrong with your withdraw. Please try again.`,
@@ -445,12 +493,24 @@ const SavingsWidgetWrapped = ({
       onWidgetStateChange?.({ hash, widgetState, txStatus: TxStatus.ERROR });
       console.log(error);
     },
-    referralCode: referralCode ? BigInt(referralCode) : undefined,
+    referralCode: referralCode ? BigInt(referralCode) : undefined
+  };
+
+  // use this to withdraw a specific amount from savings
+  const savingsWithdraw = usePsmSwapExactOut({
+    ...savingsWithdrawParams,
     enabled:
       (widgetState.action === SavingsAction.WITHDRAW ||
         (widgetState.action === SavingsAction.APPROVE && txStatus === TxStatus.SUCCESS)) &&
       !isMaxWithdraw &&
       allowance !== undefined
+  });
+
+  const batchSavingsWithdraw = useBatchPsmSwapExactOut({
+    ...savingsWithdrawParams,
+    enabled:
+      (widgetState.action === SavingsAction.WITHDRAW || widgetState.action === SavingsAction.APPROVE) &&
+      !isMaxWithdraw
   });
 
   const needsAllowance = !!(!allowance || allowance < (amountToApprove || 0n));
@@ -483,22 +543,28 @@ const SavingsWidgetWrapped = ({
     }
   }, [tabIndex, isConnectedAndEnabled]);
 
-  // If we're in the supply or withdraw flow and we need allowance, set the action to approve,
+  // If we're in the supply or withdraw flow and we need allowance and  batch transactions are not supported, set the action to approve
   useEffect(() => {
     if (widgetState.flow === SavingsFlow.SUPPLY && widgetState.screen === SavingsScreen.ACTION) {
       setWidgetState((prev: WidgetState) => ({
         ...prev,
-        action: needsAllowance && !allowanceLoading ? SavingsAction.APPROVE : SavingsAction.SUPPLY
+        action:
+          needsAllowance && !allowanceLoading && !shouldUseBatch
+            ? SavingsAction.APPROVE
+            : SavingsAction.SUPPLY
       }));
     }
 
     if (widgetState.flow === SavingsFlow.WITHDRAW && widgetState.screen === SavingsScreen.ACTION) {
       setWidgetState((prev: WidgetState) => ({
         ...prev,
-        action: needsAllowance && !allowanceLoading ? SavingsAction.APPROVE : SavingsAction.WITHDRAW
+        action:
+          needsAllowance && !allowanceLoading && !shouldUseBatch
+            ? SavingsAction.APPROVE
+            : SavingsAction.WITHDRAW
       }));
     }
-  }, [widgetState.flow, widgetState.screen, needsAllowance, allowanceLoading]);
+  }, [widgetState.flow, widgetState.screen, needsAllowance, allowanceLoading, shouldUseBatch]);
 
   useEffect(() => {
     setShowStepIndicator(true);
@@ -537,6 +603,17 @@ const SavingsWidgetWrapped = ({
         (isMaxWithdraw ? !savingsWithdrawAll.prepared : !savingsWithdraw.prepared) ||
         isAmountWaitingForDebounce;
 
+  const batchWithdrawDisabled = isSuccessfulWithdraw
+    ? false
+    : [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
+      isWithdrawBalanceError ||
+      (isMaxWithdraw ? !batchSavingsWithdrawAll.prepared : !batchSavingsWithdraw.prepared) ||
+      isAmountWaitingForDebounce ||
+      // If the user has allowance, don't send a batch transaction as it's only 1 contract call
+      hasAllowance ||
+      allowanceLoading ||
+      !batchSupported;
+
   const supplyDisabled =
     [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
     isSupplyBalanceError ||
@@ -544,6 +621,17 @@ const SavingsWidgetWrapped = ({
     !savingsSupply.prepared ||
     savingsSupply.isLoading ||
     isAmountWaitingForDebounce;
+
+  const batchSupplyDisabled =
+    [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
+    isSupplyBalanceError ||
+    !batchSavingsSupply.prepared ||
+    batchSavingsSupply.isLoading ||
+    isAmountWaitingForDebounce ||
+    // If the user has allowance, don't send a batch transaction as it's only 1 contract call
+    hasAllowance ||
+    allowanceLoading ||
+    !batchSupported;
 
   const approveDisabled =
     [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
@@ -572,11 +660,34 @@ const SavingsWidgetWrapped = ({
     setExternalLink(undefined);
     savingsSupply.execute();
   };
+  const batchSupplyOnClick = () => {
+    if (hasAllowance) {
+      // If the user has allowance, just send the individual transaction as it will be more gas efficient
+      supplyOnClick();
+      return;
+    }
+    setWidgetState((prev: WidgetState) => ({ ...prev, screen: SavingsScreen.TRANSACTION }));
+    setTxStatus(TxStatus.INITIALIZED);
+    setExternalLink(undefined);
+    batchSavingsSupply.execute();
+  };
   const withdrawOnClick = () => {
     setWidgetState((prev: WidgetState) => ({ ...prev, screen: SavingsScreen.TRANSACTION }));
     setTxStatus(TxStatus.INITIALIZED);
     setExternalLink(undefined);
     const executeFunction = isMaxWithdraw ? savingsWithdrawAll.execute : savingsWithdraw.execute;
+    executeFunction();
+  };
+  const batchWithdrawOnClick = () => {
+    if (hasAllowance) {
+      // If the user has allowance, just send the individual transaction as it will be more gas efficient
+      withdrawOnClick();
+      return;
+    }
+    setWidgetState((prev: WidgetState) => ({ ...prev, screen: SavingsScreen.TRANSACTION }));
+    setTxStatus(TxStatus.INITIALIZED);
+    setExternalLink(undefined);
+    const executeFunction = isMaxWithdraw ? batchSavingsWithdrawAll.execute : batchSavingsWithdraw.execute;
     executeFunction();
   };
   const nextOnClick = () => {
@@ -615,9 +726,13 @@ const SavingsWidgetWrapped = ({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === SavingsAction.SUPPLY
-      ? supplyOnClick()
+      ? shouldUseBatch
+        ? batchSupplyOnClick()
+        : supplyOnClick()
       : widgetState.action === SavingsAction.WITHDRAW
-        ? withdrawOnClick()
+        ? shouldUseBatch
+          ? batchWithdrawOnClick()
+          : withdrawOnClick()
         : widgetState.action === SavingsAction.APPROVE
           ? approveOnClick()
           : undefined;
@@ -633,14 +748,18 @@ const SavingsWidgetWrapped = ({
         ? nextOnClick
         : txStatus === TxStatus.ERROR
           ? errorOnClick
-          : (widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.APPROVE) ||
-              (widgetState.flow === SavingsFlow.WITHDRAW && widgetState.action === SavingsAction.APPROVE)
-            ? approveOnClick
-            : widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.SUPPLY
-              ? supplyOnClick
-              : widgetState.flow === SavingsFlow.WITHDRAW && widgetState.action === SavingsAction.WITHDRAW
-                ? withdrawOnClick
-                : undefined;
+          : shouldUseBatch
+            ? widgetState.flow === SavingsFlow.SUPPLY
+              ? batchSupplyOnClick
+              : batchWithdrawOnClick
+            : (widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.APPROVE) ||
+                (widgetState.flow === SavingsFlow.WITHDRAW && widgetState.action === SavingsAction.APPROVE)
+              ? approveOnClick
+              : widgetState.flow === SavingsFlow.SUPPLY && widgetState.action === SavingsAction.SUPPLY
+                ? supplyOnClick
+                : widgetState.flow === SavingsFlow.WITHDRAW && widgetState.action === SavingsAction.WITHDRAW
+                  ? withdrawOnClick
+                  : undefined;
 
   const showSecondaryButton =
     txStatus === TxStatus.ERROR ||
@@ -719,11 +838,22 @@ const SavingsWidgetWrapped = ({
   useEffect(() => {
     setIsDisabled(
       isConnectedAndEnabled &&
-        ((widgetState.action === SavingsAction.SUPPLY && supplyDisabled) ||
-          (widgetState.action === SavingsAction.WITHDRAW && withdrawDisabled) ||
+        ((widgetState.action === SavingsAction.SUPPLY &&
+          (shouldUseBatch ? batchSupplyDisabled : supplyDisabled)) ||
+          (widgetState.action === SavingsAction.WITHDRAW &&
+            (shouldUseBatch ? batchWithdrawDisabled : withdrawDisabled)) ||
           (widgetState.action === SavingsAction.APPROVE && approveDisabled))
     );
-  }, [widgetState.action, supplyDisabled, withdrawDisabled, approveDisabled, isConnectedAndEnabled]);
+  }, [
+    widgetState.action,
+    supplyDisabled,
+    withdrawDisabled,
+    approveDisabled,
+    isConnectedAndEnabled,
+    shouldUseBatch,
+    batchSupplyDisabled,
+    batchWithdrawDisabled
+  ]);
 
   // Set isLoading to be consumed by WidgetButton
   useEffect(() => {

--- a/packages/widgets/src/widgets/UpgradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/index.tsx
@@ -510,13 +510,15 @@ export function UpgradeWidgetWrapped({
 
   // Handle the error onClicks separately to keep it clear
   const errorOnClick = () => {
-    return widgetState.action === UpgradeAction.UPGRADE
-      ? upgradeOnClick()
-      : widgetState.action === UpgradeAction.REVERT
-        ? revertOnClick()
-        : widgetState.action === UpgradeAction.APPROVE
-          ? approveOnClick()
-          : undefined;
+    return shouldUseBatch
+      ? batchTransactionOnClick()
+      : widgetState.action === UpgradeAction.UPGRADE
+        ? upgradeOnClick()
+        : widgetState.action === UpgradeAction.REVERT
+          ? revertOnClick()
+          : widgetState.action === UpgradeAction.APPROVE
+            ? approveOnClick()
+            : undefined;
   };
 
   const batchTransactionOnClick = () => {


### PR DESCRIPTION
### What does this PR do?
Adds support for batch transactions in the L2 savings widget (Metamask currently only supports Base), to work in parallel with common transactions

### Testing steps:
- Connect with the shared testing account in Base and navigate to the L2 savings widget
- Attempt to supply with an amount that requires allowance
- The widget button should automatically trigger the 'Upgrade' step, without needing the approval step before
- Trigger the transaction and check in Metamask that the transaction populated is indeed a batch transaction
- Confirm the tx in the wallet and wait for it to be executed. The webapp should display the status accordingly