### PR TITLE
Refactor: Simplify getTokenDecimals usage by handling undefined tokens internally

### DIFF
--- a/packages/hooks/src/psm/usePreviewSwapExactIn.ts
+++ b/packages/hooks/src/psm/usePreviewSwapExactIn.ts
@@ -29,7 +29,7 @@ export const usePreviewSwapExactIn = (
     };
   }
   // use the correct decimals for the out token
-  const tokenDecimals = outToken ? getTokenDecimals(outToken, chainId) : 18;
+  const tokenDecimals = getTokenDecimals(outToken, chainId);
 
   // Format the result
   const formattedAmount = formatBigInt(amountOut, { unit: tokenDecimals });

--- a/packages/hooks/src/psm/usePreviewSwapExactOut.ts
+++ b/packages/hooks/src/psm/usePreviewSwapExactOut.ts
@@ -26,7 +26,7 @@ export const usePreviewSwapExactOut = (
     };
   }
   // use the correct decimals for the in token
-  const tokenDecimals = inToken ? getTokenDecimals(inToken, chainId) : 18;
+  const tokenDecimals = getTokenDecimals(inToken, chainId);
 
   // Format the result
   const formattedAmount = formatBigInt(amountIn, { unit: tokenDecimals });

--- a/packages/hooks/src/tokens/tokens.constants.ts
+++ b/packages/hooks/src/tokens/tokens.constants.ts
@@ -21,11 +21,18 @@ import {
 import { TokenMapping, Token, TokenForChain } from './types';
 import { TENDERLY_BASE_CHAIN_ID, TENDERLY_CHAIN_ID, TENDERLY_ARBITRUM_CHAIN_ID } from '../constants';
 
-export function getTokenDecimals(token: Token | TokenForChain, chainId: number): number {
+export function getTokenDecimals(
+  token: Token | TokenForChain | undefined | null,
+  chainId: number,
+  defaultDecimals = 18
+): number {
+  if (!token) {
+    return defaultDecimals;
+  }
   if (typeof token.decimals === 'number') {
     return token.decimals;
   }
-  return token.decimals[chainId] ?? 18; // fallback to 18 if not specified
+  return token.decimals[chainId] ?? defaultDecimals; // fallback to 18 if not specified
 }
 
 export function tokenArrayFiltered(arr: Array<TokenForChain>, elementToRemove?: TokenForChain) {

--- a/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
+++ b/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
@@ -86,7 +86,7 @@ export function TokenInput({
   const [height, setHeight] = useState(0);
   const [searchQuery, setSearchQuery] = useState('');
   const chainId = useChainId();
-  const decimals = token ? getTokenDecimals(token, chainId) : 18;
+  const decimals = getTokenDecimals(token, chainId);
   const color = useMemo(() => {
     return token?.color || tokenColors.find(t => t.symbol === token?.symbol)?.color || '#6d7ce3';
   }, [token]);

--- a/packages/widgets/src/shared/components/ui/transaction/BatchTransactionStatus.tsx
+++ b/packages/widgets/src/shared/components/ui/transaction/BatchTransactionStatus.tsx
@@ -31,7 +31,7 @@ export function TransactionDetail() {
             <TokenIconWithBalance
               token={originToken}
               balance={formatBigInt(originAmount, {
-                unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+                unit: getTokenDecimals(originToken, chainId)
               })}
               textLarge
             />
@@ -41,7 +41,7 @@ export function TransactionDetail() {
                 <TokenIconWithBalance
                   token={targetToken}
                   balance={formatBigInt(targetAmount, {
-                    unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+                    unit: getTokenDecimals(targetToken, chainId)
                   })}
                   textLarge
                 />

--- a/packages/widgets/src/shared/components/ui/transaction/TransactionStatus.tsx
+++ b/packages/widgets/src/shared/components/ui/transaction/TransactionStatus.tsx
@@ -31,7 +31,7 @@ function TransactionDetail() {
             <TokenIconWithBalance
               token={originToken}
               balance={formatBigInt(originAmount, {
-                unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+                unit: getTokenDecimals(originToken, chainId)
               })}
               textLarge
             />
@@ -41,7 +41,7 @@ function TransactionDetail() {
                 <TokenIconWithBalance
                   token={targetToken}
                   balance={formatBigInt(targetAmount, {
-                    unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+                    unit: getTokenDecimals(targetToken, chainId)
                   })}
                   textLarge
                 />

--- a/packages/widgets/src/widgets/BalancesWidget/lib/getAmount.ts
+++ b/packages/widgets/src/widgets/BalancesWidget/lib/getAmount.ts
@@ -17,7 +17,7 @@ export const getAmount = ({
     case ModuleEnum.TRADE:
       return formatBigInt(absBigInt('fromAmount' in item ? item.fromAmount : 0n), {
         compact: true,
-        unit: 'fromToken' in item ? getTokenDecimals(item.fromToken as Token, chainId) : 18
+        unit: getTokenDecimals('fromToken' in item ? (item.fromToken as Token) : undefined, chainId)
       });
     case ModuleEnum.UPGRADE:
       switch (item.type) {
@@ -38,7 +38,7 @@ export const getAmount = ({
     case ModuleEnum.SAVINGS:
       return formatBigInt(absBigInt('assets' in item ? item.assets : 0n), {
         compact: true,
-        unit: 'token' in item ? getTokenDecimals(item.token, chainId) : 18
+        unit: getTokenDecimals('token' in item ? item.token : undefined, chainId)
       });
   }
 };

--- a/packages/widgets/src/widgets/L2TradeWidget/components/L2TradeTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/components/L2TradeTransactionStatus.tsx
@@ -91,11 +91,11 @@ export const L2TradeTransactionStatus = ({
               txStatus: flowTxStatus,
               originToken,
               originAmount: formatBigInt(originAmount, {
-                unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+                unit: getTokenDecimals(originToken, chainId)
               }),
               targetToken,
               targetAmount: formatBigInt(targetAmount, {
-                unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+                unit: getTokenDecimals(targetToken, chainId)
               }),
               needsAllowance: flowNeedsAllowance
             })
@@ -108,7 +108,7 @@ export const L2TradeTransactionStatus = ({
               txStatus: flowTxStatus,
               action,
               amount: formatBigInt(originAmount, {
-                unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+                unit: getTokenDecimals(originToken, chainId)
               }),
               symbol: originToken.symbol
             })

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -140,7 +140,7 @@ function TradeWidgetWrapped({
 
   const initialOriginAmount = parseUnits(
     validatedExternalState?.amount || '0',
-    originToken ? getTokenDecimals(originToken, chainId) : 18
+    getTokenDecimals(originToken, chainId)
   );
 
   const [originAmount, setOriginAmount] = useState(initialOriginAmount);
@@ -148,7 +148,7 @@ function TradeWidgetWrapped({
 
   const initialTargetAmount = parseUnits(
     validatedExternalState?.amount || '0',
-    targetToken ? getTokenDecimals(targetToken, chainId) : 18
+    getTokenDecimals(targetToken, chainId)
   );
 
   const [targetAmount, setTargetAmount] = useState(initialTargetAmount);
@@ -351,7 +351,7 @@ function TradeWidgetWrapped({
       externalWidgetState?.amount !==
         formatBigInt(originAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         });
 
     if ((tokensHasChanged || amountHasChanged) && txStatus === TxStatus.IDLE) {
@@ -871,12 +871,8 @@ function TradeWidgetWrapped({
                     value: (() => {
                       if (!originAmount || originAmount === 0n || !targetAmount) return '1:1';
 
-                      const originDecimals = originToken
-                        ? getTokenDecimals(originToken as Token, chainId)
-                        : 18;
-                      const targetDecimals = targetToken
-                        ? getTokenDecimals(targetToken as Token, chainId)
-                        : 18;
+                      const originDecimals = getTokenDecimals(originToken as Token, chainId);
+                      const targetDecimals = getTokenDecimals(targetToken as Token, chainId);
 
                       // Convert to decimal values
                       const originValue = Number(formatUnits(originAmount, originDecimals));
@@ -897,7 +893,7 @@ function TradeWidgetWrapped({
                   {
                     label: t`Tokens to receive`,
                     value: `${formatBigInt(targetAmount, {
-                      unit: targetToken ? getTokenDecimals(targetToken as Token, chainId) : 18,
+                      unit: getTokenDecimals(targetToken as Token, chainId),
                       compact: true
                     })} ${targetToken?.symbol}`
                   },
@@ -907,11 +903,11 @@ function TradeWidgetWrapped({
                       originBalance?.value !== undefined && originAmount > 0n
                         ? [
                             formatBigInt(originBalance.value, {
-                              unit: originToken ? getTokenDecimals(originToken as Token, chainId) : 18,
+                              unit: getTokenDecimals(originToken as Token, chainId),
                               compact: true
                             }),
                             formatBigInt(originBalance.value - originAmount, {
-                              unit: originToken ? getTokenDecimals(originToken as Token, chainId) : 18,
+                              unit: getTokenDecimals(originToken as Token, chainId),
                               compact: true
                             })
                           ]
@@ -923,11 +919,11 @@ function TradeWidgetWrapped({
                       targetBalance?.value !== undefined && targetAmount > 0n
                         ? [
                             formatBigInt(targetBalance.value, {
-                              unit: targetToken ? getTokenDecimals(targetToken as Token, chainId) : 18,
+                              unit: getTokenDecimals(targetToken as Token, chainId),
                               compact: true
                             }),
                             formatBigInt(targetBalance.value + targetAmount, {
-                              unit: targetToken ? getTokenDecimals(targetToken as Token, chainId) : 18,
+                              unit: getTokenDecimals(targetToken as Token, chainId),
                               compact: true
                             })
                           ]

--- a/packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCardCore.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCardCore.tsx
@@ -7,7 +7,13 @@ import { StatsOverviewCardCore } from '@widgets/shared/components/ui/card/StatsO
 import { MotionHStack } from '@widgets/shared/components/ui/layout/MotionHStack';
 import { PairTokenIcons } from '@widgets/shared/components/ui/token/PairTokenIcon';
 import { PopoverRateInfo } from '@widgets/shared/components/ui/PopoverRateInfo';
-import { RewardContract, TOKENS, WriteHook, useRewardsChartInfo } from '@jetstreamgg/sky-hooks';
+import {
+  RewardContract,
+  TOKENS,
+  WriteHook,
+  useRewardsChartInfo,
+  getTokenDecimals
+} from '@jetstreamgg/sky-hooks';
 import { formatBigInt, formatDecimalPercentage } from '@jetstreamgg/sky-utils';
 import { Trans } from '@lingui/react/macro';
 import { motion } from 'framer-motion';
@@ -36,12 +42,7 @@ export const RewardsStatsCardCore = ({
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }) => {
   const chainId = useChainId();
-  const rewardTokenDecimals = rewardContract.rewardToken.decimals;
-  const parsedRewardTokenDecimals = !rewardTokenDecimals
-    ? 18
-    : typeof rewardTokenDecimals === 'number'
-      ? rewardTokenDecimals
-      : rewardTokenDecimals[chainId] || 18;
+  const parsedRewardTokenDecimals = getTokenDecimals(rewardContract.rewardToken, chainId);
   const MIN_CLAIM_DISPLAY = BigInt(10 ** (parsedRewardTokenDecimals - 2)); // 0.01
 
   const {

--- a/packages/widgets/src/widgets/RewardsWidget/components/RewardsTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/components/RewardsTransactionStatus.tsx
@@ -83,7 +83,7 @@ export const RewardsTransactionStatus = ({
           rewardsClaimLoadingButtonText({
             txStatus,
             amount: formatBigInt(rewardAmount, {
-              unit: rewardToken ? getTokenDecimals(rewardToken, chainId) : 18
+              unit: getTokenDecimals(rewardToken, chainId)
             }),
             symbol: rewardToken.symbol
           })
@@ -95,7 +95,7 @@ export const RewardsTransactionStatus = ({
           rewardsClaimSubtitle({
             txStatus,
             amount: formatBigInt(rewardAmount, {
-              unit: rewardToken ? getTokenDecimals(rewardToken, chainId) : 18
+              unit: getTokenDecimals(rewardToken, chainId)
             }),
             symbol: rewardToken.symbol
           })
@@ -113,7 +113,7 @@ export const RewardsTransactionStatus = ({
             rewardsSupplyLoadingButtonText({
               txStatus: flowTxStatus,
               amount: formatBigInt(rewardAmount, {
-                unit: rewardToken ? getTokenDecimals(rewardToken, chainId) : 18
+                unit: getTokenDecimals(rewardToken, chainId)
               }),
               symbol: rewardToken.symbol,
               action
@@ -126,7 +126,7 @@ export const RewardsTransactionStatus = ({
             rewardsSupplySubtitle({
               txStatus: flowTxStatus,
               amount: formatBigInt(rewardAmount, {
-                unit: rewardToken ? getTokenDecimals(rewardToken, chainId) : 18
+                unit: getTokenDecimals(rewardToken, chainId)
               }),
               symbol: rewardToken.symbol,
               needsAllowance: flowNeedsAllowance
@@ -162,7 +162,7 @@ export const RewardsTransactionStatus = ({
             rewardsWithdrawLoadingButtonText({
               txStatus,
               amount: formatBigInt(rewardAmount, {
-                unit: rewardToken ? getTokenDecimals(rewardToken, chainId) : 18
+                unit: getTokenDecimals(rewardToken, chainId)
               }),
               symbol: rewardToken.symbol
             })
@@ -174,7 +174,7 @@ export const RewardsTransactionStatus = ({
             rewardsWithdrawSubtitle({
               txStatus,
               amount: formatBigInt(rewardAmount, {
-                unit: rewardToken ? getTokenDecimals(rewardToken, chainId) : 18
+                unit: getTokenDecimals(rewardToken, chainId)
               }),
               symbol: rewardToken.symbol
             })

--- a/packages/widgets/src/widgets/SavingsWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SupplyWithdraw.tsx
@@ -130,7 +130,7 @@ export const SupplyWithdraw = ({
                 error
                   ? t`Insufficient funds. Your balance is ${formatUnits(
                       savingsBalance || 0n,
-                      inputToken ? getTokenDecimals(inputToken, chainId) : 18
+                      getTokenDecimals(inputToken, chainId)
                     )} ${inputToken?.symbol}.`
                   : undefined
               }

--- a/packages/widgets/src/widgets/TradeWidget/components/TradeTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeTransactionStatus.tsx
@@ -123,11 +123,11 @@ export const TradeTransactionStatus = ({
             ethFlowTxStatus,
             originToken,
             originAmount: formatBigInt(originAmount, {
-              unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+              unit: getTokenDecimals(originToken, chainId)
             }),
             targetToken,
             targetAmount: formatBigInt(targetAmount, {
-              unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+              unit: getTokenDecimals(targetToken, chainId)
             })
           })
         )
@@ -145,7 +145,7 @@ export const TradeTransactionStatus = ({
             tradeApproveLoadingButtonText({
               txStatus,
               amount: formatBigInt(originAmount, {
-                unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+                unit: getTokenDecimals(originToken, chainId)
               }),
               symbol: originToken.symbol
             })
@@ -174,11 +174,11 @@ export const TradeTransactionStatus = ({
               txStatus,
               originToken,
               originAmount: formatBigInt(originAmount, {
-                unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+                unit: getTokenDecimals(originToken, chainId)
               }),
               targetToken,
               targetAmount: formatBigInt(targetAmount, {
-                unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+                unit: getTokenDecimals(targetToken, chainId)
               })
             })
           )

--- a/packages/widgets/src/widgets/TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/index.tsx
@@ -149,13 +149,13 @@ function TradeWidgetWrapped({
   const [targetToken, setTargetToken] = useState<TokenForChain | undefined>(initialTargetToken);
   const initialOriginAmount = parseUnits(
     validatedExternalState?.amount || '0',
-    originToken ? getTokenDecimals(originToken, chainId) : 18
+    getTokenDecimals(originToken, chainId)
   );
   const [originAmount, setOriginAmount] = useState(initialOriginAmount);
   const debouncedOriginAmount = useDebounce(originAmount);
   const initialTargetAmount = parseUnits(
     validatedExternalState?.targetAmount || '0',
-    targetToken ? getTokenDecimals(targetToken, chainId) : 18
+    getTokenDecimals(targetToken, chainId)
   );
   const [targetAmount, setTargetAmount] = useState(initialTargetAmount);
   const debouncedTargetAmount = useDebounce(targetAmount);
@@ -305,7 +305,7 @@ function TradeWidgetWrapped({
         hash,
         description: t`Approving ${formatBigInt(debouncedOriginAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         })} ${originToken?.symbol ?? ''}`
       });
       setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
@@ -353,11 +353,11 @@ function TradeWidgetWrapped({
       //hardcoding the locale used for the externalized widget state because the widget consumer expects a constistent formatting
       const executedSellAmountEnUs = formatBigInt(executedSellAmount, {
         locale: 'en-US',
-        unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+        unit: getTokenDecimals(originToken, chainId)
       });
       const executedBuyAmountEnUs = formatBigInt(executedBuyAmount, {
         locale: 'en-US',
-        unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+        unit: getTokenDecimals(targetToken, chainId)
       });
       setFormattedExecutedSellAmount(executedSellAmountEnUs);
       setFormattedExecutedBuyAmount(executedBuyAmountEnUs);
@@ -367,10 +367,10 @@ function TradeWidgetWrapped({
         title: t`Trade successful`,
         description: t`You traded ${formatBigInt(executedSellAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         })} ${originToken?.symbol ?? ''} for ${formatBigInt(executedBuyAmount, {
           locale,
-          unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+          unit: getTokenDecimals(targetToken, chainId)
         })} ${targetToken?.symbol ?? ''}`,
         status: TxStatus.SUCCESS,
         type: notificationTypeMaping[targetToken?.symbol?.toUpperCase() || 'none']
@@ -413,11 +413,11 @@ function TradeWidgetWrapped({
       //hardcoding the locale used for the externalized widget state because the widget consumer expects a constistent formatting
       const executedSellAmountEnUs = formatBigInt(executedSellAmount, {
         locale: 'en-US',
-        unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+        unit: getTokenDecimals(originToken, chainId)
       });
       const executedBuyAmountEnUs = formatBigInt(executedBuyAmount, {
         locale: 'en-US',
-        unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+        unit: getTokenDecimals(targetToken, chainId)
       });
       setFormattedExecutedSellAmount(executedSellAmountEnUs);
       setFormattedExecutedBuyAmount(executedBuyAmountEnUs);
@@ -427,10 +427,10 @@ function TradeWidgetWrapped({
         title: t`Trade successful`,
         description: t`You traded ${formatBigInt(executedSellAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         })} ${originToken?.symbol ?? ''} for ${formatBigInt(executedBuyAmount, {
           locale,
-          unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+          unit: getTokenDecimals(targetToken, chainId)
         })} ${targetToken?.symbol ?? ''}`,
         status: TxStatus.SUCCESS,
         type: notificationTypeMaping[targetToken?.symbol?.toUpperCase() || 'none']
@@ -483,7 +483,7 @@ function TradeWidgetWrapped({
         hash,
         description: t`Sending ${formatBigInt(debouncedOriginAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         })} ${originToken?.symbol ?? ''} to the EthFlow contract`
       });
       setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
@@ -503,11 +503,11 @@ function TradeWidgetWrapped({
       //hardcoding the locale used for the externalized widget state because the widget consumer expects a constistent formatting
       const executedSellAmountEnUs = formatBigInt(executedSellAmount, {
         locale: 'en-US',
-        unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+        unit: getTokenDecimals(originToken, chainId)
       });
       const executedBuyAmountEnUs = formatBigInt(executedBuyAmount, {
         locale: 'en-US',
-        unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+        unit: getTokenDecimals(targetToken, chainId)
       });
       setFormattedExecutedSellAmount(executedSellAmountEnUs);
       setFormattedExecutedBuyAmount(executedBuyAmountEnUs);
@@ -517,10 +517,10 @@ function TradeWidgetWrapped({
         title: t`Trade successful`,
         description: t`You traded ${formatBigInt(executedSellAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         })} ${originToken?.symbol ?? ''} for ${formatBigInt(executedBuyAmount, {
           locale,
-          unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18
+          unit: getTokenDecimals(targetToken, chainId)
         })} ${targetToken?.symbol ?? ''}`,
         status: TxStatus.SUCCESS,
         type: notificationTypeMaping[targetToken?.symbol?.toUpperCase() || 'none']
@@ -822,7 +822,7 @@ function TradeWidgetWrapped({
       externalWidgetState?.amount !==
         formatBigInt(originAmount, {
           locale,
-          unit: originToken ? getTokenDecimals(originToken, chainId) : 18
+          unit: getTokenDecimals(originToken, chainId)
         });
 
     if ((tokensHasChanged || amountHasChanged) && txStatus === TxStatus.IDLE) {

--- a/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeRevert.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeRevert.tsx
@@ -176,7 +176,7 @@ export function UpgradeRevert({
                   {
                     label: t`Tokens to receive`,
                     value: `${formatBigInt(targetAmount, {
-                      unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18,
+                      unit: getTokenDecimals(targetToken, chainId),
                       compact: true
                     })} ${targetToken?.symbol}`
                   },
@@ -217,11 +217,11 @@ export function UpgradeRevert({
                       originBalance !== undefined && originAmount > 0n
                         ? [
                             formatBigInt(originBalance, {
-                              unit: originToken ? getTokenDecimals(originToken, chainId) : 18,
+                              unit: getTokenDecimals(originToken, chainId),
                               compact: true
                             }),
                             formatBigInt(originBalance - originAmount, {
-                              unit: originToken ? getTokenDecimals(originToken, chainId) : 18,
+                              unit: getTokenDecimals(originToken, chainId),
                               compact: true
                             })
                           ]
@@ -233,11 +233,11 @@ export function UpgradeRevert({
                       targetBalance !== undefined && targetAmount > 0n
                         ? [
                             formatBigInt(targetBalance, {
-                              unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18,
+                              unit: getTokenDecimals(targetToken, chainId),
                               compact: true
                             }),
                             formatBigInt(targetBalance + targetAmount, {
-                              unit: targetToken ? getTokenDecimals(targetToken, chainId) : 18,
+                              unit: getTokenDecimals(targetToken, chainId),
                               compact: true
                             })
                           ]


### PR DESCRIPTION
This PR refactors the `getTokenDecimals` function to handle undefined/null tokens internally, eliminating the need for defensive ternary checks throughout the codebase. The function signature now explicitly accepts `Token | TokenForChain | undefined | null` and returns `defaultDecimals` if defined or a default value of 18 decimals when the token is undefined.

As a result of this change, we've removed 40+ redundant ternary checks across 15 files, simplifying patterns like `token ? getTokenDecimals(token, chainId) : 18` to just `getTokenDecimals(token, chainId)`. This makes the code cleaner, more maintainable, and ensures consistent handling of undefined tokens across the entire application.

## Changes

### Core Function Update
- Updated `getTokenDecimals` in `/packages/hooks/src/tokens/tokens.constants.ts` to accept undefined/null tokens
- Function now returns default decimals (18) when token is undefined