### PR TITLE
Reset amount and token in the claim all transaction screen

### DIFF
--- a/packages/widgets/src/widgets/RewardsWidget/components/RewardsClaimAllTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/components/RewardsClaimAllTransactionStatus.tsx
@@ -17,8 +17,21 @@ export const RewardsClaimAllTransactionStatus = ({
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 }) => {
   const { i18n } = useLingui();
-  const { setTxTitle, setTxSubtitle, setTxDescription, txStatus, setLoadingText, setStep } =
-    useContext(WidgetContext);
+  const {
+    setTxTitle,
+    setTxSubtitle,
+    setTxDescription,
+    txStatus,
+    setLoadingText,
+    setStep,
+    setOriginAmount,
+    setOriginToken
+  } = useContext(WidgetContext);
+
+  useEffect(() => {
+    setOriginToken();
+    setOriginAmount();
+  }, []);
 
   // Sets the title and subtitle of the card
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where, when claiming all rewards after performing another rewards widget transaction, the selected token and input amount would carry over from the previous action.
Fixes it by resetting the amount and token to undefined in the claim all transaction screen.

### Testing steps:
- Go to the rewards widget
- Go to a reward contract where you have rewards to claim
- Claim that specific reward
- Navigate back to the reward overview screen
- Click on the claim all rewards button
- No token or amounts should be displayed