### PR TITLE
Move ConfigProvider to separate file to fix HMR

### DIFF
--- a/apps/webapp/src/modules/config/context/ConfigContext.tsx
+++ b/apps/webapp/src/modules/config/context/ConfigContext.tsx
@@ -1,19 +1,13 @@
-import { ReactElement, ReactNode, createContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { createContext } from 'react';
 import { SiteConfig } from '../types/site-config';
 import { UserConfig } from '../types/user-config';
 import { defaultConfig as siteConfig } from '../default-config';
-// import { detect, fromUrl, fromNavigator } from '@lingui/detect-locale';
-// import { QueryParams } from '@/lib/constants';
-import { i18n } from '@lingui/core';
-import { dynamicActivate } from '@jetstreamgg/sky-utils';
 import { Intent } from '@/lib/enums';
-// import { z } from 'zod';
 import { RewardContract } from '@jetstreamgg/sky-hooks';
-import { ALLOWED_EXTERNAL_DOMAINS, USER_SETTINGS_KEY } from '@/lib/constants';
 import { SealToken } from '@/modules/seal/constants';
 import { StakeToken } from '@/modules/stake/constants';
 
-type LinkedActionConfig = {
+export type LinkedActionConfig = {
   inputAmount?: string;
   initialAction?: string | null;
   linkedAction?: string;
@@ -51,7 +45,7 @@ export const StepMap: Record<LinkedActionSteps, StepIndicatorStates[]> = {
 };
 
 // Default user config
-const defaultUserConfig: UserConfig = {
+export const defaultUserConfig: UserConfig = {
   locale: undefined,
   intent: Intent.BALANCES_INTENT,
   sealToken: SealToken.MKR,
@@ -59,7 +53,7 @@ const defaultUserConfig: UserConfig = {
   batchEnabled: false // Default to false to show activation prompt
 };
 
-const defaultLinkedActionConfig = {
+export const defaultLinkedActionConfig = {
   step: 0,
   showLinkedAction: false
 };
@@ -117,123 +111,3 @@ export const ConfigContext = createContext<ConfigContextProps>({
   setExternalLinkModalUrl: () => {},
   onExternalLinkClicked: () => {}
 });
-
-export const ConfigProvider = ({ children }: { children: ReactNode }): ReactElement => {
-  const [userConfig, setUserConfig] = useState<UserConfig>(defaultUserConfig);
-  const [loaded, setLoaded] = useState<boolean>(false);
-  const [selectedRewardContract, setSelectedRewardContract] = useState<RewardContract | undefined>(undefined);
-  const [selectedSealUrnIndex, setSelectedSealUrnIndex] = useState<number | undefined>(undefined);
-  const [selectedStakeUrnIndex, setSelectedStakeUrnIndex] = useState<number | undefined>(undefined);
-  const [linkedActionConfig, setLinkedActionConfig] = useState(defaultLinkedActionConfig);
-  const [externalLinkModalOpened, setExternalLinkModalOpened] = useState(false);
-  const [externalLinkModalUrl, setExternalLinkModalUrl] = useState('');
-
-  // Check the user settings on load, and set locale
-  useEffect(() => {
-    // const localeFromUrl = fromUrl(QueryParams.Locale);
-    // const backupLocale = detect(fromNavigator(), () => 'en');
-    const settings = window.localStorage.getItem(USER_SETTINGS_KEY);
-    try {
-      const parsed = JSON.parse(settings || '{}');
-      // Use Zod to parse and validate the user settings
-      //throws an error if settings don't match the zod schema
-      // const parsedAndValidated = userSettingsSchema.parse(parsed);
-      // const localeFromConfig = parsedAndValidated.locale;
-      setUserConfig({
-        ...userConfig,
-        ...parsed,
-        // locale: localeFromUrl || localeFromConfig || backupLocale
-        locale: 'en',
-        batchEnabled:
-          // If the feature flag is enabled, but the local storage item is not set, default to enabled
-          import.meta.env.VITE_BATCH_TX_ENABLED === 'true' ? (parsed.batchEnabled ?? true) : undefined
-      });
-    } catch (e) {
-      console.log('Error parsing user settings', e);
-      window.localStorage.setItem(USER_SETTINGS_KEY, JSON.stringify(userConfig));
-    }
-    setLoaded(true);
-  }, []);
-
-  const updateUserConfig = (config: UserConfig) => {
-    setUserConfig(config);
-    window.localStorage.setItem(USER_SETTINGS_KEY, JSON.stringify(config));
-
-    // We needed to reload because changing the wagmi client messed with the rainbowkit buttons.
-    // https://github.com/rainbow-me/rainbowkit/issues/953
-    // TODO: Reenable if problem persist window.location.reload();
-  };
-
-  const setIntent = (intent: Intent) => {
-    updateUserConfig({
-      ...userConfig,
-      intent: intent
-    });
-  };
-
-  const updateLinkedActionConfig = useCallback(
-    (config: Partial<LinkedActionConfig>) => {
-      setLinkedActionConfig(prevConfig => ({
-        ...prevConfig,
-        ...config
-      }));
-    },
-    [setLinkedActionConfig]
-  );
-
-  // Convenience function to safely exit linked action mode
-  const exitLinkedActionMode = useCallback(() => {
-    setLinkedActionConfig(defaultLinkedActionConfig);
-  }, [setLinkedActionConfig]);
-
-  const locale = useMemo(() => {
-    // const locale = userConfig.locale || 'en';
-    const locale = 'en';
-    dynamicActivate(i18n, locale);
-    return locale;
-  }, [userConfig]);
-
-  const onExternalLinkClicked = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-      const href = e.currentTarget.getAttribute('href');
-      if (!href) return;
-
-      const hrefUrl = new URL(href);
-      if (!ALLOWED_EXTERNAL_DOMAINS.includes(hrefUrl.hostname)) {
-        e.preventDefault();
-        setExternalLinkModalUrl(href);
-        setExternalLinkModalOpened(true);
-      }
-    },
-    [setExternalLinkModalUrl, setExternalLinkModalOpened]
-  );
-
-  return (
-    <ConfigContext.Provider
-      value={{
-        siteConfig,
-        userConfig,
-        updateUserConfig,
-        loaded,
-        locale,
-        setIntent,
-        selectedRewardContract,
-        setSelectedRewardContract,
-        selectedSealUrnIndex,
-        setSelectedSealUrnIndex,
-        selectedStakeUrnIndex: selectedStakeUrnIndex,
-        setSelectedStakeUrnIndex: setSelectedStakeUrnIndex,
-        linkedActionConfig,
-        updateLinkedActionConfig,
-        exitLinkedActionMode,
-        externalLinkModalOpened,
-        setExternalLinkModalOpened,
-        externalLinkModalUrl,
-        setExternalLinkModalUrl,
-        onExternalLinkClicked
-      }}
-    >
-      {children}
-    </ConfigContext.Provider>
-  );
-};

--- a/apps/webapp/src/modules/config/context/ConfigProvider.tsx
+++ b/apps/webapp/src/modules/config/context/ConfigProvider.tsx
@@ -1,0 +1,134 @@
+import { ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { UserConfig } from '../types/user-config';
+import { RewardContract } from '@jetstreamgg/sky-hooks';
+import { ALLOWED_EXTERNAL_DOMAINS, USER_SETTINGS_KEY } from '@/lib/constants';
+import { Intent } from '@/lib/enums';
+import { dynamicActivate } from '@jetstreamgg/sky-utils';
+import { i18n } from '@lingui/core';
+import {
+  ConfigContext,
+  defaultLinkedActionConfig,
+  defaultUserConfig,
+  LinkedActionConfig
+} from './ConfigContext';
+import { defaultConfig as siteConfig } from '../default-config';
+
+export const ConfigProvider = ({ children }: { children: ReactNode }): ReactElement => {
+  const [userConfig, setUserConfig] = useState<UserConfig>(defaultUserConfig);
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const [selectedRewardContract, setSelectedRewardContract] = useState<RewardContract | undefined>(undefined);
+  const [selectedSealUrnIndex, setSelectedSealUrnIndex] = useState<number | undefined>(undefined);
+  const [selectedStakeUrnIndex, setSelectedStakeUrnIndex] = useState<number | undefined>(undefined);
+  const [linkedActionConfig, setLinkedActionConfig] = useState(defaultLinkedActionConfig);
+  const [externalLinkModalOpened, setExternalLinkModalOpened] = useState(false);
+  const [externalLinkModalUrl, setExternalLinkModalUrl] = useState('');
+
+  // Check the user settings on load, and set locale
+  useEffect(() => {
+    // const localeFromUrl = fromUrl(QueryParams.Locale);
+    // const backupLocale = detect(fromNavigator(), () => 'en');
+    const settings = window.localStorage.getItem(USER_SETTINGS_KEY);
+    try {
+      const parsed = JSON.parse(settings || '{}');
+      // Use Zod to parse and validate the user settings
+      //throws an error if settings don't match the zod schema
+      // const parsedAndValidated = userSettingsSchema.parse(parsed);
+      // const localeFromConfig = parsedAndValidated.locale;
+      setUserConfig({
+        ...userConfig,
+        ...parsed,
+        // locale: localeFromUrl || localeFromConfig || backupLocale
+        locale: 'en',
+        batchEnabled:
+          // If the feature flag is enabled, but the local storage item is not set, default to enabled
+          import.meta.env.VITE_BATCH_TX_ENABLED === 'true' ? (parsed.batchEnabled ?? true) : undefined
+      });
+    } catch (e) {
+      console.log('Error parsing user settings', e);
+      window.localStorage.setItem(USER_SETTINGS_KEY, JSON.stringify(userConfig));
+    }
+    setLoaded(true);
+  }, []);
+
+  const updateUserConfig = (config: UserConfig) => {
+    setUserConfig(config);
+    window.localStorage.setItem(USER_SETTINGS_KEY, JSON.stringify(config));
+
+    // We needed to reload because changing the wagmi client messed with the rainbowkit buttons.
+    // https://github.com/rainbow-me/rainbowkit/issues/953
+    // TODO: Reenable if problem persist window.location.reload();
+  };
+
+  const setIntent = (intent: Intent) => {
+    updateUserConfig({
+      ...userConfig,
+      intent: intent
+    });
+  };
+
+  const updateLinkedActionConfig = useCallback(
+    (config: Partial<LinkedActionConfig>) => {
+      setLinkedActionConfig(prevConfig => ({
+        ...prevConfig,
+        ...config
+      }));
+    },
+    [setLinkedActionConfig]
+  );
+
+  // Convenience function to safely exit linked action mode
+  const exitLinkedActionMode = useCallback(() => {
+    setLinkedActionConfig(defaultLinkedActionConfig);
+  }, [setLinkedActionConfig]);
+
+  const locale = useMemo(() => {
+    // const locale = userConfig.locale || 'en';
+    const locale = 'en';
+    dynamicActivate(i18n, locale);
+    return locale;
+  }, [userConfig]);
+
+  const onExternalLinkClicked = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      const href = e.currentTarget.getAttribute('href');
+      if (!href) return;
+
+      const hrefUrl = new URL(href);
+      if (!ALLOWED_EXTERNAL_DOMAINS.includes(hrefUrl.hostname)) {
+        e.preventDefault();
+        setExternalLinkModalUrl(href);
+        setExternalLinkModalOpened(true);
+      }
+    },
+    [setExternalLinkModalUrl, setExternalLinkModalOpened]
+  );
+
+  return (
+    <ConfigContext.Provider
+      value={{
+        siteConfig,
+        userConfig,
+        updateUserConfig,
+        loaded,
+        locale,
+        setIntent,
+        selectedRewardContract,
+        setSelectedRewardContract,
+        selectedSealUrnIndex,
+        setSelectedSealUrnIndex,
+        selectedStakeUrnIndex: selectedStakeUrnIndex,
+        setSelectedStakeUrnIndex: setSelectedStakeUrnIndex,
+        linkedActionConfig,
+        updateLinkedActionConfig,
+        exitLinkedActionMode,
+        externalLinkModalOpened,
+        setExternalLinkModalOpened,
+        externalLinkModalUrl,
+        setExternalLinkModalUrl,
+        onExternalLinkClicked
+      }}
+    >
+      {children}
+    </ConfigContext.Provider>
+  );
+};

--- a/apps/webapp/src/pages/main.tsx
+++ b/apps/webapp/src/pages/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ConfigProvider } from '../modules/config/context/ConfigContext';
+import { ConfigProvider } from '../modules/config/context/ConfigProvider';
 import { App } from './App';
 import { ErrorBoundary } from '../modules/layout/components/ErrorBoundary';
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue that was causing HMR in dev mode to break. Whenever HMR was applied, the `ConfigContext` was reset to its default props, and they were never updated to the actual values (so even the update functions were a no-op).

### Testing steps:

1.  Run the webapp locally
2. Attempt to navigate through the widgets, it should work well
3. Attempt to perform a change in any webapp files and save (I tested it by adding a console.log() to the `SavingsWidgetPane` file). After saving, the app should automatically update without requiring a page reload. Widget navigation should still work fine and the selected widget should remain (so not redirect to the balances page).
4. Try to use the app normally