### PR TITLE
Fix mobile menu bug where clicking ‘Advanced’ resets the section

### DIFF
--- a/apps/webapp/src/modules/utils/deleteSearchParams.ts
+++ b/apps/webapp/src/modules/utils/deleteSearchParams.ts
@@ -9,7 +9,8 @@ export const deleteSearchParams = (searchParams: URLSearchParams): URLSearchPara
       QueryParams.Details !== key &&
       QueryParams.Widget !== key &&
       QueryParams.Network !== key &&
-      QueryParams.Chat !== key
+      QueryParams.Chat !== key &&
+      QueryParams.AdvancedModule !== key
     ) {
       keysToDelete.push(key);
     }


### PR DESCRIPTION
### Testing steps

On mobiles, navigate to the Advanced menu, click in the stUSDS module and then click the Adavanced menu item in the mobile menu. The user should remain in the stUSDS and don't go back to the advanced module list.

This isn't an issue on tablets or desktop.