### PR TITLE
Loosen peerDependencies version ranges and remove some dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,7 +59,6 @@ updates:
           - "lucide-react"
           - "embla-carousel*"
           - "tailwind-merge"
-          - "tailwind-variants"
           - "class-variance-authority"
           - "clsx"
         update-types:

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -54,7 +54,6 @@
     "@wagmi/core": "catalog:",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
-    "copy-to-clipboard": "catalog:",
     "date-fns": "catalog:",
     "embla-carousel-autoplay": "catalog:",
     "embla-carousel-fade": "catalog:",

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -69,7 +69,6 @@
     "react-router-dom": "catalog:",
     "recharts": "catalog:",
     "rehype-sanitize": "catalog:",
-    "tailwind-variants": "catalog:",
     "viem": "catalog:",
     "vite": "catalog:",
     "wagmi": "catalog:"

--- a/apps/webapp/src/components/ui/card.tsx
+++ b/apps/webapp/src/components/ui/card.tsx
@@ -1,56 +1,93 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
-import { tv, type VariantProps } from 'tailwind-variants';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-const card = tv({
-  base: 'rounded-[20px] bg-card p-4 text-text text-base font-normal leading-normal',
-  // Slot styles will apply to every slot before slot variants are applied
-  slots: {
-    header: 'flex justify-between space-y-1.5',
-    title: '',
-    description: '',
-    content: '',
-    footer: ''
-  },
-  // Variants can be different things like "size", "intent", "position", and have sub-categories
+const cardVariants = cva('rounded-[20px] bg-card p-4 text-text text-base font-normal leading-normal', {
   variants: {
-    // This is called "variant" for consistency, it's arbitrary, it could be called "intent".
     variant: {
-      // Each variant can define classes for any slot
-      default: {
-        title: 'text-xl font-custom-450 leading-normal lg:text-2xl lg:leading-8',
-        content: 'p-6 pt-0'
-      },
-      pool: { base: 'leading-tight lg:px-5 lg:py-4' },
-      stats: {
-        base: 'p-5 w-full min-w-[220px]',
-        header: 'p-0',
-        title: 'text-sm font-normal leading-tight text-textSecondary',
-        content: 'pt-0'
-      },
-      statsCompact: { base: 'p-3 lg:pl-4 lg:pb-4 lg:pt-3 lg:pr-3' },
-      stepper: {
-        base: 'w-full rounded-none border text-sm'
-      },
-      spotlight: {
-        base: 'p-10 bg-[linear-gradient(0deg,_#581BE0_0%,_#2A197D_100%)]'
-      }
+      default: '',
+      pool: 'leading-tight lg:px-5 lg:py-4',
+      stats: 'p-5 w-full min-w-[220px]',
+      statsCompact: 'p-3 lg:pl-4 lg:pb-4 lg:pt-3 lg:pr-3',
+      stepper: 'w-full rounded-none border text-sm',
+      spotlight: 'p-10 bg-[linear-gradient(0deg,_#581BE0_0%,_#2A197D_100%)]'
     }
   },
-  // Default variant is applied if no other variant is specified
   defaultVariants: {
     variant: 'default'
+  }
+});
+
+const cardHeaderVariants = cva('flex justify-between space-y-1.5', {
+  variants: {
+    variant: {
+      default: '',
+      pool: '',
+      stats: 'p-0',
+      statsCompact: '',
+      stepper: '',
+      spotlight: ''
+    }
   },
-  // This matches the variant name and applies the styles to the specified slots
-  compoundSlots: [{ variant: 'stats', slots: ['base', 'header', 'title', 'content'], className: '' }]
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+const cardTitleVariants = cva('', {
+  variants: {
+    variant: {
+      default: 'text-xl font-custom-450 leading-normal lg:text-2xl lg:leading-8',
+      pool: '',
+      stats: 'text-sm font-normal leading-tight text-textSecondary',
+      statsCompact: '',
+      stepper: '',
+      spotlight: ''
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+const cardContentVariants = cva('', {
+  variants: {
+    variant: {
+      default: 'p-6 pt-0',
+      pool: '',
+      stats: 'pt-0',
+      statsCompact: '',
+      stepper: '',
+      spotlight: ''
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+const cardFooterVariants = cva('flex items-center p-6 pt-0', {
+  variants: {
+    variant: {
+      default: '',
+      pool: '',
+      stats: '',
+      statsCompact: '',
+      stepper: '',
+      spotlight: ''
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
 });
 
 const Card = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardVariants>
 >(({ className, variant, children, ...props }, ref) => (
-  <div ref={ref} className={cn(card({ variant }).base(), className)} {...props}>
+  <div ref={ref} className={cn(cardVariants({ variant }), className)} {...props}>
     {React.Children.map(children, child => {
       if (React.isValidElement(child)) {
         const childType = child.type as React.ComponentType;
@@ -60,7 +97,7 @@ const Card = React.forwardRef<
           return React.cloneElement(child, {
             ...(child.props || {}),
             variant
-          } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof card>);
+          } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof cardVariants>);
         }
       }
       return child;
@@ -71,10 +108,10 @@ Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardHeaderVariants>
 >(({ variant, className, children, ...props }, ref) => {
   return (
-    <div ref={ref} className={cn(card({ variant }).header(), className)} {...props}>
+    <div ref={ref} className={cn(cardHeaderVariants({ variant }), className)} {...props}>
       {React.Children.map(children, child => {
         if (React.isValidElement(child)) {
           const childType = child.type as React.ComponentType;
@@ -83,7 +120,7 @@ const CardHeader = React.forwardRef<
             return React.cloneElement(child, {
               ...(child.props || {}),
               variant
-            } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof card>);
+            } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof cardTitleVariants>);
           }
           return React.cloneElement(child, { ...(child.props || {}) });
         }
@@ -96,9 +133,9 @@ CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLHeadingElement> & VariantProps<typeof cardTitleVariants>
 >(({ variant, className, ...props }, ref) => (
-  <h3 ref={ref} className={cn(card({ variant }).title(), className)} {...props} />
+  <h3 ref={ref} className={cn(cardTitleVariants({ variant }), className)} {...props} />
 ));
 CardTitle.displayName = 'CardTitle';
 
@@ -112,17 +149,17 @@ CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardContentVariants>
 >(({ variant, className, ...props }, ref) => (
-  <div ref={ref} className={cn(card({ variant }).content(), className)} {...props} />
+  <div ref={ref} className={cn(cardContentVariants({ variant }), className)} {...props} />
 ));
 CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardFooterVariants>
 >(({ variant, className, ...props }, ref) => (
-  <div ref={ref} className={cn(card({ variant }), 'flex items-center p-6 pt-0', className)} {...props} />
+  <div ref={ref} className={cn(cardFooterVariants({ variant }), className)} {...props} />
 ));
 CardFooter.displayName = 'CardFooter';
 

--- a/apps/webapp/src/modules/ui/hooks/useClipboard.tsx
+++ b/apps/webapp/src/modules/ui/hooks/useClipboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import copy from 'copy-to-clipboard';
+import { copyToClipboard } from '@jetstreamgg/sky-utils';
 
 export function useClipboard(text: string) {
   const [hasCopied, setHasCopied] = useState(false);
@@ -10,8 +10,11 @@ export function useClipboard(text: string) {
   const timeout = 1500;
 
   const onCopy = useCallback(() => {
-    const didCopy = copy(textState);
-    setHasCopied(didCopy);
+    copyToClipboard(
+      textState,
+      () => setHasCopied(true),
+      () => setHasCopied(false)
+    );
   }, [textState]);
 
   useEffect(() => {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -29,11 +29,10 @@
   "sideEffects": false,
   "peerDependencies": {
     "@tanstack/react-query": ">=5.0.0",
-    "@wagmi/core": ">=2.0.0",
+    "@wagmi/core": ">=2.12.0",
     "react": ">=18.0.0",
-    "react-dom": ">=18.0.0",
-    "viem": ">=2.0.0",
-    "wagmi": ">=2.0.0"
+    "viem": ">=2.13.0",
+    "wagmi": ">=2.12.0"
   },
   "dependencies": {
     "@jetstreamgg/sky-utils": "workspace:^",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -28,12 +28,12 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "@tanstack/react-query": "^5.85.6",
-    "@wagmi/core": "^2.20.3",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "viem": "^2.36.0",
-    "wagmi": "^2.16.9"
+    "@tanstack/react-query": ">=5.0.0",
+    "@wagmi/core": ">=2.0.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
+    "viem": ">=2.0.0",
+    "wagmi": ">=2.0.0"
   },
   "dependencies": {
     "@jetstreamgg/sky-utils": "workspace:^",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,11 +25,10 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@tanstack/react-query": "^5.85.6",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "viem": "^2.36.0",
-    "wagmi": "^2.16.9"
+    "@tanstack/react-query": ">=5.0.0",
+    "react": ">=18.0.0",
+    "viem": ">=2.0.0",
+    "wagmi": ">=2.0.0"
   },
   "devDependencies": {
     "@lingui/core": "catalog:",

--- a/packages/utils/src/clipboard.ts
+++ b/packages/utils/src/clipboard.ts
@@ -1,0 +1,21 @@
+/**
+ * Copy text to clipboard with callback for success/failure
+ * @param text - The text to copy to clipboard
+ * @param onSuccess - Callback when copy succeeds
+ * @param onError - Callback when copy fails
+ */
+export function copyToClipboard(
+  text: string,
+  onSuccess?: () => void,
+  onError?: (error: Error) => void
+): void {
+  navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      onSuccess?.();
+    })
+    .catch(err => {
+      console.error('Failed to copy text to clipboard', err);
+      onError?.(err);
+    });
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -36,3 +36,4 @@ export * from './collection';
 export * from './getChainIcon';
 export * from './i18n';
 export * from './hooks/useIsTouchDevice';
+export { copyToClipboard } from './clipboard';

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -47,7 +47,6 @@
     "lucide-react": "catalog:",
     "react-jazzicon": "catalog:",
     "tailwind-merge": "catalog:",
-    "tailwind-variants": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -51,19 +51,17 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@lingui/detect-locale": ">=5.0.0",
-    "@lingui/macro": ">=5.0.0",
     "@lingui/react": ">=5.0.0",
     "@tanstack/react-query": ">=5.0.0",
     "framer-motion": ">=11.0.0",
     "react": ">=18.0.0",
-    "react-dom": ">=18.0.0",
     "react-router-dom": ">=6.0.0",
-    "viem": ">=2.0.0",
-    "wagmi": ">=2.0.0"
+    "viem": ">=2.13.0",
+    "wagmi": ">=2.12.0"
   },
   "devDependencies": {
     "@lingui/core": "catalog:",
+    "@lingui/macro": "catalog:",
     "@lingui/swc-plugin": "catalog:",
     "@lingui/vite-plugin": "catalog:",
     "@tailwindcss/vite": "catalog:",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -43,7 +43,6 @@
     "@radix-ui/react-tooltip": "catalog:",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
-    "copy-to-clipboard": "catalog:",
     "lucide-react": "catalog:",
     "react-jazzicon": "catalog:",
     "tailwind-merge": "catalog:",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -51,16 +51,16 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@lingui/detect-locale": "^5.4.1",
-    "@lingui/macro": "^5.4.1",
-    "@lingui/react": "^5.4.1",
-    "@tanstack/react-query": "^5.85.6",
-    "framer-motion": "^11.18.2",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "react-router-dom": "^6.30.1",
-    "viem": "^2.36.0",
-    "wagmi": "^2.16.9"
+    "@lingui/detect-locale": ">=5.0.0",
+    "@lingui/macro": ">=5.0.0",
+    "@lingui/react": ">=5.0.0",
+    "@tanstack/react-query": ">=5.0.0",
+    "framer-motion": ">=11.0.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
+    "react-router-dom": ">=6.0.0",
+    "viem": ">=2.0.0",
+    "wagmi": ">=2.0.0"
   },
   "devDependencies": {
     "@lingui/core": "catalog:",

--- a/packages/widgets/src/components/ui/card.tsx
+++ b/packages/widgets/src/components/ui/card.tsx
@@ -1,83 +1,115 @@
 import * as React from 'react';
 import { cn } from '@widgets/lib/utils';
-import { tv, type VariantProps } from 'tailwind-variants';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { motion } from 'framer-motion';
 
-const card = tv({
-  // Base styles apply to the base component before variant styles are applied
-  base: 'rounded-[20px] bg-card p-4 lg:p-5 text-text text-base font-normal leading-normal data-[status=success]:bg-radial-(--gradient-position)',
-
-  // Slot styles will apply to every slot before slot variants are applied
-  slots: {
-    header: 'flex justify-between space-y-1.5',
-    title: '',
-    description: '',
-    content: '',
-    footer: ''
-  },
-
-  // Variants can be different things like "size", "intent", "position", and have sub-categories
-  variants: {
-    // This is called "variant" for consistency, it's arbitrary, it could be called "intent".
-    variant: {
-      // Each variant can define classes for any slot
-      default: {
-        title: 'text-xl font-semibold leading-normal lg:text-2xl lg:leading-loose',
-        content: 'pt-0'
-      },
-      pool: { base: 'leading-tight lg:px-5 lg:py-4 cursor-pointer' },
-      stats: {
-        base: 'py-3 px-5 lg:px-5 w-full',
-        header: 'p-0',
-        title: 'text-sm font-normal leading-tight text-textSecondary',
-        content: 'pt-0'
-      },
-      statsCompact: { base: 'p-3 lg:pl-4 lg:pb-4 lg:pt-3 lg:pr-3' },
-      statsInteractive: {
-        base: 'hover:bg-radial-(--gradient-position) hover:from-primary-start/100 hover:to-primary-end/100 transition group/interactive-card cursor-pointer px-4 py-3 lg:px-4 lg:py-3 w-full',
-        header: 'p-0',
-        title: 'text-sm font-normal leading-tight text-textSecondary',
-        content: 'pt-0 mt-1'
-      },
-      widget: {
-        base: 'flex flex-col p-0 lg:p-0 rounded-none bg-widget',
-        header: 'space-y-0 px-0 pt-0'
-      },
-      address: {
-        base: 'py-3 px-5'
-      },
-      fade: { base: 'pb-3 lg:pb-3 bg-transparent bg-linear-to-b from-card via-transparent to-transparent' },
-      history: {
-        base: 'hover:bg-radial-(--gradient-position) from-primary-alt-start/2 to-primary-alt-end/2 hover:from-primary-alt-start/20 hover:to-primary-alt-end/20 active:from-primary-alt-start/25 active:to-primary-alt-end/25 transition'
+const cardVariants = cva(
+  'rounded-[20px] bg-card p-4 lg:p-5 text-text text-base font-normal leading-normal data-[status=success]:bg-radial-(--gradient-position)',
+  {
+    variants: {
+      variant: {
+        default: '',
+        pool: 'leading-tight lg:px-5 lg:py-4 cursor-pointer',
+        stats: 'py-3 px-5 lg:px-5 w-full',
+        statsCompact: 'p-3 lg:pl-4 lg:pb-4 lg:pt-3 lg:pr-3',
+        statsInteractive:
+          'hover:bg-radial-(--gradient-position) hover:from-primary-start/100 hover:to-primary-end/100 transition group/interactive-card cursor-pointer px-4 py-3 lg:px-4 lg:py-3 w-full',
+        widget: 'flex flex-col p-0 lg:p-0 rounded-none bg-widget',
+        address: 'py-3 px-5',
+        fade: 'pb-3 lg:pb-3 bg-transparent bg-linear-to-b from-card via-transparent to-transparent',
+        history:
+          'hover:bg-radial-(--gradient-position) from-primary-alt-start/2 to-primary-alt-end/2 hover:from-primary-alt-start/20 hover:to-primary-alt-end/20 active:from-primary-alt-start/25 active:to-primary-alt-end/25 transition'
       }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+const cardHeaderVariants = cva('flex justify-between space-y-1.5', {
+  variants: {
+    variant: {
+      default: '',
+      pool: '',
+      stats: 'p-0',
+      statsCompact: '',
+      statsInteractive: 'p-0',
+      widget: 'space-y-0 px-0 pt-0',
+      address: '',
+      fade: '',
+      history: ''
     }
   },
-
-  // Default variant is applied if no other variant is specified
   defaultVariants: {
     variant: 'default'
-  },
-
-  // This matches the variant name and applies the styles to the specified slots
-  compoundSlots: [
-    {
-      variant: 'widget',
-      slots: ['base', 'header'],
-      className: ''
-    },
-    {
-      variant: 'stats',
-      slots: ['base', 'header', 'title', 'content'],
-      className: ''
-    }
-  ]
+  }
 });
+
+const cardTitleVariants = cva('', {
+  variants: {
+    variant: {
+      default: 'text-xl font-semibold leading-normal lg:text-2xl lg:leading-loose',
+      pool: '',
+      stats: 'text-sm font-normal leading-tight text-textSecondary',
+      statsCompact: '',
+      statsInteractive: 'text-sm font-normal leading-tight text-textSecondary',
+      widget: '',
+      address: '',
+      fade: '',
+      history: ''
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+const cardContentVariants = cva('', {
+  variants: {
+    variant: {
+      default: 'pt-0',
+      pool: '',
+      stats: 'pt-0',
+      statsCompact: '',
+      statsInteractive: 'pt-0 mt-1',
+      widget: '',
+      address: '',
+      fade: '',
+      history: ''
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+const cardFooterVariants = cva('flex items-center pt-0', {
+  variants: {
+    variant: {
+      default: '',
+      pool: '',
+      stats: '',
+      statsCompact: '',
+      statsInteractive: '',
+      widget: '',
+      address: '',
+      fade: '',
+      history: ''
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+export type CardVariant = VariantProps<typeof cardVariants>['variant'];
 
 const Card = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardVariants>
 >(({ className, variant, children, ...props }, ref) => (
-  <div ref={ref} className={cn(card({ variant }).base(), className)} {...props}>
+  <div ref={ref} className={cn(cardVariants({ variant }), className)} {...props}>
     {React.Children.map(children, child => {
       if (React.isValidElement(child)) {
         const childType = child.type as React.ComponentType;
@@ -88,7 +120,7 @@ const Card = React.forwardRef<
           return React.cloneElement(child, {
             ...(child.props || {}),
             variant
-          } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof card>);
+          } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof cardVariants>);
         }
       }
       return child;
@@ -99,10 +131,10 @@ Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardHeaderVariants>
 >(({ variant, className, children, ...props }, ref) => {
   return (
-    <div ref={ref} className={cn(card({ variant }).header(), className)} {...props}>
+    <div ref={ref} className={cn(cardHeaderVariants({ variant }), className)} {...props}>
       {React.Children.map(children, child => {
         if (React.isValidElement(child)) {
           const childType = child.type as React.ComponentType;
@@ -111,7 +143,7 @@ const CardHeader = React.forwardRef<
             return React.cloneElement(child, {
               ...(child.props || {}),
               variant
-            } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof card>);
+            } as React.HTMLAttributes<HTMLElement> & VariantProps<typeof cardTitleVariants>);
           }
           return React.cloneElement(child, { ...(child.props || {}) });
         }
@@ -124,25 +156,25 @@ CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<
   HTMLHeadingElement,
-  React.HTMLAttributes<HTMLHeadingElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLHeadingElement> & VariantProps<typeof cardTitleVariants>
 >(({ variant, className, ...props }, ref) => (
-  <h3 ref={ref} className={cn(card({ variant }).title(), className)} {...props} />
+  <h3 ref={ref} className={cn(cardTitleVariants({ variant }), className)} {...props} />
 ));
 CardTitle.displayName = 'CardTitle';
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardContentVariants>
 >(({ variant, className, ...props }, ref) => (
-  <div ref={ref} className={cn(card({ variant }).content(), className)} {...props} />
+  <div ref={ref} className={cn(cardContentVariants({ variant }), className)} {...props} />
 ));
 CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof card>
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardFooterVariants>
 >(({ variant, className, ...props }, ref) => (
-  <div ref={ref} className={cn(card({ variant }).footer(), 'flex items-center pt-0', className)} {...props} />
+  <div ref={ref} className={cn(cardFooterVariants({ variant }), className)} {...props} />
 ));
 CardFooter.displayName = 'CardFooter';
 

--- a/packages/widgets/src/shared/hooks/useClipboard.tsx
+++ b/packages/widgets/src/shared/hooks/useClipboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import copy from 'copy-to-clipboard';
+import { copyToClipboard } from '@jetstreamgg/sky-utils';
 
 export function useClipboard(text: string) {
   const [hasCopied, setHasCopied] = useState(false);
@@ -10,8 +10,11 @@ export function useClipboard(text: string) {
   const timeout = 1500;
 
   const onCopy = useCallback(() => {
-    const didCopy = copy(textState);
-    setHasCopied(didCopy);
+    copyToClipboard(
+      textState,
+      () => setHasCopied(true),
+      () => setHasCopied(false)
+    );
   }, [textState]);
 
   useEffect(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ catalogs:
     clsx:
       specifier: ^2.1.0
       version: 2.1.1
-    copy-to-clipboard:
-      specifier: ^3.3.3
-      version: 3.3.3
     date-fns:
       specifier: ^3.6.0
       version: 3.6.0
@@ -234,9 +231,6 @@ catalogs:
     tailwind-merge:
       specifier: ^2.6.0
       version: 2.6.0
-    tailwind-variants:
-      specifier: ^0.3.1
-      version: 0.3.1
     tailwindcss:
       specifier: ^4.1.12
       version: 4.1.12
@@ -438,9 +432,6 @@ importers:
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
-      copy-to-clipboard:
-        specifier: 'catalog:'
-        version: 3.3.3
       date-fns:
         specifier: 'catalog:'
         version: 3.6.0
@@ -483,9 +474,6 @@ importers:
       rehype-sanitize:
         specifier: 'catalog:'
         version: 6.0.0
-      tailwind-variants:
-        specifier: 'catalog:'
-        version: 0.3.1(tailwindcss@4.1.12)
       viem:
         specifier: 'catalog:'
         version: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -548,7 +536,7 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@wagmi/core':
-        specifier: ^2.20.3
+        specifier: '>=2.12.0'
         version: 2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       graphql:
         specifier: 'catalog:'
@@ -557,7 +545,7 @@ importers:
         specifier: 'catalog:'
         version: 7.2.0(graphql@16.11.0)
       react:
-        specifier: ^19.1.1
+        specifier: '>=18.0.0'
         version: 19.1.1
     devDependencies:
       '@tanstack/react-query':
@@ -615,11 +603,8 @@ importers:
         specifier: 'catalog:'
         version: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       react:
-        specifier: ^19.1.1
+        specifier: '>=18.0.0'
         version: 19.1.1
-      react-dom:
-        specifier: ^19.1.1
-        version: 19.1.1(react@19.1.1)
       tiny-invariant:
         specifier: 'catalog:'
         version: 1.3.3
@@ -660,14 +645,8 @@ importers:
       '@jetstreamgg/sky-utils':
         specifier: workspace:^
         version: link:../utils
-      '@lingui/detect-locale':
-        specifier: ^5.4.1
-        version: 5.4.1
-      '@lingui/macro':
-        specifier: ^5.4.1
-        version: 5.4.1(@lingui/babel-plugin-lingui-macro@5.4.1(babel-plugin-macros@3.1.0)(typescript@5.9.2))(babel-plugin-macros@3.1.0)(react@19.1.1)
       '@lingui/react':
-        specifier: ^5.4.1
+        specifier: '>=5.0.0'
         version: 5.4.1(@lingui/babel-plugin-lingui-macro@5.4.1(babel-plugin-macros@3.1.0)(typescript@5.9.2))(babel-plugin-macros@3.1.0)(react@19.1.1)
       '@radix-ui/react-accordion':
         specifier: 'catalog:'
@@ -711,11 +690,8 @@ importers:
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
-      copy-to-clipboard:
-        specifier: 'catalog:'
-        version: 3.3.3
       framer-motion:
-        specifier: ^11.18.2
+        specifier: '>=11.0.0'
         version: 11.18.2(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       lucide-react:
         specifier: 'catalog:'
@@ -724,14 +700,11 @@ importers:
         specifier: 'catalog:'
         version: 1.0.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-router-dom:
-        specifier: ^6.30.1
+        specifier: '>=6.0.0'
         version: 6.30.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       tailwind-merge:
         specifier: 'catalog:'
         version: 2.6.0
-      tailwind-variants:
-        specifier: 'catalog:'
-        version: 0.3.1(tailwindcss@4.1.12)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -739,6 +712,9 @@ importers:
       '@lingui/core':
         specifier: 'catalog:'
         version: 5.4.1(@lingui/babel-plugin-lingui-macro@5.4.1(babel-plugin-macros@3.1.0)(typescript@5.9.2))(babel-plugin-macros@3.1.0)
+      '@lingui/macro':
+        specifier: 'catalog:'
+        version: 5.4.1(@lingui/babel-plugin-lingui-macro@5.4.1(babel-plugin-macros@3.1.0)(typescript@5.9.2))(babel-plugin-macros@3.1.0)(react@19.1.1)
       '@lingui/swc-plugin':
         specifier: 'catalog:'
         version: 5.6.1(@lingui/core@5.4.1(@lingui/babel-plugin-lingui-macro@5.4.1(babel-plugin-macros@3.1.0)(typescript@5.9.2))(babel-plugin-macros@3.1.0))
@@ -3478,9 +3454,6 @@ packages:
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
-  copy-to-clipboard@3.3.3:
-    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
-
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -6090,17 +6063,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwind-merge@2.5.4:
-    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
-
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
-
-  tailwind-variants@0.3.1:
-    resolution: {integrity: sha512-krn67M3FpPwElg4FsZrOQd0U26o7UDH/QOkK8RNaiCCrr052f6YJPBUfNKnPo/s/xRzNPtv1Mldlxsg8Tb46BQ==}
-    engines: {node: '>=16.x', pnpm: '>=7.x'}
-    peerDependencies:
-      tailwindcss: '*'
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -6170,9 +6134,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toggle-selection@1.0.6:
-    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -10489,10 +10450,6 @@ snapshots:
 
   cookie-es@1.2.2: {}
 
-  copy-to-clipboard@3.3.3:
-    dependencies:
-      toggle-selection: 1.0.6
-
   core-util-is@1.0.3: {}
 
   cosmiconfig@7.1.0:
@@ -13507,14 +13464,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwind-merge@2.5.4: {}
-
   tailwind-merge@2.6.0: {}
-
-  tailwind-variants@0.3.1(tailwindcss@4.1.12):
-    dependencies:
-      tailwind-merge: 2.5.4
-      tailwindcss: 4.1.12
 
   tailwindcss-animate@1.0.7(tailwindcss@4.1.12):
     dependencies:
@@ -13583,8 +13533,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toggle-selection@1.0.6: {}
 
   tr46@0.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,7 +81,6 @@ catalog:
   rehype-sanitize: ^6.0.0
   rollup-plugin-visualizer: ^5.14.0
   tailwind-merge: ^2.6.0
-  tailwind-variants: ^0.3.1
   tailwindcss: ^4.1.12
   tailwindcss-animate: ^1.0.7
   tiny-invariant: ^1.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,6 @@ catalog:
   '@wagmi/core': ^2.20.3
   class-variance-authority: ^0.7.1
   clsx: ^2.1.0
-  copy-to-clipboard: ^3.3.3
   date-fns: ^3.6.0
   dotenv: ^16.6.1
   embla-carousel-autoplay: ^8.6.0


### PR DESCRIPTION
### What does this PR do?
This PR loosens the peer dependency version ranges in the hooks, utils, and widgets packages to allow their minimum compatible versions to be used. This brings the benefits that:
A. Dependabot won't run into issues when missing updating the deps in the peer dependencies, and
B. Potential users of the packages don't need to use each specific package's versions that we use in the monorepo

Some other minor changes include:
- Replace the use of `tailwind-variants` for `class-variance-authority` (CVA) in the `Card` component in both `webapp` and `widgets`. This allows for the removal of the `tailwind-variants` dependency.
- Remove the `copy-to-clipboard` package and replace it with a new internal utility in `@jetstreamgg/sky-utils` that uses the native `navigator.clipboard` API.

### Testing steps:
1. Run `pnpm install` and ensure the application builds and runs without errors.
2. Visually inspect all instances of the `Card` component throughout the application to confirm there are no visual regressions.
3. Find a "copy" button (e.g., for a wallet address) and click it.
4. Verify that the text is successfully copied to your clipboard by pasting it elsewhere.