### PR TITLE
Pnpm minimum release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-auto-install-peers=true
-dedupe-peer-dependents=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
   - 'apps/*'
   # all packages in subdirs of packages/ and components/
   - 'packages/*'
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
### What does this PR do?
- Sets the minimum release age for new packages to 24 hours, so that a new package version needs to be at least 24 hours old before it can be installed in the monorepo
- Remove old pnpm configs that were using the default values

### Testing steps
You can run `pnpm config list` locally and it will return a list of the current configs in the repo. It should contain `minimum-release-age=1440`