### PR TITLE
Capitalize rates only

### DIFF
--- a/packages/widgets/src/data/tooltips/index.ts
+++ b/packages/widgets/src/data/tooltips/index.ts
@@ -21,7 +21,7 @@ Open Safe[Wallet]`
   },
   {
     id: 'borrow-rate',
-    title: 'Borrow rate',
+    title: 'Borrow Rate',
     tooltip:
       'The Borrow Rate is determined by Sky Ecosystem Governance through a process of community-driven, decentralized onchain voting.'
   },

--- a/packages/widgets/src/data/tooltips/legacy-tooltips.ts
+++ b/packages/widgets/src/data/tooltips/legacy-tooltips.ts
@@ -32,7 +32,7 @@ export const legacyTooltips: Tooltip[] = [
   },
   {
     id: 'borrow-rate',
-    title: 'Borrow rate',
+    title: 'Borrow Rate',
     tooltip:
       'The Borrow Rate is determined by Sky Ecosystem Governance through a process of community-driven, decentralized onchain voting.'
   },
@@ -106,7 +106,7 @@ export const legacyTooltips: Tooltip[] = [
   },
   {
     id: 'borrow-rate-seal',
-    title: 'Borrow rate',
+    title: 'Borrow Rate',
     tooltip:
       'The Borrow Rate is determined by Sky Ecosystem Governance through a process of community-driven, decentralized onchain voting.'
   }

--- a/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
+++ b/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
@@ -78,7 +78,7 @@ const getContent = (
     )
   },
   dtc: {
-    title: 'Debt Ceiling',
+    title: 'Debt ceiling',
     description: (
       <Text className="leading-5 text-white/80" variant="small">
         The debt ceiling is the maximum amount of debt or tokens that can be issued within the SKY protocol,

--- a/packages/widgets/src/widgets/L2TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/L2TradeWidget/index.tsx
@@ -869,7 +869,7 @@ function TradeWidgetWrapped({
                 fetchingMessage={t`Fetching transaction details`}
                 transactionData={[
                   {
-                    label: t`Exchange rate`,
+                    label: t`Exchange Rate`,
                     tooltipText: getTooltipById('exchange-rate')?.tooltip || '',
                     value: (() => {
                       if (!originAmount || originAmount === 0n || !targetAmount) return '1:1';

--- a/packages/widgets/src/widgets/SealModuleWidget/components/PositionDetailsAccordion.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/PositionDetailsAccordion.tsx
@@ -75,7 +75,7 @@ export function PositionDetailAccordion({
           {!!collateralData?.stabilityFee && (
             <motion.div className="flex justify-between" variants={positionAnimations}>
               <TextWithTooltip
-                text={getTooltipById('borrow-rate-seal')?.title || 'Borrow rate'}
+                text={getTooltipById('borrow-rate-seal')?.title || 'Borrow Rate'}
                 tooltip={getTooltipById('borrow-rate-seal')?.tooltip || ''}
                 textClassName="leading-4"
                 contentClassname="w-[400px]"

--- a/packages/widgets/src/widgets/SealModuleWidget/components/PositionSummary.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/PositionSummary.tsx
@@ -241,7 +241,7 @@ export const PositionSummary = () => {
         hideIfNoDebt: true
       },
       {
-        label: t`Borrow rate`,
+        label: t`Borrow Rate`,
         value: collateralData?.stabilityFee ? formatPercent(collateralData?.stabilityFee) : undefined,
         hideIfNoDebt: true,
         tooltipText: getTooltipById('borrow-rate-seal')?.tooltip || ''

--- a/packages/widgets/src/widgets/SealModuleWidget/components/Repay.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/Repay.tsx
@@ -193,7 +193,7 @@ const PositionManagerOverviewContainer = ({
   const txData = useMemo(
     () => [
       {
-        label: t`Borrow rate`,
+        label: t`Borrow Rate`,
         value: collateralData?.stabilityFee ? formatPercent(collateralData?.stabilityFee) : '',
         tooltipText: getTooltipById('borrow-rate-seal')?.tooltip || ''
       },

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/Borrow.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/Borrow.tsx
@@ -190,7 +190,7 @@ const PositionManagerOverviewContainer = ({
   const txData = useMemo(
     () => [
       {
-        label: t`Borrow rate`,
+        label: t`Borrow Rate`,
         value: collateralData?.stabilityFee ? formatPercent(collateralData?.stabilityFee) : '',
         tooltipText: getTooltipById('borrow')?.tooltip || ''
       },

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionDetailsAccordion.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionDetailsAccordion.tsx
@@ -74,7 +74,7 @@ export function PositionDetailAccordion({
           {!!collateralData?.stabilityFee && (
             <motion.div className="flex justify-between" variants={positionAnimations}>
               <TextWithTooltip
-                text={getTooltipById('borrow')?.title || 'Borrow rate'}
+                text={getTooltipById('borrow')?.title || 'Borrow Rate'}
                 tooltip={getTooltipById('borrow')?.tooltip || ''}
                 textClassName="leading-4"
                 contentClassname="w-[400px]"

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/PositionSummary.tsx
@@ -294,7 +294,7 @@ export const PositionSummary = ({
         hideIfNoDebt: true
       },
       {
-        label: t`Borrow rate`,
+        label: t`Borrow Rate`,
         value: collateralData?.stabilityFee ? formatPercent(collateralData?.stabilityFee) : undefined,
         hideIfNoDebt: true,
         tooltipText: getTooltipById('borrow')?.tooltip || ''

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/Repay.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/Repay.tsx
@@ -174,7 +174,7 @@ const PositionManagerOverviewContainer = ({
   const txData = useMemo(
     () => [
       {
-        label: t`Borrow rate`,
+        label: t`Borrow Rate`,
         value: collateralData?.stabilityFee ? formatPercent(collateralData?.stabilityFee) : '',
         tooltipText: getTooltipById('borrow')?.tooltip || ''
       },

--- a/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeRevert.tsx
+++ b/packages/widgets/src/widgets/UpgradeWidget/components/UpgradeRevert.tsx
@@ -127,7 +127,7 @@ export function UpgradeRevert({
                 fetchingMessage={t`Fetching transaction details`}
                 transactionData={[
                   {
-                    label: t`Exchange rate`,
+                    label: t`Exchange Rate`,
                     tooltipText: getTooltipById('exchange-rate')?.tooltip || '',
                     value: (() => {
                       // Check if it's MKR to SKY conversion


### PR DESCRIPTION
Update Borrow Rate and Exchange Rate to be capitalized. And lowercase 'ceiling' in popover.
