### PR TITLE
Add Binance Wallet to the wallet list configuration

### DIFF
--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -6,7 +6,8 @@ import {
   rainbowWallet,
   walletConnectWallet,
   metaMaskWallet,
-  coinbaseWallet
+  coinbaseWallet,
+  binanceWallet
 } from '@rainbow-me/rainbowkit/wallets';
 import {
   TENDERLY_CHAIN_ID,
@@ -82,7 +83,7 @@ const connectors = connectorsForWallets(
   [
     {
       groupName: 'Suggested',
-      wallets: [metaMaskWallet, coinbaseWallet, walletConnectWallet, rainbowWallet, safeWallet]
+      wallets: [metaMaskWallet, coinbaseWallet, walletConnectWallet, rainbowWallet, safeWallet, binanceWallet]
     }
   ],
   {


### PR DESCRIPTION
### What does this PR do?

This PR adds the Binance Wallet to the "Suggested" group of wallet options in the RainbowKit connection modal.

### Testing steps:

1.  Run the webapp locally.
2.  Click the "Connect Wallet" button.
3.  Verify that "Binance Wallet" now appears in the list of suggested wallets.
4. Connect to it using the QR with the mobile application
5. Attempt to perform any transaction