### PR TITLE
Prevent details pane to remain on screen when going from mobile bpi to desktop

### DIFF
--- a/apps/webapp/src/modules/app/components/DetailsPane.tsx
+++ b/apps/webapp/src/modules/app/components/DetailsPane.tsx
@@ -39,7 +39,7 @@ const MotionDetailsWrapper = forwardRef<
 export const DetailsPane = ({ intent }: DetailsPaneProps) => {
   const defaultDetail = Intent.BALANCES_INTENT;
   const [intentState, setIntentState] = useState<Intent>(intent || defaultDetail);
-  const [keys, setKeys] = useState([0, 1, 2, 3, 4]);
+  const [keys, setKeys] = useState([0, 1, 2, 3, 4, 5, 6]);
   const { isConnectedAndAcceptedTerms } = useConnectedContext();
   const { bpi } = useBreakpointIndex();
 
@@ -48,7 +48,7 @@ export const DetailsPane = ({ intent }: DetailsPaneProps) => {
       if (prevIntentState !== intent) {
         // By giving the keys a new value, we force the motion component to animate the new component in, even if it's
         // the same component as before. This prevents the component from being re-added before being removed
-        setKeys(prevKeys => prevKeys.map(key => key + 5));
+        setKeys(prevKeys => prevKeys.map(key => key + 7));
       }
 
       return intent || defaultDetail;
@@ -96,20 +96,20 @@ export const DetailsPane = ({ intent }: DetailsPaneProps) => {
               );
             case Intent.SEAL_INTENT:
               return (
-                <MotionDetailsWrapper key={keys[3]}>
+                <MotionDetailsWrapper key={keys[4]}>
                   <SealDetailsPane />
                 </MotionDetailsWrapper>
               );
             case Intent.STAKE_INTENT:
               return (
-                <MotionDetailsWrapper key={keys[3]}>
+                <MotionDetailsWrapper key={keys[5]}>
                   <StakeDetailsPane />
                 </MotionDetailsWrapper>
               );
             case Intent.BALANCES_INTENT:
             default:
               return (
-                <MotionDetailsWrapper key={keys[4]}>
+                <MotionDetailsWrapper key={keys[6]}>
                   <BalancesDetails />
                 </MotionDetailsWrapper>
               );

--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -212,7 +212,7 @@ export function MainApp() {
   return (
     <AppContainer>
       {(bpi > BP.sm || !chatParam) && (
-        <WidgetPane intent={intent}>
+        <WidgetPane key={`widget-pane-${bpi}`} intent={intent}>
           {bpi === BP.sm && detailsParam && <DetailsPane intent={intent} />}
         </WidgetPane>
       )}


### PR DESCRIPTION
When the user navigates from a mobile breakpoint to a desktop breakpoint we were rendering 2 Details pane at the same time. One in the widgets pane (like the mobile view) and one in the details pane.

![image](https://github.com/user-attachments/assets/b7bb7ff6-468d-4e65-8ffd-f42511c2c3ac)
