### PR TITLE
fix cursor for popover rate info

### DIFF
--- a/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
+++ b/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
@@ -254,7 +254,7 @@ export const PopoverRateInfo = ({
   return (
     <Popover>
       <PopoverTrigger asChild onClick={e => e.stopPropagation()} className="z-10">
-        <span className="inline-flex items-center">
+        <span className="inline-flex cursor-pointer items-center">
           <Info className={iconClassName} width={width} height={height} />
         </span>
       </PopoverTrigger>


### PR DESCRIPTION
After fixing the nested button hydration error by using asChild on PopoverTrigger (#786), the popover icon no longer shows a pointer cursor on hover. This is because:

1. PopoverTrigger normally renders a `<button>` element which has default `cursor: pointer` styling
2. When using `asChild`, it doesn't render its own button but merges props with the child element
3. The `<span>` element we're using doesn't have a default pointer cursor

**Solution**

Add the `cursor-pointer` class to the span element that wraps the Info icon. This will restore the hover cursor behavior while maintaining the fix for the nested button issue.