### PR TITLE
Ba labs data for rate chart, stusds suppliers, expert chart

### DIFF
--- a/apps/webapp/src/modules/expert/components/ExpertChart.tsx
+++ b/apps/webapp/src/modules/expert/components/ExpertChart.tsx
@@ -1,19 +1,22 @@
-import { useTokenChartInfo, TokenChartInfoParsed } from '@jetstreamgg/sky-hooks';
+import { useStUsdsChartInfo } from '@jetstreamgg/sky-hooks';
 import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useState } from 'react';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
 import { Trans } from '@lingui/react/macro';
-import { useParseTokenChartData } from '@/modules/ui/hooks/useParseTokenChartData';
+import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useChainId } from 'wagmi';
-import { getExpertModules, ExpertModule } from '../../advanced/helpers/expertModules';
 
-function calculateCumulativeTotalSupply(tokenChartData: TokenChartInfoParsed[]) {
-  if (!tokenChartData || tokenChartData.length === 0) return [];
+type TvlChartInfoParsed = {
+  blockTimestamp: number;
+  amount: bigint;
+};
 
-  const mergedData = new Map<number, TokenChartInfoParsed>();
+function calculateCumulativeTotalSupply(chartData: TvlChartInfoParsed[]) {
+  if (!chartData || chartData.length === 0) return [];
 
-  tokenChartData.forEach(entry => {
+  const mergedData = new Map<number, TvlChartInfoParsed>();
+
+  chartData.forEach(entry => {
     const foundData = mergedData.get(entry.blockTimestamp);
     if (foundData) {
       mergedData.set(entry.blockTimestamp, {
@@ -29,24 +32,16 @@ function calculateCumulativeTotalSupply(tokenChartData: TokenChartInfoParsed[]) 
 }
 
 // Hook to fetch and aggregate expert modules chart data
-function useExpertModulesChartInfo({ expertModules }: { expertModules: ExpertModule[] }) {
+function useExpertModulesChartInfo() {
   // TODO: Loop through all expert modules when more are added
   // Currently only handling stUSDS
-  const [stUsdsModule] = expertModules;
-
-  const {
-    data: stUsdsChartData,
-    isLoading: isLoadingStUsds,
-    error: errorStUsds
-  } = useTokenChartInfo({
-    tokenAddress: stUsdsModule?.tokenAddress
-  });
+  const { data: stUsdsChartData, isLoading: isLoadingStUsds, error: errorStUsds } = useStUsdsChartInfo();
 
   // When more modules are added, fetch their data and combine like this:
   const combinedChartData = stUsdsChartData ? [...stUsdsChartData] : [];
 
-  // For now, just use stUSDS data
-  const data = calculateCumulativeTotalSupply(combinedChartData || []);
+  // Aggregate the data (currently just stUSDS, but ready for more modules)
+  const data = calculateCumulativeTotalSupply(combinedChartData);
 
   return {
     data,
@@ -58,15 +53,11 @@ function useExpertModulesChartInfo({ expertModules }: { expertModules: ExpertMod
 export function ExpertChart() {
   const [activeChart, setActiveChart] = useState('tvl');
   const [timeFrame, setTimeFrame] = useState<TimeFrame>('w');
-  const chainId = useChainId();
-
-  // Get all expert modules for the current chain
-  const expertModules = getExpertModules(chainId);
 
   // Fetch and aggregate chart data for all expert modules
-  const { data: expertModulesChartData, isLoading, error } = useExpertModulesChartInfo({ expertModules });
+  const { data: expertModulesChartData, isLoading, error } = useExpertModulesChartInfo();
 
-  const chartData = useParseTokenChartData(timeFrame, expertModulesChartData);
+  const chartData = useParseSavingsChartData(timeFrame, expertModulesChartData);
 
   return (
     <div>

--- a/apps/webapp/src/modules/expert/components/ExpertChart.tsx
+++ b/apps/webapp/src/modules/expert/components/ExpertChart.tsx
@@ -3,7 +3,7 @@ import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useState } from 'react';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
 import { Trans } from '@lingui/react/macro';
-import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
+import { useParseTvlChartData } from '@/modules/ui/hooks/useParseTvlChartData';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 type TvlChartInfoParsed = {
@@ -57,7 +57,7 @@ export function ExpertChart() {
   // Fetch and aggregate chart data for all expert modules
   const { data: expertModulesChartData, isLoading, error } = useExpertModulesChartInfo();
 
-  const chartData = useParseSavingsChartData(timeFrame, expertModulesChartData);
+  const chartData = useParseTvlChartData(timeFrame, expertModulesChartData);
 
   return (
     <div>

--- a/apps/webapp/src/modules/expert/components/ExpertSuppliersCard.tsx
+++ b/apps/webapp/src/modules/expert/components/ExpertSuppliersCard.tsx
@@ -1,19 +1,23 @@
 import { StatsCard } from '@/modules/ui/components/StatsCard';
 import { t } from '@lingui/core/macro';
 import { Text } from '@/modules/layout/components/Typography';
+import { useOverallSkyData } from '@jetstreamgg/sky-hooks';
+import { formatNumber } from '@jetstreamgg/sky-utils';
 
 export function ExpertSuppliersCard(): React.ReactElement {
-  // TODO: Implement actual expert suppliers data fetching
+  const { data, isLoading, error } = useOverallSkyData();
+  const suppliersCount = data && formatNumber(data.stusdsSuppliers);
 
   return (
     <StatsCard
       title={t`Expert Suppliers`}
       content={
         <Text className="mt-2" variant="large">
-          TODO
+          {suppliersCount || 0}
         </Text>
       }
-      isLoading={false}
+      isLoading={isLoading}
+      error={error}
     />
   );
 }

--- a/apps/webapp/src/modules/rewards/hooks/useParseRewardsChartData.ts
+++ b/apps/webapp/src/modules/rewards/hooks/useParseRewardsChartData.ts
@@ -8,7 +8,7 @@ export function useParseRewardsChartData(
   chartData: RewardsChartInfoParsed[]
 ): { totalSupplied: Data[]; rate: Data[] } {
   return useMemo(() => {
-    const sortedChartData = chartData.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
+    const sortedChartData = [...chartData].sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
     // Determine the start and end timestamps based on the timeFrame
     const { startTimestamp, endTimestamp } = determineTimeframeBounds(timeFrame, sortedChartData);
@@ -87,18 +87,18 @@ function generateDataPoints(
   dataType: 'totalSupplied' | 'rate'
 ): Data[] {
   // Sort chartData by timestamp in ascending order to ensure correct processing
-  chartData.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
+  const sortedChartData = [...chartData].sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
   let dataPoints;
   if (timeFrame === 'all' || timeFrame === 'y') {
     // Handle 'all' timeframe by generating equidistant points across the entire dataset
     const totalPoints = 7; // Including start and end, with 5 in between
     const interval = (endTimestamp - startTimestamp) / (totalPoints - 1);
-    dataPoints = interpolateDataPoints(chartData, startTimestamp, endTimestamp, interval, dataType);
+    dataPoints = interpolateDataPoints(sortedChartData, startTimestamp, endTimestamp, interval, dataType);
   } else {
     // For other timeframes, calculate the interval based on the timeframe
     const interval = getTimeFrameInterval(timeFrame);
-    dataPoints = interpolateDataPoints(chartData, startTimestamp, endTimestamp, interval, dataType);
+    dataPoints = interpolateDataPoints(sortedChartData, startTimestamp, endTimestamp, interval, dataType);
   }
 
   //Find min and max points

--- a/apps/webapp/src/modules/savings/components/SavingsChart.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsChart.tsx
@@ -3,7 +3,7 @@ import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useState } from 'react';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
 import { Trans } from '@lingui/react/macro';
-import { useParseSavingsChartData } from '../hooks/useParseSavingsChartData';
+import { useParseTvlChartData } from '@/modules/ui/hooks/useParseTvlChartData';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useChainId } from 'wagmi';
 import { isL2ChainId } from '@jetstreamgg/sky-utils';
@@ -16,7 +16,7 @@ export function SavingsChart() {
   const chartChainId = isL2Chain ? 1 : chainId; // use mainnet for L2s
 
   const { data: savingsChartInfo, isLoading, error } = useSavingsChartInfo(chartChainId);
-  const chartData = useParseSavingsChartData(timeFrame, savingsChartInfo || []);
+  const chartData = useParseTvlChartData(timeFrame, savingsChartInfo || []);
 
   return (
     <div>

--- a/apps/webapp/src/modules/seal/components/SealChart.tsx
+++ b/apps/webapp/src/modules/seal/components/SealChart.tsx
@@ -1,6 +1,6 @@
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
-import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
+import { useParseTvlChartData } from '@/modules/ui/hooks/useParseTvlChartData';
 import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useSealHistoricData } from '@jetstreamgg/sky-hooks';
 import { Trans } from '@lingui/react/macro';
@@ -19,8 +19,8 @@ export function SealChart() {
       amount: parseEther(normalizedSupply)
     };
   });
-  // We can reuse the useParseSavingsChartData hook here as the format of the data is the same
-  const chartData = useParseSavingsChartData(timeFrame, formattedSealChartInfo || []);
+  // We can reuse the useParseTvlChartData hook here as the format of the data is the same
+  const chartData = useParseTvlChartData(timeFrame, formattedSealChartInfo || []);
 
   return (
     <div>

--- a/apps/webapp/src/modules/stake/components/StakeChart.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeChart.tsx
@@ -1,6 +1,6 @@
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
-import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
+import { useParseTvlChartData } from '@/modules/ui/hooks/useParseTvlChartData';
 import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useStakeHistoricData } from '@jetstreamgg/sky-hooks';
 import { Trans } from '@lingui/react/macro';
@@ -19,8 +19,8 @@ export function StakeChart() {
       amount: parseEther(normalizedSupply)
     };
   });
-  // We can reuse the useParseSavingsChartData hook here as the format of the data is the same
-  const chartData = useParseSavingsChartData(timeFrame, formattedStakeChartInfo || []);
+
+  const chartData = useParseTvlChartData(timeFrame, formattedStakeChartInfo || []);
 
   return (
     <div>

--- a/apps/webapp/src/modules/stusds/components/StUSDSChart.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUSDSChart.tsx
@@ -3,34 +3,44 @@ import { Chart, TimeFrame } from '@/modules/ui/components/Chart';
 import { useState } from 'react';
 import { ErrorBoundary } from '@/modules/layout/components/ErrorBoundary';
 import { Trans } from '@lingui/react/macro';
-import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
+import { useParseStUsdsChartData } from '../hooks/useParseStUsdsChartData';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
+enum ChartName {
+  TVL = 'tvl',
+  RATE = 'rate'
+}
+
 export function StUSDSChart() {
-  const [activeChart, setActiveChart] = useState('tvl');
+  const [activeChart, setActiveChart] = useState<ChartName>(ChartName.TVL);
   const [timeFrame, setTimeFrame] = useState<TimeFrame>('w');
 
   const { data: stUsdsChartInfo, isLoading, error } = useStUsdsChartInfo();
-  const chartData = useParseSavingsChartData(timeFrame, stUsdsChartInfo || []);
+  const chartData = useParseStUsdsChartData(timeFrame, stUsdsChartInfo || []);
+
+  const availableCharts = [ChartName.TVL, ChartName.RATE];
 
   return (
     <div>
       <ErrorBoundary variant="small">
         <div className="mb-4 flex">
-          <Tabs value={activeChart} onValueChange={value => setActiveChart(value)}>
+          <Tabs value={activeChart} onValueChange={value => setActiveChart(value as ChartName)}>
             <TabsList className="flex">
-              <TabsTrigger position="whole" value="tvl">
-                <Trans>TVL</Trans>
-              </TabsTrigger>
+              {availableCharts.map((chart, index) => (
+                <TabsTrigger key={chart} position={index === 0 ? 'left' : 'right'} value={chart}>
+                  <Trans>{chart === ChartName.TVL ? 'TVL' : 'Rate'}</Trans>
+                </TabsTrigger>
+              ))}
             </TabsList>
           </Tabs>
         </div>
         <Chart
           dataTestId="stusds-chart"
-          data={chartData}
+          data={activeChart === ChartName.TVL ? chartData.tvl : chartData.rate}
           isLoading={isLoading}
           error={error}
-          symbol={'USDS'}
+          isPercentage={activeChart === ChartName.RATE}
+          symbol={activeChart === ChartName.TVL ? 'USDS' : undefined}
           onTimeFrameChange={tf => {
             setTimeFrame(tf);
           }}

--- a/apps/webapp/src/modules/stusds/components/StUSDSChart.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUSDSChart.tsx
@@ -30,7 +30,7 @@ export function StUSDSChart() {
           data={chartData}
           isLoading={isLoading}
           error={error}
-          symbol={'stUSDS'}
+          symbol={'USDS'}
           onTimeFrameChange={tf => {
             setTimeFrame(tf);
           }}

--- a/apps/webapp/src/modules/stusds/components/StUSDSSuppliersCard.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUSDSSuppliersCard.tsx
@@ -2,20 +2,23 @@ import { StatsCard } from '@/modules/ui/components/StatsCard';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Text } from '@/modules/layout/components/Typography';
+import { useOverallSkyData } from '@jetstreamgg/sky-hooks';
+import { formatNumber } from '@jetstreamgg/sky-utils';
 
 export function StUSDSSuppliersCard() {
   const { i18n } = useLingui();
-
-  const suppliersCount = 'TODO';
+  const { data, isLoading, error } = useOverallSkyData();
+  const suppliersCount = data && formatNumber(data.stusdsSuppliers);
 
   return (
     <StatsCard
       className="h-full"
-      isLoading={false}
+      isLoading={isLoading}
+      error={error}
       title={i18n._(msg`Suppliers`)}
       content={
         <Text variant="large" className="mt-2">
-          {suppliersCount}
+          {suppliersCount || 0}
         </Text>
       }
     />

--- a/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
+++ b/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { Data, TimeFrame } from '@/modules/ui/components/Chart';
+import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
+
+type StUsdsChartInfoParsed = {
+  blockTimestamp: number;
+  amount: bigint;
+  rate?: bigint;
+};
+
+export function useParseStUsdsChartData(
+  timeFrame: TimeFrame,
+  chartData: StUsdsChartInfoParsed[]
+): { tvl: Data[]; rate: Data[] } {
+  // For TVL, use amount field
+  const tvlData = useParseSavingsChartData(timeFrame, chartData);
+
+  // For rate, transform the data to use rate field as amount
+  const rateChartData = useMemo(
+    () =>
+      chartData.map(item => ({
+        blockTimestamp: item.blockTimestamp,
+        amount: item.rate || 0n // Use rate as amount for the parser
+      })),
+    [chartData]
+  );
+
+  // Parse rate data
+  const parsedRateData = useParseSavingsChartData(timeFrame, rateChartData);
+
+  // Convert rate values to percentages
+  const rateData = useMemo(
+    () =>
+      parsedRateData.map(point => ({
+        ...point,
+        value: point.value / 1e16 // Convert from 1e18 to percentage
+      })),
+    [parsedRateData]
+  );
+
+  return { tvl: tvlData, rate: rateData };
+}

--- a/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
+++ b/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
@@ -33,7 +33,7 @@ export function useParseStUsdsChartData(
     () =>
       parsedRateData.map(point => ({
         ...point,
-        value: point.value / 1e16 // Convert from 1e18 to percentage
+        value: point.value * 100 // Convert from decimal (0.045) to percentage (4.5)
       })),
     [parsedRateData]
   );

--- a/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
+++ b/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
@@ -18,10 +18,12 @@ export function useParseStUsdsChartData(
   // For rate, transform the data to use rate field as amount
   const rateChartData = useMemo(
     () =>
-      chartData.map(item => ({
-        blockTimestamp: item.blockTimestamp,
-        amount: item.rate || 0n // Use rate as amount for the parser
-      })),
+      chartData
+        .filter(item => item.rate !== undefined && item.rate !== null)
+        .map(item => ({
+          blockTimestamp: item.blockTimestamp,
+          amount: item.rate as bigint // Use rate as amount for the parser
+        })),
     [chartData]
   );
 

--- a/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
+++ b/apps/webapp/src/modules/stusds/hooks/useParseStUsdsChartData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Data, TimeFrame } from '@/modules/ui/components/Chart';
-import { useParseSavingsChartData } from '@/modules/savings/hooks/useParseSavingsChartData';
+import { useParseTvlChartData } from '@/modules/ui/hooks/useParseTvlChartData';
 
 type StUsdsChartInfoParsed = {
   blockTimestamp: number;
@@ -13,7 +13,7 @@ export function useParseStUsdsChartData(
   chartData: StUsdsChartInfoParsed[]
 ): { tvl: Data[]; rate: Data[] } {
   // For TVL, use amount field
-  const tvlData = useParseSavingsChartData(timeFrame, chartData);
+  const tvlData = useParseTvlChartData(timeFrame, chartData);
 
   // For rate, transform the data to use rate field as amount
   const rateChartData = useMemo(
@@ -26,7 +26,7 @@ export function useParseStUsdsChartData(
   );
 
   // Parse rate data
-  const parsedRateData = useParseSavingsChartData(timeFrame, rateChartData);
+  const parsedRateData = useParseTvlChartData(timeFrame, rateChartData);
 
   // Convert rate values to percentages
   const rateData = useMemo(

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -379,9 +379,9 @@ export function Chart({
       return 0;
     }
 
-    const offset = 1; // to prevent Infinity values. maybe it should be a smaller number
+    const offset = isPercentage ? 0.001 : 1;
     const first = data[0].value + offset;
-    const last = data[data.length - 1].value;
+    const last = data[data.length - 1].value + offset;
 
     return ((last - first) / first) * 100;
   }, [data]);

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -384,7 +384,7 @@ export function Chart({
     const last = data[data.length - 1].value + offset;
 
     return ((last - first) / first) * 100;
-  }, [data]);
+  }, [data, isPercentage]);
   const formattedPercentage = formatPercentage(percentage, isLarge);
   const isZeroPercentage = formattedPercentage.replace('-', '').replace(/%/g, '') === '0';
   const [activeTimeframe, setActiveTimeframe] = useState<TimeFrame>('w');

--- a/apps/webapp/src/modules/ui/hooks/useParseTokenChartData.ts
+++ b/apps/webapp/src/modules/ui/hooks/useParseTokenChartData.ts
@@ -7,7 +7,7 @@ type TokenChartTvl = { blockTimestamp: number; amount: bigint; holders: number }
 
 export function useParseTokenChartData(timeFrame: TimeFrame, tvl: TokenChartTvl[]): Data[] {
   return useMemo(() => {
-    const sortedTvl = tvl.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
+    const sortedTvl = [...tvl].sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
     // Determine the start and end timestamps based on the timeFrame
     const { startTimestamp, endTimestamp } = determineTimeframeBounds(timeFrame, sortedTvl);
@@ -131,18 +131,18 @@ function generateDataPoints(
   timeFrame: TimeFrame
 ): Data[] {
   // Sort tvl by timestamp in ascending order to ensure correct processing
-  tvl.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
+  const sortedTvl = [...tvl].sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
   let dataPoints;
   if (timeFrame === 'all' || timeFrame === 'y') {
     // Handle 'all' timeframe by generating equidistant points across the entire dataset
     const totalPoints = 7; // Including start and end, with 5 in between
     const interval = (endTimestamp - startTimestamp) / (totalPoints - 1);
-    dataPoints = interpolateDataPoints(tvl, startTimestamp, endTimestamp, interval);
+    dataPoints = interpolateDataPoints(sortedTvl, startTimestamp, endTimestamp, interval);
   } else {
     // For other timeframes, calculate the interval based on the timeframe
     const interval = getTimeFrameInterval(timeFrame);
-    dataPoints = interpolateDataPoints(tvl, startTimestamp, endTimestamp, interval);
+    dataPoints = interpolateDataPoints(sortedTvl, startTimestamp, endTimestamp, interval);
   }
 
   //Find min and max points

--- a/apps/webapp/src/modules/ui/hooks/useParseTvlChartData.ts
+++ b/apps/webapp/src/modules/ui/hooks/useParseTvlChartData.ts
@@ -3,9 +3,9 @@ import { useMemo } from 'react';
 import { Data, TimeFrame } from '@/modules/ui/components/Chart';
 import { getTimeFrameInterval } from '@/modules/rewards/helpers/getTimeFrameInterval';
 
-type SavingsTvl = { blockTimestamp: number; amount: bigint };
+type TvlData = { blockTimestamp: number; amount: bigint };
 
-export function useParseSavingsChartData(timeFrame: TimeFrame, tvl: SavingsTvl[]): Data[] {
+export function useParseTvlChartData(timeFrame: TimeFrame, tvl: TvlData[]): Data[] {
   return useMemo(() => {
     const sortedTvl = tvl.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
@@ -13,7 +13,7 @@ export function useParseSavingsChartData(timeFrame: TimeFrame, tvl: SavingsTvl[]
     const { startTimestamp, endTimestamp } = determineTimeframeBounds(timeFrame, sortedTvl);
 
     // Filter TVL changes within the determined timeframe
-    let prevItem: SavingsTvl | undefined;
+    let prevItem: TvlData | undefined;
     const relevantChanges = sortedTvl.filter((item, index) => {
       const found = item.blockTimestamp >= startTimestamp && item.blockTimestamp <= endTimestamp;
       if (found && !prevItem && index > 0) {
@@ -39,7 +39,7 @@ export function useParseSavingsChartData(timeFrame: TimeFrame, tvl: SavingsTvl[]
 
 function determineTimeframeBounds(
   timeFrame: TimeFrame,
-  tvl: SavingsTvl[]
+  tvl: TvlData[]
 ): { startTimestamp: number; endTimestamp: number } {
   const now = Date.now() / 1000; // Current timestamp in seconds
   let startTimestamp: number;
@@ -70,7 +70,7 @@ function determineTimeframeBounds(
 }
 
 const interpolateDataPoints = (
-  tvl: SavingsTvl[],
+  tvl: TvlData[],
   startTimestamp: number,
   endTimestamp: number,
   interval: number,
@@ -113,7 +113,7 @@ const interpolateDataPoints = (
 };
 
 // Helper function to find the most recent change before or at currentTime
-function findMostRecentChange(tvl: SavingsTvl[], currentTime: number): [SavingsTvl, number] | undefined {
+function findMostRecentChange(tvl: TvlData[], currentTime: number): [TvlData, number] | undefined {
   for (let i = tvl.length - 1; i >= 0; i--) {
     if (tvl[i].blockTimestamp <= currentTime) {
       return [tvl[i], i];
@@ -123,7 +123,7 @@ function findMostRecentChange(tvl: SavingsTvl[], currentTime: number): [SavingsT
 }
 
 function generateDataPoints(
-  tvl: SavingsTvl[],
+  tvl: TvlData[],
   startTimestamp: number,
   endTimestamp: number,
   timeFrame: TimeFrame

--- a/apps/webapp/src/modules/ui/hooks/useParseTvlChartData.ts
+++ b/apps/webapp/src/modules/ui/hooks/useParseTvlChartData.ts
@@ -7,7 +7,7 @@ type TvlData = { blockTimestamp: number; amount: bigint };
 
 export function useParseTvlChartData(timeFrame: TimeFrame, tvl: TvlData[]): Data[] {
   return useMemo(() => {
-    const sortedTvl = tvl.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
+    const sortedTvl = [...tvl].sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
     // Determine the start and end timestamps based on the timeFrame
     const { startTimestamp, endTimestamp } = determineTimeframeBounds(timeFrame, sortedTvl);
@@ -129,18 +129,18 @@ function generateDataPoints(
   timeFrame: TimeFrame
 ): Data[] {
   // Sort tvl by timestamp in ascending order to ensure correct processing
-  tvl.sort((a, b) => a.blockTimestamp - b.blockTimestamp);
+  const sortedTvl = [...tvl].sort((a, b) => a.blockTimestamp - b.blockTimestamp);
 
   let dataPoints;
   if (timeFrame === 'all' || timeFrame === 'y') {
     // Handle 'all' timeframe by generating equidistant points across the entire dataset
     const totalPoints = 7; // Including start and end, with 5 in between
     const interval = (endTimestamp - startTimestamp) / (totalPoints - 1);
-    dataPoints = interpolateDataPoints(tvl, startTimestamp, endTimestamp, interval);
+    dataPoints = interpolateDataPoints(sortedTvl, startTimestamp, endTimestamp, interval);
   } else {
     // For other timeframes, calculate the interval based on the timeframe
     const interval = getTimeFrameInterval(timeFrame);
-    dataPoints = interpolateDataPoints(tvl, startTimestamp, endTimestamp, interval);
+    dataPoints = interpolateDataPoints(sortedTvl, startTimestamp, endTimestamp, interval);
   }
 
   //Find min and max points

--- a/apps/webapp/src/modules/upgrade/components/MkrUpgradedPercentage.tsx
+++ b/apps/webapp/src/modules/upgrade/components/MkrUpgradedPercentage.tsx
@@ -18,11 +18,7 @@ export function MkrUpgradedPercentage() {
       title={t`% of MKR upgraded`}
       isLoading={isLoading}
       error={error}
-      content={
-        <div className="mt-2 flex items-center">
-          <Text className="ml-2">{percentageValue} %</Text>
-        </div>
-      }
+      content={<Text>{percentageValue} %</Text>}
     />
   );
 }

--- a/apps/webapp/src/test/e2e/tests/expert-stusds.spec.ts
+++ b/apps/webapp/src/test/e2e/tests/expert-stusds.spec.ts
@@ -212,7 +212,7 @@ test.describe('Expert Module - stUSDS', () => {
     await approveOrPerformAction(page, 'Upgrade');
 
     // Check that Rewards modal is visible
-    await expect(page.getByText('Go to Expert')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Go to Expert' })).toBeVisible();
 
     // Click on Close button
     await page.getByRole('button', { name: 'Go to Expert' }).click();

--- a/packages/hooks/src/shared/useOverallSkyData.ts
+++ b/packages/hooks/src/shared/useOverallSkyData.ts
@@ -13,6 +13,7 @@ type OverallSkyApiResponse = {
   total_save?: string;
   sky_ecosystem_tvl?: string;
   ssr_depositor_count?: number;
+  stusds_depositor_count?: number;
   sky_price_usd?: string;
   usdc_price_usd?: string;
   weth_price_usd?: string;
@@ -28,6 +29,7 @@ type OverallSkyData = {
   totalSavingsTvl: string;
   skyEcosystemTvl: string;
   ssrSuppliers: number;
+  stusdsSuppliers: number;
   skyPriceUsd: string;
   usdcPriceUsd: string;
   wethPriceUsd: string;
@@ -44,6 +46,7 @@ function transformOverallSkyData(data: OverallSkyApiResponse[]): OverallSkyData 
     totalSavingsTvl: '',
     skyEcosystemTvl: '',
     ssrSuppliers: 0,
+    stusdsSuppliers: 0,
     skyPriceUsd: '',
     usdcPriceUsd: '',
     wethPriceUsd: '',
@@ -60,6 +63,7 @@ function transformOverallSkyData(data: OverallSkyApiResponse[]): OverallSkyData 
       result.totalSavingsTvl = item.total_save ?? '';
       result.skyEcosystemTvl = item.sky_ecosystem_tvl ?? '';
       result.ssrSuppliers = item.ssr_depositor_count ?? 0;
+      result.stusdsSuppliers = item.stusds_depositor_count ?? 0;
     } else if ('sky_price_usd' in item) {
       result.skyPriceUsd = item.sky_price_usd ?? '';
     } else if ('usdc_price_usd' in item) {

--- a/packages/hooks/src/stusds/useStUsdsChartInfo.ts
+++ b/packages/hooks/src/stusds/useStUsdsChartInfo.ts
@@ -8,7 +8,7 @@ import { ReadHook } from '../hooks';
 
 type StUsdsChartInfo = {
   date: string;
-  stusds_tvl: string;
+  stusds_tvl: string | null;
   stusds_rate: string | null;
 };
 

--- a/packages/hooks/src/stusds/useStUsdsChartInfo.ts
+++ b/packages/hooks/src/stusds/useStUsdsChartInfo.ts
@@ -9,20 +9,33 @@ import { ReadHook } from '../hooks';
 type StUsdsChartInfo = {
   date: string;
   stusds_tvl: string;
+  stusds_rate: string | null;
 };
 
 type StUsdsChartInfoParsed = {
   blockTimestamp: number;
   amount: bigint;
+  rate?: bigint;
 };
 
 function transformBaLabsChartData(results: StUsdsChartInfo[]): StUsdsChartInfoParsed[] {
   const parsed = results.map((item: StUsdsChartInfo) => {
-    const stUsdsTvl = Number(item.stusds_tvl).toFixed(18); //remove scientific notation if it exists
-    return {
+    const result: StUsdsChartInfoParsed = {
       blockTimestamp: new Date(item?.date).getTime() / 1000,
-      amount: parseEther(stUsdsTvl)
+      amount: 0n // Default tvl amount
     };
+
+    if (item.stusds_tvl !== null) {
+      const stUsdsTvl = Number(item.stusds_tvl).toFixed(18); //remove scientific notation if it exists
+      result.amount = parseEther(stUsdsTvl);
+    }
+
+    if (item.stusds_rate !== null) {
+      const stUsdsRate = Number(item.stusds_rate).toFixed(18); //remove scientific notation if it exists
+      result.rate = parseEther(stUsdsRate);
+    }
+
+    return result;
   });
   return parsed;
 }

--- a/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeStats.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeStats.tsx
@@ -37,14 +37,7 @@ export const UpgradeStats = () => {
         }
       ></StatsCard>
 
-      <StatsCard
-        title={t`% of MKR upgraded`}
-        content={
-          <div className="mt-1 flex items-center">
-            <Text className="ml-2">{percentageValue} %</Text>
-          </div>
-        }
-      ></StatsCard>
+      <StatsCard title={t`% of MKR upgraded`} content={<Text>{percentageValue} %</Text>}></StatsCard>
     </div>
   );
 };


### PR DESCRIPTION
  - renames useParseSavingsChartData to useParseTvlChartData
  - Adds rate chart functionality to stUSDS with dual TVL/rate chart tabs
  - Implements stUSDS supplier count display using real data from useOverallSkyData
  - Switches expert chart to use dedicated useStUsdsChartInfo hook instead of generic token chart hook
  - Updates chart offset calculation to handle percentage values properly
  - Removes unnecessary margin in the upgrade stats card

  Testing steps:

  1. Navigate to stUSDS page and verify both TVL and Rate chart tabs display correctly
  2. Check that stUSDS supplier count shows actual data (0) instead of "TODO"
  3. Verify expert chart displays stUSDS TVL data correctly
  4. Test savings, seal, and stake charts still function properly after hook refactor
  5. Confirm chart percentage calculations now works correctly for rate charts