### PR TITLE
Implement changes from widget refactor PRs #2 and #3 in stUSDS widget

### DIFF
--- a/packages/hooks/src/stusds/useBatchStUsdsDeposit.ts
+++ b/packages/hooks/src/stusds/useBatchStUsdsDeposit.ts
@@ -9,6 +9,7 @@ import { useSendBatchTransactionFlow } from '../shared/useSendBatchTransactionFl
 
 export function useBatchStUsdsDeposit({
   amount,
+  onMutate = () => null,
   onSuccess = () => null,
   onError = () => null,
   onStart = () => null,
@@ -55,6 +56,7 @@ export function useBatchStUsdsDeposit({
     calls,
     chainId,
     enabled,
+    onMutate,
     onSuccess,
     onError,
     onStart

--- a/packages/hooks/src/stusds/useBatchStUsdsDeposit.ts
+++ b/packages/hooks/src/stusds/useBatchStUsdsDeposit.ts
@@ -5,7 +5,7 @@ import { stUsdsImplementationAbi } from './useReadStUsdsImplementation';
 import { Abi, Call, erc20Abi } from 'viem';
 import { useStUsdsAllowance } from './useStUsdsAllowance';
 import { getWriteContractCall } from '../shared/getWriteContractCall';
-import { useSendBatchTransactionFlow } from '../shared/useSendBatchTransactionFlow';
+import { useTransactionFlow } from '../shared/useTransactionFlow';
 
 export function useBatchStUsdsDeposit({
   amount,
@@ -14,6 +14,7 @@ export function useBatchStUsdsDeposit({
   onError = () => null,
   onStart = () => null,
   enabled: activeTabEnabled = true,
+  shouldUseBatch = true,
   referral = 0
 }: BatchWriteHookParams & {
   amount: bigint;
@@ -52,10 +53,11 @@ export function useBatchStUsdsDeposit({
     activeTabEnabled &&
     !!connectedAddress;
 
-  const sendBatchTransactionFlowResults = useSendBatchTransactionFlow({
+  const transactionFlowResults = useTransactionFlow({
     calls,
     chainId,
     enabled,
+    shouldUseBatch,
     onMutate,
     onSuccess,
     onError,
@@ -63,7 +65,7 @@ export function useBatchStUsdsDeposit({
   });
 
   return {
-    ...sendBatchTransactionFlowResults,
-    error: sendBatchTransactionFlowResults.error || allowanceError
+    ...transactionFlowResults,
+    error: transactionFlowResults.error || allowanceError
   };
 }

--- a/packages/hooks/src/stusds/useStUsdsApprove.ts
+++ b/packages/hooks/src/stusds/useStUsdsApprove.ts
@@ -6,6 +6,7 @@ import { useApproveToken } from '../tokens/useApproveToken';
 export function useStUsdsApprove({
   amount,
   gas,
+  onMutate = () => null,
   onSuccess = () => null,
   onError = () => null,
   onStart = () => null
@@ -21,6 +22,7 @@ export function useStUsdsApprove({
     spender: stUsdsAddress[chainId as keyof typeof stUsdsAddress],
     amount,
     gas,
+    onMutate,
     onError,
     onSuccess,
     onStart

--- a/packages/hooks/src/stusds/useStUsdsDeposit.ts
+++ b/packages/hooks/src/stusds/useStUsdsDeposit.ts
@@ -8,6 +8,7 @@ import { Abi } from 'viem';
 export function useStUsdsDeposit({
   amount,
   gas,
+  onMutate = () => null,
   onSuccess = () => null,
   onError = () => null,
   onStart = () => null,
@@ -33,6 +34,7 @@ export function useStUsdsDeposit({
     chainId,
     gas,
     enabled,
+    onMutate,
     onSuccess,
     onError,
     onStart

--- a/packages/hooks/src/stusds/useStUsdsWithdraw.ts
+++ b/packages/hooks/src/stusds/useStUsdsWithdraw.ts
@@ -11,6 +11,7 @@ import { Abi } from 'viem';
 export function useStUsdsWithdraw({
   amount,
   gas,
+  onMutate = () => null,
   onSuccess = () => null,
   onError = () => null,
   onStart = () => null,
@@ -75,6 +76,7 @@ export function useStUsdsWithdraw({
     chainId,
     gas,
     enabled,
+    onMutate,
     onSuccess,
     onError,
     onStart

--- a/packages/widgets/src/widgets/StUSDSWidget/hooks/useStUsdsTransactionCallbacks.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/hooks/useStUsdsTransactionCallbacks.tsx
@@ -10,7 +10,6 @@ interface UseStUsdsTransactionCallbacksParameters
   amount: bigint;
   mutateAllowance: () => void;
   mutateStUsds: () => void;
-  retryPrepareDeposit: () => void;
 }
 
 export const useStUsdsTransactionCallbacks = ({
@@ -19,8 +18,7 @@ export const useStUsdsTransactionCallbacks = ({
   onWidgetStateChange,
   onNotification,
   mutateAllowance,
-  mutateStUsds,
-  retryPrepareDeposit
+  mutateStUsds
 }: UseStUsdsTransactionCallbacksParameters) => {
   const { handleOnMutate, handleOnStart, handleOnSuccess, handleOnError } = useTransactionCallbacks({
     addRecentTransaction,
@@ -28,48 +26,12 @@ export const useStUsdsTransactionCallbacks = ({
     onNotification
   });
 
-  const approveTransactionCallbacks = useMemo<TransactionCallbacks>(
-    () => ({
-      onMutate: handleOnMutate,
-      onStart: hash => {
-        handleOnStart({
-          hash,
-          recentTransactionDescription: t`Approving ${formatBigInt(amount)} USDS`
-        });
-      },
-      onSuccess: hash => {
-        handleOnSuccess({
-          hash,
-          notificationTitle: t`Approve successful`,
-          notificationDescription: t`You approved ${formatBigInt(amount)} USDS`
-        });
-        mutateAllowance();
-        retryPrepareDeposit();
-      },
-      onError: (error, hash) => {
-        handleOnError({
-          error,
-          hash,
-          notificationTitle: t`Approval failed`,
-          notificationDescription: t`We could not approve your token allowance.`
-        });
-        mutateAllowance();
-      }
-    }),
-    [
-      amount,
-      handleOnMutate,
-      handleOnError,
-      handleOnStart,
-      handleOnSuccess,
-      mutateAllowance,
-      retryPrepareDeposit
-    ]
-  );
-
   const supplyTransactionCallbacks = useMemo<TransactionCallbacks>(
     () => ({
-      onMutate: handleOnMutate,
+      onMutate: () => {
+        mutateAllowance();
+        handleOnMutate();
+      },
       onStart: hash => {
         handleOnStart({
           hash,
@@ -130,5 +92,5 @@ export const useStUsdsTransactionCallbacks = ({
     [amount, handleOnMutate, handleOnError, handleOnStart, handleOnSuccess, mutateAllowance, mutateStUsds]
   );
 
-  return { approveTransactionCallbacks, supplyTransactionCallbacks, withdrawTransactionCallbacks };
+  return { supplyTransactionCallbacks, withdrawTransactionCallbacks };
 };

--- a/packages/widgets/src/widgets/StUSDSWidget/hooks/useStUsdsTransactionCallbacks.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/hooks/useStUsdsTransactionCallbacks.tsx
@@ -22,7 +22,7 @@ export const useStUsdsTransactionCallbacks = ({
   mutateStUsds,
   retryPrepareDeposit
 }: UseStUsdsTransactionCallbacksParameters) => {
-  const { handleOnStart, handleOnSuccess, handleOnError } = useTransactionCallbacks({
+  const { handleOnMutate, handleOnStart, handleOnSuccess, handleOnError } = useTransactionCallbacks({
     addRecentTransaction,
     onWidgetStateChange,
     onNotification
@@ -30,6 +30,7 @@ export const useStUsdsTransactionCallbacks = ({
 
   const approveTransactionCallbacks = useMemo<TransactionCallbacks>(
     () => ({
+      onMutate: handleOnMutate,
       onStart: hash => {
         handleOnStart({
           hash,
@@ -55,11 +56,20 @@ export const useStUsdsTransactionCallbacks = ({
         mutateAllowance();
       }
     }),
-    [amount, handleOnError, handleOnStart, handleOnSuccess, mutateAllowance, retryPrepareDeposit]
+    [
+      amount,
+      handleOnMutate,
+      handleOnError,
+      handleOnStart,
+      handleOnSuccess,
+      mutateAllowance,
+      retryPrepareDeposit
+    ]
   );
 
   const supplyTransactionCallbacks = useMemo<TransactionCallbacks>(
     () => ({
+      onMutate: handleOnMutate,
       onStart: hash => {
         handleOnStart({
           hash,
@@ -86,11 +96,12 @@ export const useStUsdsTransactionCallbacks = ({
         mutateStUsds();
       }
     }),
-    [amount, handleOnError, handleOnStart, handleOnSuccess, mutateAllowance, mutateStUsds]
+    [amount, handleOnMutate, handleOnError, handleOnStart, handleOnSuccess, mutateAllowance, mutateStUsds]
   );
 
   const withdrawTransactionCallbacks = useMemo<TransactionCallbacks>(
     () => ({
+      onMutate: handleOnMutate,
       onStart: hash => {
         handleOnStart({
           hash,
@@ -116,7 +127,7 @@ export const useStUsdsTransactionCallbacks = ({
         mutateStUsds();
       }
     }),
-    [amount, handleOnError, handleOnStart, handleOnSuccess, mutateAllowance, mutateStUsds]
+    [amount, handleOnMutate, handleOnError, handleOnStart, handleOnSuccess, mutateAllowance, mutateStUsds]
   );
 
   return { approveTransactionCallbacks, supplyTransactionCallbacks, withdrawTransactionCallbacks };

--- a/packages/widgets/src/widgets/StUSDSWidget/hooks/useStUsdsTransactions.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/hooks/useStUsdsTransactions.tsx
@@ -1,9 +1,4 @@
-import {
-  useBatchStUsdsDeposit,
-  useStUsdsApprove,
-  useStUsdsDeposit,
-  useStUsdsWithdraw
-} from '@jetstreamgg/sky-hooks';
+import { useBatchStUsdsDeposit, useStUsdsWithdraw } from '@jetstreamgg/sky-hooks';
 import { WidgetContext } from '@widgets/context/WidgetContext';
 import { WidgetProps } from '@widgets/shared/types/widgetState';
 import { useContext } from 'react';
@@ -12,19 +7,19 @@ import { useStUsdsTransactionCallbacks } from './useStUsdsTransactionCallbacks';
 
 interface UseStUsdsTransactionsParameters
   extends Pick<WidgetProps, 'addRecentTransaction' | 'onWidgetStateChange' | 'onNotification'> {
-  allowance: bigint | undefined;
   amount: bigint;
   referralCode: number | undefined;
   max: boolean;
+  shouldUseBatch: boolean;
   mutateAllowance: () => void;
   mutateStUsds: () => void;
 }
 
 export const useStUsdsTransactions = ({
-  allowance,
   amount,
   referralCode,
   max,
+  shouldUseBatch,
   mutateAllowance,
   mutateStUsds,
   addRecentTransaction,
@@ -32,39 +27,21 @@ export const useStUsdsTransactions = ({
   onNotification
 }: UseStUsdsTransactionsParameters) => {
   const { widgetState } = useContext(WidgetContext);
-  const { approveTransactionCallbacks, supplyTransactionCallbacks, withdrawTransactionCallbacks } =
-    useStUsdsTransactionCallbacks({
-      amount,
-      addRecentTransaction,
-      onWidgetStateChange,
-      onNotification,
-      mutateAllowance,
-      mutateStUsds,
-      retryPrepareDeposit: () => stUsdsDeposit.retryPrepare()
-    });
-
-  const stUsdsApprove = useStUsdsApprove({
+  const { supplyTransactionCallbacks, withdrawTransactionCallbacks } = useStUsdsTransactionCallbacks({
     amount,
-    enabled: widgetState.action === StUSDSAction.APPROVE && allowance !== undefined,
-    ...approveTransactionCallbacks
-  });
-
-  const stUsdsDepositParams = {
-    amount,
-    referral: referralCode,
-    ...supplyTransactionCallbacks
-  };
-
-  const stUsdsDeposit = useStUsdsDeposit({
-    ...stUsdsDepositParams,
-    enabled: widgetState.action === StUSDSAction.SUPPLY && allowance !== undefined
+    addRecentTransaction,
+    onWidgetStateChange,
+    onNotification,
+    mutateAllowance,
+    mutateStUsds
   });
 
   const batchStUsdsDeposit = useBatchStUsdsDeposit({
-    ...stUsdsDepositParams,
-    enabled:
-      (widgetState.action === StUSDSAction.SUPPLY || widgetState.action === StUSDSAction.APPROVE) &&
-      allowance !== undefined
+    amount,
+    referral: referralCode,
+    shouldUseBatch,
+    enabled: widgetState.action === StUSDSAction.SUPPLY || widgetState.action === StUSDSAction.APPROVE,
+    ...supplyTransactionCallbacks
   });
 
   const stUsdsWithdraw = useStUsdsWithdraw({
@@ -74,10 +51,5 @@ export const useStUsdsTransactions = ({
     ...withdrawTransactionCallbacks
   });
 
-  return {
-    stUsdsApprove,
-    stUsdsDeposit,
-    batchStUsdsDeposit,
-    stUsdsWithdraw
-  };
+  return { batchStUsdsDeposit, stUsdsWithdraw };
 };

--- a/packages/widgets/src/widgets/StUSDSWidget/index.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/index.tsx
@@ -68,7 +68,7 @@ const StUSDSWidgetWrapped = ({
 
   const { mutate: mutateStUsds, data: stUsdsData, isLoading: isStUsdsDataLoading } = useStUsdsData();
   const { data: capacityData } = useStUsdsCapacityData();
-  const { data: allowance, mutate: mutateAllowance, isLoading: allowanceLoading } = useStUsdsAllowance();
+  const { data: allowance, mutate: mutateAllowance } = useStUsdsAllowance();
   const initialAmount =
     validatedExternalState?.amount && validatedExternalState.amount !== '0'
       ? parseUnits(validatedExternalState.amount, 18)
@@ -80,7 +80,7 @@ const StUSDSWidgetWrapped = ({
   const [max, setMax] = useState<boolean>(false);
   const linguiCtx = useLingui();
   const usds = TOKENS.usds;
-  const { data: batchSupported, isLoading: isBatchSupportLoading } = useIsBatchSupported();
+  const { data: batchSupported } = useIsBatchSupported();
 
   useEffect(() => {
     setAmount(initialAmount);
@@ -104,21 +104,21 @@ const StUSDSWidgetWrapped = ({
 
   useNotifyWidgetState({ widgetState, txStatus, onWidgetStateChange });
 
-  const { stUsdsApprove, stUsdsDeposit, batchStUsdsDeposit, stUsdsWithdraw } = useStUsdsTransactions({
-    allowance,
+  const needsAllowance = !!(!allowance || allowance < debouncedAmount);
+  const shouldUseBatch =
+    !!batchEnabled && !!batchSupported && needsAllowance && widgetState.flow === StUSDSFlow.SUPPLY;
+
+  const { batchStUsdsDeposit, stUsdsWithdraw } = useStUsdsTransactions({
     amount,
     referralCode,
     max,
+    shouldUseBatch,
     mutateAllowance,
     mutateStUsds,
     addRecentTransaction,
     onWidgetStateChange,
     onNotification
   });
-
-  const needsAllowance = !!(!allowance || allowance < debouncedAmount);
-  const shouldUseBatch =
-    !!batchEnabled && !!batchSupported && needsAllowance && widgetState.flow === StUSDSFlow.SUPPLY;
 
   useEffect(() => {
     //Initialize the supply flow only when we are connected
@@ -146,29 +146,6 @@ const StUSDSWidgetWrapped = ({
       });
     }
   }, [tabIndex, isConnectedAndEnabled]);
-
-  // If we're in the supply flow, need allowance and batch transactions are not supported, set the action to approve
-  useEffect(() => {
-    if (
-      widgetState.flow === StUSDSFlow.SUPPLY &&
-      (widgetState.screen === StUSDSScreen.ACTION || widgetState.screen === StUSDSScreen.REVIEW)
-    ) {
-      setWidgetState((prev: WidgetState) => ({
-        ...prev,
-        action:
-          needsAllowance && !allowanceLoading && !shouldUseBatch && !isBatchSupportLoading
-            ? StUSDSAction.APPROVE
-            : StUSDSAction.SUPPLY
-      }));
-    }
-  }, [
-    widgetState.flow,
-    widgetState.screen,
-    needsAllowance,
-    allowanceLoading,
-    shouldUseBatch,
-    isBatchSupportLoading
-  ]);
 
   useEffect(() => {
     setShowStepIndicator(widgetState.flow === StUSDSFlow.SUPPLY);
@@ -202,34 +179,12 @@ const StUSDSWidgetWrapped = ({
     !stUsdsWithdraw.prepared ||
     isAmountWaitingForDebounce;
 
-  const supplyDisabled =
-    [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
-    isSupplyBalanceError ||
-    allowance === undefined ||
-    !stUsdsDeposit.prepared ||
-    stUsdsDeposit.isLoading ||
-    isAmountWaitingForDebounce;
-
   const batchSupplyDisabled =
     [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
     isSupplyBalanceError ||
     !batchStUsdsDeposit.prepared ||
     batchStUsdsDeposit.isLoading ||
-    isAmountWaitingForDebounce ||
-    // If the user has allowance, don't send a batch transaction as it's only 1 contract call
-    !needsAllowance ||
-    allowanceLoading ||
-    !batchSupported;
-
-  const approveDisabled =
-    [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
-    isSupplyBalanceError ||
-    !stUsdsApprove.prepared ||
-    stUsdsApprove.isLoading ||
-    (txStatus === TxStatus.SUCCESS && !stUsdsDeposit.prepared) || //disable next button if supply not prepared
-    allowance === undefined ||
-    isAmountWaitingForDebounce ||
-    (!!batchEnabled && isBatchSupportLoading);
+    isAmountWaitingForDebounce;
 
   // Handle external state changes
   useEffect(() => {
@@ -258,12 +213,7 @@ const StUSDSWidgetWrapped = ({
 
     setWidgetState((prev: WidgetState) => ({
       ...prev,
-      action:
-        prev.flow === StUSDSFlow.WITHDRAW
-          ? StUSDSAction.WITHDRAW
-          : needsAllowance
-            ? StUSDSAction.APPROVE
-            : StUSDSAction.SUPPLY,
+      action: prev.flow === StUSDSFlow.WITHDRAW ? StUSDSAction.WITHDRAW : StUSDSAction.SUPPLY,
       screen: StUSDSScreen.ACTION
     }));
 
@@ -293,14 +243,10 @@ const StUSDSWidgetWrapped = ({
   // Handle the error onClicks separately to keep it clean
   const errorOnClick = () => {
     return widgetState.action === StUSDSAction.SUPPLY
-      ? shouldUseBatch
-        ? batchStUsdsDeposit.execute()
-        : stUsdsDeposit.execute()
+      ? batchStUsdsDeposit.execute()
       : widgetState.action === StUSDSAction.WITHDRAW
         ? stUsdsWithdraw.execute()
-        : widgetState.action === StUSDSAction.APPROVE
-          ? stUsdsApprove.execute()
-          : undefined;
+        : undefined;
   };
 
   const onClickAction = !isConnectedAndEnabled
@@ -312,27 +258,12 @@ const StUSDSWidgetWrapped = ({
         : widgetState.screen === StUSDSScreen.ACTION
           ? reviewOnClick
           : widgetState.flow === StUSDSFlow.SUPPLY
-            ? shouldUseBatch
-              ? batchStUsdsDeposit.execute
-              : widgetState.action === StUSDSAction.APPROVE
-                ? stUsdsApprove.execute
-                : stUsdsDeposit.execute
-            : widgetState.flow === StUSDSFlow.WITHDRAW && widgetState.action === StUSDSAction.WITHDRAW
+            ? batchStUsdsDeposit.execute
+            : widgetState.flow === StUSDSFlow.WITHDRAW
               ? stUsdsWithdraw.execute
               : undefined;
 
   const showSecondaryButton = txStatus === TxStatus.ERROR || widgetState.screen === StUSDSScreen.REVIEW;
-
-  useEffect(() => {
-    if (stUsdsDeposit.prepareError) {
-      console.log(stUsdsDeposit.prepareError);
-      onNotification?.({
-        title: t`Error preparing transaction`,
-        description: stUsdsDeposit.prepareError.message,
-        status: TxStatus.ERROR
-      });
-    }
-  }, [stUsdsDeposit.prepareError]);
 
   useEffect(() => {
     if (stUsdsWithdraw.prepareError) {
@@ -360,7 +291,7 @@ const StUSDSWidgetWrapped = ({
   // Ref: https://lingui.dev/tutorials/react-patterns#memoization-pitfall
   useEffect(() => {
     if (isConnectedAndEnabled) {
-      if (txStatus === TxStatus.SUCCESS && widgetState.action !== StUSDSAction.APPROVE) {
+      if (txStatus === TxStatus.SUCCESS) {
         setButtonText(t`Back to stUSDS`);
       } else if (txStatus === TxStatus.ERROR) {
         setButtonText(t`Retry`);
@@ -369,65 +300,34 @@ const StUSDSWidgetWrapped = ({
       } else if (widgetState.screen === StUSDSScreen.ACTION) {
         setButtonText(t`Review`);
       } else if (widgetState.screen === StUSDSScreen.REVIEW) {
-        if (shouldUseBatch) {
+        if (widgetState.flow === StUSDSFlow.WITHDRAW) {
+          setButtonText(t`Confirm withdrawal`);
+        } else if (shouldUseBatch) {
           setButtonText(t`Confirm bundled transaction`);
-        } else if (widgetState.action === StUSDSAction.APPROVE) {
+        } else if (needsAllowance) {
           setButtonText(t`Confirm 2 transactions`);
         } else if (widgetState.flow === StUSDSFlow.SUPPLY) {
           setButtonText(t`Confirm supply`);
-        } else if (widgetState.flow === StUSDSFlow.WITHDRAW) {
-          setButtonText(t`Confirm withdrawal`);
         }
       }
     } else {
       setButtonText(t`Connect Wallet`);
     }
-  }, [widgetState, txStatus, linguiCtx, amount, isConnectedAndEnabled, shouldUseBatch]);
+  }, [widgetState, txStatus, linguiCtx, amount, isConnectedAndEnabled, shouldUseBatch, needsAllowance]);
 
   // Set widget button to be disabled depending on which action we're in
   useEffect(() => {
     setIsDisabled(
       isConnectedAndEnabled &&
-        ((widgetState.action === StUSDSAction.SUPPLY &&
-          (shouldUseBatch ? batchSupplyDisabled : supplyDisabled)) ||
-          (widgetState.action === StUSDSAction.WITHDRAW && withdrawDisabled) ||
-          (widgetState.action === StUSDSAction.APPROVE && approveDisabled))
+        ((widgetState.action === StUSDSAction.SUPPLY && batchSupplyDisabled) ||
+          (widgetState.action === StUSDSAction.WITHDRAW && withdrawDisabled))
     );
-  }, [
-    widgetState.action,
-    supplyDisabled,
-    withdrawDisabled,
-    approveDisabled,
-    isConnectedAndEnabled,
-    shouldUseBatch,
-    batchSupplyDisabled
-  ]);
-
-  // After a successful approval, wait for the next hook (supply) to be prepared and send the transaction
-  useEffect(() => {
-    if (
-      widgetState.action === StUSDSAction.APPROVE &&
-      txStatus === TxStatus.SUCCESS &&
-      stUsdsDeposit.prepared
-    ) {
-      setWidgetState((prev: WidgetState) => ({
-        ...prev,
-        action: StUSDSAction.SUPPLY
-      }));
-      stUsdsDeposit.execute();
-    }
-  }, [widgetState.action, txStatus, stUsdsDeposit.prepared]);
+  }, [widgetState.action, withdrawDisabled, isConnectedAndEnabled, batchSupplyDisabled]);
 
   // Set isLoading to be consumed by WidgetButton
   useEffect(() => {
-    setIsLoading(
-      isConnecting ||
-        txStatus === TxStatus.LOADING ||
-        txStatus === TxStatus.INITIALIZED ||
-        // Keep the loading state after a successful approval as a new transaction will automatically pop up
-        (widgetState.action === StUSDSAction.APPROVE && txStatus === TxStatus.SUCCESS)
-    );
-  }, [isConnecting, txStatus, widgetState.action]);
+    setIsLoading(isConnecting || txStatus === TxStatus.LOADING || txStatus === TxStatus.INITIALIZED);
+  }, [isConnecting, txStatus]);
 
   const debouncedBalanceError = useDebounce(isSupplyBalanceError, 2000);
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

This PR refactors and significantly simplifies the stUSDS deposit transaction flow. It consolidates the separate `approve`, `deposit`, and `batch deposit` hooks into a single, unified `useBatchStUsdsDeposit` hook.

This new hook, powered by the more generic `useTransactionFlow`, intelligently determines whether to execute a single deposit transaction (if allowance is sufficient) or a bundled approve-and-deposit transaction. This removes a significant amount of complex state management, `useEffect` hooks, and conditional logic from the `StUSDSWidget` component, making the code cleaner and more robust.

An `onMutate` callback has also been added to the transaction hooks to enable pre-flight actions, such as refetching the latest allowance before a transaction is sent.

### Testing steps:

1.  Navigate to the stUSDS widget.
2.  **Test Supply (with insufficient allowance):**
    *   Connect a wallet with USDS but no allowance for the stUSDS contract.
    *   Enter an amount to supply.
    *   Proceed to the review screen. The button should say "Confirm bundled transaction".
    *   Confirm the transaction. It should be a single, batched transaction for both `approve` and `deposit`.
    *   Verify the transaction succeeds and balances update correctly.
3.  **Test Supply (with sufficient allowance):**
    *   Use a wallet that now has sufficient USDS allowance.
    *   Enter an amount to supply.
    *   Proceed to the review screen. The button should say "Confirm supply".
    *   Confirm the transaction. It should be a single transaction for just `deposit`.
    *   Verify the transaction succeeds.
4.  **Test Withdraw:**
    *   Switch to the "Withdraw" tab.
    *   Enter an amount and confirm the withdrawal.
    *   Verify the transaction succeeds and balances are updated correctly.