### PR TITLE
Revert bundled MKR upgrade limitation

### DIFF
--- a/packages/utils/src/hooks/useIsMetaMaskWallet.ts
+++ b/packages/utils/src/hooks/useIsMetaMaskWallet.ts
@@ -1,9 +1,0 @@
-import { useAccount } from 'wagmi';
-
-const METAMASK_CONNECTOR_ID = 'io.metamask';
-
-export const useIsMetaMaskWallet = () => {
-  const { connector } = useAccount();
-
-  return connector?.id === METAMASK_CONNECTOR_ID;
-};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,7 +29,6 @@ export * from './localization';
 export * from './hooks/useFormatDate';
 export * from './hooks/useIsSafeWallet';
 export * from './hooks/useIsSmartContractWallet';
-export * from './hooks/useIsMetaMaskWallet';
 export * from './math.constants';
 export * from './collection';
 export * from './getChainIcon';

--- a/packages/widgets/src/shared/components/ui/transaction/TransactionReview.tsx
+++ b/packages/widgets/src/shared/components/ui/transaction/TransactionReview.tsx
@@ -20,14 +20,12 @@ export function TransactionReview({
   batchEnabled,
   setBatchEnabled,
   transactionDetail,
-  legalBatchTxUrl,
-  isBatchFlowSupported = true
+  legalBatchTxUrl
 }: {
   batchEnabled?: boolean;
   setBatchEnabled?: (enabled: boolean) => void;
   transactionDetail?: React.ReactElement;
   legalBatchTxUrl?: string;
-  isBatchFlowSupported?: boolean;
 }) {
   const { txTitle, txSubtitle, stepTwoTitle, showStepIndicator } = useContext(WidgetContext);
   const { data: batchSupported } = useIsBatchSupported();
@@ -71,53 +69,42 @@ export function TransactionReview({
         {batchEnabled !== undefined && !!setBatchEnabled && !!batchSupported && (
           <motion.div variants={positionAnimations}>
             <CardFooter className="border-selectActive border-t pt-5">
-              <div>
-                <HStack className="w-full items-center justify-between">
-                  <HStack className="flex-wrap gap-1 space-x-0">
-                    <HStack className="gap-1 space-x-0">
-                      <Text className="text-[13px]">Bundle transactions</Text>
-                      <InfoTooltip
-                        contentClassname="max-w-[350px]"
-                        iconClassName="text-[13px]"
-                        content={
-                          <>
-                            <Text className="text-[13px]">Bundle transactions</Text>
-                            <Text className="text-[13px] text-white/60">
-                              Bundled transactions are set &apos;on&apos; by default to complete transactions
-                              in a single step. Combining actions improves the user experience and reduces gas
-                              fees. Manually toggle off to cancel this feature.
-                              {legalBatchTxUrl && (
-                                <>
-                                  <br />
-                                  <br />
-                                  <ExternalLink
-                                    href={legalBatchTxUrl}
-                                    className="text-textEmphasis hover:text-textEmphasis self-start text-sm hover:underline"
-                                    showIcon={false}
-                                  >
-                                    <Trans>Legal Notice</Trans>
-                                  </ExternalLink>
-                                </>
-                              )}
-                            </Text>
-                          </>
-                        }
-                      />
-                    </HStack>
-                    <Text className="text-textSecondary text-[13px]">(toggled on by default)</Text>
+              <HStack className="w-full items-center justify-between">
+                <HStack className="flex-wrap gap-1 space-x-0">
+                  <HStack className="gap-1 space-x-0">
+                    <Text className="text-[13px]">Bundle transactions</Text>
+                    <InfoTooltip
+                      contentClassname="max-w-[350px]"
+                      iconClassName="text-[13px]"
+                      content={
+                        <>
+                          <Text className="text-[13px]">Bundle transactions</Text>
+                          <Text className="text-[13px] text-white/60">
+                            Bundled transactions are set &apos;on&apos; by default to complete transactions in
+                            a single step. Combining actions improves the user experience and reduces gas
+                            fees. Manually toggle off to cancel this feature.
+                            {legalBatchTxUrl && (
+                              <>
+                                <br />
+                                <br />
+                                <ExternalLink
+                                  href={legalBatchTxUrl}
+                                  className="text-textEmphasis hover:text-textEmphasis self-start text-sm hover:underline"
+                                  showIcon={false}
+                                >
+                                  <Trans>Legal Notice</Trans>
+                                </ExternalLink>
+                              </>
+                            )}
+                          </Text>
+                        </>
+                      }
+                    />
                   </HStack>
-                  <Switch
-                    checked={batchEnabled}
-                    onCheckedChange={setBatchEnabled}
-                    disabled={!isBatchFlowSupported}
-                  />
+                  <Text className="text-textSecondary text-[13px]">(toggled on by default)</Text>
                 </HStack>
-                {!isBatchFlowSupported && (
-                  <Text className="text-textSecondary mt-2 text-[11px]">
-                    This flow is currently not supported as a bundled transaction by your wallet provider.
-                  </Text>
-                )}
-              </div>
+                <Switch checked={batchEnabled} onCheckedChange={setBatchEnabled} />
+              </HStack>
             </CardFooter>
           </motion.div>
         )}

--- a/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeTransactionReview.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeTransactionReview.tsx
@@ -23,8 +23,7 @@ export const UpgradeTransactionReview = ({
   targetToken,
   targetAmount,
   needsAllowance,
-  legalBatchTxUrl,
-  isBatchFlowSupported
+  legalBatchTxUrl
 }: {
   batchEnabled?: boolean;
   setBatchEnabled?: (enabled: boolean) => void;
@@ -35,7 +34,6 @@ export const UpgradeTransactionReview = ({
   targetAmount: bigint;
   needsAllowance: boolean;
   legalBatchTxUrl?: string;
-  isBatchFlowSupported?: boolean;
 }) => {
   const { i18n } = useLingui();
   const { data: batchSupported } = useIsBatchSupported();
@@ -99,7 +97,6 @@ export const UpgradeTransactionReview = ({
       batchEnabled={batchEnabled}
       setBatchEnabled={setBatchEnabled}
       legalBatchTxUrl={legalBatchTxUrl}
-      isBatchFlowSupported={isBatchFlowSupported}
     />
   );
 };

--- a/packages/widgets/src/widgets/UpgradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/index.tsx
@@ -17,14 +17,7 @@ import { Heading, Text } from '@widgets/shared/components/ui/Typography';
 import { UpgradeTransactionStatus } from './components/UpgradeTransactionStatus';
 import { useAccount, useChainId } from 'wagmi';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  useDebounce,
-  getTransactionLink,
-  useIsSafeWallet,
-  math,
-  formatBigInt,
-  useIsMetaMaskWallet
-} from '@jetstreamgg/sky-utils';
+import { useDebounce, getTransactionLink, useIsSafeWallet, math, formatBigInt } from '@jetstreamgg/sky-utils';
 import { useTokenAllowance } from '@jetstreamgg/sky-hooks';
 import { useUpgraderManager } from './hooks/useUpgraderManager';
 import { TxStatus, notificationTypeMaping } from '@widgets/shared/constants';
@@ -265,7 +258,6 @@ export function UpgradeWidgetWrapped({
   });
 
   const { data: batchSupported, isLoading: isBatchSupportLoading } = useIsBatchSupported();
-  const isMetaMaskWallet = useIsMetaMaskWallet();
 
   const {
     data: allowance,
@@ -281,10 +273,7 @@ export function UpgradeWidgetWrapped({
         : mkrSkyAddress[chainId as keyof typeof mkrSkyAddress]
   });
   const hasAllowance = !!(allowance && debouncedOriginAmount !== 0n && allowance >= debouncedOriginAmount);
-  // MKR to SKY conversion is not supported in MetaMask as a bundled transaction as it's throwing missleading warnings
-  // So we we avoid the bundled Upgrade MKR flow in MetaMask for now
-  const shouldAvoidBundledFlow = originToken.symbol === 'MKR' && isMetaMaskWallet;
-  const shouldUseBatch = !!batchEnabled && !!batchSupported && !hasAllowance && !shouldAvoidBundledFlow;
+  const shouldUseBatch = !!batchEnabled && !!batchSupported && !hasAllowance;
 
   const actionManager = useUpgraderManager({
     token: originToken,
@@ -848,7 +837,7 @@ export function UpgradeWidgetWrapped({
         ) : widgetState.screen === UpgradeScreen.REVIEW ? (
           <CardAnimationWrapper key="widget-transaction-review">
             <UpgradeTransactionReview
-              batchEnabled={batchEnabled && !shouldAvoidBundledFlow}
+              batchEnabled={batchEnabled}
               setBatchEnabled={setBatchEnabled}
               isBatchTransaction={shouldUseBatch}
               originToken={originToken}
@@ -857,7 +846,6 @@ export function UpgradeWidgetWrapped({
               targetAmount={math.calculateConversion(originToken, debouncedOriginAmount)}
               needsAllowance={!hasAllowance}
               legalBatchTxUrl={legalBatchTxUrl}
-              isBatchFlowSupported={!shouldAvoidBundledFlow}
             />
           </CardAnimationWrapper>
         ) : (


### PR DESCRIPTION
### What does this PR do?
Reverts the bundled MKR upgrade restriction after the Blockaid whitelist. Metamask shouldn't be flagging the batch MKR upgrade transactions anymore