### PR TITLE
Set step to 2 on flows that don't require allowance

### DIFF
--- a/packages/widgets/src/widgets/RewardsWidget/components/RewardsTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/components/RewardsTransactionStatus.tsx
@@ -104,6 +104,7 @@ export const RewardsTransactionStatus = ({
       if (selectedRewardContract) {
         setTxDescription(i18n._(rewardsClaimTxDescription({ txStatus, selectedRewardContract })));
       }
+      setStep(2);
     } else if (flow === RewardsFlow.SUPPLY) {
       setStepTwoTitle(t`Supply`);
 

--- a/packages/widgets/src/widgets/SavingsWidget/components/SavingsTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SavingsTransactionStatus.tsx
@@ -150,11 +150,7 @@ export const SavingsTransactionStatus = ({
           )
         );
 
-        if (isBatchTransaction) setStep(2);
-        else if (flowTxStatus !== TxStatus.SUCCESS) {
-          if (needsAllowance) setStep(1);
-          else setStep(2);
-        }
+        setStep(2);
       }
     }
   }, [txStatus, flow, action, screen, i18n.locale, needsAllowance]);

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/StakeModuleTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/StakeModuleTransactionStatus.tsx
@@ -257,6 +257,7 @@ export const StakeModuleTransactionStatus = ({
       setLoadingText(i18n._(claimLoadingButtonText({ txStatus })));
       setTxTitle(i18n._(claimTitle[txStatus]));
       setTxSubtitle(i18n._(claimSubtitle[txStatus]));
+      setStep(2);
     }
   }, [txStatus, screen, flow, action, i18n.locale, needsAllowance]);
 


### PR DESCRIPTION
### What does this PR do?
It fixes an issue where some flows that don't require allowance would not render the correct color and icon to the card on a successful transaction, given that it was detecting an incorrect intermediate step.
Fixes this issue https://app.shortcut.com/dux-makerdao/story/3800/fix-success-icon-in-rewards-flow

### Testing steps:
- Attempt to perform a rewards claim, savings withdrawal, or staking engine claim.
- Upon a successful transaction, the card should be colored purple, and the check icon should be used