### PR TITLE
Don't show the steps on rewards claim flows

### DIFF
--- a/packages/widgets/src/widgets/RewardsWidget/index.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/index.tsx
@@ -397,8 +397,10 @@ const RewardsWidgetWrapped = ({
 
   useEffect(() => {
     // Only the supply flow requires token allowance
-    setShowStepIndicator(widgetState.flow === RewardsFlow.SUPPLY);
-  }, [widgetState.flow]);
+    setShowStepIndicator(
+      widgetState.flow === RewardsFlow.SUPPLY && widgetState.action !== RewardsAction.CLAIM
+    );
+  }, [widgetState.flow, widgetState.action]);
 
   useEffect(() => {
     if (widgetState.action === RewardsAction.CLAIM) {


### PR DESCRIPTION
### What does this PR do?
Fixes this issue when claiming rewards:
<img width="410" height="520" alt="image" src="https://github.com/user-attachments/assets/dc2f52fc-d28c-4d43-87a9-842ab89f6fb2" />
