### PR TITLE
Chart label fixes

### DIFF
--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -28,7 +28,7 @@ import { VStack } from '@/modules/layout/components/VStack';
 import { Warning } from '@/modules/icons/Warning';
 
 const dateFormat = 'MMM d';
-const monthFormat = 'MMM';
+const monthFormat = 'MMM y';
 
 export type TimeFrame = 'w' | 'm' | 'y' | 'all';
 
@@ -170,12 +170,12 @@ const formatedXAxis = (data: Data[], tf: TimeFrame, bpi: BP) => {
 
   filteredData.push(data[data.length - 1]); // Always include the last element
 
-  const finalFormat = tf === 'y' ? monthFormat : dateFormat;
+  const finalFormat = ['y', 'all'].includes(tf) ? monthFormat : dateFormat;
   return filteredData.map(item => format(new Date(item.date?.toISOString()), finalFormat));
 };
 
 const formatDate = (date: Date, tf: TimeFrame) => {
-  const finalFormat = tf === 'y' ? monthFormat : dateFormat;
+  const finalFormat = ['y', 'all'].includes(tf) ? monthFormat : dateFormat;
   return format(date, finalFormat);
 };
 

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -445,7 +445,7 @@ export function Chart({
       </Card>
       <HStack className="mt-3 justify-between">
         {dateAxis.map((date, index) => (
-          <Text className="text-selectActive leading-none" variant="small" key={`${date}+${index}`}>
+          <Text className="text-selectActive" variant="small" key={`${date}+${index}`}>
             {date}
           </Text>
         ))}


### PR DESCRIPTION
### What does this PR do?

This PR updates the date formatting for the chart's X-axis. For the 'Year' and 'All' timeframes, the axis labels will now display both the month and the year (e.g., 'Jan 2023') for better clarity across multiple years.

Additionally, it fixes the X-axis cutoff by removing the `leading-none` class from the date axis labels.

### Testing steps:

1.  Navigate to the page containing the chart.
2.  Select the **'Year'** timeframe.
3.  Verify that the X-axis labels show both the month and year (e.g., 'Jan 2023', 'Feb 2023').
4.  Select the **'All'** timeframe.
5.  Verify the X-axis labels also show the month and year.
6.  Switch to the **'Week'** and **'Month'** timeframes and confirm the labels show the month and day as before (e.g., 'Jan 15').
7.  Visually confirm the date labels at the bottom of the chart are correctly aligned.