### PR TITLE
Fixes staking engine delegates search by address

### DIFF
--- a/packages/hooks/src/stake/useStakeUserDelegates.ts
+++ b/packages/hooks/src/stake/useStakeUserDelegates.ts
@@ -100,6 +100,11 @@ export function useStakeUserDelegates({
   const sortDelegatesFn =
     sortType === 'totalDelegated' ? sortDelegatesByTotalDelegatedFn : sortDelegatesByAlignedFn;
 
+  // Reset hasInitiallyOrdered when search changes
+  useEffect(() => {
+    hasInitiallyOrdered.current = false;
+  }, [search]);
+
   // Memoize the delegates transformation to prevent unnecessary re-computations
   const delegatesWithTotals = useMemo(() => {
     if (!delegates) return undefined;


### PR DESCRIPTION
Reset hasInitiallyOrdered state when search input changes in useStakeUserDelegates hook to fix the search

### Before
<img width="408" height="1045" alt="image" src="https://github.com/user-attachments/assets/1a7d0bca-1e38-4572-9147-d68a3529f94f" />

### Now
<img width="408" height="1045" alt="image" src="https://github.com/user-attachments/assets/602b5064-937b-4f32-89e1-ca90387b132a" />


