### PR TITLE
susds icon in savings widget

### DIFF
--- a/packages/widgets/src/widgets/L2SavingsWidget/components/L2SavingsStatsCard.tsx
+++ b/packages/widgets/src/widgets/L2SavingsWidget/components/L2SavingsStatsCard.tsx
@@ -87,7 +87,7 @@ export const L2SavingsStatsCard = ({
     <StatsOverviewCardCore
       headerLeftContent={
         <MotionHStack className="items-center" gap={2} variants={positionAnimations}>
-          <TokenIcon className="h-6 w-6" token={{ symbol: 'USDS' }} />
+          <TokenIcon className="h-6 w-6" token={{ symbol: 'sUSDS' }} />
           <Text>Sky Savings Rate</Text>
         </MotionHStack>
       }

--- a/packages/widgets/src/widgets/SavingsWidget/components/SavingsStatsCardCore.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SavingsStatsCardCore.tsx
@@ -22,7 +22,7 @@ export const SavingsStatsCardCore = ({
     <StatsOverviewCardCore
       headerLeftContent={
         <MotionHStack className="items-center" gap={2} variants={positionAnimations}>
-          <TokenIcon className="h-6 w-6" token={{ symbol: 'USDS' }} />
+          <TokenIcon className="h-6 w-6" token={{ symbol: 'sUSDS' }} />
           <Text>Sky Savings Rate</Text>
         </MotionHStack>
       }


### PR DESCRIPTION
<img width="460" height="668" alt="Screenshot 2025-08-19 at 1 14 40 PM" src="https://github.com/user-attachments/assets/dbb3231f-7c62-4779-ac84-4178e6856383" />

<img width="444" height="666" alt="Screenshot 2025-08-19 at 1 14 46 PM" src="https://github.com/user-attachments/assets/3f75fa1f-556a-432b-b3ae-15a6228ce03a" />
