### PR TITLE
Show the right network icons for the chatbot suggested actions

### DIFF
--- a/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
+++ b/apps/webapp/src/modules/chat/components/ChatIntentsRow.tsx
@@ -11,10 +11,18 @@ import { chainIdNameMapping, intentModifiesState } from '../lib/intentUtils';
 import { useChainId } from 'wagmi';
 import { ConfirmationWarningRow } from './ConfirmationWarningRow';
 import { HStack } from '@/modules/layout/components/HStack';
-import { Info } from '@/modules/icons';
+import {
+  ArbitrumChain as Arbitrumone,
+  Info,
+  MainnetChain as Ethereum,
+  OptimismChain as Opmainnet,
+  BaseChain as Base,
+  UnichainChain as Unichain
+} from '@/modules/icons';
 import { Tooltip, TooltipArrow, TooltipPortal, TooltipTrigger } from '@/components/ui/tooltip';
 import { TooltipContent } from '@/components/ui/tooltip';
 import { Trans } from '@lingui/react/macro';
+import { capitalizeFirstLetter } from '@/lib/helpers/string/capitalizeFirstLetter';
 
 type ChatIntentsRowProps = {
   intents: ChatIntent[];
@@ -91,6 +99,17 @@ const IntentRow = ({ intent, shouldDisableActionButtons }: IntentRowProps) => {
     useNetworkFromIntentUrl(intentUrl) || chainIdNameMapping[chainId as keyof typeof chainIdNameMapping];
   const modifiesState = intentModifiesState(intent);
 
+  const networkIcons = {
+    Ethereum,
+    Arbitrumone,
+    Opmainnet,
+    Base,
+    Unichain
+  };
+
+  const IconComponent =
+    networkIcons[capitalizeFirstLetter(network || '') as keyof typeof networkIcons] || Ethereum;
+
   return (
     <Button
       variant="suggest"
@@ -108,13 +127,7 @@ const IntentRow = ({ intent, shouldDisableActionButtons }: IntentRowProps) => {
       }}
     >
       {intent.title}
-      {network && (
-        <img
-          src={`/networks/${network}.svg`}
-          alt={`${network} logo`}
-          className={`ml-2 h-5 w-5 ${shouldDisableActionButtons ? 'opacity-30' : ''}`}
-        />
-      )}
+      <IconComponent className="h-4.5 w-4.5 ml-2" />
     </Button>
   );
 };

--- a/apps/webapp/src/modules/chat/hooks/useNetworkFromUrl.tsx
+++ b/apps/webapp/src/modules/chat/hooks/useNetworkFromUrl.tsx
@@ -2,15 +2,19 @@ import { tenderly, tenderlyArbitrum, tenderlyBase } from '@/data/wagmi/config/co
 import { QueryParams } from '@/lib/constants';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
 import { testnetNameMapping } from '../lib/intentUtils';
-import { arbitrum, base, mainnet } from 'viem/chains';
+import { arbitrum, base, mainnet, optimism, unichain } from 'viem/chains';
 
 const validNetworks = [
   normalizeUrlParam(base.name),
   normalizeUrlParam(mainnet.name),
   normalizeUrlParam(arbitrum.name),
+  'arbitrum',
   normalizeUrlParam(tenderly.name),
   normalizeUrlParam(tenderlyBase.name),
-  normalizeUrlParam(tenderlyArbitrum.name)
+  normalizeUrlParam(tenderlyArbitrum.name),
+  normalizeUrlParam(unichain.name),
+  normalizeUrlParam(optimism.name),
+  'optimism'
 ];
 
 export const useNetworkFromIntentUrl = (url: string) => {

--- a/apps/webapp/src/modules/chat/lib/intentUtils.ts
+++ b/apps/webapp/src/modules/chat/lib/intentUtils.ts
@@ -36,7 +36,8 @@ export const testnetNameMapping = {
   [normalizeUrlParam(tenderlyBase.name)]: normalizeUrlParam(base.name),
   [normalizeUrlParam(tenderlyArbitrum.name)]: normalizeUrlParam(arbitrum.name),
   [normalizeUrlParam(unichain.name)]: normalizeUrlParam(unichain.name),
-  [normalizeUrlParam(optimism.name)]: normalizeUrlParam(optimism.name)
+  [normalizeUrlParam(optimism.name)]: normalizeUrlParam(optimism.name),
+  optimism: normalizeUrlParam(optimism.name)
 } as const;
 
 export const intents = {


### PR DESCRIPTION
Fixes missing icons for Unichain and Optimism
<img width="381" height="88" alt="image" src="https://github.com/user-attachments/assets/60e4c589-9d36-4346-876f-de3296e1e6ce" />
<img width="381" height="88" alt="image" src="https://github.com/user-attachments/assets/029a89fe-7589-4472-b956-b5ed640d669e" />
