### PR TITLE
move tooltip trigger in widget button

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -233,7 +233,7 @@ export function WidgetNavigation({
                           variant="icons"
                           value={widgetIntent}
                           className={cn(
-                            'text-textSecondary data-[state=active]:text-text w-full px-1',
+                            'text-textSecondary data-[state=active]:text-text relative w-full px-1',
                             'lg:justify-start lg:gap-1.5 lg:bg-transparent lg:px-4 lg:py-2 lg:hover:bg-transparent',
                             'lg:data-[state=active]:text-text lg:data-[state=active]:bg-transparent',
                             'disabled:cursor-not-allowed disabled:text-[rgba(198,194,255,0.4)]',
@@ -246,15 +246,19 @@ export function WidgetNavigation({
                           )}
                           disabled={options?.disabled || false}
                         >
+                          <div className="flex flex-col items-center justify-center gap-1">
+                            {!isMobile && icon({ color: 'inherit' })}
+                            <Text variant="small" className="leading-4 text-inherit">
+                              <Trans>{label}</Trans>
+                            </Text>
+                          </div>
                           <Tooltip delayDuration={150}>
-                            <TooltipTrigger asChild>
-                              <div className="flex flex-col items-center justify-center gap-1">
-                                {!isMobile && icon({ color: 'inherit' })}
-                                <Text variant="small" className="leading-4 text-inherit">
-                                  <Trans>{label}</Trans>
-                                </Text>
-                              </div>
-                            </TooltipTrigger>
+                            <TooltipTrigger
+                              className={cn(
+                                'absolute inset-0 h-full w-full',
+                                (options?.disabled || false) && 'pointer-events-none'
+                              )}
+                            />
                             {description && !isMobile && (
                               <TooltipPortal>
                                 <TooltipContent side="right">


### PR DESCRIPTION
The widget button tooltip should now trigger when hovering on the outer edge of the button
