### PR TITLE
Show balance and rewards on My Rewards overview

### DIFF
--- a/packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCard.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCard.tsx
@@ -1,13 +1,22 @@
 import { HStack } from '@widgets/shared/components/ui/layout/HStack';
 import { MotionVStack } from '@widgets/shared/components/ui/layout/MotionVStack';
 import { Text } from '@widgets/shared/components/ui/Typography';
-import { RewardContract, useRewardContractInfo, useRewardsChartInfo } from '@jetstreamgg/sky-hooks';
+import {
+  RewardContract,
+  useRewardContractInfo,
+  useRewardsChartInfo,
+  useRewardsSuppliedBalance,
+  useRewardsRewardsBalance,
+  TOKENS
+} from '@jetstreamgg/sky-hooks';
 import { t } from '@lingui/core/macro';
 import { Skeleton } from '@widgets/components/ui/skeleton';
 import { formatBigInt, formatNumber } from '@jetstreamgg/sky-utils';
 import { RewardsStatsCardCore } from './RewardsStatsCardCore';
 import { Warning } from '@widgets/shared/components/icons/Warning';
 import { positionAnimations } from '@widgets/shared/animation/presets';
+import { useAccount, useChainId } from 'wagmi';
+import { TokenIcon } from '@widgets/shared/components/ui/token/TokenIcon';
 
 export const RewardsStatsCard = ({
   rewardContract,
@@ -20,6 +29,9 @@ export const RewardsStatsCard = ({
   isConnectedAndEnabled: boolean;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }) => {
+  const { address } = useAccount();
+  const chainId = useChainId();
+
   const { data, isLoading, error } = useRewardContractInfo({
     chainId: rewardContract.chainId,
     rewardContractAddress: rewardContract.contractAddress
@@ -33,9 +45,34 @@ export const RewardsStatsCard = ({
     rewardContractAddress: rewardContract.contractAddress
   });
 
+  // User's supplied balance
+  const {
+    data: suppliedBalance,
+    isLoading: suppliedBalanceLoading,
+    error: suppliedBalanceError
+  } = useRewardsSuppliedBalance({
+    chainId,
+    address,
+    contractAddress: rewardContract.contractAddress as `0x${string}`
+  });
+
+  // User's unclaimed rewards
+  const {
+    data: rewardsBalance,
+    isLoading: rewardsBalanceLoading,
+    error: rewardsBalanceError
+  } = useRewardsRewardsBalance({
+    chainId,
+    address,
+    contractAddress: rewardContract.contractAddress as `0x${string}`
+  });
+
   const mostRecentData = chartData
     ? [...chartData].sort((a, b) => b.blockTimestamp - a.blockTimestamp)[0]
     : null;
+
+  // Check if user has a balance to determine which stats to show
+  const hasUserBalance = suppliedBalance && suppliedBalance > 0n;
 
   return (
     <RewardsStatsCardCore
@@ -46,8 +83,24 @@ export const RewardsStatsCard = ({
       content={
         <HStack className="mt-5 justify-between" gap={2}>
           <MotionVStack className="justify-between" gap={2} variants={positionAnimations}>
-            <Text className="text-textSecondary text-sm leading-4">{t`TVL`}</Text>
-            {data ? (
+            <Text className="text-textSecondary text-sm leading-4">
+              {hasUserBalance ? t`Supplied Balance` : t`TVL`}
+            </Text>
+            {hasUserBalance ? (
+              // Show user's supplied balance
+              suppliedBalance ? (
+                <Text>
+                  {formatBigInt(suppliedBalance, { maxDecimals: 0 })} {rewardContract.supplyToken.symbol}
+                </Text>
+              ) : suppliedBalanceLoading ? (
+                <Skeleton className="bg-textSecondary h-5 w-10" />
+              ) : suppliedBalanceError ? (
+                <Warning boxSize={16} viewBox="0 0 16 16" />
+              ) : (
+                <Text>0 {rewardContract.supplyToken.symbol}</Text>
+              )
+            ) : // Show TVL for non-user contracts
+            data ? (
               <Text>{formatBigInt(data?.totalSupplied, { maxDecimals: 0 })} USDS</Text>
             ) : isLoading ? (
               <Skeleton className="bg-textSecondary h-5 w-10" />
@@ -56,8 +109,34 @@ export const RewardsStatsCard = ({
             ) : null}
           </MotionVStack>
           <MotionVStack className="items-end justify-between" gap={2} variants={positionAnimations}>
-            <Text className="text-textSecondary text-sm leading-4">{t`Suppliers`}</Text>
-            {mostRecentData ? (
+            <Text className="text-textSecondary text-sm leading-4">
+              {hasUserBalance ? t`Accumulated Rewards` : t`Suppliers`}
+            </Text>
+            {hasUserBalance ? (
+              // Show user's accumulated rewards
+              rewardsBalance !== undefined ? (
+                <HStack className="items-center" gap={1}>
+                  <TokenIcon token={rewardContract.rewardToken} width={16} className="h-4 w-4" />
+                  <Text>
+                    {formatBigInt(rewardsBalance, {
+                      compact: rewardContract.rewardToken.symbol === TOKENS.cle.symbol,
+                      maxDecimals: 2
+                    })}{' '}
+                    {rewardContract.rewardToken.symbol}
+                  </Text>
+                </HStack>
+              ) : rewardsBalanceLoading ? (
+                <Skeleton className="bg-textSecondary h-5 w-10" />
+              ) : rewardsBalanceError ? (
+                <Warning boxSize={16} viewBox="0 0 16 16" />
+              ) : (
+                <HStack className="items-center" gap={1}>
+                  <TokenIcon token={rewardContract.rewardToken} width={16} className="h-4 w-4" />
+                  <Text>0 {rewardContract.rewardToken.symbol}</Text>
+                </HStack>
+              )
+            ) : // Show Suppliers for non-user contracts
+            mostRecentData ? (
               <Text>{formatNumber(mostRecentData?.suppliers, { maxDecimals: 0 })}</Text>
             ) : isLoadingChart ? (
               <Skeleton className="bg-textSecondary h-5 w-10" />


### PR DESCRIPTION
### What does this PR do?

This PR updates the `RewardsStatsCard` to conditionally display user-specific data. If a connected user has a supplied balance in the rewards contract, the card will now show their personal "Supplied Balance" and "Accumulated Rewards". If the user has no balance, it will continue to show the contract's total "TVL" and number of "Suppliers" as before.

### Testing steps:

1.  Navigate to the Rewards page.
2.  **With a wallet that has NOT supplied to a contract:** Verify the stats card shows the contract's "TVL" and total "Suppliers".
3.  **With a wallet that HAS supplied to a contract:**
    *   Verify the corresponding stats card now displays your "Supplied Balance" and your "Accumulated Rewards".
    *   Verify that cards for other contracts where you have no balance still show "TVL" and "Suppliers".
4.  Confirm that loading and error states (skeletons and warning icons) are handled correctly for the new user-specific data.

<img width="876" height="1310" alt="Screenshot 2025-08-29 at 2 34 02 PM" src="https://github.com/user-attachments/assets/eb43d0c4-4ae4-455f-8cf5-ccaeda4783c9" />
