### PR TITLE
don't load balances when no acct

### DIFF
--- a/packages/hooks/src/stusds/useStUsdsData.ts
+++ b/packages/hooks/src/stusds/useStUsdsData.ts
@@ -132,7 +132,8 @@ export function useStUsdsData(address?: `0x${string}`): StUsdsHook {
   } = useTokenBalance({
     address: acct,
     chainId: chainId,
-    token: usdsAddress[chainId as keyof typeof usdsAddress]
+    token: usdsAddress[chainId as keyof typeof usdsAddress],
+    enabled: !!acct
   });
 
   // Get vault's USDS balance (available liquidity)
@@ -167,7 +168,7 @@ export function useStUsdsData(address?: `0x${string}`): StUsdsHook {
     return userStUsdsBalance;
   }, [userConvertedAssets, userStUsdsBalance, totalAssets, totalSupply]);
 
-  const isLoading = isContractLoading || userUsdsLoading || vaultUsdsLoading;
+  const isLoading = isContractLoading || (!!acct && userUsdsLoading) || vaultUsdsLoading;
 
   const data: StUsdsHookData | undefined = useMemo(() => {
     if (!contractData) return undefined;


### PR DESCRIPTION
Before:
<img width="1390" height="523" alt="Screenshot 2025-08-12 at 11 38 55 AM" src="https://github.com/user-attachments/assets/f2e75da3-b048-4aad-a18c-a0fc8b6452e1" />

After: visit Stusds page without wallet connected, the data should load quickly