### PR TITLE
Stake claim token fix

### DIFF
--- a/apps/webapp/src/modules/rewards/components/RewardsTokenInfo.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsTokenInfo.tsx
@@ -4,9 +4,7 @@ import { t } from '@lingui/core/macro';
 import { Text } from '@/modules/layout/components/Typography';
 import { StatsCard } from '@/modules/ui/components/StatsCard';
 import { PopoverInfo } from '@/modules/ui/components/PopoverInfo';
-import { useOverallSkyData } from '@jetstreamgg/sky-hooks';
 import { formatDecimalPercentage } from '@jetstreamgg/sky-utils';
-import { TOKENS } from '@jetstreamgg/sky-hooks';
 import { TokenIconWithBalance } from '@/modules/ui/components/TokenIconWithBalance';
 import { useSubgraphUrl } from '@/modules/app/hooks/useSubgraphUrl';
 
@@ -34,24 +32,25 @@ export function RewardsTokenInfo({ rewardContract }: { rewardContract: RewardCon
   const mostRecentReward = historicRewardsTokenData
     ?.slice()
     .sort((a, b) => b.blockTimestamp - a.blockTimestamp)[0];
-
-  const { data: skyData, isLoading: skyIsLoading, error: skyError } = useOverallSkyData();
+  const mostRecentRate = mostRecentReward?.rate;
 
   return (
     <div className="xl:scrollbar-thin flex w-full flex-wrap justify-between gap-3 overflow-auto xl:flex-nowrap">
       <StatsCard
         visible={
-          rewardContract.supplyToken.symbol === TOKENS.usds.symbol &&
-          rewardContract.rewardToken.symbol === TOKENS.sky.symbol &&
-          !!skyData?.usdsSkyCRate
+          !!rewardContract.supplyToken.symbol &&
+          !!rewardContract.rewardToken.symbol &&
+          !!mostRecentRate &&
+          !isNaN(parseFloat(mostRecentRate)) &&
+          parseFloat(mostRecentRate) > 0
         }
         title={t`Rate`}
-        isLoading={skyIsLoading}
-        error={skyError}
+        isLoading={historicRewardsTokenIsLoading}
+        error={historicRewardsTokenError}
         content={
           <div className="mt-2 flex flex-row items-center gap-2">
             <Text className="text-bullish" variant="large">
-              {formatDecimalPercentage(parseFloat(skyData?.usdsSkyCRate || '0'))}
+              {formatDecimalPercentage(parseFloat(mostRecentRate || '0'))}
             </Text>
             <PopoverInfo type="str" />
           </div>

--- a/apps/webapp/src/modules/stake/components/StakeHistory.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeHistory.tsx
@@ -74,19 +74,21 @@ const mapTypeEnumToIcon = (type: TransactionTypeEnum) => {
   }
 };
 
-// TODO: Eventually rewards will be claimed for different tokens as well,
-// so we would need to fetch the reward token dynamically
-const mapTypeEnumToTokenSymbol = (type: TransactionTypeEnum) => {
-  switch (type) {
+const MapTypeEnumToTokenSymbol = ({ item }: { item: StakeHistoryItem }) => {
+  const rewardContract = 'rewardContract' in item ? (item.rewardContract as `0x${string}`) : undefined;
+  const { data: rewardContractTokens } = useRewardContractTokens(rewardContract);
+
+  switch (item.type) {
     case TransactionTypeEnum.STAKE:
     case TransactionTypeEnum.UNSTAKE:
-      return 'SKY';
+      return <>SKY</>;
     case TransactionTypeEnum.STAKE_BORROW:
     case TransactionTypeEnum.STAKE_REPAY:
+      return <>USDS</>;
     case TransactionTypeEnum.STAKE_REWARD:
-      return 'USDS';
+      return <>{rewardContractTokens?.rewardsToken.symbol || 'USDS'}</>;
     default:
-      return '';
+      return <></>;
   }
 };
 
@@ -94,7 +96,11 @@ const highlightedEvents = [TransactionTypeEnum.STAKE, TransactionTypeEnum.UNSTAK
 
 const mapStakeRowToLeftText = (s: StakeHistoryItem) => {
   if ('amount' in s) {
-    return `${formatBigInt(s.amount || 0n, { compact: true })} ${mapTypeEnumToTokenSymbol(s.type)}`;
+    return (
+      <>
+        {formatBigInt(s.amount || 0n, { compact: true })} <MapTypeEnumToTokenSymbol item={s} />
+      </>
+    );
   }
   if ('rewardContract' in s) {
     return <SelectRewardsText contractAddress={s.rewardContract as `0x${string}`} />;

--- a/apps/webapp/src/modules/stake/components/StakeHistory.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeHistory.tsx
@@ -86,7 +86,7 @@ const MapTypeEnumToTokenSymbol = ({ item }: { item: StakeHistoryItem }) => {
     case TransactionTypeEnum.STAKE_REPAY:
       return <>USDS</>;
     case TransactionTypeEnum.STAKE_REWARD:
-      return <>{rewardContractTokens?.rewardsToken.symbol || 'USDS'}</>;
+      return <>{rewardContractTokens?.rewardsToken.symbol || ''}</>;
     default:
       return <></>;
   }

--- a/apps/webapp/src/modules/ui/components/HighlightRate.tsx
+++ b/apps/webapp/src/modules/ui/components/HighlightRate.tsx
@@ -6,7 +6,7 @@ import { LoadingErrorWrapper } from './LoadingErrorWrapper';
 import { PopoverInfo } from './PopoverInfo';
 import { TOKENS } from '@jetstreamgg/sky-hooks';
 import { useOverallSkyData } from '@jetstreamgg/sky-hooks';
-import { useRewardsRate } from '@jetstreamgg/sky-hooks';
+import { useRewardsChartInfo } from '@jetstreamgg/sky-hooks';
 import { formatDecimalPercentage } from '@jetstreamgg/sky-utils';
 
 // TODO export PairTokenIcons from widgets?
@@ -95,18 +95,21 @@ export function RewardsRate({
 
   // Use dynamic rate calculation instead of hardcoded API field
   const {
-    data: rateData,
-    isLoading,
-    error
-  } = useRewardsRate({
-    contractAddress: selectedRewardContract.contractAddress as `0x${string}`,
-    chainId
+    data: chartData,
+    isLoading: isLoadingChart,
+    error: errorChart
+  } = useRewardsChartInfo({
+    rewardContractAddress: selectedRewardContract.contractAddress
   });
+
+  const mostRecentData = chartData
+    ? [...chartData].sort((a, b) => b.blockTimestamp - a.blockTimestamp)[0]
+    : null;
 
   return (
     <LoadingErrorWrapper
-      isLoading={isLoading}
-      error={error}
+      isLoading={isLoadingChart}
+      error={errorChart}
       errorComponent={<Text variant="medium">There was an error fetching the rewards rate</Text>}
     >
       {selectedRewardContract ? (
@@ -120,9 +123,11 @@ export function RewardsRate({
               {selectedRewardContract.name}
             </Text>
           </div>
-          {rateData?.formatted ? (
+          {mostRecentData?.rate ? (
             <div className="flex items-center gap-2">
-              <Heading className="text-[32px]">Rate {rateData.formatted}</Heading>
+              <Heading className="text-[32px]">
+                Rate {formatDecimalPercentage(parseFloat(mostRecentData.rate))}
+              </Heading>
               <PopoverInfo type="str" />
             </div>
           ) : (


### PR DESCRIPTION
### What does this PR do?

This PR updates the Stake History component to dynamically display the correct token symbol for reward transactions.

Previously, reward claims were hardcoded to show the 'USDS' symbol. This change refactors the logic to use the `useRewardContractTokens` hook, which fetches the actual reward token symbol from the relevant contract. This ensures the history is accurate even when different staking pools offer different reward tokens.

Additionally, it correctly labels `STAKE_BORROW` and `STAKE_REPAY` transactions with the 'USDS' symbol.

![Screenshot 2025-07-01 at 2 26 54 PM](https://github.com/user-attachments/assets/4d393fb8-a95a-4e88-8751-6680cf4df60c)


### Testing steps:

1.  Navigate to the Staking page.
2.  Examine the "Stake History" list.
3.  Verify that `Stake` and `Unstake` transactions show the "SKY" token symbol.
4.  Verify that `Borrow` and `Repay` transactions show the "USDS" token symbol.
5.  Verify that "Claim Rewards" transactions show the correct symbol for the reward token they are associated with (e.g., not always 'USDS').