### PR TITLE
Use bulk vnet cleanup to prevent resource accumulation in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Teardown VNet (if required)
         if: ${{always() && matrix.vnet}}
         run: |
-          pnpm run vnet:delete:ci
+          pnpm run vnet:delete:all:ci
         env:
           TENDERLY_API_KEY: ${{ secrets.TENDERLY_API_KEY }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
           REACT_VERSION: ${{ matrix.react-version }}
 
       - name: Delete Tenderly virtual testnet fork
-        run: pnpm vnet:delete:ci
+        run: pnpm vnet:delete:all:ci
         env:
           TENDERLY_API_KEY: ${{ secrets.TENDERLY_API_KEY }}
         if: always()


### PR DESCRIPTION
Use `vnet:delete:all:ci` script instead of `vnet:delete:ci` to delete all the existing vnets older than 45 minutes. 
Have in mind that if there are too many vnets it may require multiple script executions due to the page limit in the script. 