### PR TITLE
always specify transition properties

### DIFF
--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primaryDisabled disabled:text-surfaceAlt',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition-[background-color,background-image,opacity,border-color,color,box-shadow] duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primaryDisabled disabled:text-surfaceAlt',
   {
     variants: {
       variant: {

--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -51,7 +51,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition-[transform,opacity] ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&

--- a/apps/webapp/src/components/ui/tabs.tsx
+++ b/apps/webapp/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ const tabsTriggerVariants = cva('', {
       default:
         'w-full inline-flex items-center justify-center whitespace-nowrap h-10 p-3 text-sm font-normal leading-none text-tabPrimary ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-surface hover:bg-surfaceHover data-[state=active]:bg-surface data-[state=active]:border-transparent data-[state=active]:text-text disabled:text-opacity duration-250 ease-out-expo',
       icons:
-        'text-xs text-textSecondary flex flex-col gap-1 items-center justify-center px-2 py-2.5 rounded-xl w-[72px] md:w-16 data-[state=active]:text-text bg-radial-(--gradient-position) from-primary-start/0 to-primary-end/0 border border-transparent data-[state=active]:from-primary-start/100 data-[state=active]:to-primary-end/100 data-[state=active]:border-border hover:from-primary-start/50 hover:to-primary-end/50 disabled:hover:from-primary-start/0 disabled:hover:to-primary-end/0 transition duration-250 ease-out-expo relative'
+        'text-xs text-textSecondary flex flex-col gap-1 items-center justify-center px-2 py-2.5 rounded-xl w-[72px] md:w-16 data-[state=active]:text-text bg-radial-(--gradient-position) from-primary-start/0 to-primary-end/0 border border-transparent data-[state=active]:from-primary-start/100 data-[state=active]:to-primary-end/100 data-[state=active]:border-border hover:from-primary-start/50 hover:to-primary-end/50 disabled:hover:from-primary-start/0 disabled:hover:to-primary-end/0 transition-[background-color,background-image,opacity,border-color,color] duration-250 ease-out-expo relative'
     },
     position: {
       default: '',

--- a/packages/widgets/src/components/ui/button.tsx
+++ b/packages/widgets/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ export type ButtonVariant =
   | 'ghost';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-[12px] text-sm font-medium ring-offset-background transition duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-[12px] text-sm font-medium ring-offset-background transition-[background-color,background-image,opacity,border-color,color,box-shadow] duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none',
   {
     variants: {
       variant: {

--- a/packages/widgets/src/shared/components/ui/transaction/BatchTransactionStatus.tsx
+++ b/packages/widgets/src/shared/components/ui/transaction/BatchTransactionStatus.tsx
@@ -84,7 +84,7 @@ export function BatchTransactionStatus({
       <motion.div variants={positionAnimations} className="my-3 w-full">
         <Card
           data-status={flowSuccess && 'success'}
-          className="ease-out-expo from-primary-start/0 to-primary-end/0 data-[status=success]:from-primary-start/100 data-[status=success]:to-primary-end/100 w-full transition duration-500"
+          className="ease-out-expo from-primary-start/0 to-primary-end/0 data-[status=success]:from-primary-start/100 data-[status=success]:to-primary-end/100 w-full transition-[background-color,background-image] duration-500"
         >
           <CardHeader>
             <motion.div variants={positionAnimations} className="flex gap-4">

--- a/packages/widgets/src/shared/components/ui/transaction/TransactionStatus.tsx
+++ b/packages/widgets/src/shared/components/ui/transaction/TransactionStatus.tsx
@@ -97,7 +97,7 @@ export function TransactionStatus({
       <motion.div variants={positionAnimations} className="my-3 w-full">
         <Card
           data-status={txStatus === TxStatus.SUCCESS && 'success'}
-          className="ease-out-expo from-primary-start/0 to-primary-end/0 data-[status=success]:from-primary-start/100 data-[status=success]:to-primary-end/100 w-full transition duration-500"
+          className="ease-out-expo from-primary-start/0 to-primary-end/0 data-[status=success]:from-primary-start/100 data-[status=success]:to-primary-end/100 w-full transition-[background-color,background-image] duration-500"
         >
           <CardHeader>
             <motion.div variants={positionAnimations}>

--- a/packages/widgets/src/widgets/TradeWidget/components/TradeConfigMenu.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeConfigMenu.tsx
@@ -50,7 +50,7 @@ export const TradeConfigMenu = ({
   // we can't use a Button inside PopoverTrigger because PopoverTrigger is already a button
   // this applies all the button styles to a div inside the PopoverTrigger
   const paginationButtonClasses =
-    'flex justify-center text-textDesaturated text-base leading-normal bg-radial-(--gradient-position) from-primary-start/0 to-primary-end/0 rounded-full hover:from-primary-start/40 hover:to-primary-end/40 hover:text-text active:text-text active:from-primary-start/20 active:to-primary-end/20 data-[state=open]:from-primary-start/80 data-[state=open]:to-primary-end/80 data-[state=open]:text-text h-min p-1.5 transition duration-250 ease-out-expo';
+    'flex justify-center text-textDesaturated text-base leading-normal bg-radial-(--gradient-position) from-primary-start/0 to-primary-end/0 rounded-full hover:from-primary-start/40 hover:to-primary-end/40 hover:text-text active:text-text active:from-primary-start/20 active:to-primary-end/20 data-[state=open]:from-primary-start/80 data-[state=open]:to-primary-end/80 data-[state=open]:text-text h-min p-1.5 transition-[background-color,background-image,opacity,color] duration-250 ease-out-expo';
 
   return widgetState.flow === TradeFlow.TRADE && widgetState.screen === TradeScreen.ACTION ? (
     <Popover>


### PR DESCRIPTION
⏺ What does this PR do?

  Fixes Safari transition issues by explicitly specifying CSS transition properties instead of using the generic transition property.

  Testing steps:
  1. Open the app in Safari browser
  2. Test button hover states and active states across the app
  3. Test sheet animations (open/close transitions)
  4. Test tab switching animations, especially the icon tabs
  5. Test transaction status card animations when transactions complete
  6. Test trade config menu button hover/active states
  7. Verify all transitions work smoothly without flickering or failing to animate

⏺ The Safari shrinking issue was caused by the universal transition property animating all CSS properties, including ones that shouldn't change. Here's what was happening:

  When you use just transition duration-250 ease-out-expo, it's equivalent to transition: all 250ms ease-out-expo, which means every single CSS property that changes will animate.

  The likely culprit was the ring-offset property from the focus states:
  focus-visible:ring-offset-2

  This adds a box-shadow with an offset to create a ring effect. In Safari, when hovering, it might have been:
  1. Triggering some focus-visible state inadvertently
  2. Or animating the ring-offset-background property (which affects layout calculations)
  3. Or animating transform/scale properties that were being set somewhere else in the cascade

  Safari and Chrome handle these edge cases differently. Safari might have been animating properties like:
  - outline-offset
  - box-shadow spread/offset values
  - Transform properties from parent elements
  - Even width/height calculations from flex/grid changes

  By specifying exactly which properties to transition:
  transition-[background-color,background-image,opacity,border-color,color,box-shadow]

  We ensure that only the intended visual properties animate, preventing any layout-affecting properties from being animated. This stops the shrinking because size/transform/offset
  properties are no longer being transitioned.

  The fix works because we're now explicitly excluding any properties that could affect the button's dimensions or position from the transition animation.
