### PR TITLE
Refactor restricted intents, restrict expert

### DIFF
--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -28,11 +28,11 @@ export enum QueryParams {
 const isRestrictedBuild = import.meta.env.VITE_RESTRICTED_BUILD === 'true';
 const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
 
-export const restrictedIntents: Intent[] = (() => {
+export const RESTRICTED_INTENTS: Intent[] = (() => {
   if (isRestrictedMiCa) {
     return [Intent.TRADE_INTENT];
   } else if (isRestrictedBuild) {
-    return [Intent.SAVINGS_INTENT, Intent.REWARDS_INTENT];
+    return [Intent.SAVINGS_INTENT, Intent.REWARDS_INTENT, Intent.EXPERT_INTENT];
   }
   return [];
 })();
@@ -114,7 +114,7 @@ export const VALID_LINKED_ACTIONS = [
 const AvailableIntentMapping = Object.entries(IntentMapping).reduce(
   (acc, [key, value]) => {
     const isRestricted = isRestrictedBuild || isRestrictedMiCa;
-    if (!isRestricted || !restrictedIntents.includes(key as Intent)) {
+    if (!isRestricted || !RESTRICTED_INTENTS.includes(key as Intent)) {
       acc[key as Intent] = value;
     }
     return acc;

--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -28,9 +28,14 @@ export enum QueryParams {
 const isRestrictedBuild = import.meta.env.VITE_RESTRICTED_BUILD === 'true';
 const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
 
-export const restrictedIntents = isRestrictedMiCa
-  ? [Intent.TRADE_INTENT]
-  : [Intent.SAVINGS_INTENT, Intent.REWARDS_INTENT];
+export const restrictedIntents: Intent[] = (() => {
+  if (isRestrictedMiCa) {
+    return [Intent.TRADE_INTENT];
+  } else if (isRestrictedBuild) {
+    return [Intent.SAVINGS_INTENT, Intent.REWARDS_INTENT];
+  }
+  return [];
+})();
 
 export const IntentMapping = {
   [Intent.BALANCES_INTENT]: 'balances',

--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { LinkedAction } from '@/modules/ui/hooks/useUserSuggestedActions';
-import { ALLOWED_EXTERNAL_DOMAINS, CHAIN_WIDGET_MAP, IntentMapping, restrictedIntents } from './constants';
+import { ALLOWED_EXTERNAL_DOMAINS, CHAIN_WIDGET_MAP, IntentMapping, RESTRICTED_INTENTS } from './constants';
 import { Intent } from './enums';
 
 export function cn(...inputs: ClassValue[]) {
@@ -85,7 +85,7 @@ export function isIntentAllowed(intent: Intent, chainId: number) {
   const isRestricted = isRestrictedBuild || isRestrictedMiCa;
 
   // First check if restricted build
-  if (isRestricted && restrictedIntents.includes(intent)) {
+  if (isRestricted && RESTRICTED_INTENTS.includes(intent)) {
     return false;
   }
   // Then check if widget is supported on current chain

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -8,7 +8,8 @@ import {
   BATCH_TX_LEGAL_NOTICE_URL,
   COMING_SOON_MAP,
   mapIntentToQueryParam,
-  QueryParams
+  QueryParams,
+  restrictedIntents
 } from '@/lib/constants';
 import { isExpertModulesEnabled } from '@/lib/feature-flags';
 import { WidgetNavigation } from '@/modules/app/components/WidgetNavigation';
@@ -196,18 +197,20 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
           ]
         ]
       : [])
-  ].map(([intent, label, icon, component, , , description]) => {
-    const comingSoon = COMING_SOON_MAP[chainId]?.includes(intent as Intent);
-    return [
-      intent as Intent,
-      label as string,
-      icon as (props: IconProps) => React.ReactNode,
-      comingSoon ? null : (component as React.ReactNode),
-      comingSoon,
-      comingSoon ? { disabled: true } : undefined,
-      description as string
-    ];
-  }) as WidgetItem[];
+  ]
+    .filter(([intent]) => !restrictedIntents.includes(intent as Intent))
+    .map(([intent, label, icon, component, , , description]) => {
+      const comingSoon = COMING_SOON_MAP[chainId]?.includes(intent as Intent);
+      return [
+        intent as Intent,
+        label as string,
+        icon as (props: IconProps) => React.ReactNode,
+        comingSoon ? null : (component as React.ReactNode),
+        comingSoon,
+        comingSoon ? { disabled: true } : undefined,
+        description as string
+      ];
+    }) as WidgetItem[];
 
   // Group the widgets in categories
   const widgetContent: WidgetContent = [

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -9,7 +9,7 @@ import {
   COMING_SOON_MAP,
   mapIntentToQueryParam,
   QueryParams,
-  restrictedIntents
+  RESTRICTED_INTENTS
 } from '@/lib/constants';
 import { isExpertModulesEnabled } from '@/lib/feature-flags';
 import { WidgetNavigation } from '@/modules/app/components/WidgetNavigation';
@@ -198,7 +198,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
         ]
       : [])
   ]
-    .filter(([intent]) => !restrictedIntents.includes(intent as Intent))
+    .filter(([intent]) => !RESTRICTED_INTENTS.includes(intent as Intent))
     .map(([intent, label, icon, component, , , description]) => {
       const comingSoon = COMING_SOON_MAP[chainId]?.includes(intent as Intent);
       return [

--- a/apps/webapp/src/modules/ui/hooks/useUserSuggestedActions.ts
+++ b/apps/webapp/src/modules/ui/hooks/useUserSuggestedActions.ts
@@ -1,4 +1,10 @@
-import { IntentMapping, ExpertIntentMapping, QueryParams, CHAIN_WIDGET_MAP } from '@/lib/constants';
+import {
+  IntentMapping,
+  ExpertIntentMapping,
+  QueryParams,
+  CHAIN_WIDGET_MAP,
+  restrictedIntents
+} from '@/lib/constants';
 import { Intent } from '@/lib/enums';
 import {
   useTokens,
@@ -454,14 +460,8 @@ const fetchUserSuggestedActions = (
     }
   }
 
-  const isRestrictedBuild = import.meta.env.VITE_RESTRICTED_BUILD === 'true';
-  const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
-
-  const restrictedIntents = isRestrictedBuild
-    ? [IntentMapping.REWARDS_INTENT, IntentMapping.SAVINGS_INTENT]
-    : isRestrictedMiCa
-      ? [IntentMapping.TRADE_INTENT]
-      : [];
+  // Convert Intent enums to their string mappings for comparison
+  const restrictedIntentStrings = restrictedIntents.map(intent => IntentMapping[intent]);
 
   const supportedIntents = CHAIN_WIDGET_MAP[chainId] || [];
 
@@ -476,12 +476,13 @@ const fetchUserSuggestedActions = (
   };
 
   const filteredSuggestedActions = suggestedActions.filter(action => {
-    if (restrictedIntents.includes(action.intent)) return false;
+    if (restrictedIntentStrings.includes(action.intent)) return false;
     return isIntentSupported(action.intent);
   });
 
   const filteredLinkedActions = linkedActions.filter(action => {
-    if (restrictedIntents.includes(action.intent) || restrictedIntents.includes(action.la)) return false;
+    if (restrictedIntentStrings.includes(action.intent) || restrictedIntentStrings.includes(action.la))
+      return false;
     return isIntentSupported(action.intent) && isIntentSupported(action.la);
   });
 

--- a/apps/webapp/src/modules/ui/hooks/useUserSuggestedActions.ts
+++ b/apps/webapp/src/modules/ui/hooks/useUserSuggestedActions.ts
@@ -3,7 +3,7 @@ import {
   ExpertIntentMapping,
   QueryParams,
   CHAIN_WIDGET_MAP,
-  restrictedIntents
+  RESTRICTED_INTENTS
 } from '@/lib/constants';
 import { Intent } from '@/lib/enums';
 import {
@@ -461,7 +461,7 @@ const fetchUserSuggestedActions = (
   }
 
   // Convert Intent enums to their string mappings for comparison
-  const restrictedIntentStrings = restrictedIntents.map(intent => IntentMapping[intent]);
+  const restrictedIntentStrings = RESTRICTED_INTENTS.map(intent => IntentMapping[intent]);
 
   const supportedIntents = CHAIN_WIDGET_MAP[chainId] || [];
 


### PR DESCRIPTION
### What does this PR do?

This PR refactors the logic for restricting application features (known as "Intents") based on build-time environment flags.

It centralizes the logic into a single `restrictedIntents` constant, which is then used by the `WidgetPane` and the `useUserSuggestedActions` hook. This ensures that features are consistently hidden from the UI and excluded from suggested actions for specific builds (e.g., MiCA-restricted).

This change also fixes a bug where "Savings" and "Rewards" intents were being restricted by default in standard, non-restricted builds.

### Testing steps:

1.  Run the application with default build flags (i.e., `VITE_RESTRICTED_BUILD` and `VITE_RESTRICTED_BUILD_MICA` are `false` or unset).
    *   **Verify:** All widgets, including Trade, Savings, and Rewards, are visible in the UI and can appear as suggested actions.

2.  Run the application with the general restricted build flag: `VITE_RESTRICTED_BUILD=true`.
    *   **Verify:** The "Savings" and "Rewards" widgets are hidden and do not appear as suggested actions.

3.  Run the application with the MiCA restricted build flag: `VITE_RESTRICTED_BUILD_MICA=true`.
    *   **Verify:** The "Trade" widget is hidden and does not appear as a suggested action.