### PR TITLE
Prevent widget changes when in a linked action

### DIFF
--- a/apps/webapp/src/modules/trade/components/TradeWidgetPane.tsx
+++ b/apps/webapp/src/modules/trade/components/TradeWidgetPane.tsx
@@ -154,6 +154,9 @@ export function TradeWidgetPane(sharedProps: SharedProps) {
 
   const Widget = isL2 ? L2TradeWidget : TradeWidget;
 
+  const shouldLockTokens =
+    linkedActionConfig.showLinkedAction && linkedActionConfig.sourceToken && linkedActionConfig.targetToken;
+
   return (
     <Widget
       key={externalWidgetState.timestamp}
@@ -176,6 +179,7 @@ export function TradeWidgetPane(sharedProps: SharedProps) {
       )}
       batchEnabled={batchEnabled}
       setBatchEnabled={setBatchEnabled}
+      tokensLocked={shouldLockTokens}
     />
   );
 }

--- a/apps/webapp/src/modules/trade/components/TradeWidgetPane.tsx
+++ b/apps/webapp/src/modules/trade/components/TradeWidgetPane.tsx
@@ -155,8 +155,9 @@ export function TradeWidgetPane(sharedProps: SharedProps) {
   const Widget = isL2 ? L2TradeWidget : TradeWidget;
 
   const shouldLockTokens =
-    linkedActionConfig.showLinkedAction && linkedActionConfig.sourceToken && linkedActionConfig.targetToken;
-
+    linkedActionConfig.showLinkedAction &&
+    !!linkedActionConfig.sourceToken &&
+    !!linkedActionConfig.targetToken;
   return (
     <Widget
       key={externalWidgetState.timestamp}

--- a/apps/webapp/src/modules/upgrade/components/UpgradeWidgetPane.tsx
+++ b/apps/webapp/src/modules/upgrade/components/UpgradeWidgetPane.tsx
@@ -193,6 +193,11 @@ export function UpgradeWidgetPane(sharedProps: SharedProps) {
     }
   };
 
+  const disallowedFlow =
+    linkedActionConfig.showLinkedAction && linkedActionConfig.sourceToken
+      ? UpgradeFlow.REVERT // If in linked action, disallow revert
+      : undefined;
+
   return (
     <UpgradeWidget
       {...sharedProps}
@@ -209,7 +214,12 @@ export function UpgradeWidgetPane(sharedProps: SharedProps) {
       onWidgetStateChange={onUpgradeWidgetStateChange}
       customNavigationLabel={customNavLabel}
       onCustomNavigation={onNavigate}
-      upgradeOptions={[TOKENS.dai, TOKENS.mkr]}
+      upgradeOptions={
+        linkedActionConfig.showLinkedAction && linkedActionConfig.sourceToken
+          ? [linkedActionConfig.sourceToken]
+          : [TOKENS.dai, TOKENS.mkr]
+      }
+      disallowedFlow={disallowedFlow}
       batchEnabled={batchEnabled}
       setBatchEnabled={setBatchEnabled}
     />

--- a/packages/widgets/src/shared/types/widgetState.d.ts
+++ b/packages/widgets/src/shared/types/widgetState.d.ts
@@ -108,4 +108,5 @@ export type WidgetProps = {
   referralCode?: number;
   shouldReset?: boolean;
   legalBatchTxUrl?: string;
+  disallowedFlow?: BalancesFlow | SavingsFlow | UpgradeFlow | RewardsFlow | TradeFlow | StakeFlow | SealFlow;
 };

--- a/packages/widgets/src/widgets/L2TradeWidget/components/L2TradeInputs.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/components/L2TradeInputs.tsx
@@ -39,6 +39,7 @@ type TradeInputsProps = {
   setMaxWithdraw?: (val: boolean) => void;
   onOriginTokenChange?: (token: TokenForChain) => void;
   onTargetTokenChange?: (token: TokenForChain) => void;
+  tokensLocked?: boolean;
 };
 
 export function L2TradeInputs({
@@ -64,7 +65,8 @@ export function L2TradeInputs({
   onOriginInputInput,
   onTargetInputInput,
   onOriginTokenChange,
-  onTargetTokenChange
+  onTargetTokenChange,
+  tokensLocked = false
   // setMaxWithdraw
 }: TradeInputsProps) {
   const separationPx = 12;
@@ -153,59 +155,61 @@ export function L2TradeInputs({
             onOriginTokenChange?.(option as TokenForChain);
           }}
           error={isBalanceError ? t`Insufficient funds` : undefined}
-          variant="top"
-          extraPadding={true}
+          variant={tokensLocked ? undefined : 'top'}
+          extraPadding={!tokensLocked}
           showPercentageButtons={isConnectedAndEnabled}
           enabled={isConnectedAndEnabled}
         />
       </motion.div>
-      <div
-        className="flex justify-center"
-        style={{
-          position: 'absolute',
-          zIndex: 10,
-          left: switchPosition.left,
-          top: switchPosition.top,
-          transform: 'translate(-50%, -50%)',
-          visibility: isSwitchVisible ? 'visible' : 'hidden',
-          cursor: switchDisabled ? 'not-allowed' : 'pointer'
-        }}
-      >
-        <Button
-          aria-label="Switch token inputs"
-          size="icon"
-          className="border-background text-tabPrimary focus:outline-hidden my-0 h-9 w-9 rounded-full bg-transparent hover:bg-transparent focus:bg-transparent active:bg-transparent disabled:bg-transparent"
-          onClick={() => {
-            const tempToken = originToken;
-            const prevOriginAmount = originAmount;
-            const prevTargetAmount = targetAmount;
-            setOriginAmount(0n);
-            setTargetAmount(0n);
-            setTimeout(() => {
-              setOriginToken(targetToken);
-              setTargetToken(tempToken);
-              setTimeout(() => {
-                if (lastUpdated === TradeSide.IN) {
-                  setTargetAmount(prevOriginAmount);
-                  setOriginAmount(0n);
-                } else {
-                  setOriginAmount(prevTargetAmount);
-                  setTargetAmount(0n);
-                }
-                onUserSwitchTokens?.(targetToken?.symbol, originToken?.symbol);
-              }, 500);
-            }, 500);
+      {!tokensLocked && (
+        <div
+          className="flex justify-center"
+          style={{
+            position: 'absolute',
+            zIndex: 10,
+            left: switchPosition.left,
+            top: switchPosition.top,
+            transform: 'translate(-50%, -50%)',
+            visibility: isSwitchVisible ? 'visible' : 'hidden',
+            cursor: switchDisabled ? 'not-allowed' : 'pointer'
           }}
-          disabled={switchDisabled}
         >
-          <ShiftArrow height={24} className="text-textDesaturated" />
-        </Button>
-      </div>
+          <Button
+            aria-label="Switch token inputs"
+            size="icon"
+            className="border-background text-tabPrimary focus:outline-hidden my-0 h-9 w-9 rounded-full bg-transparent hover:bg-transparent focus:bg-transparent active:bg-transparent disabled:bg-transparent"
+            onClick={() => {
+              const tempToken = originToken;
+              const prevOriginAmount = originAmount;
+              const prevTargetAmount = targetAmount;
+              setOriginAmount(0n);
+              setTargetAmount(0n);
+              setTimeout(() => {
+                setOriginToken(targetToken);
+                setTargetToken(tempToken);
+                setTimeout(() => {
+                  if (lastUpdated === TradeSide.IN) {
+                    setTargetAmount(prevOriginAmount);
+                    setOriginAmount(0n);
+                  } else {
+                    setOriginAmount(prevTargetAmount);
+                    setTargetAmount(0n);
+                  }
+                  onUserSwitchTokens?.(targetToken?.symbol, originToken?.symbol);
+                }, 500);
+              }, 500);
+            }}
+            disabled={switchDisabled}
+          >
+            <ShiftArrow height={24} className="text-textDesaturated" />
+          </Button>
+        </div>
+      )}
       <motion.div variants={positionAnimations} ref={bottomInputRef}>
         <TradeInput
           className="w-full"
           label={t`Choose a token to receive`}
-          variant="bottom"
+          variant={tokensLocked ? undefined : 'bottom'}
           token={targetToken as Token}
           balance={targetBalance?.value}
           onChange={onTargetInputChange}

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -98,6 +98,7 @@ export type TradeWidgetProps = WidgetProps & {
   widgetTitle?: ReactNode;
   batchEnabled?: boolean;
   setBatchEnabled?: (enabled: boolean) => void;
+  tokensLocked?: boolean;
 };
 
 export const L2TradeWidget = ({
@@ -120,7 +121,8 @@ export const L2TradeWidget = ({
   widgetTitle,
   shouldReset = false,
   batchEnabled,
-  setBatchEnabled
+  setBatchEnabled,
+  tokensLocked = false
 }: TradeWidgetProps) => {
   const key = shouldReset ? 'reset' : undefined;
   return (
@@ -147,6 +149,7 @@ export const L2TradeWidget = ({
           batchEnabled={batchEnabled}
           setBatchEnabled={setBatchEnabled}
           legalBatchTxUrl={legalBatchTxUrl}
+          tokensLocked={tokensLocked}
         />
       </WidgetProvider>
     </ErrorBoundary>
@@ -172,7 +175,8 @@ function TradeWidgetWrapped({
   referralCode,
   widgetTitle,
   batchEnabled,
-  setBatchEnabled
+  setBatchEnabled,
+  tokensLocked = false
 }: TradeWidgetProps): React.ReactElement {
   const { mutate: addToWallet } = useAddTokenToWallet();
   const [showAddToken, setShowAddToken] = useState(false);
@@ -1264,10 +1268,11 @@ function TradeWidgetWrapped({
               }}
               lastUpdated={lastUpdated}
               targetAmount={targetAmount}
-              originTokenList={originTokenList}
-              targetTokenList={targetTokenList}
+              originTokenList={tokensLocked && originToken ? [originToken] : originTokenList}
+              targetTokenList={tokensLocked && targetToken ? [targetToken] : targetTokenList}
               isBalanceError={isBalanceError}
-              canSwitchTokens={true}
+              canSwitchTokens={!tokensLocked}
+              tokensLocked={tokensLocked}
               isConnectedAndEnabled={isConnectedAndEnabled}
             />
             {!!originAmount && !!targetAmount && !isBalanceError && (

--- a/packages/widgets/src/widgets/TradeWidget/components/TradeInputs.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeInputs.tsx
@@ -48,6 +48,7 @@ type TradeInputsProps = {
   onTargetTokenChange?: (token: TokenForChain) => void;
   onOriginInputChange?: (val: bigint, userTriggered?: boolean) => void;
   enableSearch?: boolean;
+  tokensLocked?: boolean;
 };
 
 export function TradeInput(props: TokenInputProps) {
@@ -86,7 +87,8 @@ export function TradeInputs({
   onOriginTokenChange,
   onTargetTokenChange,
   onOriginInputChange,
-  enableSearch = false
+  enableSearch = false,
+  tokensLocked = false
 }: TradeInputsProps) {
   const separationPx = 12;
   const separationMb = 'mb-[12px]';
@@ -206,50 +208,52 @@ export function TradeInputs({
             onOriginTokenChange?.(option as TokenForChain);
           }}
           error={isBalanceError ? t`Insufficient funds` : undefined}
-          variant="top"
-          extraPadding={true}
+          variant={tokensLocked ? undefined : 'top'}
+          extraPadding={!tokensLocked}
           showPercentageButtons={isConnectedAndEnabled}
           enabled={isConnectedAndEnabled}
           enableSearch={enableSearch}
         />
       </motion.div>
-      <div
-        className="flex justify-center"
-        style={{
-          position: 'absolute',
-          zIndex: 10,
-          left: switchPosition.left,
-          top: switchPosition.top,
-          transform: 'translate(-50%, -50%)',
-          visibility: isSwitchVisible ? 'visible' : 'hidden',
-          cursor: switchDisabled ? 'not-allowed' : 'pointer'
-        }}
-      >
-        <Button
-          aria-label="Switch token inputs"
-          size="icon"
-          className="border-background text-tabPrimary focus:outline-hidden my-0 h-9 w-9 rounded-full bg-transparent hover:bg-transparent focus:bg-transparent active:bg-transparent disabled:bg-transparent"
-          onClick={() => {
-            setLastSwitchTimestamp(Date.now());
-            const auxOriginAmount = originAmount;
-            const auxOriginToken = originToken;
-            setLastUpdated(TradeSide.OUT);
-            setOriginToken(targetToken);
-            setTargetToken(auxOriginToken);
-            setOriginAmount(0n);
-            setTargetAmount(auxOriginAmount);
-            onUserSwitchTokens?.(targetToken?.symbol, auxOriginToken?.symbol);
+      {!tokensLocked && (
+        <div
+          className="flex justify-center"
+          style={{
+            position: 'absolute',
+            zIndex: 10,
+            left: switchPosition.left,
+            top: switchPosition.top,
+            transform: 'translate(-50%, -50%)',
+            visibility: isSwitchVisible ? 'visible' : 'hidden',
+            cursor: switchDisabled ? 'not-allowed' : 'pointer'
           }}
-          disabled={switchDisabled}
         >
-          <ShiftArrow height={24} className="text-textDesaturated" />
-        </Button>
-      </div>
+          <Button
+            aria-label="Switch token inputs"
+            size="icon"
+            className="border-background text-tabPrimary focus:outline-hidden my-0 h-9 w-9 rounded-full bg-transparent hover:bg-transparent focus:bg-transparent active:bg-transparent disabled:bg-transparent"
+            onClick={() => {
+              setLastSwitchTimestamp(Date.now());
+              const auxOriginAmount = originAmount;
+              const auxOriginToken = originToken;
+              setLastUpdated(TradeSide.OUT);
+              setOriginToken(targetToken);
+              setTargetToken(auxOriginToken);
+              setOriginAmount(0n);
+              setTargetAmount(auxOriginAmount);
+              onUserSwitchTokens?.(targetToken?.symbol, auxOriginToken?.symbol);
+            }}
+            disabled={switchDisabled}
+          >
+            <ShiftArrow height={24} className="text-textDesaturated" />
+          </Button>
+        </div>
+      )}
       <motion.div variants={positionAnimations} ref={bottomInputRef}>
         <TradeInput
           className="w-full"
           label={t`Choose a token to receive`}
-          variant="bottom"
+          variant={tokensLocked ? undefined : 'bottom'}
           token={targetToken as Token}
           balance={targetBalance?.value}
           onChange={newValue => {

--- a/packages/widgets/src/widgets/TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/index.tsx
@@ -63,6 +63,7 @@ export type TradeWidgetProps = WidgetProps & {
   disallowedPairs?: Record<string, SUPPORTED_TOKEN_SYMBOLS[]>;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   widgetTitle?: ReactNode;
+  tokensLocked?: boolean;
 };
 
 export const TradeWidget = ({
@@ -80,7 +81,8 @@ export const TradeWidget = ({
   customNavigationLabel,
   onExternalLinkClicked,
   enabled = true,
-  shouldReset = false
+  shouldReset = false,
+  tokensLocked = false
 }: TradeWidgetProps) => {
   const key = shouldReset ? 'reset' : undefined;
   return (
@@ -102,6 +104,7 @@ export const TradeWidget = ({
           onCustomNavigation={onCustomNavigation}
           onExternalLinkClicked={onExternalLinkClicked}
           enabled={enabled}
+          tokensLocked={tokensLocked}
         />
       </WidgetProvider>
     </ErrorBoundary>
@@ -122,7 +125,8 @@ function TradeWidgetWrapped({
   onCustomNavigation,
   customNavigationLabel,
   onExternalLinkClicked,
-  enabled = true
+  enabled = true,
+  tokensLocked = false
 }: TradeWidgetProps): React.ReactElement {
   const { mutate: addToWallet } = useAddTokenToWallet();
   const [showAddToken, setShowAddToken] = useState(false);
@@ -1261,11 +1265,11 @@ function TradeWidgetWrapped({
               targetAmount={targetAmount}
               quoteData={quoteData}
               quoteError={quoteError}
-              originTokenList={originTokenList}
-              targetTokenList={targetTokenList}
+              originTokenList={tokensLocked && originToken ? [originToken] : originTokenList}
+              targetTokenList={tokensLocked && targetToken ? [targetToken] : targetTokenList}
               isBalanceError={isBalanceError}
               isQuoteLoading={isQuoteLoading}
-              canSwitchTokens={true}
+              canSwitchTokens={!tokensLocked}
               priceImpact={priceImpact}
               feePercentage={feePercentage}
               isConnectedAndEnabled={isConnectedAndEnabled}
@@ -1273,6 +1277,7 @@ function TradeWidgetWrapped({
               tradeAnyway={tradeAnyway}
               setTradeAnyway={setTradeAnyway}
               enableSearch={true}
+              tokensLocked={tokensLocked}
               onOriginTokenChange={(token: TokenForChain) => {
                 onWidgetStateChange?.({
                   originToken: token.symbol,

--- a/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeRevert.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeRevert.tsx
@@ -31,6 +31,7 @@ type Props = WidgetProps & {
   onMenuItemChange?: (token: Token) => void;
   isConnectedAndEnabled: boolean;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+  disallowedFlow?: string;
 };
 
 export function UpgradeRevert({
@@ -49,9 +50,14 @@ export function UpgradeRevert({
   onToggle,
   onOriginInputChange,
   onMenuItemChange,
-  isConnectedAndEnabled = true
+  isConnectedAndEnabled = true,
+  disallowedFlow
 }: Props): React.ReactElement {
   const chainId = useChainId();
+
+  // Check if each flow is disabled
+  const isUpgradeDisabled = disallowedFlow === UpgradeFlow.UPGRADE;
+  const isRevertDisabled = disallowedFlow === UpgradeFlow.REVERT;
 
   return (
     <VStack className="w-full items-center justify-center">
@@ -63,6 +69,8 @@ export function UpgradeRevert({
               data-testid="upgrade-toggle-left"
               value={UpgradeFlow.UPGRADE}
               onClick={() => onToggle(0)}
+              disabled={isUpgradeDisabled}
+              className={isUpgradeDisabled ? '!pointer-events-auto !cursor-not-allowed opacity-50' : ''}
             >
               {leftTabTitle}
             </TabsTrigger>
@@ -71,6 +79,8 @@ export function UpgradeRevert({
               data-testid="upgrade-toggle-right"
               value={UpgradeFlow.REVERT}
               onClick={() => onToggle(1)}
+              disabled={isRevertDisabled}
+              className={isRevertDisabled ? '!pointer-events-auto !cursor-not-allowed opacity-50' : ''}
             >
               {rightTabTitle}
             </TabsTrigger>

--- a/packages/widgets/src/widgets/UpgradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/index.tsx
@@ -104,7 +104,8 @@ export const UpgradeWidget = ({
   legalBatchTxUrl,
   upgradeOptions = defaultUpgradeOptions,
   enabled = true,
-  shouldReset = false
+  shouldReset = false,
+  disallowedFlow
 }: UpgradeWidgetProps) => {
   const key = shouldReset ? 'reset' : undefined;
   return (
@@ -127,6 +128,7 @@ export const UpgradeWidget = ({
           batchEnabled={batchEnabled}
           setBatchEnabled={setBatchEnabled}
           legalBatchTxUrl={legalBatchTxUrl}
+          disallowedFlow={disallowedFlow}
         />
       </WidgetProvider>
     </ErrorBoundary>
@@ -148,7 +150,8 @@ export function UpgradeWidgetWrapped({
   batchEnabled,
   setBatchEnabled,
   legalBatchTxUrl,
-  enabled = true
+  enabled = true,
+  disallowedFlow
 }: UpgradeWidgetProps): React.ReactElement {
   const validatedExternalState = getValidatedState(externalWidgetState);
   const shouldAllowExternalUpdate = useRef(true);
@@ -871,8 +874,14 @@ export function UpgradeWidgetWrapped({
                 targetToken={targetToken}
                 originBalance={originBalance?.value}
                 targetBalance={targetBalance?.value}
+                disallowedFlow={disallowedFlow}
                 onToggle={(index: 0 | 1) => {
                   if (tabIndex === index) {
+                    return;
+                  }
+
+                  const targetFlow = index === 0 ? UpgradeFlow.UPGRADE : UpgradeFlow.REVERT;
+                  if (disallowedFlow && disallowedFlow === targetFlow) {
                     return;
                   }
 


### PR DESCRIPTION
This PR enhances the linked action user experience by preventing unintended token or flow changes during multi-step transactions. When users enter a linked action flow from either the Upgrade or Trade widgets, the UI now locks specific elements to maintain transaction continuity and prevent confusion.

For the Upgrade widget, when initiated as part of a linked action, the system locks both the source token selection and prevents switching between upgrade/revert flows. This ensures users complete the intended upgrade path without accidentally changing tokens or reversing the flow direction.

For the Trade widget, the implementation locks both source and target tokens to the linked action requirements and completely removes the token swap button. Additionally, the rounded visual styling is removed from locked token inputs to provide clear visual feedback that these selections are fixed.

These changes are implemented through a new tokensLocked boolean prop that maintains domain separation - the widgets remain agnostic to the business logic of "linked actions" and simply respond to whether token selection should be restricted. The disallowedFlow prop for the Upgrade widget similarly prevents tab switching without the widget needing to understand why.

  ### Testing Steps

  Upgrade Widget Linked Actions:

  1. Navigate to the app with linked action parameters:
  `/?widget=upgrade&source_token=DAI&linked_action=savings`
  2. Verify that only DAI appears in the token dropdown (MKR should not be available)
  3. Verify that the "Revert" tab is disabled with a not-allowed cursor
  4. Attempt to click the Revert tab - it should not switch
  5. Complete the upgrade transaction and proceed to the linked savings action

  Trade Widget Linked Actions:

  1. Navigate to the app with trade linked action parameters:
`  /?widget=trade&source_token=USDS&target_token=USDC&linked_action=rewards`
  2. Verify that the token swap button (arrows) is completely hidden
  3. Verify that both token dropdowns only show the locked tokens (USDS for source, USDC for target)
  4. Verify that the token inputs don't have rounded corners (visual indication of locked state)
  5. Complete the trade and verify the flow continues to the rewards widget

  Non-Linked Action Behavior:

  1. Navigate to /upgrade without linked action parameters
  2. Verify both DAI and MKR are available in the dropdown
  3. Verify you can switch between Upgrade and Revert tabs freely
  4. Navigate to /trade without linked action parameters
  5. Verify the swap button is visible and functional
  6. Verify you can select any available tokens from the dropdowns
  7. Verify token inputs have their normal rounded styling

### Trade widget with fixed tokens and no switch button
<img width="573" height="1120" alt="image" src="https://github.com/user-attachments/assets/9787eccf-3a64-4e83-85d8-2fa772ad83a2" />

### Upgrade widget with fixed token and downgrade flow disabled
<img width="573" height="1120" alt="image" src="https://github.com/user-attachments/assets/ebc68b70-6ffb-4b13-a36e-7c90c9c2cc30" />
