### PR TITLE
Prevent duplicate history entries when switching networks

### DIFF
--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -64,10 +64,15 @@ export function MainApp() {
         if (err.name === 'UserRejectedRequestError') {
           const chainName = chains.find(c => c.id === chainId)?.name;
           if (chainName) {
-            setSearchParams(params => {
-              params.set(QueryParams.Network, normalizeUrlParam(chainName));
-              return params;
-            });
+            const normalizedChainName = normalizeUrlParam(chainName);
+            const currentNetwork = searchParams.get(QueryParams.Network);
+            // Only update if the network actually changed
+            if (currentNetwork !== normalizedChainName) {
+              setSearchParams(params => {
+                params.set(QueryParams.Network, normalizedChainName);
+                return params;
+              });
+            }
           }
         }
       }
@@ -146,11 +151,16 @@ export function MainApp() {
     // If there's no network param, default to the current chain
     if (!network) {
       const chainName = chains.find(c => c.id === chainId)?.name;
-      if (chainName)
-        setSearchParams(params => {
-          params.set(QueryParams.Network, normalizeUrlParam(chainName));
-          return params;
-        });
+      if (chainName) {
+        const normalizedChainName = normalizeUrlParam(chainName);
+        // Only set if not already present (double-check in case of race condition)
+        if (!searchParams.get(QueryParams.Network)) {
+          setSearchParams(params => {
+            params.set(QueryParams.Network, normalizedChainName);
+            return params;
+          });
+        }
+      }
     } else {
       // If the network param doesn't match the current chain, switch chains
       const parsedChainId = chains.find(
@@ -167,10 +177,15 @@ export function MainApp() {
     const handleChainChange = ({ chainId: newChainId }: { chainId?: number | undefined }) => {
       const newChainName = chains.find(c => c.id === newChainId)?.name;
       if (newChainName) {
-        setSearchParams(params => {
-          params.set(QueryParams.Network, normalizeUrlParam(newChainName));
-          return params;
-        });
+        const normalizedNewChainName = normalizeUrlParam(newChainName);
+        const currentNetwork = searchParams.get(QueryParams.Network);
+        // Only update if the network actually changed
+        if (currentNetwork !== normalizedNewChainName) {
+          setSearchParams(params => {
+            params.set(QueryParams.Network, normalizedNewChainName);
+            return params;
+          });
+        }
       }
     };
 

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -57,7 +57,7 @@ export function ChainModal({
   const client = useClient();
   const chains = useChains();
   const isSafeWallet = useIsSafeWallet();
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const {
     handleSwitchChain,
     isPending: isSwitchChainPending,
@@ -119,13 +119,23 @@ export function ChainModal({
                     onSuccess: (_, { chainId: newChainId }) => {
                       const newChainName = chains.find(c => c.id === newChainId)?.name;
                       if (newChainName) {
-                        setSearchParams((params: URLSearchParams) => {
-                          params.set(QueryParams.Network, normalizeUrlParam(newChainName));
-                          if (nextIntent) {
-                            params.set(QueryParams.Widget, mapIntentToQueryParam(nextIntent));
-                          }
-                          return params;
-                        });
+                        const normalizedNewChainName = normalizeUrlParam(newChainName);
+                        const currentNetwork = searchParams.get(QueryParams.Network);
+                        // Only update if the network actually changed
+                        if (currentNetwork !== normalizedNewChainName) {
+                          setSearchParams(
+                            (params: URLSearchParams) => {
+                              if (currentNetwork !== normalizedNewChainName) {
+                                params.set(QueryParams.Network, normalizedNewChainName);
+                              }
+                              if (nextIntent) {
+                                params.set(QueryParams.Widget, mapIntentToQueryParam(nextIntent));
+                              }
+                              return params;
+                            },
+                            { replace: true }
+                          );
+                        }
                       }
                     },
                     onSettled: () => setOpen(false)


### PR DESCRIPTION
Prevent to set the search params if the network doesn't change

### How to test it

1. Navigate through the app changing widgets, params and network.
2. Navigate back with the browser back button
3. You shouldn't see any repeated element in the history