### PR TITLE
Add publishConfig for public access in package.json files

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -64,5 +64,8 @@
     "sky ecosystem"
   ],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,5 +52,8 @@
     "date-fns": "^3.6.0",
     "ethers": "^6.15.0",
     "tiny-invariant": "^1.3.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -93,5 +93,8 @@
     "sky ecosystem"
   ],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
### What does this PR do?

* Adds `publishConfig: { access: "public" }` to all published packages:
  * `@jetstreamgg/sky-hooks`
  * `@jetstreamgg/sky-widgets`
  * `@jetstreamgg/sky-utils`
