### PR TITLE
Fetch terms from GitHuh

### DIFF
--- a/apps/webapp/src/modules/chat/components/ChatbotTermsModal.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatbotTermsModal.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
-import { Text } from '@/modules/layout/components/Typography';
 import { TermsDialog } from '@/modules/ui/components/TermsDialog';
+import { TermsMarkdownRenderer } from '@/modules/ui/components/markdown/TermsMarkdownRenderer';
 import { Checkbox } from '@/components/ui/checkbox';
 import { CheckedState } from '@radix-ui/react-checkbox';
 
@@ -14,6 +14,7 @@ interface ChatbotTermsModalProps {
   termsContent?: string;
   isLoading?: boolean;
   error?: string | null;
+  termsLoadedSuccessfully?: boolean;
 }
 
 export const ChatbotTermsModal: React.FC<ChatbotTermsModalProps> = ({
@@ -23,7 +24,8 @@ export const ChatbotTermsModal: React.FC<ChatbotTermsModalProps> = ({
   termsVersion,
   termsContent,
   isLoading = false,
-  error = null
+  error = null,
+  termsLoadedSuccessfully = true
 }) => {
   const [isChecked, setIsChecked] = useState(false);
   const [hasScrolledToEnd, setHasScrolledToEnd] = useState(false);
@@ -84,16 +86,17 @@ export const ChatbotTermsModal: React.FC<ChatbotTermsModalProps> = ({
       isOpen={isOpen}
       onOpenChange={handleOpenChange}
       title={t`Chatbot Terms of Service`}
-      content={<Text className="whitespace-pre-wrap text-sm text-violet-100/90">{termsContent}</Text>}
+      content={termsContent ? <TermsMarkdownRenderer markdown={termsContent} /> : null}
       termsVersion={termsVersion}
       error={error}
       isLoading={isLoading}
-      onAccept={onAccept}
+      onAccept={termsLoadedSuccessfully ? onAccept : () => {}}
       onDecline={onDecline}
-      acceptButtonText={getButtonText()}
+      acceptButtonText={termsLoadedSuccessfully ? getButtonText() : undefined}
+      declineButtonText={termsLoadedSuccessfully ? t`Reject` : t`Close`}
       acceptButtonDisabled={!isChecked}
-      additionalContent={checkboxContent}
-      showScrollInstruction={true}
+      additionalContent={termsLoadedSuccessfully ? checkboxContent : undefined}
+      showScrollInstruction={termsLoadedSuccessfully}
       scrollInstructionText={t`Please scroll to the bottom and read the entire terms; the checkbox will become enabled afterward.`}
     />
   );

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -26,6 +26,7 @@ export default ({ mode }: { mode: modeEnum }) => {
   const RPC_PROVIDER_OPTIMISM = process.env.VITE_RPC_PROVIDER_OPTIMISM || '';
   const RPC_PROVIDER_UNICHAIN = process.env.VITE_RPC_PROVIDER_UNICHAIN || '';
 
+  // TODO: Update the githubusercontent.com url when the terms document is ready in the right location
   const CONTENT_SECURITY_POLICY = `
     default-src 'self';
     script-src 'self'
@@ -78,6 +79,7 @@ export default ({ mode }: { mode: modeEnum }) => {
       https://enhanced-provider.rainbow.me
       https://mainnet.unichain.org/
       https://mainnet.optimism.io/
+      https://raw.githubusercontent.com/jetstreamgg/tarmac/main/README.md
       cloudflareinsights.com;
     frame-src 'self'
       https://verify.walletconnect.com


### PR DESCRIPTION
Fetched the terms content from a public repository in Github, in this case it's our own tarmac repo just for testing purposes.

### Notes:
- We are using this repo's README file as the content to fetch
- The expected format for this TERMS.md file should be

```
YYYY-MM-dd
<text>
```
Example:
```
2025-07-15
# Terms Of Service
Lorem ipsum...
```

### How to test it:

**Happy path**
1. Delete the chatbot cookie so the terms modal shows up
2. Type something in the chatbot pane
3. The modal should render the tarmac's README.md
4. Accept the terms and chat with the chatbot

**Error fetching content**

1. Modify the CSP to change the github url a little bit, append '123' at the end of the url, for instance (this will force a fetch error)
2. Delete the cookie
3. Chat with the chatbot 
4. The modal should render an error and the only option the user has is to close the modal

**File with the wrong format**

If you comment the lines that add the mock date to the response you'll trigger a format error and you'll see a different modal content