### PR TITLE
[RFC] Bundled action: claim all rewards from a single staking position

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -144,6 +144,7 @@ export { useUrnSelectedVoteDelegate as useStakeUrnSelectedVoteDelegate } from '.
 export { useStakeSkyAllowance, useStakeUsdsAllowance } from './stake/useStakeAllowance';
 export { useStakeSkyApprove, useStakeUsdsApprove } from './stake/useStakeApprove';
 export { useClaimRewards as useStakeClaimRewards } from './stake/useClaimRewards';
+export { useBatchClaimAllRewards as useBatchStakeClaimAllRewards } from './stake/useBatchClaimAllRewards';
 export { useStakeRewardsData } from './stake/useStakeRewardsData';
 export { useStakePosition } from './stake/useStakePosition';
 export { useBatchStakeMulticall } from './stake/useBatchStakeMulticall';

--- a/packages/hooks/src/stake/useBatchClaimAllRewards.tsx
+++ b/packages/hooks/src/stake/useBatchClaimAllRewards.tsx
@@ -1,0 +1,55 @@
+import { useAccount, useChainId } from 'wagmi';
+import { BatchWriteHook, BatchWriteHookParams } from '../hooks';
+import { useRewardContractsToClaim } from '../rewards/useRewardContractsToClaim';
+import { useStakeRewardContracts } from './useStakeRewardContracts';
+import { getWriteContractCall, stakeModuleAddress, useStakeUrnAddress, useTransactionFlow } from '..';
+import { Call } from 'viem';
+import { stakeModuleAbi } from '../generated';
+
+export function useBatchClaimAllRewards({
+  index,
+  onMutate = () => null,
+  onSuccess = () => null,
+  onError = () => null,
+  onStart = () => null,
+  enabled: paramEnabled = true,
+  shouldUseBatch = true
+}: BatchWriteHookParams & {
+  index: bigint | undefined;
+}): BatchWriteHook {
+  const chainId = useChainId();
+  const { address } = useAccount();
+
+  const { data: urnAddress } = useStakeUrnAddress(index || 0n);
+  const { data: stakeRewardContracts } = useStakeRewardContracts();
+  const { data: rewardContractsToClaim } = useRewardContractsToClaim({
+    rewardContractAddresses: stakeRewardContracts?.map(({ contractAddress }) => contractAddress) || [],
+    userAddress: urnAddress,
+    chainId,
+    enabled: !!stakeRewardContracts && !!urnAddress
+  });
+
+  // Calls for the batch transaction
+  const calls: Call[] =
+    rewardContractsToClaim?.map(({ contractAddress }) =>
+      getWriteContractCall({
+        to: stakeModuleAddress[chainId as keyof typeof stakeModuleAddress],
+        abi: stakeModuleAbi,
+        functionName: 'getReward',
+        args: [address!, index!, contractAddress, address!]
+      })
+    ) || [];
+
+  const enabled = index !== undefined && !!address && !!calls.length && paramEnabled;
+
+  return useTransactionFlow({
+    calls,
+    chainId,
+    enabled,
+    shouldUseBatch,
+    onMutate,
+    onSuccess,
+    onError,
+    onStart
+  });
+}

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/ManagePosition.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/ManagePosition.tsx
@@ -14,6 +14,9 @@ export const ManagePosition = ({
   tabSide,
   claimPrepared,
   claimExecute,
+  claimAllPrepared,
+  claimAllExecute,
+  batchEnabledAndSupported,
   onStakeUrnChange,
   onWidgetStateChange,
   needsAllowance,
@@ -31,6 +34,9 @@ export const ManagePosition = ({
   tabSide: 'left' | 'right';
   claimPrepared: boolean;
   claimExecute: () => void;
+  claimAllPrepared: boolean;
+  claimAllExecute: () => void;
+  batchEnabledAndSupported: boolean;
   onStakeUrnChange?: OnStakeUrnChange;
   onWidgetStateChange?: (params: WidgetStateChangeParams) => void;
   needsAllowance: boolean;
@@ -41,7 +47,14 @@ export const ManagePosition = ({
   legalBatchTxUrl?: string;
 }) => {
   return currentAction === StakeAction.OVERVIEW ? (
-    <UrnsList claimPrepared={claimPrepared} claimExecute={claimExecute} onStakeUrnChange={onStakeUrnChange} />
+    <UrnsList
+      claimPrepared={claimPrepared}
+      claimExecute={claimExecute}
+      claimAllPrepared={claimAllPrepared}
+      claimAllExecute={claimAllExecute}
+      batchEnabledAndSupported={batchEnabledAndSupported}
+      onStakeUrnChange={onStakeUrnChange}
+    />
   ) : (
     <Wizard
       isConnectedAndEnabled={isConnectedAndEnabled}

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionDetail.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionDetail.tsx
@@ -41,6 +41,9 @@ type Props = {
   index: bigint;
   claimPrepared: boolean;
   claimExecute: () => void;
+  claimAllPrepared: boolean;
+  claimAllExecute: () => void;
+  batchEnabledAndSupported: boolean;
 };
 
 // Copied from TransactionDetail, it could be reusable
@@ -57,7 +60,10 @@ export function PositionDetail({
   urnAddress,
   index,
   claimPrepared,
-  claimExecute
+  claimExecute,
+  claimAllPrepared,
+  claimAllExecute,
+  batchEnabledAndSupported
 }: Props) {
   const { data: rewardContractTokens } = useRewardContractTokens(selectedRewardContract);
   const { data: selectedDelegateName } = useDelegateName(selectedVoteDelegate);
@@ -177,6 +183,9 @@ export function PositionDetail({
           index={index}
           claimPrepared={claimPrepared}
           claimExecute={claimExecute}
+          claimAllPrepared={claimAllPrepared}
+          claimAllExecute={claimAllExecute}
+          batchEnabledAndSupported={batchEnabledAndSupported}
         />
       )}
     </MotionVStack>

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/UrnPosition.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/UrnPosition.tsx
@@ -28,6 +28,9 @@ interface UrnPositionProps {
   index: bigint;
   claimPrepared: boolean;
   claimExecute: () => void;
+  claimAllPrepared: boolean;
+  claimAllExecute: () => void;
+  batchEnabledAndSupported: boolean;
   onStakeUrnChange?: OnStakeUrnChange;
 }
 
@@ -35,6 +38,9 @@ export const UrnPosition: React.FC<UrnPositionProps> = ({
   index,
   claimPrepared,
   claimExecute,
+  claimAllPrepared,
+  claimAllExecute,
+  batchEnabledAndSupported,
   onStakeUrnChange
 }) => {
   const { data: urnAddress } = useStakeUrnAddress(index);
@@ -121,6 +127,9 @@ export const UrnPosition: React.FC<UrnPositionProps> = ({
         index={index}
         claimPrepared={claimPrepared}
         claimExecute={claimExecute}
+        claimAllPrepared={claimAllPrepared}
+        claimAllExecute={claimAllExecute}
+        batchEnabledAndSupported={batchEnabledAndSupported}
       />
     </Card>
   );

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/UrnsList.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/UrnsList.tsx
@@ -8,10 +8,16 @@ import { OnStakeUrnChange } from '..';
 export const UrnsList = ({
   claimPrepared,
   claimExecute,
+  claimAllPrepared,
+  claimAllExecute,
+  batchEnabledAndSupported,
   onStakeUrnChange
 }: {
   claimPrepared: boolean;
   claimExecute: () => void;
+  claimAllPrepared: boolean;
+  claimAllExecute: () => void;
+  batchEnabledAndSupported: boolean;
   onStakeUrnChange?: OnStakeUrnChange;
 }) => {
   const { data: currentIndex } = useCurrentUrnIndex();
@@ -33,6 +39,9 @@ export const UrnsList = ({
               index={BigInt(index)}
               claimPrepared={claimPrepared}
               claimExecute={claimExecute}
+              claimAllPrepared={claimAllPrepared}
+              claimAllExecute={claimAllExecute}
+              batchEnabledAndSupported={batchEnabledAndSupported}
               onStakeUrnChange={onStakeUrnChange}
             />
           ))}

--- a/packages/widgets/src/widgets/StakeModuleWidget/hooks/useStakeTransactions.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/hooks/useStakeTransactions.tsx
@@ -1,6 +1,10 @@
 import { WidgetProps } from '@widgets/shared/types/widgetState';
 import { useStakeTransactionCallbacks } from './useStakeTransactionCallbacks';
-import { useBatchStakeMulticall, useStakeClaimRewards } from '@jetstreamgg/sky-hooks';
+import {
+  useBatchStakeClaimAllRewards,
+  useBatchStakeMulticall,
+  useStakeClaimRewards
+} from '@jetstreamgg/sky-hooks';
 import { useContext } from 'react';
 import { WidgetContext } from '@widgets/context/WidgetContext';
 import { StakeAction } from '../lib/constants';
@@ -69,5 +73,13 @@ export const useStakeTransactions = ({
     ...claimTransactionCallbacks
   });
 
-  return { batchMulticall, claimRewards };
+  const claimAllRewards = useBatchStakeClaimAllRewards({
+    index: indexToClaim,
+    // Always use batch transactions for this flow
+    shouldUseBatch: true,
+    enabled: indexToClaim !== undefined && !rewardContractToClaim,
+    ...claimTransactionCallbacks
+  });
+
+  return { batchMulticall, claimRewards, claimAllRewards };
 };

--- a/packages/widgets/src/widgets/StakeModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/index.tsx
@@ -169,7 +169,7 @@ function StakeModuleWidgetWrapped({
   const needsAllowance = needsLockAllowance || needsUsdsAllowance;
   const shouldUseBatch = !!batchEnabled && !!batchSupported && needsAllowance;
 
-  const { batchMulticall, claimRewards } = useStakeTransactions({
+  const { batchMulticall, claimRewards, claimAllRewards } = useStakeTransactions({
     lockAmount: debouncedLockAmount,
     usdsAmount: debouncedUsdsAmount,
     calldata,
@@ -555,7 +555,9 @@ function StakeModuleWidgetWrapped({
         : shouldOpenFromWidgetButton
           ? handleClickOpenPosition
           : widgetState.flow === StakeFlow.MANAGE && widgetState.action === StakeAction.CLAIM
-            ? claimRewards.execute
+            ? rewardContractToClaim
+              ? claimRewards.execute
+              : claimAllRewards.execute
             : widgetState.flow === StakeFlow.OPEN || widgetState.flow === StakeFlow.MANAGE
               ? nextOnClick
               : undefined;
@@ -720,6 +722,9 @@ function StakeModuleWidgetWrapped({
                       tabSide={tabSide}
                       claimPrepared={claimRewards.prepared}
                       claimExecute={claimRewards.execute}
+                      claimAllPrepared={claimAllRewards.prepared}
+                      claimAllExecute={claimAllRewards.execute}
+                      batchEnabledAndSupported={!!batchEnabled && !!batchSupported}
                       onStakeUrnChange={onStakeUrnChange}
                       onWidgetStateChange={onWidgetStateChange}
                       needsAllowance={needsAllowance}


### PR DESCRIPTION
Builds on #574, merge that one first

### What does this PR do?

This PR introduces a "Claim All" feature for staking rewards, allowing users to claim all pending rewards for a single staked position in one batch transaction.

-   Adds a new `useBatchClaimAllRewards` hook that bundles multiple reward claims into a single multicall.
-   Updates the `ClaimRewardsDropdown` component with a "Claim all rewards" option.
-   Integrates this new transaction flow into the Stake Module Widget, using it when the "Claim all" option is selected.
-   The feature is only available when the connected wallet supports batch transactions and batch transactions are enabled by the user.

### Testing steps:

1.  Navigate to the Stake page with a position that has multiple types of claimable rewards.
2.  In the position details, click the "Select reward to claim" dropdown.
3.  Select the new "Claim all rewards" option.
4.  The main button should update to "Claim all rewards". Click it.
5.  Confirm the batch transaction in your wallet.
6.  Verify that all pending rewards for that position have been successfully claimed.
7.  Verify that claiming a single, specific reward still works as expected.