### PR TITLE
QA items

### DIFF
--- a/packages/utils/src/formatValue.ts
+++ b/packages/utils/src/formatValue.ts
@@ -67,7 +67,8 @@ export function formatBigInt(amount: bigint, options?: FormatOptions): string {
 
 export function formatNumber(amount: number, options?: FormatOptions): string {
   const absAmount = Math.abs(amount);
-  const smallestNumber = 1 / Math.pow(10, SMALL_NUM_DECIMALS); //0.0001 if SMALL_NUM_DECIMALS is 4
+  // If the maxDecimals is provided, set the smallestNumber with that amount of decimals
+  const smallestNumber = 1 / Math.pow(10, options?.maxDecimals || SMALL_NUM_DECIMALS); //0.0001 if SMALL_NUM_DECIMALS is 4
   const lessThanSmallest = absAmount > 0 && absAmount < smallestNumber / 2;
   const amountToFormat = lessThanSmallest ? smallestNumber : amount;
   const result = createNumberFormatter({ ...options, amount: amountToFormat }).format(

--- a/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
+++ b/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
@@ -212,7 +212,17 @@ export const PopoverRateInfo = ({
         <PopoverClose onClick={e => e.stopPropagation()} className="absolute right-4 top-4 z-10">
           <Close className="h-5 w-5 cursor-pointer text-white" />
         </PopoverClose>
-        <div className="scrollbar-thin mt-2 max-h-[calc(var(--radix-popover-content-available-height)-64px)] overflow-y-auto">
+        <div
+          className="scrollbar-thin mt-2 max-h-[calc(var(--radix-popover-content-available-height)-64px)] overflow-y-auto"
+          // The `onWheel` and `onTouchMove` stopPropagation handlers allow to scroll through the popover
+          // content when rendered on top of another focus capturing elements, like modals.
+          onWheel={e => {
+            e.stopPropagation();
+          }}
+          onTouchMove={e => {
+            e.stopPropagation();
+          }}
+        >
           {content[type].description}
         </div>
         <PopoverArrow />

--- a/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
+++ b/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
@@ -364,7 +364,7 @@ export function TokenInput({
         <PopoverContent
           className="bg-container rounded-[20px] border-0 p-2 pr-0 pt-5 backdrop-blur-[50px]"
           sideOffset={4}
-          avoidCollisions={false}
+          avoidCollisions={true}
           style={{ width: `${width}px` }}
         >
           <VStack className="w-full space-y-2">


### PR DESCRIPTION
### What does this PR do?
- Prevent token input popover from colliding with edge of viewport:
On small height screens, the token input popover would render and be cut by the edge of the viewport. Setting the `avoidCollisions` property to `true` lets the popover detect edges render the popover content above if there's not enough space below.
- Fix an issue where using the `formatNumber` function with the `maxDecimals` set to something larger than `SMALL_NUM_DECIMALS (4)` would cause small numbers to be formatted as `<0%`
- Fix issue that prevented popovers to be scrolled through when rendered on top of modals

### Testing steps:
- Decrease the viewport screen enough so the popover doesn't have enough space to render below and check that it correctly renders above.
- Select different tokens and check that the behavior is the expected one.
- There used to be a previous issue where this property would cause the popover flashing. Check that this is not the case anymore.
For the popover scroll issue: 
- Navigate to the stake page and go to the open position flow
- At the top of the widget, click on the `(i)` icon next to the `1/4 STEPS` to open the modal
- Next, click on the `(i)` icon in the (3) delegate section to open the popover
- Attempt to scroll through the text using the mouse wheel, it should be possible now