### PR TITLE
Fix chat bubble alignment and add back bubble background color

### DIFF
--- a/apps/webapp/src/modules/chat/components/ChatBubble.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatBubble.tsx
@@ -108,7 +108,7 @@ export const ChatBubble = ({
         </Text>
       </HStack>
       <VStack
-        className={`gap-2 ${user === UserType.user ? 'xl:bg-primary xl:w-fit xl:self-end xl:rounded-2xl xl:rounded-tr-[2px] xl:py-3 xl:pl-5 xl:pr-7' : '@2xl/chat:ml-10'}`}
+        className={`gap-2 ${user === UserType.user ? 'xl:bg-radial-(--gradient-position) xl:from-primary-start/100 xl:to-primary-end/100 xl:w-fit xl:self-end xl:rounded-2xl xl:rounded-tr-[2px] xl:py-3 xl:pb-0 xl:pl-5 xl:pr-7' : '@2xl/chat:ml-10'}`}
       >
         <Text
           variant="medium"

--- a/apps/webapp/src/modules/chat/components/ChatBubble.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatBubble.tsx
@@ -124,7 +124,7 @@ export const ChatBubble = ({
         ) : (
           <div className="space-y-5">
             <HStack className="items-center space-x-[6px]">
-              {isError && <ChatError boxSize={16} />}
+              {isError && <ChatError boxSize={16} className="mb-3" />}
               <div className="text-white/75">
                 <ChatMarkdownRenderer markdown={message} />
               </div>


### PR DESCRIPTION
### What does this PR do?
- Fix vertical alignment between the error icon and the error message in the bot response
![image](https://github.com/user-attachments/assets/799184b4-1137-4542-b696-dc5df770f3c3)

- Add back the purple background to the user messages
![image](https://github.com/user-attachments/assets/7fa41d55-6bf6-4ca9-9feb-abf1f5a9e9fd)

