### PR TITLE
Replace multicall for individual calls in stake batch transactions

### DIFF
--- a/packages/hooks/src/stake/useBatchStakeMulticall.ts
+++ b/packages/hooks/src/stake/useBatchStakeMulticall.ts
@@ -47,6 +47,7 @@ export function useBatchStakeMulticall({
       args: [stakeModuleAddress[chainId as keyof typeof stakeModuleAddress], usdsAmount]
     });
 
+    // Individual transaction using `multicall`
     const multicallCall = getWriteContractCall({
       to: stakeModuleAddress[chainId as keyof typeof stakeModuleAddress],
       abi: stakeModuleAbi,
@@ -54,9 +55,19 @@ export function useBatchStakeMulticall({
       args: [calldata]
     });
 
+    // Individual array of transactions, intended to be used in a batch transaction
+    const individualCalls: Call[] = calldata.map(data => ({
+      to: stakeModuleAddress[chainId as keyof typeof stakeModuleAddress],
+      data
+    }));
+
     if (!hasSkyAllowance) calls.push(approveSkyCall);
     if (!hasUsdsAllowance) calls.push(approveUsdsCall);
-    calls.push(multicallCall);
+    // If the user wallet supports it and user has batch tx enabled, send the calls individually
+    // in a batch tx for optimized gas consumption and improved transaction readability
+    if (shouldUseBatch) {
+      calls.push(...individualCalls);
+    } else calls.push(multicallCall);
   }
 
   const enabled =

--- a/packages/widgets/src/widgets/StakeModuleWidget/index.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/index.tsx
@@ -177,7 +177,7 @@ function StakeModuleWidgetWrapped({
     indexToClaim,
     setIndexToClaim,
     rewardContractToClaim,
-    shouldUseBatch,
+    shouldUseBatch: !!batchEnabled && !!batchSupported && (needsAllowance || calldata.length > 1),
     setRewardContractToClaim,
     mutateStakeSkyAllowance,
     mutateStakeUsdsAllowance,


### PR DESCRIPTION
### What does this PR do?

This PR refactors the batch staking logic to use the wallet's native batch transaction capabilities instead of the contract's `multicall` function when available.

If a user has batch transactions enabled and their wallet supports it, the hook now constructs an array of individual transactions (e.g., `approve` + `open` + `lock` + `selectReward` + `selectVoteDelegate`). This results in better gas optimization and improved transaction readability in the wallet's confirmation UI.

The `multicall` function is kept as a fallback for wallets without batch support or when the feature is disabled. This new batching logic is only triggered when there's a benefit, such as when a token approval is required or when the list of calls is greater than 1 (e.g. opening a new position requires multiple functions to be called).

### Testing steps:

1.  Navigate to the staking page.
2.  Go through the open new position flow and get to the review step.
3.  Enable batch transactions.
4.  **Verify:** The wallet confirmation prompt should show a list of individual transactions (e.g., `Approve SKY`, `Open`, `Lock`, etc) instead of a single `multicall` transaction.
5.  Go back to the review step and disable batch transactions (or perform another flow in Tenderly that doesn't support batch txs.
6.  After approving, MM should prompt a `multicall` transaction