### PR TITLE
reset isAutoSwitching after network change

### DIFF
--- a/apps/webapp/src/modules/app/hooks/useEnhancedNetworkToast.tsx
+++ b/apps/webapp/src/modules/app/hooks/useEnhancedNetworkToast.tsx
@@ -158,7 +158,8 @@ export function useEnhancedNetworkToast() {
           requiresMainnet(previousIntent) &&
           currentIntent &&
           isMultichain(currentIntent) &&
-          isL2ChainId(currentChain.id)
+          isL2ChainId(currentChain.id) &&
+          currentIntent !== previousIntent
         ) {
           const widgetName = getWidgetName(currentIntent);
           title = `We've switched you back to ${currentChain.name}, the last network you used for ${widgetName}.`;

--- a/apps/webapp/src/modules/app/hooks/useNetworkAutoSwitch.ts
+++ b/apps/webapp/src/modules/app/hooks/useNetworkAutoSwitch.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useChains } from 'wagmi';
 import { Intent } from '@/lib/enums';
@@ -41,6 +41,16 @@ export function useNetworkAutoSwitch({
   const { selectedRewardContract } = useConfigContext();
   const [isAutoSwitching, setIsAutoSwitching] = useState(false);
   const [previousIntent, setPreviousIntent] = useState<Intent | undefined>(currentIntent);
+  const [previousChainId, setPreviousChainId] = useState<number | undefined>(currentChainId);
+
+  // Reset isAutoSwitching after network change completes
+  useEffect(() => {
+    if (currentChainId && previousChainId && currentChainId !== previousChainId && isAutoSwitching) {
+      // Network has changed, reset the auto-switching flag
+      setIsAutoSwitching(false);
+    }
+    setPreviousChainId(currentChainId);
+  }, [currentChainId, previousChainId, isAutoSwitching]);
 
   const handleWidgetNavigation = useCallback(
     (targetIntent: Intent) => {


### PR DESCRIPTION
⏺ What does this PR do?

  Fixes the auto-switching state management to properly reset after network changes complete. Previously, the isAutoSwitching flag could remain stuck in a true state, causing
  incorrect behavior.

  Testing steps:

  1. Start on an L2 widget
  2. switch to mainnet only widget: make sure auto switching toast is shown
  3. switch back to the l2 widget: make sure switching back to previous l2 toast is shown
  4. switch to a different network in the same widget: make sure it just shows the regular network switching toast