### PR TITLE
handle stusds balance module filtering

### DIFF
--- a/packages/hooks/src/stusds/useStUsdsData.ts
+++ b/packages/hooks/src/stusds/useStUsdsData.ts
@@ -4,7 +4,7 @@ import { useTokenBalance } from '../tokens/useTokenBalance';
 import { usdsAddress, stUsdsAddress, stUsdsAbi } from '../generated';
 import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
 import { DataSource, ReadHook } from '../hooks';
-import { getEtherscanLink } from '@jetstreamgg/sky-utils';
+import { getEtherscanLink, isTestnetId } from '@jetstreamgg/sky-utils';
 
 export type StUsdsHookData = {
   totalAssets: bigint;
@@ -27,7 +27,8 @@ export type StUsdsHook = ReadHook & {
 };
 
 export function useStUsdsData(address?: `0x${string}`): StUsdsHook {
-  const chainId = useChainId();
+  const connectedChainId = useChainId();
+  const chainId = isTestnetId(connectedChainId) ? 314310 : 1; //StUsds is only on mainnet / mainnet testnet
   const { address: connectedAddress } = useAccount();
   const acct = address || connectedAddress;
 

--- a/packages/hooks/src/tokens/tokens.constants.ts
+++ b/packages/hooks/src/tokens/tokens.constants.ts
@@ -181,7 +181,7 @@ export const TOKENS: TokenMapping = {
     address: stUsdsAddress, // TODO: no stUsdsConfig for now as it comes from the wagmi etherscan plugin
     name: 'stUSDS',
     symbol: 'stUSDS',
-    color: '#1AAB9B',
+    color: '#EB5EDF',
     decimals: 18
   }
 };

--- a/packages/hooks/src/tokens/tokens.constants.ts
+++ b/packages/hooks/src/tokens/tokens.constants.ts
@@ -16,7 +16,8 @@ import {
   sUsdsL2Address,
   usdcL2Address,
   usdsL2Address,
-  spkConfig
+  spkConfig,
+  stUsdsAddress
 } from '../generated';
 import { TokenMapping, Token, TokenForChain } from './types';
 import { TENDERLY_BASE_CHAIN_ID, TENDERLY_CHAIN_ID, TENDERLY_ARBITRUM_CHAIN_ID } from '../constants';
@@ -174,6 +175,13 @@ export const TOKENS: TokenMapping = {
     name: 'Spark',
     symbol: 'SPK',
     color: '#FA5768',
+    decimals: 18
+  },
+  stusds: {
+    address: stUsdsAddress, // TODO: no stUsdsConfig for now as it comes from the wagmi etherscan plugin
+    name: 'stUSDS',
+    symbol: 'stUSDS',
+    color: '#1AAB9B',
     decimals: 18
   }
 };

--- a/packages/widgets/src/config/default-config.ts
+++ b/packages/widgets/src/config/default-config.ts
@@ -20,7 +20,8 @@ import {
   usdcL2Address,
   usdsL2Address,
   sUsdsL2Address,
-  spkAddress
+  spkAddress,
+  stUsdsAddress
 } from '@jetstreamgg/sky-hooks';
 import {
   TENDERLY_ARBITRUM_CHAIN_ID,
@@ -29,7 +30,7 @@ import {
 } from '@widgets/shared/constants';
 import { SUPPORTED_TOKEN_SYMBOLS } from '..';
 
-const { usds, mkr, sky, susds, eth, weth, usdc, usdt, dai, spk } = TOKENS;
+const { usds, mkr, sky, susds, eth, weth, usdc, usdt, dai, spk, stusds } = TOKENS;
 
 // It stores all the RPCs the application will use, and also the user configured-ones
 export const defaultConfig: WidgetsConfig = {
@@ -44,7 +45,8 @@ export const defaultConfig: WidgetsConfig = {
       { ...susds, address: sUsdsAddress[mainnet.id] },
       { ...mkr, address: mkrAddress[mainnet.id] },
       { ...sky, address: skyAddress[mainnet.id] },
-      { ...spk, address: spkAddress[mainnet.id] }
+      { ...spk, address: spkAddress[mainnet.id] },
+      { ...stusds, address: stUsdsAddress[mainnet.id] }
     ],
     [TENDERLY_CHAIN_ID]: [
       eth,
@@ -56,7 +58,8 @@ export const defaultConfig: WidgetsConfig = {
       { ...susds, address: sUsdsAddress[TENDERLY_CHAIN_ID] },
       { ...mkr, address: mkrAddress[TENDERLY_CHAIN_ID] },
       { ...sky, address: skyAddress[TENDERLY_CHAIN_ID] },
-      { ...spk, address: spkAddress[TENDERLY_CHAIN_ID] }
+      { ...spk, address: spkAddress[TENDERLY_CHAIN_ID] },
+      { ...stusds, address: stUsdsAddress[TENDERLY_CHAIN_ID] }
     ],
     [base.id]: [
       eth,

--- a/packages/widgets/src/widgets/BalancesWidget/components/BalancesContent.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/BalancesContent.tsx
@@ -15,7 +15,8 @@ import {
   TokenItem,
   useTotalUserSealed,
   useMultiChainSavingsBalances,
-  useTotalUserStaked
+  useTotalUserStaked,
+  useStUsdsData
 } from '@jetstreamgg/sky-hooks';
 import { Heading, Text } from '@widgets/shared/components/ui/Typography';
 import { Trans } from '@lingui/react/macro';
@@ -209,6 +210,7 @@ export const BalancesContent = ({
     isLoading: stakeLoading,
     error: totalUserStakedError
   } = useTotalUserStaked();
+  const { data: stUsdsData, isLoading: stUsdsLoading, error: stUsdsError } = useStUsdsData();
 
   const hideSeal = Boolean(
     totalUserSealedError ||
@@ -219,6 +221,12 @@ export const BalancesContent = ({
   const hideStake = Boolean(
     totalUserStakedError ||
       (totalUserStaked === 0n && hideZeroBalances) ||
+      (!showAllNetworks && !isMainnetId(currentChainId))
+  );
+
+  const hideStUSDS = Boolean(
+    stUsdsError ||
+      stUsdsData?.userSuppliedUsds === 0n || //always hide zero balances for advanced modules
       (!showAllNetworks && !isMainnetId(currentChainId))
   );
 
@@ -289,6 +297,8 @@ export const BalancesContent = ({
               sealLoading={sealLoading}
               sealBalance={totalUserSealed}
               hideStake={hideStake}
+              hideStUSDS={hideStUSDS}
+              stusdsLoading={stUsdsLoading}
               stakeLoading={stakeLoading}
               stakeBalance={totalUserStaked}
               totalUserRewardsSupplied={totalUserRewardsSupplied}


### PR DESCRIPTION
- always hide the stusds module card if the balance is 0
- show the correct data on non-mainnet networks
- filter out the card if we're only showing cards on a different network
