### PR TITLE
Multichain UX - Return to origin

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetMenuItemTooltip.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetMenuItemTooltip.tsx
@@ -15,7 +15,6 @@ interface WidgetMenuItemTooltipProps {
   description?: string;
   widgetIntent: Intent;
   currentChainId?: number;
-  currentIntent?: Intent;
   label: string;
   isMobile: boolean;
   disabled?: boolean;
@@ -31,7 +30,6 @@ export function WidgetMenuItemTooltip({
   description,
   widgetIntent,
   currentChainId,
-  currentIntent,
   label,
   isMobile,
   disabled = false,

--- a/apps/webapp/src/modules/app/components/WidgetMenuItemTooltip.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetMenuItemTooltip.tsx
@@ -39,19 +39,11 @@ export function WidgetMenuItemTooltip({
 }: WidgetMenuItemTooltipProps) {
   const chains = useChains();
   const [, setSearchParams] = useSearchParams();
-  const { setIsSwitchingNetwork, saveWidgetNetwork } = useNetworkSwitch();
+  const { setIsSwitchingNetwork } = useNetworkSwitch();
 
   const handleNetworkSwitch = (chainId: number) => {
-    // Save current network if switching from multichain widget
-    if (
-      currentIntent &&
-      currentChainId &&
-      isMultichain(currentIntent) &&
-      currentIntent !== Intent.BALANCES_INTENT
-    ) {
-      saveWidgetNetwork(currentIntent, currentChainId);
-    }
-
+    // Rule 1: Manual network changes always win
+    // Return-to-Origin pattern will handle auto-switching as needed
     // Navigate to widget on selected network
     const chain = chains.find(c => c.id === chainId);
     if (chain) {

--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -51,7 +51,7 @@ export function WidgetNavigation({
   } = useConfigContext();
   const isRewardsOverview = !selectedRewardContract && intent === Intent.REWARDS_INTENT;
 
-  const { setIsSwitchingNetwork, saveWidgetNetwork } = useNetworkSwitch();
+  const { setIsSwitchingNetwork } = useNetworkSwitch();
   const chains = useChains();
   const { showNetworkToast } = useEnhancedNetworkToast();
   const [previousChainId, setPreviousChainId] = useState<number | undefined>(currentChainId);
@@ -85,10 +85,8 @@ export function WidgetNavigation({
           previousIntent: previousIntent,
           isAutoSwitch: isAutoSwitching,
           onNetworkSwitch: chainId => {
-            // Save the manually selected network for the current widget
-            if (intent && isMultichain(intent) && intent !== Intent.BALANCES_INTENT) {
-              saveWidgetNetwork(intent, chainId);
-            }
+            // Rule 1: Manual network changes always win
+            // No need to track per-widget - Return-to-Origin pattern handles this
           }
         });
       }
@@ -100,7 +98,6 @@ export function WidgetNavigation({
     intent,
     previousIntent,
     showNetworkToast,
-    saveWidgetNetwork,
     setIsSwitchingNetwork,
     isAutoSwitching
   ]);

--- a/apps/webapp/src/modules/app/hooks/useEnhancedNetworkToast.tsx
+++ b/apps/webapp/src/modules/app/hooks/useEnhancedNetworkToast.tsx
@@ -172,8 +172,17 @@ export function useEnhancedNetworkToast() {
           title = previousChain ? 'The network has changed' : `Switched to ${currentChain.name}`;
         }
       } else {
-        // Manual network switch
-        title = previousChain ? 'The network has changed' : `Switched to ${currentChain.name}`;
+        // Check if user manually switched from a mainnet-only widget to L2 and was redirected to Balances
+        if (
+          previousIntent &&
+          requiresMainnet(previousIntent) &&
+          currentIntent === Intent.BALANCES_INTENT &&
+          isL2ChainId(currentChain.id)
+        ) {
+          title = 'We\'ve redirected you to Balances. The previous module is only available on mainnet.';
+        } else {
+          title = previousChain ? 'The network has changed' : `Switched to ${currentChain.name}`;
+        }
       }
 
       const toastContent = (

--- a/apps/webapp/src/modules/app/hooks/useEnhancedNetworkToast.tsx
+++ b/apps/webapp/src/modules/app/hooks/useEnhancedNetworkToast.tsx
@@ -152,7 +152,7 @@ export function useEnhancedNetworkToast() {
           const widgetName = getWidgetName(currentIntent);
           title = `To access ${widgetName}, you need to be on mainnet. We've switched your network automatically.`;
         }
-        // Check if switching BACK to L2 for a multichain widget that was previously used on L2
+        // Check if switching BACK to L2 from a mainnet-only widget (Return-to-Origin)
         else if (
           previousIntent &&
           requiresMainnet(previousIntent) &&
@@ -161,13 +161,11 @@ export function useEnhancedNetworkToast() {
           isL2ChainId(currentChain.id) &&
           currentIntent !== previousIntent
         ) {
-          const widgetName = getWidgetName(currentIntent);
-          title = `We've switched you back to ${currentChain.name}, the last network you used for ${widgetName}.`;
+          title = `We've returned you to ${currentChain.name}, your last network before mainnet.`;
         }
-        // Generic auto-switch for returning to a saved network preference
+        // Generic auto-switch message for other cases
         else if (currentIntent && isMultichain(currentIntent) && previousChain) {
-          const widgetName = getWidgetName(currentIntent);
-          title = `We've switched you to ${currentChain.name}, the last network you used for ${widgetName}.`;
+          title = `We've switched you to ${currentChain.name}.`;
         }
         // Default auto-switch message
         else {

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -11,12 +11,10 @@ import { useState } from 'react';
 import { Intent } from '@/lib/enums';
 import { useChainModalContext } from '@/modules/ui/context/ChainModalContext';
 import { useSearchParams } from 'react-router-dom';
-import { mapIntentToQueryParam, mapQueryParamToIntent, QueryParams } from '@/lib/constants';
+import { mapIntentToQueryParam, QueryParams } from '@/lib/constants';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
 import { useIsSafeWallet } from '@jetstreamgg/sky-utils';
 import { Trans } from '@lingui/react/macro';
-import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
-import { isMultichain } from '@/lib/widget-network-map';
 
 enum ChainModalVariant {
   default = 'default',
@@ -66,8 +64,6 @@ export function ChainModal({
     isPending: isSwitchChainPending,
     variables: switchChainVariables
   } = useChainModalContext();
-  const { saveWidgetNetwork } = useNetworkSwitch();
-  const currentIntent = mapQueryParamToIntent(searchParams.get(QueryParams.Widget));
 
   return (
     <Dialog open={open} onOpenChange={disabled ? undefined : setOpen}>
@@ -122,14 +118,9 @@ export function ChainModal({
                   handleSwitchChain({
                     chainId: chain.id,
                     onSuccess: (_, { chainId: newChainId }) => {
-                      // Track the manual network change for multichain widgets (except Balances)
-                      if (
-                        currentIntent &&
-                        isMultichain(currentIntent) &&
-                        currentIntent !== Intent.BALANCES_INTENT
-                      ) {
-                        saveWidgetNetwork(currentIntent, newChainId);
-                      }
+                      // Rule 1: Manual network changes always win
+                      // Don't clear origin on manual switch - user's choice takes precedence
+                      // Origin will only be cleared when it's used for auto-return
 
                       const newChainName = chains.find(c => c.id === newChainId)?.name;
                       if (newChainName) {

--- a/apps/webapp/src/modules/ui/context/NetworkSwitchContext.tsx
+++ b/apps/webapp/src/modules/ui/context/NetworkSwitchContext.tsx
@@ -1,47 +1,21 @@
 import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
-import { Intent } from '@/lib/enums';
-
-type WidgetNetworkState = {
-  [Intent.TRADE_INTENT]?: number;
-  [Intent.SAVINGS_INTENT]?: number;
-  // Balances widget is excluded from tracking
-};
 
 interface NetworkSwitchContextValue {
   isSwitchingNetwork: boolean;
   setIsSwitchingNetwork: (isSwitching: boolean) => void;
-  widgetNetworks: WidgetNetworkState;
-  saveWidgetNetwork: (intent: Intent, chainId: number) => void;
-  getWidgetNetwork: (intent: Intent) => number | undefined;
-  clearWidgetNetwork: (intent: Intent) => void;
+  originNetwork: number | undefined;
+  setOriginNetwork: (chainId: number | undefined) => void;
+  clearOriginNetwork: () => void;
 }
 
 const NetworkSwitchContext = createContext<NetworkSwitchContextValue | undefined>(undefined);
 
 export function NetworkSwitchProvider({ children }: { children: ReactNode }) {
   const [isSwitchingNetwork, setIsSwitchingNetwork] = useState(false);
-  const [widgetNetworks, setWidgetNetworks] = useState<WidgetNetworkState>({});
+  const [originNetwork, setOriginNetwork] = useState<number | undefined>(undefined);
 
-  const saveWidgetNetwork = useCallback((intent: Intent, chainId: number) => {
-    setWidgetNetworks(prev => ({
-      ...prev,
-      [intent]: chainId
-    }));
-  }, []);
-
-  const getWidgetNetwork = useCallback(
-    (intent: Intent): number | undefined => {
-      return widgetNetworks[intent as keyof WidgetNetworkState];
-    },
-    [widgetNetworks]
-  );
-
-  const clearWidgetNetwork = useCallback((intent: Intent) => {
-    setWidgetNetworks(prev => {
-      const next = { ...prev };
-      delete next[intent as keyof WidgetNetworkState];
-      return next;
-    });
+  const clearOriginNetwork = useCallback(() => {
+    setOriginNetwork(undefined);
   }, []);
 
   return (
@@ -49,10 +23,9 @@ export function NetworkSwitchProvider({ children }: { children: ReactNode }) {
       value={{
         isSwitchingNetwork,
         setIsSwitchingNetwork,
-        widgetNetworks,
-        saveWidgetNetwork,
-        getWidgetNetwork,
-        clearWidgetNetwork
+        originNetwork,
+        setOriginNetwork,
+        clearOriginNetwork
       }}
     >
       {children}


### PR DESCRIPTION
### What does this PR do?

Updates multichain UX switch logic:

1. **Manual network changes always win**
    
    - If the user explicitly selects a network (via app selector or wallet), switch to that network and keep using it.
        
2. **Entering a mainnet-only widget**
    
    - If the current network is **not** Mainnet, save the **origin** as the current network, then force switch to Mainnet.
        
    - If already on Mainnet, do nothing (do not set or change origin).
        
3. **Navigating from mainnet-only to a multichain widget**
    
    - If an **origin** exists, switch to the origin network **once**, then **clear the origin**.
        
    - If no origin exists, stay on the current network (Mainnet).
        
4. **Navigating between multichain widgets**
    
    - Do not change networks automatically. Continue using the current network.
        
5. **Re-entering mainnet-only while on Mainnet**
    
    - No change to network or origin.
        
6. **Repeated mainnet-only visits without leaving mainnet-only**
    
    - No change to network or origin. The origin remains whatever it last was until you eventually leave mainnet-only for a multichain widget.
        
7. **Manual network changes while in mainnet-only**
    
    - If the user manually switches networks while in a mainnet-only widget, and the widget truly requires Mainnet, the app redirects to the Balances widget.
        
8. **Clearing the origin**
    
    - The origin must be cleared **immediately after** it is used to return from Mainnet to a multichain widget, so it does not affect subsequent navigations.