### PR TITLE
[multichain UX] add networks to menu item hover

### DIFF
--- a/apps/webapp/scripts/sync-content.sh
+++ b/apps/webapp/scripts/sync-content.sh
@@ -311,6 +311,7 @@ import {
   unichainFaqItems
 } from './sharedFaqItems';
 import { getBundledTransactionsFaqItems } from './getBundledTransactionsFaqItems';
+import { deduplicateFaqItems } from './utils';
 
 export const getBalancesFaqItems = (chainId: number) => {
   const items = [
@@ -322,7 +323,8 @@ export const getBalancesFaqItems = (chainId: number) => {
     ...(isUnichainChainId(chainId) ? unichainFaqItems : []),
     ...getBundledTransactionsFaqItems()
   ];
-  return items.sort((a, b) => a.index - b.index);
+  
+  return deduplicateFaqItems(items);
 };
 
 const generalFaqItems = ${match[1]};
@@ -362,6 +364,7 @@ import {
   optimismFaqItems,
   unichainFaqItems
 } from './sharedFaqItems';
+import { deduplicateFaqItems } from './utils';
 
 export const getSavingsFaqItems = (chainId: number) => {
   const items = [
@@ -373,7 +376,8 @@ export const getSavingsFaqItems = (chainId: number) => {
     ...(isUnichainChainId(chainId) ? unichainFaqItems : []),
     ...(isL2ChainId(chainId) ? L2SavingsFaqItems : [])
   ];
-  return items.sort((a, b) => a.index - b.index);
+  
+  return deduplicateFaqItems(items);
 };
 
 const generalFaqItems = ${match[1]};
@@ -415,6 +419,7 @@ import {
   optimismFaqItems,
   unichainFaqItems
 } from './sharedFaqItems';
+import { deduplicateFaqItems } from './utils';
 
 export const getTradeFaqItems = (chainId: number) => {
   const items = [
@@ -426,7 +431,8 @@ export const getTradeFaqItems = (chainId: number) => {
     ...(isUnichainChainId(chainId) ? unichainFaqItems : []),
     ...(isL2ChainId(chainId) ? L2TradeFaqItems : [])
   ];
-  return items.sort((a, b) => a.index - b.index);
+  
+  return deduplicateFaqItems(items);
 };
 
 const generalFaqItems = ${match[1]};

--- a/apps/webapp/src/components/NetworkSwitcher.tsx
+++ b/apps/webapp/src/components/NetworkSwitcher.tsx
@@ -21,7 +21,7 @@ export function NetworkSwitcher() {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 flex h-9 items-center justify-center rounded-lg border border-transparent px-[9px] bg-blend-overlay hover:border-transparent hover:bg-white/10 focus:border-transparent focus:bg-white/15">
+          <div className="bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 flex items-center justify-center rounded-xl border border-transparent px-[9px] py-2 bg-blend-overlay hover:border-transparent hover:bg-white/10 focus:border-transparent focus:bg-white/15">
             <Loader2 className="h-5 w-5 animate-spin text-white" />
           </div>
         </TooltipTrigger>

--- a/apps/webapp/src/data/faqs/getBalancesFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getBalancesFaqItems.ts
@@ -13,6 +13,7 @@ import {
   unichainFaqItems
 } from './sharedFaqItems';
 import { getBundledTransactionsFaqItems } from './getBundledTransactionsFaqItems';
+import { deduplicateFaqItems } from './utils';
 
 export const getBalancesFaqItems = (chainId: number) => {
   const items = [
@@ -24,7 +25,8 @@ export const getBalancesFaqItems = (chainId: number) => {
     ...(isUnichainChainId(chainId) ? unichainFaqItems : []),
     ...getBundledTransactionsFaqItems()
   ];
-  return items.sort((a, b) => a.index - b.index);
+
+  return deduplicateFaqItems(items);
 };
 
 const generalFaqItems = [

--- a/apps/webapp/src/data/faqs/getSavingsFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getSavingsFaqItems.ts
@@ -13,6 +13,7 @@ import {
   optimismFaqItems,
   unichainFaqItems
 } from './sharedFaqItems';
+import { deduplicateFaqItems } from './utils';
 
 export const getSavingsFaqItems = (chainId: number) => {
   const items = [
@@ -24,7 +25,8 @@ export const getSavingsFaqItems = (chainId: number) => {
     ...(isUnichainChainId(chainId) ? unichainFaqItems : []),
     ...(isL2ChainId(chainId) ? L2SavingsFaqItems : [])
   ];
-  return items.sort((a, b) => a.index - b.index);
+
+  return deduplicateFaqItems(items);
 };
 
 const generalFaqItems = [

--- a/apps/webapp/src/data/faqs/getStakeFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getStakeFaqItems.ts
@@ -106,7 +106,7 @@ Delegates in receipt of token voting power can never directly access any tokens 
     {
       question: 'Where can I learn about Sky Ecosystem Governance?',
       answer:
-        'For a deep dive into the facets and checks and balances of Sky Ecosystem Governance, please refer to the [Sky Forum](https://forum.sky.money/), the [Sky Governance Voting Portal](https://vote.makerdao.com/), and the [Sky Atlas.](https://sky-atlas.powerhouse.io/)The Sky Atlas is the definitive rulebook of the Sky Ecosystem, as determined by Sky Ecosystem Governance.',
+        'For a deep dive into the facets and checks and balances of Sky Ecosystem Governance, please refer to the [Sky Forum](https://forum.sky.money/), the [Sky Governance Voting Portal](https://vote.sky.money/), and the [Sky Atlas.](https://sky-atlas.powerhouse.io/)The Sky Atlas is the definitive rulebook of the Sky Ecosystem, as determined by Sky Ecosystem Governance.',
       index: 13
     }
   ];

--- a/apps/webapp/src/data/faqs/getTradeFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getTradeFaqItems.ts
@@ -13,6 +13,7 @@ import {
   optimismFaqItems,
   unichainFaqItems
 } from './sharedFaqItems';
+import { deduplicateFaqItems } from './utils';
 
 export const getTradeFaqItems = (chainId: number) => {
   const items = [
@@ -24,7 +25,8 @@ export const getTradeFaqItems = (chainId: number) => {
     ...(isUnichainChainId(chainId) ? unichainFaqItems : []),
     ...(isL2ChainId(chainId) ? L2TradeFaqItems : [])
   ];
-  return items.sort((a, b) => a.index - b.index);
+
+  return deduplicateFaqItems(items);
 };
 
 const generalFaqItems = [

--- a/apps/webapp/src/data/faqs/utils.ts
+++ b/apps/webapp/src/data/faqs/utils.ts
@@ -1,0 +1,14 @@
+// Utility function to deduplicate FAQ items by question
+export function deduplicateFaqItems<T extends { question: string; index: number }>(items: T[]): T[] {
+  // Deduplicate by question (title), keeping the first occurrence
+  const seen = new Set<string>();
+  const deduplicatedItems = items.filter(item => {
+    if (seen.has(item.question)) {
+      return false;
+    }
+    seen.add(item.question);
+    return true;
+  });
+
+  return deduplicatedItems.sort((a, b) => a.index - b.index);
+}

--- a/apps/webapp/src/modules/app/components/WidgetMenuItemTooltip.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetMenuItemTooltip.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { Intent } from '@/lib/enums';
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipPortal } from '@/components/ui/tooltip';
+import { getChainIcon } from '@jetstreamgg/sky-utils';
+import { getSupportedChainIds } from '@/data/wagmi/config/config.default';
+import { useChains } from 'wagmi';
+import { isMultichain } from '@/lib/widget-network-map';
+import { useSearchParams } from 'react-router-dom';
+import { deleteSearchParams } from '@/modules/utils/deleteSearchParams';
+import { QueryParams, mapIntentToQueryParam } from '@/lib/constants';
+import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
+import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
+
+interface WidgetMenuItemTooltipProps {
+  description?: string;
+  widgetIntent: Intent;
+  currentChainId?: number;
+  currentIntent?: Intent;
+  label: string;
+  isMobile: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Tooltip component for widget menu items
+ * Displays widget description and supported network icons
+ * Handles network switching when clicking on network icons
+ */
+export function WidgetMenuItemTooltip({
+  description,
+  widgetIntent,
+  currentChainId,
+  currentIntent,
+  label,
+  isMobile,
+  disabled = false,
+  children
+}: WidgetMenuItemTooltipProps) {
+  const chains = useChains();
+  const [, setSearchParams] = useSearchParams();
+  const { setIsSwitchingNetwork, saveWidgetNetwork } = useNetworkSwitch();
+
+  const handleNetworkSwitch = (chainId: number) => {
+    // Save current network if switching from multichain widget
+    if (
+      currentIntent &&
+      currentChainId &&
+      isMultichain(currentIntent) &&
+      currentIntent !== Intent.BALANCES_INTENT
+    ) {
+      saveWidgetNetwork(currentIntent, currentChainId);
+    }
+
+    // Navigate to widget on selected network
+    const chain = chains.find(c => c.id === chainId);
+    if (chain) {
+      setIsSwitchingNetwork(true);
+      setSearchParams(prevParams => {
+        const searchParams = deleteSearchParams(prevParams);
+        searchParams.set(QueryParams.Network, normalizeUrlParam(chain.name));
+        searchParams.set(QueryParams.Widget, mapIntentToQueryParam(widgetIntent));
+        return searchParams;
+      });
+    }
+  };
+
+  const renderNetworkIcons = () => {
+    if (!currentChainId || widgetIntent === Intent.BALANCES_INTENT) {
+      return null;
+    }
+
+    const supportedChainIds = getSupportedChainIds(currentChainId);
+
+    if (isMultichain(widgetIntent)) {
+      // Show all supported chains for multichain widgets (excluding Balances)
+      return supportedChainIds.map(chainId => {
+        const chain = chains.find(c => c.id === chainId);
+        if (!chain) return null;
+
+        return (
+          <button
+            key={chainId}
+            onClick={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleNetworkSwitch(chainId);
+            }}
+            className="flex items-center justify-center rounded-full p-1 transition-all hover:bg-white/10"
+            title={`Go to ${label} on ${chain.name}`}
+          >
+            {getChainIcon(chainId, 'h-5 w-5')}
+          </button>
+        );
+      });
+    } else {
+      // Show only Ethereum mainnet for mainnet-only widgets
+      const mainnetId =
+        supportedChainIds.find(id => {
+          const chain = chains.find(c => c.id === id);
+          return chain && (chain.name === 'Ethereum' || chain.name.includes('mainnet'));
+        }) || supportedChainIds[0];
+
+      const chain = chains.find(c => c.id === mainnetId);
+      if (!chain) return null;
+
+      return (
+        <button
+          key={mainnetId}
+          onClick={e => {
+            e.preventDefault();
+            e.stopPropagation();
+            handleNetworkSwitch(mainnetId);
+          }}
+          className="flex items-center justify-center rounded-full p-1 transition-all hover:bg-white/10"
+          title={`Go to ${label} on ${chain.name}`}
+        >
+          {getChainIcon(mainnetId, 'h-5 w-5')}
+        </button>
+      );
+    }
+  };
+
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild disabled={disabled}>
+        {children}
+      </TooltipTrigger>
+      {description && !isMobile && (
+        <TooltipPortal>
+          <TooltipContent side="right" className="max-w-xs">
+            <p className="text-sm">{description}</p>
+            {currentChainId && widgetIntent !== Intent.BALANCES_INTENT && (
+              <>
+                <p className="mt-2 text-xs text-gray-400">Supported on:</p>
+                <div className="mt-1 flex gap-2">{renderNetworkIcons()}</div>
+              </>
+            )}
+          </TooltipContent>
+        </TooltipPortal>
+      )}
+    </Tooltip>
+  );
+}

--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -10,8 +10,7 @@ import { cardAnimations } from '@/modules/ui/animation/presets';
 import { AnimationLabels } from '@/modules/ui/animation/constants';
 import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { QueryParams, mapIntentToQueryParam } from '@/lib/constants';
-import { requiresMainnet, isMultichain } from '@/lib/widget-network-map';
-import { isL2ChainId } from '@jetstreamgg/sky-utils';
+import { isMultichain } from '@/lib/widget-network-map';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
 import { LinkedActionWrapper } from '@/modules/ui/components/LinkedActionWrapper';
 import { useSearchParams } from 'react-router-dom';
@@ -24,6 +23,7 @@ import { DualSwitcher } from '@/components/DualSwitcher';
 import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
 import { useChains } from 'wagmi';
 import { useEnhancedNetworkToast } from '@/modules/app/hooks/useEnhancedNetworkToast';
+import { useNetworkAutoSwitch } from '@/modules/app/hooks/useNetworkAutoSwitch';
 import {
   Tooltip,
   TooltipContent,
@@ -63,109 +63,20 @@ export function WidgetNavigation({
   const isRewardsOverview = !selectedRewardContract && intent === Intent.REWARDS_INTENT;
 
   const [, setSearchParams] = useSearchParams();
-  const { setIsSwitchingNetwork, saveWidgetNetwork, getWidgetNetwork } = useNetworkSwitch();
+  const { setIsSwitchingNetwork, saveWidgetNetwork } = useNetworkSwitch();
   const chains = useChains();
   const { showNetworkToast } = useEnhancedNetworkToast();
   const [previousChainId, setPreviousChainId] = useState<number | undefined>(currentChainId);
-  const [previousIntent, setPreviousIntent] = useState<Intent | undefined>(intent);
-  const [isAutoSwitching, setIsAutoSwitching] = useState(false);
+
+  // Use the new network auto-switch hook
+  const { handleWidgetNavigation, isAutoSwitching, previousIntent } = useNetworkAutoSwitch({
+    currentChainId,
+    currentIntent: intent
+  });
 
   const handleWidgetChange = (value: string) => {
     const targetIntent = value as Intent;
-    const queryParam = mapIntentToQueryParam(targetIntent);
-
-    // Store the previous intent before switching
-    setPreviousIntent(intent);
-
-    // Save current network for multichain widgets before switching (except Balances)
-    if (intent && currentChainId && isMultichain(intent) && intent !== Intent.BALANCES_INTENT) {
-      saveWidgetNetwork(intent, currentChainId);
-    }
-
-    // Check if target widget has a saved network preference
-    // Only restore network if:
-    // 1. Target is multichain (but not Balances)
-    // 2. We have a saved preference for that specific widget
-    // 3. The saved network is different from current
-    const savedNetwork = getWidgetNetwork(targetIntent);
-    const shouldRestoreNetwork =
-      savedNetwork &&
-      isMultichain(targetIntent) &&
-      targetIntent !== Intent.BALANCES_INTENT &&
-      savedNetwork !== currentChainId;
-
-    // Check if we need to switch networks
-    if (currentChainId && requiresMainnet(targetIntent) && isL2ChainId(currentChainId)) {
-      // Set switching state to show loading indicator
-      setIsSwitchingNetwork(true);
-      setIsAutoSwitching(true);
-
-      // Auto-switch to mainnet
-      setSearchParams(prevParams => {
-        const searchParams = deleteSearchParams(prevParams);
-        // Set network to Ethereum mainnet
-        searchParams.set(QueryParams.Network, normalizeUrlParam('Ethereum'));
-        searchParams.set(QueryParams.Widget, queryParam);
-
-        // Handle rewards-specific params
-        if (targetIntent === Intent.REWARDS_INTENT && selectedRewardContract?.contractAddress) {
-          searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
-        }
-
-        return searchParams;
-      });
-    } else if (shouldRestoreNetwork) {
-      // Restore saved network for multichain widget
-      const savedChain = chains.find(c => c.id === savedNetwork);
-      if (savedChain) {
-        setIsSwitchingNetwork(true);
-        setIsAutoSwitching(true);
-        setSearchParams(prevParams => {
-          const searchParams = deleteSearchParams(prevParams);
-          searchParams.set(QueryParams.Network, normalizeUrlParam(savedChain.name));
-          searchParams.set(QueryParams.Widget, queryParam);
-
-          // Handle rewards-specific params
-          if (targetIntent === Intent.REWARDS_INTENT) {
-            if (selectedRewardContract?.contractAddress)
-              searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
-          } else {
-            searchParams.delete(QueryParams.Reward);
-          }
-          return searchParams;
-        });
-      } else {
-        // Fallback to normal widget change if saved chain not found
-        setSearchParams(prevParams => {
-          const searchParams = deleteSearchParams(prevParams);
-          searchParams.set(QueryParams.Widget, queryParam);
-
-          // Handle rewards-specific params
-          if (targetIntent === Intent.REWARDS_INTENT) {
-            if (selectedRewardContract?.contractAddress)
-              searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
-          } else {
-            searchParams.delete(QueryParams.Reward);
-          }
-          return searchParams;
-        });
-      }
-    } else {
-      // Normal widget change without network switch
-      setSearchParams(prevParams => {
-        const searchParams = deleteSearchParams(prevParams);
-        searchParams.set(QueryParams.Widget, queryParam);
-
-        // Handle rewards-specific params
-        if (targetIntent === Intent.REWARDS_INTENT) {
-          if (selectedRewardContract?.contractAddress)
-            searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
-        } else {
-          searchParams.delete(QueryParams.Reward);
-        }
-        return searchParams;
-      });
-    }
+    handleWidgetNavigation(targetIntent);
   };
 
   // Track network changes and show enhanced toast
@@ -192,9 +103,6 @@ export function WidgetNavigation({
             }
           }
         });
-
-        // Reset auto-switching flag after showing toast
-        setIsAutoSwitching(false);
       }
     }
     setPreviousChainId(currentChainId);

--- a/apps/webapp/src/modules/app/hooks/useNetworkAutoSwitch.ts
+++ b/apps/webapp/src/modules/app/hooks/useNetworkAutoSwitch.ts
@@ -1,0 +1,173 @@
+import { useState, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useChains } from 'wagmi';
+import { Intent } from '@/lib/enums';
+import { requiresMainnet, isMultichain } from '@/lib/widget-network-map';
+import { isL2ChainId } from '@jetstreamgg/sky-utils';
+import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
+import { QueryParams, mapIntentToQueryParam } from '@/lib/constants';
+import { deleteSearchParams } from '@/modules/utils/deleteSearchParams';
+import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
+import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
+
+interface UseNetworkAutoSwitchProps {
+  currentChainId?: number;
+  currentIntent?: Intent;
+}
+
+interface UseNetworkAutoSwitchReturn {
+  handleWidgetNavigation: (targetIntent: Intent) => void;
+  isAutoSwitching: boolean;
+  previousIntent: Intent | undefined;
+  setPreviousIntent: (intent: Intent | undefined) => void;
+}
+
+/**
+ * Hook to handle automatic network switching when navigating between widgets
+ *
+ * Responsibilities:
+ * - Auto-switches to mainnet for mainnet-only widgets
+ * - Restores saved network preferences for multichain widgets
+ * - Manages search params for network and widget navigation
+ * - Tracks auto-switching state for UI feedback
+ */
+export function useNetworkAutoSwitch({
+  currentChainId,
+  currentIntent
+}: UseNetworkAutoSwitchProps): UseNetworkAutoSwitchReturn {
+  const [, setSearchParams] = useSearchParams();
+  const chains = useChains();
+  const { setIsSwitchingNetwork, saveWidgetNetwork, getWidgetNetwork } = useNetworkSwitch();
+  const { selectedRewardContract } = useConfigContext();
+  const [isAutoSwitching, setIsAutoSwitching] = useState(false);
+  const [previousIntent, setPreviousIntent] = useState<Intent | undefined>(currentIntent);
+
+  const handleWidgetNavigation = useCallback(
+    (targetIntent: Intent) => {
+      const queryParam = mapIntentToQueryParam(targetIntent);
+
+      // Store the previous intent before switching
+      setPreviousIntent(currentIntent);
+
+      // Save current network for multichain widgets before switching (except Balances)
+      if (
+        currentIntent &&
+        currentChainId &&
+        isMultichain(currentIntent) &&
+        currentIntent !== Intent.BALANCES_INTENT
+      ) {
+        saveWidgetNetwork(currentIntent, currentChainId);
+      }
+
+      // Check if target widget has a saved network preference
+      const savedNetwork = getWidgetNetwork(targetIntent);
+
+      // Determine if we should restore a saved network preference
+      // This happens when:
+      // 1. We're coming FROM a mainnet-only widget (previous intent requires mainnet)
+      // 2. We're going TO a multichain widget (but not Balances)
+      // 3. We have a saved preference for that widget
+      // 4. The saved network is different from current (we're on mainnet, want to go back to L2)
+      const shouldRestoreNetwork =
+        currentIntent &&
+        requiresMainnet(currentIntent) && // Coming from mainnet-only widget
+        isMultichain(targetIntent) && // Going to multichain widget
+        targetIntent !== Intent.BALANCES_INTENT &&
+        savedNetwork &&
+        savedNetwork !== currentChainId; // Saved network is different (likely an L2)
+
+      // Check if we need to switch networks
+      if (currentChainId && requiresMainnet(targetIntent) && isL2ChainId(currentChainId)) {
+        // Auto-switch to mainnet for mainnet-only widgets (they're not available on L2)
+        setIsSwitchingNetwork(true);
+        setIsAutoSwitching(true);
+
+        setSearchParams(prevParams => {
+          const searchParams = deleteSearchParams(prevParams);
+          // Set network to Ethereum mainnet
+          searchParams.set(QueryParams.Network, normalizeUrlParam('Ethereum'));
+          searchParams.set(QueryParams.Widget, queryParam);
+
+          // Handle rewards-specific params
+          if (targetIntent === Intent.REWARDS_INTENT && selectedRewardContract?.contractAddress) {
+            searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
+          }
+
+          return searchParams;
+        });
+      } else if (shouldRestoreNetwork) {
+        // Returning from mainnet-only widget to multichain widget, restore previous L2 network
+        const savedChain = chains.find(c => c.id === savedNetwork);
+        if (savedChain) {
+          setIsSwitchingNetwork(true);
+          setIsAutoSwitching(true);
+
+          setSearchParams(prevParams => {
+            const searchParams = deleteSearchParams(prevParams);
+            searchParams.set(QueryParams.Network, normalizeUrlParam(savedChain.name));
+            searchParams.set(QueryParams.Widget, queryParam);
+
+            // Handle rewards-specific params
+            if (targetIntent === Intent.REWARDS_INTENT) {
+              if (selectedRewardContract?.contractAddress) {
+                searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
+              }
+            } else {
+              searchParams.delete(QueryParams.Reward);
+            }
+            return searchParams;
+          });
+        } else {
+          // Fallback to normal widget change if saved chain not found
+          setSearchParams(prevParams => {
+            const searchParams = deleteSearchParams(prevParams);
+            searchParams.set(QueryParams.Widget, queryParam);
+
+            // Handle rewards-specific params
+            if (targetIntent === Intent.REWARDS_INTENT) {
+              if (selectedRewardContract?.contractAddress) {
+                searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
+              }
+            } else {
+              searchParams.delete(QueryParams.Reward);
+            }
+            return searchParams;
+          });
+        }
+      } else {
+        // Normal widget change without network switch
+        setSearchParams(prevParams => {
+          const searchParams = deleteSearchParams(prevParams);
+          searchParams.set(QueryParams.Widget, queryParam);
+
+          // Handle rewards-specific params
+          if (targetIntent === Intent.REWARDS_INTENT) {
+            if (selectedRewardContract?.contractAddress) {
+              searchParams.set(QueryParams.Reward, selectedRewardContract.contractAddress);
+            }
+          } else {
+            searchParams.delete(QueryParams.Reward);
+          }
+          return searchParams;
+        });
+      }
+    },
+    [
+      currentChainId,
+      currentIntent,
+      chains,
+      saveWidgetNetwork,
+      getWidgetNetwork,
+      setIsSwitchingNetwork,
+      setSearchParams,
+      selectedRewardContract
+    ]
+  );
+
+  return {
+    handleWidgetNavigation,
+    isAutoSwitching,
+    previousIntent,
+    setPreviousIntent
+  };
+}

--- a/apps/webapp/src/modules/stusds/components/StUSDSChart.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUSDSChart.tsx
@@ -1,19 +1,16 @@
-import { useSavingsChartInfo } from '@jetstreamgg/sky-hooks';
+import { useStUsdsChartInfo } from '@jetstreamgg/sky-hooks';
 import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useState } from 'react';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
 import { Trans } from '@lingui/react/macro';
 import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useChainId } from 'wagmi';
 
 export function StUSDSChart() {
   const [activeChart, setActiveChart] = useState('tvl');
   const [timeFrame, setTimeFrame] = useState<TimeFrame>('w');
-  const chainId = useChainId();
 
-  // TODO: Replace with useStUSDSChartInfo when available
-  const { data: stUsdsChartInfo, isLoading, error } = useSavingsChartInfo(chainId);
+  const { data: stUsdsChartInfo, isLoading, error } = useStUsdsChartInfo();
   const chartData = useParseSavingsChartData(timeFrame, stUsdsChartInfo || []);
 
   return (

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -32,7 +32,8 @@ export {
   useStUsdsPreviewWithdraw,
   useStUsdsRateData,
   useStUsdsCapacityData,
-  useStUsdsHistory
+  useStUsdsHistory,
+  useStUsdsChartInfo
 } from './stusds';
 
 export type {

--- a/packages/hooks/src/stusds/index.ts
+++ b/packages/hooks/src/stusds/index.ts
@@ -29,6 +29,7 @@ export { useStUsdsCapacityData } from './useStUsdsCapacityData';
 export type { StUsdsCapacityData, StUsdsCapacityDataHook } from './useStUsdsCapacityData';
 export { useStUsdsHistory } from './useStUsdsHistory';
 export type { StUsdsHistoryHook } from './useStUsdsHistory';
+export { useStUsdsChartInfo } from './useStUsdsChartInfo';
 
 // Types
 export type { StUsdsHistoryItem, StUsdsVaultMetrics, StUsdsUserMetrics } from './stusds.d';

--- a/packages/hooks/src/stusds/useStUsdsChartInfo.ts
+++ b/packages/hooks/src/stusds/useStUsdsChartInfo.ts
@@ -1,0 +1,84 @@
+import { useQuery } from '@tanstack/react-query';
+import { parseEther } from 'viem';
+import { getBaLabsApiUrl } from '../helpers/getSubgraphUrl';
+import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
+import { useChainId } from 'wagmi';
+import { formatBaLabsUrl } from '../helpers';
+import { ReadHook } from '../hooks';
+
+type StUsdsChartInfo = {
+  date: string;
+  stusds_tvl: string;
+};
+
+type StUsdsChartInfoParsed = {
+  blockTimestamp: number;
+  amount: bigint;
+};
+
+function transformBaLabsChartData(results: StUsdsChartInfo[]): StUsdsChartInfoParsed[] {
+  const parsed = results.map((item: StUsdsChartInfo) => {
+    const stUsdsTvl = Number(item.stusds_tvl).toFixed(18); //remove scientific notation if it exists
+    return {
+      blockTimestamp: new Date(item?.date).getTime() / 1000,
+      amount: parseEther(stUsdsTvl)
+    };
+  });
+  return parsed;
+}
+
+async function fetchStUsdsChartInfo(url: URL): Promise<StUsdsChartInfoParsed[]> {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+
+    const data: { results: StUsdsChartInfo[] } = await response.json();
+
+    const result = transformBaLabsChartData(data?.results || []);
+
+    return result;
+  } catch (error) {
+    console.error('Error fetching BaLabs data:', error);
+    return [];
+  }
+}
+
+export function useStUsdsChartInfo(): ReadHook & { data?: StUsdsChartInfoParsed[] } {
+  const chainId = useChainId();
+  const baseUrl = getBaLabsApiUrl(chainId) || '';
+  let url: URL | undefined;
+  if (baseUrl) {
+    const endpoint = `${baseUrl}/overall/historic/`;
+    url = formatBaLabsUrl(new URL(endpoint));
+  }
+
+  const {
+    data,
+    error,
+    refetch: mutate,
+    isLoading
+  } = useQuery({
+    enabled: Boolean(baseUrl),
+    queryKey: ['stusds-chart', url],
+    queryFn: () => (url ? fetchStUsdsChartInfo(url) : Promise.resolve([]))
+  });
+
+  return {
+    data,
+    isLoading: !data && isLoading,
+    error: error as Error,
+    mutate,
+    dataSources: [
+      {
+        title: 'BA Labs API',
+        href: url?.href || 'https://blockanalitica.com/',
+        onChain: false,
+        trustLevel: TRUST_LEVELS[TrustLevelEnum.TWO]
+      }
+    ]
+  };
+}


### PR DESCRIPTION
### What does this PR do?

This PR enhances the widget navigation tooltips by adding a "network switcher" feature. When a user hovers over a widget icon in the sidebar, the tooltip now displays the icons of the chains that support that widget. Users can click on any of these chain icons to directly navigate to the widget on the selected network. This provides a quick and intuitive way to switch between networks for a given feature.

The implementation distinguishes between:
-   **Multichain widgets:** Shows all supported network icons.
-   **Mainnet-only widgets:** Shows only the Ethereum mainnet icon.
-   The "Balances" widget, which is excluded from this feature.

### Testing steps:

1.  Run the application.
2.  Hover over a multichain widget icon (e.g., "Swap") in the left-hand navigation bar.
3.  **Verify:** The tooltip appears with a "Supported on:" section containing multiple chain icons.
4.  Click on a chain icon that is different from the currently active network.
5.  **Verify:** The application correctly navigates to that widget on the newly selected chain, and the URL updates accordingly.
6.  Hover over a mainnet-only widget icon.
7.  **Verify:** The tooltip's "Supported on:" section shows only the Ethereum mainnet icon.
8.  Click the mainnet icon and verify it navigates correctly.
9.  Hover over the "Balances" widget icon.
10. **Verify:** The tooltip appears without the "Supported on:" section or any chain icons.