### PR TITLE
Fix upgrade MKR not working due to the usage of the wrong upgrader contract

### DIFF
--- a/.changeset/fine-groups-laugh.md
+++ b/.changeset/fine-groups-laugh.md
@@ -1,0 +1,5 @@
+---
+'@jetstreamgg/sky-hooks': patch
+---
+
+Updated mkrSky mainnet contract address in hooks package

--- a/packages/hooks/generate-with-retry.js
+++ b/packages/hooks/generate-with-retry.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const MAX_RETRIES = 5;
+const RETRY_DELAY = 2000; // 2 seconds
+
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function runGenerate(attempt = 1) {
+  console.log(`\n🔄 Attempt ${attempt}/${MAX_RETRIES}: Running wagmi generate...`);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('pnpm', ['run', 'generate'], {
+      cwd: path.resolve(__dirname),
+      stdio: 'pipe',
+      shell: true
+    });
+
+    let output = '';
+    let errorOutput = '';
+
+    child.stdout.on('data', data => {
+      const text = data.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+
+    child.stderr.on('data', data => {
+      const text = data.toString();
+      errorOutput += text;
+      process.stderr.write(text);
+    });
+
+    child.on('close', code => {
+      if (code === 0) {
+        console.log('\n✅ Successfully generated wagmi hooks!');
+        resolve(true);
+      } else {
+        // Check if it's a rate limit error
+        const combinedOutput = output + errorOutput;
+        if (combinedOutput.includes('rate limit') || combinedOutput.includes('Max calls per sec')) {
+          if (attempt < MAX_RETRIES) {
+            console.log(`\n⏳ Rate limit hit. Waiting ${RETRY_DELAY}ms before retry...`);
+            reject({ rateLimited: true });
+          } else {
+            console.error('\n❌ Max retries reached. Generation failed.');
+            reject({ rateLimited: false });
+          }
+        } else {
+          console.error('\n❌ Generation failed with non-rate-limit error.');
+          reject({ rateLimited: false });
+        }
+      }
+    });
+
+    child.on('error', error => {
+      console.error('Failed to start process:', error);
+      reject({ rateLimited: false });
+    });
+  });
+}
+
+async function main() {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await runGenerate(attempt);
+      process.exit(0);
+    } catch (error) {
+      if (error.rateLimited && attempt < MAX_RETRIES) {
+        await sleep(RETRY_DELAY);
+        continue;
+      } else {
+        process.exit(1);
+      }
+    }
+  }
+}
+
+main().catch(error => {
+  console.error('Unexpected error:', error);
+  process.exit(1);
+});

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -23,7 +23,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "generate": "wagmi generate"
+    "generate": "wagmi generate",
+    "generate:retry": "node generate-with-retry.js"
   },
   "sideEffects": false,
   "peerDependencies": {

--- a/packages/hooks/src/contracts.ts
+++ b/packages/hooks/src/contracts.ts
@@ -124,7 +124,7 @@ export const contracts: { name: string; address: Record<ChainId, `0x${string}`> 
   {
     name: 'mkrSky',
     address: {
-      [mainnet.id]: '0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B',
+      [mainnet.id]: '0xA1Ea1bA18E88C381C724a75F23a130420C403f9a',
       [TENDERLY_CHAIN_ID]: '0x831C6C334f8DDeE62246a5c81B82c8e18008b38f'
     }
   },

--- a/packages/hooks/src/generated.ts
+++ b/packages/hooks/src/generated.ts
@@ -4796,7 +4796,7 @@ export const mkrConfig = { address: mkrAddress, abi: mkrAbi } as const;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const mkrSkyAbi = [
   {
@@ -4811,13 +4811,32 @@ export const mkrSkyAbi = [
   {
     type: 'event',
     anonymous: false,
+    inputs: [{ name: 'skyAmt', internalType: 'uint256', type: 'uint256', indexed: false }],
+    name: 'Burn'
+  },
+  {
+    type: 'event',
+    anonymous: false,
     inputs: [
-      { name: 'caller', internalType: 'address', type: 'address', indexed: true },
-      { name: 'usr', internalType: 'address', type: 'address', indexed: true },
-      { name: 'mkrAmt', internalType: 'uint256', type: 'uint256', indexed: false },
-      { name: 'skyAmt', internalType: 'uint256', type: 'uint256', indexed: false }
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      { name: 'take', internalType: 'uint256', type: 'uint256', indexed: false }
     ],
-    name: 'MkrToSky'
+    name: 'Collect'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'usr', internalType: 'address', type: 'address', indexed: true }],
+    name: 'Deny'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'what', internalType: 'bytes32', type: 'bytes32', indexed: true },
+      { name: 'data', internalType: 'uint256', type: 'uint256', indexed: false }
+    ],
+    name: 'File'
   },
   {
     type: 'event',
@@ -4825,10 +4844,55 @@ export const mkrSkyAbi = [
     inputs: [
       { name: 'caller', internalType: 'address', type: 'address', indexed: true },
       { name: 'usr', internalType: 'address', type: 'address', indexed: true },
+      { name: 'mkrAmt', internalType: 'uint256', type: 'uint256', indexed: false },
       { name: 'skyAmt', internalType: 'uint256', type: 'uint256', indexed: false },
-      { name: 'mkrAmt', internalType: 'uint256', type: 'uint256', indexed: false }
+      { name: 'skyFee', internalType: 'uint256', type: 'uint256', indexed: false }
     ],
-    name: 'SkyToMkr'
+    name: 'MkrToSky'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'usr', internalType: 'address', type: 'address', indexed: true }],
+    name: 'Rely'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'skyAmt', internalType: 'uint256', type: 'uint256' }],
+    name: 'burn',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'to', internalType: 'address', type: 'address' }],
+    name: 'collect',
+    outputs: [{ name: 'take_', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'usr', internalType: 'address', type: 'address' }],
+    name: 'deny',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'fee',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'what', internalType: 'bytes32', type: 'bytes32' },
+      { name: 'data', internalType: 'uint256', type: 'uint256' }
+    ],
+    name: 'file',
+    outputs: [],
+    stateMutability: 'nonpayable'
   },
   {
     type: 'function',
@@ -4856,6 +4920,13 @@ export const mkrSkyAbi = [
   },
   {
     type: 'function',
+    inputs: [{ name: 'usr', internalType: 'address', type: 'address' }],
+    name: 'rely',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
     inputs: [],
     name: 'sky',
     outputs: [{ name: '', internalType: 'contract GemLike', type: 'address' }],
@@ -4863,26 +4934,30 @@ export const mkrSkyAbi = [
   },
   {
     type: 'function',
-    inputs: [
-      { name: 'usr', internalType: 'address', type: 'address' },
-      { name: 'skyAmt', internalType: 'uint256', type: 'uint256' }
-    ],
-    name: 'skyToMkr',
-    outputs: [],
-    stateMutability: 'nonpayable'
+    inputs: [],
+    name: 'take',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '', internalType: 'address', type: 'address' }],
+    name: 'wards',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
   }
 ] as const;
 
 /**
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const mkrSkyAddress = {
-  1: '0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B',
+  1: '0xA1Ea1bA18E88C381C724a75F23a130420C403f9a',
   314310: '0x831C6C334f8DDeE62246a5c81B82c8e18008b38f'
 } as const;
 
 /**
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const mkrSkyConfig = { address: mkrSkyAddress, abi: mkrSkyAbi } as const;
 
@@ -18418,14 +18493,25 @@ export const useWatchMkrApproval = /*#__PURE__*/ createUseWatchContractEvent({
 /**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useReadMkrSky = /*#__PURE__*/ createUseReadContract({ abi: mkrSkyAbi, address: mkrSkyAddress });
 
 /**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"fee"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useReadMkrSkyFee = /*#__PURE__*/ createUseReadContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'fee'
+});
+
+/**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"mkr"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useReadMkrSkyMkr = /*#__PURE__*/ createUseReadContract({
   abi: mkrSkyAbi,
@@ -18436,7 +18522,7 @@ export const useReadMkrSkyMkr = /*#__PURE__*/ createUseReadContract({
 /**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"rate"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useReadMkrSkyRate = /*#__PURE__*/ createUseReadContract({
   abi: mkrSkyAbi,
@@ -18447,7 +18533,7 @@ export const useReadMkrSkyRate = /*#__PURE__*/ createUseReadContract({
 /**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"sky"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useReadMkrSkySky = /*#__PURE__*/ createUseReadContract({
   abi: mkrSkyAbi,
@@ -18456,9 +18542,31 @@ export const useReadMkrSkySky = /*#__PURE__*/ createUseReadContract({
 });
 
 /**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"take"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useReadMkrSkyTake = /*#__PURE__*/ createUseReadContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'take'
+});
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"wards"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useReadMkrSkyWards = /*#__PURE__*/ createUseReadContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'wards'
+});
+
+/**
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useWriteMkrSky = /*#__PURE__*/ createUseWriteContract({
   abi: mkrSkyAbi,
@@ -18466,9 +18574,53 @@ export const useWriteMkrSky = /*#__PURE__*/ createUseWriteContract({
 });
 
 /**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"burn"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWriteMkrSkyBurn = /*#__PURE__*/ createUseWriteContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'burn'
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"collect"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWriteMkrSkyCollect = /*#__PURE__*/ createUseWriteContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'collect'
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"deny"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWriteMkrSkyDeny = /*#__PURE__*/ createUseWriteContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'deny'
+});
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"file"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWriteMkrSkyFile = /*#__PURE__*/ createUseWriteContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'file'
+});
+
+/**
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"mkrToSky"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useWriteMkrSkyMkrToSky = /*#__PURE__*/ createUseWriteContract({
   abi: mkrSkyAbi,
@@ -18477,20 +18629,20 @@ export const useWriteMkrSkyMkrToSky = /*#__PURE__*/ createUseWriteContract({
 });
 
 /**
- * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"skyToMkr"`
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"rely"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
-export const useWriteMkrSkySkyToMkr = /*#__PURE__*/ createUseWriteContract({
+export const useWriteMkrSkyRely = /*#__PURE__*/ createUseWriteContract({
   abi: mkrSkyAbi,
   address: mkrSkyAddress,
-  functionName: 'skyToMkr'
+  functionName: 'rely'
 });
 
 /**
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useSimulateMkrSky = /*#__PURE__*/ createUseSimulateContract({
   abi: mkrSkyAbi,
@@ -18498,9 +18650,53 @@ export const useSimulateMkrSky = /*#__PURE__*/ createUseSimulateContract({
 });
 
 /**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"burn"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useSimulateMkrSkyBurn = /*#__PURE__*/ createUseSimulateContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'burn'
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"collect"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useSimulateMkrSkyCollect = /*#__PURE__*/ createUseSimulateContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'collect'
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"deny"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useSimulateMkrSkyDeny = /*#__PURE__*/ createUseSimulateContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'deny'
+});
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"file"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useSimulateMkrSkyFile = /*#__PURE__*/ createUseSimulateContract({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  functionName: 'file'
+});
+
+/**
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"mkrToSky"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useSimulateMkrSkyMkrToSky = /*#__PURE__*/ createUseSimulateContract({
   abi: mkrSkyAbi,
@@ -18509,20 +18705,20 @@ export const useSimulateMkrSkyMkrToSky = /*#__PURE__*/ createUseSimulateContract
 });
 
 /**
- * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"skyToMkr"`
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link mkrSkyAbi}__ and `functionName` set to `"rely"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
-export const useSimulateMkrSkySkyToMkr = /*#__PURE__*/ createUseSimulateContract({
+export const useSimulateMkrSkyRely = /*#__PURE__*/ createUseSimulateContract({
   abi: mkrSkyAbi,
   address: mkrSkyAddress,
-  functionName: 'skyToMkr'
+  functionName: 'rely'
 });
 
 /**
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useWatchMkrSky = /*#__PURE__*/ createUseWatchContractEvent({
   abi: mkrSkyAbi,
@@ -18530,9 +18726,53 @@ export const useWatchMkrSky = /*#__PURE__*/ createUseWatchContractEvent({
 });
 
 /**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"Burn"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWatchMkrSkyBurn = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  eventName: 'Burn'
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"Collect"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWatchMkrSkyCollect = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  eventName: 'Collect'
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"Deny"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWatchMkrSkyDeny = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  eventName: 'Deny'
+});
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"File"`
+ *
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
+ */
+export const useWatchMkrSkyFile = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: mkrSkyAbi,
+  address: mkrSkyAddress,
+  eventName: 'File'
+});
+
+/**
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"MkrToSky"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
 export const useWatchMkrSkyMkrToSky = /*#__PURE__*/ createUseWatchContractEvent({
   abi: mkrSkyAbi,
@@ -18541,14 +18781,14 @@ export const useWatchMkrSkyMkrToSky = /*#__PURE__*/ createUseWatchContractEvent(
 });
 
 /**
- * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"SkyToMkr"`
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link mkrSkyAbi}__ and `eventName` set to `"Rely"`
  *
- * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B)
+ * [__View Contract on Ethereum Etherscan__](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a)
  */
-export const useWatchMkrSkySkyToMkr = /*#__PURE__*/ createUseWatchContractEvent({
+export const useWatchMkrSkyRely = /*#__PURE__*/ createUseWatchContractEvent({
   abi: mkrSkyAbi,
   address: mkrSkyAddress,
-  eventName: 'SkyToMkr'
+  eventName: 'Rely'
 });
 
 /**

--- a/packages/hooks/src/upgrade/useUpgradeHistory.ts
+++ b/packages/hooks/src/upgrade/useUpgradeHistory.ts
@@ -32,6 +32,12 @@ async function fetchUpgradeHistory(
         blockTimestamp
         transactionHash
       }
+      mkrToSkyUpgradeV2S(where: {usr: "${address}"}) {
+        mkrAmt
+        skyAmt
+        blockTimestamp
+        transactionHash
+      }
       skyToMkrReverts(where: {usr: "${address}"}) {
         mkrAmt
         skyAmt
@@ -42,7 +48,7 @@ async function fetchUpgradeHistory(
   `;
 
   const response: Record<
-    'daiToUsdsUpgrades' | 'usdsToDaiReverts' | 'mkrToSkyUpgrades' | 'skyToMkrReverts',
+    'daiToUsdsUpgrades' | 'usdsToDaiReverts' | 'mkrToSkyUpgrades' | 'skyToMkrReverts' | 'mkrToSkyUpgradeV2S',
     UpgradeResponses
   > = await request(urlSubgraph, query);
 
@@ -76,6 +82,18 @@ async function fetchUpgradeHistory(
     chainId
   }));
 
+  const mkrToSkyUpgradeV2S: MkrSkyRow[] = response.mkrToSkyUpgradeV2S.map(
+    (d: UpgradeResponse<MkrSkyRow>) => ({
+      mkrAmt: BigInt(d.mkrAmt),
+      skyAmt: BigInt(d.skyAmt),
+      blockTimestamp: new Date(parseInt(d.blockTimestamp) * 1000),
+      transactionHash: d.transactionHash,
+      module: ModuleEnum.UPGRADE,
+      type: TransactionTypeEnum.MKR_TO_SKY,
+      chainId
+    })
+  );
+
   const skyToMkrReverts: MkrSkyRow[] = response.skyToMkrReverts.map((w: UpgradeResponse<MkrSkyRow>) => ({
     mkrAmt: -BigInt(w.mkrAmt), //make withdrawals negative
     skyAmt: -BigInt(w.skyAmt),
@@ -86,7 +104,13 @@ async function fetchUpgradeHistory(
     chainId
   }));
 
-  const combined = [...daiToUsdsUpgrades, ...usdsToDaiReverts, ...mkrToSkyUpgrades, ...skyToMkrReverts];
+  const combined = [
+    ...daiToUsdsUpgrades,
+    ...usdsToDaiReverts,
+    ...mkrToSkyUpgrades,
+    ...mkrToSkyUpgradeV2S,
+    ...skyToMkrReverts
+  ];
   return combined.sort((a, b) => b.blockTimestamp.getTime() - a.blockTimestamp.getTime());
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the `mkrSky` mainnet contract address in the `sky-hooks` package. It also adds support for V2 MKR-to-SKY upgrade events in the `useUpgradeHistory` hook to ensure a complete transaction history.

Additionally, it introduces a `generate:retry` script to make the Wagmi hook generation process more resilient to API rate-limiting errors.

### Testing steps:

1.  Connect to the application on Mainnet.
2.  Navigate to the MKR/SKY upgrade page and verify that interactions with the new contract address work as expected.
3.  View the transaction history for an account that has performed a V2 MKR-to-SKY upgrade and confirm the transaction appears correctly in the list.