### PR TITLE
[multichain UX] track network across widgets

### DIFF
--- a/apps/webapp/src/modules/ui/context/NetworkSwitchContext.tsx
+++ b/apps/webapp/src/modules/ui/context/NetworkSwitchContext.tsx
@@ -1,20 +1,58 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import { Intent } from '@/lib/enums';
+
+type WidgetNetworkState = {
+  [Intent.TRADE_INTENT]?: number;
+  [Intent.SAVINGS_INTENT]?: number;
+  // Balances widget is excluded from tracking
+};
 
 interface NetworkSwitchContextValue {
   isSwitchingNetwork: boolean;
   setIsSwitchingNetwork: (isSwitching: boolean) => void;
+  widgetNetworks: WidgetNetworkState;
+  saveWidgetNetwork: (intent: Intent, chainId: number) => void;
+  getWidgetNetwork: (intent: Intent) => number | undefined;
+  clearWidgetNetwork: (intent: Intent) => void;
 }
 
 const NetworkSwitchContext = createContext<NetworkSwitchContextValue | undefined>(undefined);
 
 export function NetworkSwitchProvider({ children }: { children: ReactNode }) {
   const [isSwitchingNetwork, setIsSwitchingNetwork] = useState(false);
+  const [widgetNetworks, setWidgetNetworks] = useState<WidgetNetworkState>({});
+
+  const saveWidgetNetwork = useCallback((intent: Intent, chainId: number) => {
+    setWidgetNetworks(prev => ({
+      ...prev,
+      [intent]: chainId
+    }));
+  }, []);
+
+  const getWidgetNetwork = useCallback(
+    (intent: Intent): number | undefined => {
+      return widgetNetworks[intent as keyof WidgetNetworkState];
+    },
+    [widgetNetworks]
+  );
+
+  const clearWidgetNetwork = useCallback((intent: Intent) => {
+    setWidgetNetworks(prev => {
+      const next = { ...prev };
+      delete next[intent as keyof WidgetNetworkState];
+      return next;
+    });
+  }, []);
 
   return (
     <NetworkSwitchContext.Provider
       value={{
         isSwitchingNetwork,
-        setIsSwitchingNetwork
+        setIsSwitchingNetwork,
+        widgetNetworks,
+        saveWidgetNetwork,
+        getWidgetNetwork,
+        clearWidgetNetwork
       }}
     >
       {children}


### PR DESCRIPTION
## What does this PR do?

This PR implements widget-specific network tracking for multichain widgets in the Sky Protocol app. The feature addresses a UX issue where users lose their preferred network context when navigating between widgets.

### Problem Solved
Previously, when users navigated from a multichain widget (e.g., Savings on Base) to a mainnet-only widget (e.g., Upgrade) and then back to the original widget, they would remain on mainnet instead of returning to their preferred network (Base).

### Implementation Details

**Key Changes:**
- Extended `NetworkSwitchContext` to track network preferences per widget during the session
- Modified `WidgetNavigation` component to save/restore network states when switching between widgets
- Updated `ChainModal` to track manual network changes for the current widget

**Tracking Behavior:**
- **Trade & Savings widgets**: Each maintains its own network preference independently
  - When leaving: Current network is saved for that specific widget
  - When returning: Widget's previously saved network is restored
- **Balances widget**: Explicitly excluded from tracking - always stays on the current network
- **Mainnet-only widgets** (Upgrade, Rewards, Stake, Expert, Seal): Continue to force mainnet as before

**Session Scope:**
- Network preferences are stored in React state (session-only)
- No browser storage is used
- All preferences are cleared on page refresh

### Files Modified
- `/apps/webapp/src/modules/ui/context/NetworkSwitchContext.tsx` - Added widget network state management
- `/apps/webapp/src/modules/app/components/WidgetNavigation.tsx` - Implemented save/restore logic
- `/apps/webapp/src/modules/ui/components/ChainModal.tsx` - Added tracking for manual network changes

## Testing Steps

1. **Test independent widget tracking:**
   - Navigate to Trade widget and switch to Optimism
   - Navigate to Savings widget and switch to Base
   - Navigate to Stake widget (forced to mainnet)
   - Navigate back to Trade → **Should restore Optimism** (not Base from Savings)
   - Navigate to Savings → **Should restore Base**

2. **Test Balances widget exclusion:**
   - Navigate to Trade and set to Arbitrum
   - Navigate to Balances (stays on Arbitrum)
   - Manually switch to Base while in Balances
   - Navigate to Upgrade (forced to mainnet)
   - Navigate back to Balances → **Should stay on mainnet** (no restoration)
   - Navigate to Trade → **Should restore Arbitrum**

3. **Test mainnet-only to multichain transitions:**
   - Navigate to Savings and set to Base
   - Navigate to Upgrade (forced to mainnet)
   - Navigate back to Savings → **Should restore Base**

4. **Test multichain to multichain navigation:**
   - Navigate to Trade (no saved state, on mainnet)
   - Switch to Arbitrum
   - Navigate to Savings (no saved state) → **Should stay on Arbitrum**
   - Navigate back to Trade → **Should stay on Arbitrum** (same as saved)

5. **Test manual network switching updates:**
   - Navigate to Trade and switch to Optimism
   - Manually switch to Base using the network switcher
   - Navigate to Rewards (forced to mainnet)
   - Navigate back to Trade → **Should restore Base** (the manually selected network)

6. **Test session persistence:**
   - Set different networks for Trade (Optimism) and Savings (Base)
   - Navigate between various widgets to confirm states persist
   - Refresh the page
   - Navigate to Trade → **Should not restore** (cleared on refresh)
   - Navigate to Savings → **Should not restore** (cleared on refresh)

7. **Test edge cases:**
   - Rapidly switch between widgets to ensure no race conditions
   - Test with network switch failures (reject in wallet) - state should remain consistent
   - Navigate directly via URL changes to ensure tracking still works

### Expected Behavior Summary
- Trade and Savings each remember their own last-used network
- Balances never saves or restores, always uses current network  
- Network preferences are widget-specific, not shared between widgets
- Manual network changes update the saved state for the current widget
- All tracking is session-only and clears on page refresh