### PR TITLE
Align widgets vertically with navbar and details pane

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -129,10 +129,10 @@ export function WidgetNavigation({
   const laExtraHeight = isMobile ? 61 : 100; // LA Wrapper and action button height
   const baseTabContentClasses = 'lg:h-full md:flex-1';
   const tabContentClasses = isRewardsOverview
-    ? `${baseTabContentClasses} pl-6 pt-2 pr-0 pb-0 md:p-3 md:pb-3 md:pr-0 md:pt-2 xl:p-4 xl:pb-4 xl:pr-0`
+    ? `${baseTabContentClasses} pl-6 pt-2 pr-0 pb-0 md:p-3 md:pb-3 md:pr-0 md:pt-2 lg:py-0 xl:p-4 xl:py-0 xl:pr-0`
     : intent === Intent.BALANCES_INTENT
-      ? `${baseTabContentClasses} pl-6 pt-2 pb-4 pr-0 md:p-3 md:pb-0 md:pr-0 md:pt-2 xl:p-4 xl:pb-0 xl:pr-0`
-      : `${baseTabContentClasses} pl-6 pt-2 pb-4 pr-0 md:pb-0 md:p-3 md:pr-0 md:pt-2 xl:p-4 xl:pr-0`;
+      ? `${baseTabContentClasses} pl-6 pt-2 pb-4 pr-0 md:p-3 md:pb-0 md:pr-0 md:pt-2 lg:py-0 xl:p-4 xl:py-0 xl:pr-0`
+      : `${baseTabContentClasses} pl-6 pt-2 pb-4 pr-0 md:pb-0 md:p-3 md:pr-0 md:pt-2 lg:py-0 xl:p-4 xl:py-0 xl:pr-0`;
   // If it's mobile, use the widget navigation row height + the height of the webiste header
   // as we're using 100vh for the content style, if not, just use the height of the navigation row
   // If the tab list is hidden, don't count it's height


### PR DESCRIPTION
### What does this PR do?
Removes padding top and bottom from widgets, so they're vertically aligned with the navbar, details pane and chat pane in desktop breakpoints

<img width="1597" height="800" alt="image" src="https://github.com/user-attachments/assets/efe72335-c211-4b8a-88f3-8b6e905d9b6e" />

<img width="1610" height="1111" alt="image" src="https://github.com/user-attachments/assets/0c389db7-3e6a-4d72-b74f-38bbaced9c72" />
