### PR TITLE
remove unnecessary loading skeletons in savings widget

### DIFF
--- a/packages/widgets/src/widgets/SavingsWidget/components/SavingsStatsCard.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SavingsStatsCard.tsx
@@ -42,7 +42,7 @@ export const SavingsStatsCard = ({
         data-testid="supplied-balance-container"
       >
         <Text className="text-textSecondary text-sm leading-4">{t`Savings balance`}</Text>
-        {isLoading ? (
+        {isLoading && isConnectedAndEnabled ? (
           <Skeleton className="bg-textSecondary h-6 w-10" />
         ) : isConnectedAndEnabled && stats?.savingsBalance !== undefined ? (
           <Text dataTestId="supplied-balance">

--- a/packages/widgets/src/widgets/SavingsWidget/components/SavingsStatsCardCore.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SavingsStatsCardCore.tsx
@@ -11,11 +11,9 @@ import { JSX } from 'react';
 
 export const SavingsStatsCardCore = ({
   content,
-  isLoading,
   onExternalLinkClicked
 }: {
   content: JSX.Element;
-  isLoading: boolean;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }) => {
   const { data: overallSkyData, isLoading: isOverallSkyDataLoading } = useOverallSkyData();
@@ -30,7 +28,7 @@ export const SavingsStatsCardCore = ({
       }
       headerRightContent={
         <MotionHStack className="items-center" gap={2} variants={positionAnimations}>
-          {isLoading || isOverallSkyDataLoading ? (
+          {isOverallSkyDataLoading ? (
             <Skeleton className="bg-textSecondary h-5 w-12" />
           ) : (
             <Text className="text-bullish">


### PR DESCRIPTION
both the savings rate and savings balance were taking a long time to load when the wallet was not connected in the mainnet savings widgets.