### PR TITLE
Improve close button visibility in the mobile menu

### DIFF
--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -37,9 +37,13 @@ function SheetContent({
   className,
   children,
   side = 'right',
+  closeButtonClassName,
+  closeIconClassName,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left';
+  closeButtonClassName?: string;
+  closeIconClassName?: string;
 }) {
   return (
     <SheetPortal>
@@ -61,8 +65,13 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
-          <XIcon className="size-4" />
+        <SheetPrimitive.Close
+          className={cn(
+            'ring-offset-background focus:ring-ring data-[state=open]:bg-secondary rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none',
+            closeButtonClassName
+          )}
+        >
+          <XIcon className={cn('size-4', closeIconClassName)} />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>

--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -151,6 +151,8 @@ export function WidgetNavigation({
             <SheetContent
               side="left"
               className="border-borderPrimary w-[280px] bg-black/10 p-0 backdrop-blur-xl"
+              closeButtonClassName="text-white"
+              closeIconClassName="size-5.5"
             >
               <div className="flex h-full flex-col">
                 <div className="p-6 pb-4">


### PR DESCRIPTION
### Before
<img width="694" height="416" alt="image" src="https://github.com/user-attachments/assets/97c40c0c-a99e-41e5-8073-c60a85310e3f" />

### After
<img width="784" height="540" alt="image" src="https://github.com/user-attachments/assets/2fbf5029-45c8-419a-aef7-0d54f47bb997" />
