### PR TITLE
Fix unnecessary extra rerenders for the widget inputs

### DIFF
--- a/packages/widgets/src/widgets/L2TradeWidget/components/L2TradeInputs.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/components/L2TradeInputs.tsx
@@ -8,6 +8,7 @@ import { TokenForChain, Token, tokenArrayFiltered } from '@jetstreamgg/hooks';
 import { t } from '@lingui/core/macro';
 import { motion } from 'framer-motion';
 import { useState, useRef, useMemo, useEffect } from 'react';
+import { TradeSide } from '@widgets/widgets/TradeWidget/lib/constants';
 
 type TokenBalanceData = Omit<GetBalanceData, 'symbol'> & {
   symbol?: string;
@@ -29,6 +30,7 @@ type TradeInputsProps = {
   isBalanceError: boolean;
   canSwitchTokens: boolean;
   isConnectedAndEnabled: boolean;
+  lastUpdated: TradeSide;
   onUserSwitchTokens?: (originToken?: string, targetToken?: string) => void;
   onOriginInputChange?: (val: bigint, userTriggered?: boolean) => void;
   onTargetInputChange: (val: bigint) => void;
@@ -55,6 +57,7 @@ export function L2TradeInputs({
   isBalanceError,
   canSwitchTokens,
   isConnectedAndEnabled = true,
+  lastUpdated,
   onUserSwitchTokens,
   onOriginInputChange,
   onTargetInputChange,
@@ -182,8 +185,13 @@ export function L2TradeInputs({
               setOriginToken(targetToken);
               setTargetToken(tempToken);
               setTimeout(() => {
-                setOriginAmount(prevTargetAmount);
-                setTargetAmount(prevOriginAmount);
+                if (lastUpdated === TradeSide.IN) {
+                  setTargetAmount(prevOriginAmount);
+                  setOriginAmount(0n);
+                } else {
+                  setOriginAmount(prevTargetAmount);
+                  setTargetAmount(0n);
+                }
                 onUserSwitchTokens?.(targetToken?.symbol, originToken?.symbol);
               }, 500);
             }, 500);

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -525,7 +525,6 @@ function TradeWidgetWrapped({
           // Only update if the amount has actually changed
           if (newAmount !== originAmount) {
             timeoutId = setTimeout(() => {
-              console.log('Updating side');
               // Batch all state updates together
               setOriginAmount(newAmount);
               // setTargetAmount(0n);
@@ -771,7 +770,9 @@ function TradeWidgetWrapped({
   const prepareError = approvePrepareError;
 
   const isAmountWaitingForDebounce =
-    debouncedOriginAmount !== originAmount || debouncedTargetAmount !== targetAmount;
+    lastUpdated === TradeSide.IN
+      ? debouncedOriginAmount !== originAmount
+      : debouncedTargetAmount !== targetAmount;
 
   const approveDisabled =
     [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -521,6 +521,7 @@ function TradeWidgetWrapped({
         }
       }
 
+      let timeoutId: NodeJS.Timeout | undefined;
       // Handle amount updates
       if (externalWidgetState?.amount !== undefined) {
         const newOriginToken = tokenList.find(
@@ -529,22 +530,28 @@ function TradeWidgetWrapped({
         if (amountHasChanged && newOriginToken !== undefined) {
           const newAmount = parseUnits(externalWidgetState.amount, getTokenDecimals(newOriginToken, chainId));
 
-          setTimeout(() => {
-            setOriginAmount(newAmount);
-            setTargetAmount(0n);
-            setLastUpdated(TradeSide.IN);
-          }, 500);
+          // Only update if the amount has actually changed
+          if (newAmount !== originAmount) {
+            timeoutId = setTimeout(() => {
+              console.log('Updating side');
+              // Batch all state updates together
+              setOriginAmount(newAmount);
+              // setTargetAmount(0n);
+              setLastUpdated(TradeSide.IN);
+            }, 500);
+          }
         }
       } else {
         setOriginAmount(0n);
         setTargetAmount(0n);
       }
 
-      setWidgetState((prev: WidgetState) => ({
-        ...prev,
-        action: needsAllowance ? TradeAction.APPROVE : TradeAction.TRADE,
-        screen: TradeScreen.ACTION
-      }));
+      // Cleanup the timeout if the component unmounts or dependencies change
+      return () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      };
     }
   }, [
     externalWidgetState?.timestamp,
@@ -553,6 +560,21 @@ function TradeWidgetWrapped({
     externalWidgetState?.targetToken,
     txStatus
   ]);
+
+  // Update external widget state when the debounced origin amount is updated
+  useEffect(() => {
+    if (originToken) {
+      const formattedValue = formatUnits(debouncedOriginAmount, getTokenDecimals(originToken, chainId));
+      const truncatedValue = truncateStringToFourDecimals(formattedValue);
+      if (truncatedValue !== externalWidgetState?.amount) {
+        onWidgetStateChange?.({
+          originAmount: truncatedValue,
+          txStatus,
+          widgetState
+        });
+      }
+    }
+  }, [debouncedOriginAmount]);
 
   const {
     execute: approveExecute,
@@ -1136,17 +1158,8 @@ function TradeWidgetWrapped({
           <CardAnimationWrapper key="widget-inputs">
             <L2TradeInputs
               setOriginAmount={setOriginAmount}
-              onOriginInputChange={(newValue: bigint, userTriggered?: boolean) => {
+              onOriginInputChange={(newValue: bigint) => {
                 setOriginAmount(newValue);
-                if (originToken && userTriggered) {
-                  const formattedValue = formatUnits(newValue, getTokenDecimals(originToken, chainId));
-                  const truncatedValue = truncateStringToFourDecimals(formattedValue);
-                  onWidgetStateChange?.({
-                    originAmount: truncatedValue,
-                    txStatus,
-                    widgetState
-                  });
-                }
               }}
               onOriginInputInput={() => {
                 setLastUpdated(TradeSide.IN);

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -46,7 +46,6 @@ import { useAddTokenToWallet } from '@widgets/shared/hooks/useAddTokenToWallet';
 import { ErrorBoundary } from '@widgets/shared/components/ErrorBoundary';
 import { AnimatePresence } from 'framer-motion';
 import { CardAnimationWrapper } from '@widgets/shared/animation/Wrappers';
-import { useNotifyWidgetState } from '@widgets/shared/hooks/useNotifyWidgetState';
 import { Heading } from '@widgets/shared/components/ui/Typography';
 import { TradeTransactionStatus } from '../TradeWidget/components/TradeTransactionStatus';
 import { useTokenImage } from '@widgets/shared/hooks/useTokenImage';
@@ -271,13 +270,6 @@ function TradeWidgetWrapped({
     setWidgetState,
     setShowStepIndicator
   } = useContext(WidgetContext);
-
-  useNotifyWidgetState({
-    widgetState,
-    txStatus,
-    targetToken: targetToken?.symbol,
-    onWidgetStateChange
-  });
 
   const pairValid = !!originToken && !!targetToken && originToken.symbol !== targetToken.symbol;
 
@@ -569,6 +561,8 @@ function TradeWidgetWrapped({
       if (truncatedValue !== externalWidgetState?.amount) {
         onWidgetStateChange?.({
           originAmount: truncatedValue,
+          originToken: originToken?.symbol,
+          targetToken: targetToken?.symbol,
           txStatus,
           widgetState
         });
@@ -1197,10 +1191,12 @@ function TradeWidgetWrapped({
                 onWidgetStateChange?.({
                   originToken: originSymbol,
                   targetToken: targetSymbol,
+                  originAmount: '',
                   txStatus,
                   widgetState
                 });
               }}
+              lastUpdated={lastUpdated}
               targetAmount={targetAmount}
               originTokenList={originTokenList}
               targetTokenList={targetTokenList}


### PR DESCRIPTION
### What does this PR do?
- Only update inputs after external state has changed if the amount in the search params is different than the current input amount
- Clean up the timeout function
- Update the external state based on the debounced origin amount instead of on every input change
- Remove the `useNotifyWidgetState` call which was causing double rerender cycles
- Update the `isAmountWaitingForDebounce` variable to only wait for debounce on a single token: the one that was last updated, as the other token should be updated automatically by the quote hooks and shouldn't wait for debounce in that case

### Testing steps:
