### PR TITLE
Add ChainModal context and refactor ChainModal component

### DIFF
--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogClose, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Text } from '@/modules/layout/components/Typography';
 import { t } from '@lingui/core/macro';
-import { useChainId, useChains, useClient, useSwitchChain } from 'wagmi';
+import { useChainId, useChains, useClient } from 'wagmi';
 import { MainnetChain, BaseChain, ArbitrumChain, Close, OptimismChain, UnichainChain } from '@/modules/icons';
 import { cn } from '@/lib/utils';
 import { base, arbitrum, optimism, unichain } from 'viem/chains';
@@ -54,9 +54,12 @@ export function ChainModal({
   const chainId = useChainId();
   const client = useClient();
   const chains = useChains();
-  const { variables: switchChainVariables, isPending: isSwitchChainPending } = useSwitchChain();
   const [, setSearchParams] = useSearchParams();
-  const { handleSwitchChain } = useChainModalContext();
+  const {
+    handleSwitchChain,
+    isPending: isSwitchChainPending,
+    variables: switchChainVariables
+  } = useChainModalContext();
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -91,10 +94,12 @@ export function ChainModal({
           {chains.map(chain => (
             <Button
               key={chain.id}
-              onClick={() =>
+              onClick={() => {
+                // Skip if chain is already selected
+                if (chain.id === chainId) return;
+
                 handleSwitchChain({
                   chainId: chain.id,
-                  nextIntent,
                   onSuccess: (_, { chainId: newChainId }) => {
                     const newChainName = chains.find(c => c.id === newChainId)?.name;
                     if (newChainName) {
@@ -108,8 +113,8 @@ export function ChainModal({
                     }
                   },
                   onSettled: () => setOpen(false)
-                })
-              }
+                });
+              }}
               className={cn(
                 'flex w-full justify-between p-1.5',
                 chainId === chain.id &&
@@ -127,7 +132,7 @@ export function ChainModal({
                   <div className="bg-bullish h-2 w-2 rounded-full" />
                 </div>
               )}
-              {isSwitchChainPending && switchChainVariables.chainId === chain.id && (
+              {isSwitchChainPending && switchChainVariables?.chainId === chain.id && (
                 <div className="mr-1.5 flex items-center gap-2">
                   <Text variant="medium">Confirm in your wallet</Text>
                   <div className="h-2 w-2 rounded-full bg-yellow-500" />

--- a/apps/webapp/src/modules/ui/context/ChainModalContext.tsx
+++ b/apps/webapp/src/modules/ui/context/ChainModalContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useCallback } from 'react';
+import { useChains, useSwitchChain } from 'wagmi';
+import { Intent } from '@/lib/enums';
+
+type ChainModalContextType = {
+  handleSwitchChain: ({
+    chainId,
+    nextIntent,
+    onSuccess,
+    onSettled
+  }: {
+    chainId: number;
+    nextIntent?: Intent;
+    onSuccess?: (data: any, variables: { chainId: number }) => void;
+    onSettled?: () => void;
+  }) => void;
+};
+
+const ChainModalContext = createContext<ChainModalContextType>({
+  handleSwitchChain: () => {}
+});
+
+export const ChainModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const chains = useChains();
+  const { switchChain } = useSwitchChain();
+
+  const handleSwitchChain = useCallback(
+    ({
+      chainId,
+      onSuccess,
+      onSettled
+    }: {
+      chainId: number;
+      onSuccess?: (data: any, variables: { chainId: number }) => void;
+      onSettled?: () => void;
+    }) => {
+      switchChain(
+        { chainId },
+        {
+          onSuccess,
+          onSettled
+        }
+      );
+    },
+    [switchChain, chains]
+  );
+
+  return (
+    <ChainModalContext.Provider
+      value={{
+        handleSwitchChain
+      }}
+    >
+      {children}
+    </ChainModalContext.Provider>
+  );
+};
+
+export const useChainModalContext = () => useContext(ChainModalContext);

--- a/apps/webapp/src/modules/ui/context/ChainModalContext.tsx
+++ b/apps/webapp/src/modules/ui/context/ChainModalContext.tsx
@@ -1,28 +1,28 @@
 import React, { createContext, useContext, useCallback } from 'react';
-import { useChains, useSwitchChain } from 'wagmi';
-import { Intent } from '@/lib/enums';
+import { useSwitchChain } from 'wagmi';
 
 type ChainModalContextType = {
   handleSwitchChain: ({
     chainId,
-    nextIntent,
     onSuccess,
     onSettled
   }: {
     chainId: number;
-    nextIntent?: Intent;
     onSuccess?: (data: any, variables: { chainId: number }) => void;
     onSettled?: () => void;
   }) => void;
+  isPending: boolean;
+  variables: { chainId: number } | undefined;
 };
 
 const ChainModalContext = createContext<ChainModalContextType>({
-  handleSwitchChain: () => {}
+  handleSwitchChain: () => {},
+  isPending: false,
+  variables: undefined
 });
 
 export const ChainModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const chains = useChains();
-  const { switchChain } = useSwitchChain();
+  const { switchChain, isPending, variables } = useSwitchChain();
 
   const handleSwitchChain = useCallback(
     ({
@@ -38,17 +38,22 @@ export const ChainModalProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         { chainId },
         {
           onSuccess,
-          onSettled
+          onSettled,
+          onError: error => {
+            console.error('[ChainModalContext] switchChain failed:', error);
+          }
         }
       );
     },
-    [switchChain, chains]
+    [switchChain]
   );
 
   return (
     <ChainModalContext.Provider
       value={{
-        handleSwitchChain
+        handleSwitchChain,
+        isPending,
+        variables
       }}
     >
       {children}

--- a/apps/webapp/src/pages/App.tsx
+++ b/apps/webapp/src/pages/App.tsx
@@ -14,6 +14,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { ConnectedProvider } from '@/modules/ui/context/ConnectedContext';
 import { TermsModalProvider } from '@/modules/ui/context/TermsModalContext';
 import { BalanceFiltersProvider } from '@/modules/ui/context/BalanceFiltersContext';
+import { ChainModalProvider } from '@/modules/ui/context/ChainModalContext';
 import { useGovernanceMigrationToast } from '@/modules/app/hooks/useGovernanceMigrationToast';
 
 import '@rainbow-me/rainbowkit/styles.css';
@@ -40,9 +41,11 @@ const AppContent = () => {
         <TermsModalProvider>
           <BalanceFiltersProvider>
             <TooltipProvider delayDuration={300}>
-              <ExternalLinkModal />
-              <Toaster />
-              <RouterProvider router={router} />
+              <ChainModalProvider>
+                <ExternalLinkModal />
+                <Toaster />
+                <RouterProvider router={router} />
+              </ChainModalProvider>
             </TooltipProvider>
           </BalanceFiltersProvider>
         </TermsModalProvider>


### PR DESCRIPTION
#### Fix network switcher URL parameter updates by extracting chain switching logic to context
Previously, when switching networks from widgets, the URL parameters weren't being updated correctly. This occurred because the handleSwitchChain callback was defined within the ChainModal component, and when widgets unmounted during navigation, the callback would be lost before it could complete the URL parameter updates.

### Solution:
- Created a new ChainModalContext that manages chain switching logic
- Moved handleSwitchChain to the context provider using useCallback for persistence
- Updated ChainModal to use the context-provided callback

This ensures that network switching callbacks persist even when individual components unmount, maintaining consistent URL parameter updates across the application.

