### PR TITLE
Refactor tooltip for mobile devices

### DIFF
--- a/apps/webapp/src/components/InfoTooltip.tsx
+++ b/apps/webapp/src/components/InfoTooltip.tsx
@@ -20,7 +20,11 @@ export function InfoTooltip({
 
   return isTouchDevice ? (
     <Popover>
-      <PopoverTrigger onClick={e => e.stopPropagation()} className="z-10">
+      <PopoverTrigger
+        onClick={e => e.stopPropagation()}
+        className="z-10"
+        aria-label="Show additional information"
+      >
         <Info size={iconSize} className={iconClassName} />
       </PopoverTrigger>
       <PopoverContent
@@ -45,7 +49,7 @@ export function InfoTooltip({
     </Popover>
   ) : (
     <Tooltip>
-      <TooltipTrigger>
+      <TooltipTrigger aria-label="Show additional information">
         <Info size={iconSize} className={iconClassName} />
       </TooltipTrigger>
       <TooltipPortal>

--- a/apps/webapp/src/components/InfoTooltip.tsx
+++ b/apps/webapp/src/components/InfoTooltip.tsx
@@ -1,19 +1,6 @@
 import { Info, X } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '../../../../components/ui/tooltip';
-import {
-  Popover,
-  PopoverArrow,
-  PopoverClose,
-  PopoverContent,
-  PopoverTrigger
-} from '../../../../components/ui/popover';
-import { Text } from '@widgets/shared/components/ui/Typography';
+import { Tooltip, TooltipArrow, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
+import { Popover, PopoverArrow, PopoverClose, PopoverContent, PopoverTrigger } from './ui/popover';
 import { useIsTouchDevice } from '@jetstreamgg/sky-utils';
 
 export function InfoTooltip({
@@ -51,7 +38,7 @@ export function InfoTooltip({
           onWheel={e => e.stopPropagation()}
           onTouchMove={e => e.stopPropagation()}
         >
-          {typeof content === 'string' ? <Text>{content}</Text> : content}
+          {typeof content === 'string' ? <p>{content}</p> : content}
         </div>
         <PopoverArrow />
       </PopoverContent>
@@ -64,7 +51,7 @@ export function InfoTooltip({
       <TooltipPortal>
         <TooltipContent className={`max-w-[400px] ${contentClassname}`} arrowPadding={10}>
           <div className="scrollbar-thin max-h-[calc(var(--radix-tooltip-content-available-height)-64px)] overflow-y-auto">
-            {typeof content === 'string' ? <Text>{content}</Text> : content}
+            {typeof content === 'string' ? <p>{content}</p> : content}
           </div>
           <TooltipArrow width={12} height={8} />
         </TooltipContent>

--- a/apps/webapp/src/components/ui/tooltip.tsx
+++ b/apps/webapp/src/components/ui/tooltip.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-
+import { useIsTouchDevice } from '@jetstreamgg/sky-utils';
 import { cn } from '@/lib/utils';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
-const Tooltip = TooltipPrimitive.Root;
+const Tooltip = ({ open, ...props }: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => {
+  const isTouchDevice = useIsTouchDevice();
+
+  // Force tooltip to be closed on touch devices
+  const controlledOpen = isTouchDevice ? false : open;
+
+  return <TooltipPrimitive.Root open={controlledOpen} {...props} />;
+};
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 

--- a/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
@@ -11,9 +11,7 @@ import { chainIdNameMapping, intentModifiesState } from '../lib/intentUtils';
 import { useChainId } from 'wagmi';
 import { ConfirmationWarningRow } from './ConfirmationWarningRow';
 import { HStack } from '@/modules/layout/components/HStack';
-import { Info } from '@/modules/icons';
-import { Tooltip, TooltipArrow, TooltipPortal, TooltipTrigger } from '@/components/ui/tooltip';
-import { TooltipContent } from '@/components/ui/tooltip';
+import { InfoTooltip } from '@/components/InfoTooltip';
 import { Trans } from '@lingui/react/macro';
 
 type ChatIntentsRowProps = {
@@ -40,22 +38,18 @@ export const ChatIntentsRow = ({ intents }: ChatIntentsRowProps) => {
         <Text className="mr-2 text-xs italic text-gray-500">
           <Trans>Try a suggested action</Trans>
         </Text>
-        <Tooltip>
-          <TooltipTrigger asChild className="cursor-pointer text-gray-400">
-            <Info width={12} height={12} />
-          </TooltipTrigger>
-          <TooltipPortal>
-            <TooltipContent arrowPadding={10} className="max-w-[300px]">
-              <Text variant="small">
-                <Trans>
-                  Selecting a suggested action will prefill transaction details, but execution still requires
-                  user review and confirmation.
-                </Trans>
-              </Text>
-              <TooltipArrow width={12} height={8} />
-            </TooltipContent>
-          </TooltipPortal>
-        </Tooltip>
+        <InfoTooltip
+          iconClassName="text-gray-400"
+          iconSize={12}
+          content={
+            <Text variant="small">
+              <Trans>
+                Selecting a suggested action will prefill transaction details, but execution still requires
+                user review and confirmation.
+              </Trans>
+            </Text>
+          }
+        />
       </HStack>
       <div className="mt-2 flex flex-wrap gap-2">
         {intents.map((intent, index) => (

--- a/packages/utils/src/hooks/useIsTouchDevice.ts
+++ b/packages/utils/src/hooks/useIsTouchDevice.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook to detect if the current device supports touch interactions.
+ * Returns false initially for SSR compatibility, then updates after mount.
+ *
+ * @returns {boolean} true if the device supports touch, false otherwise
+ */
+export function useIsTouchDevice(): boolean {
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+  useEffect(() => {
+    setIsTouchDevice('ontouchstart' in window || navigator.maxTouchPoints > 0);
+  }, []);
+
+  return isTouchDevice;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -33,3 +33,4 @@ export * from './math.constants';
 export * from './collection';
 export * from './getChainIcon';
 export * from './i18n';
+export * from './hooks/useIsTouchDevice';

--- a/packages/widgets/src/components/ui/tooltip.tsx
+++ b/packages/widgets/src/components/ui/tooltip.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { useIsTouchDevice } from '@jetstreamgg/sky-utils';
 
 import { cn } from '@widgets/lib/utils';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
-const Tooltip = TooltipPrimitive.Root;
+const Tooltip = ({ open, ...props }: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => {
+  const isTouchDevice = useIsTouchDevice();
+
+  // Force tooltip to be closed on touch devices
+  const controlledOpen = isTouchDevice ? false : open;
+
+  return <TooltipPrimitive.Root open={controlledOpen} {...props} />;
+};
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 

--- a/packages/widgets/src/shared/components/ui/tooltip/InfoTooltip.tsx
+++ b/packages/widgets/src/shared/components/ui/tooltip/InfoTooltip.tsx
@@ -33,7 +33,11 @@ export function InfoTooltip({
 
   return isTouchDevice ? (
     <Popover>
-      <PopoverTrigger onClick={e => e.stopPropagation()} className="z-10">
+      <PopoverTrigger
+        onClick={e => e.stopPropagation()}
+        className="z-10"
+        aria-label="Show additional information"
+      >
         <Info size={iconSize} className={iconClassName} />
       </PopoverTrigger>
       <PopoverContent
@@ -58,7 +62,7 @@ export function InfoTooltip({
     </Popover>
   ) : (
     <Tooltip>
-      <TooltipTrigger>
+      <TooltipTrigger aria-label="Show additional information">
         <Info size={iconSize} className={iconClassName} />
       </TooltipTrigger>
       <TooltipPortal>


### PR DESCRIPTION
### What does this PR do?

This PR improves the user experience for tooltips on mobile and touch-enabled devices. It introduces a new `InfoTooltip` component that conditionally renders a standard tooltip on desktop (on hover) and an on-click popover on touch devices.

To achieve this, the PR also adds:
- A `useIsTouchDevice` hook to detect the user's device type.
- An update to the base `Tooltip` component to disable it on touch devices, preventing inconsistent behavior.
- A refactor of the info icon in the chat interface to use the new `InfoTooltip` component.

### Testing steps:

1.  Navigate to the chat interface where the "Try a suggested action" text is visible.
2.  **On Desktop:**
    - Hover over the `i` icon.
    - **Expected:** A tooltip should appear.
    - Move your mouse away.
    - **Expected:** The tooltip should disappear.
3.  **On a Mobile Device (or using browser device emulation):**
    - Tap the `i` icon.
    - **Expected:** A popover should appear.
    - Tap outside of the popover.
    - **Expected:** The popover should close.