### PR TITLE
stUSDS QA fixes

### DIFF
--- a/apps/webapp/src/modules/expert/components/ExpertWidgetPane.tsx
+++ b/apps/webapp/src/modules/expert/components/ExpertWidgetPane.tsx
@@ -31,14 +31,14 @@ export function ExpertWidgetPane(sharedProps: SharedProps) {
         ) : (
           <WidgetContainer
             header={
-              <div className="space-y-1">
-                <Heading variant="x-large">
-                  <Trans>Expert</Trans>
-                </Heading>
-                <Text className="text-textSecondary" variant="small">
-                  <Trans>Higher-risk options for more experienced users</Trans>
-                </Text>
-              </div>
+              <Heading variant="x-large">
+                <Trans>Expert</Trans>
+              </Heading>
+            }
+            subHeader={
+              <Text className="text-textSecondary" variant="small">
+                <Trans>Higher-risk options for more experienced users</Trans>
+              </Text>
             }
             rightHeader={sharedProps.rightHeaderComponent}
           >

--- a/apps/webapp/src/modules/ui/components/LinkedActionCard.tsx
+++ b/apps/webapp/src/modules/ui/components/LinkedActionCard.tsx
@@ -93,8 +93,11 @@ export const LinkedActionCard = ({
           ) : (
             <SavingsRate />
           )}
-          <Link to={urlWithRetainedParams} onClick={handleClick}>
-            <Button variant="light" className="w-fit px-5">
+          <Link to={urlWithRetainedParams} onClick={handleClick} className="w-fit">
+            <Button
+              variant="light"
+              className="h-auto min-h-10 w-fit max-w-full whitespace-normal text-balance px-5"
+            >
               {buttonText}
             </Button>
           </Link>

--- a/apps/webapp/src/modules/ui/components/LinkedActionCard.tsx
+++ b/apps/webapp/src/modules/ui/components/LinkedActionCard.tsx
@@ -75,8 +75,8 @@ export const LinkedActionCard = ({
   return (
     <Card variant="spotlight" className="relative w-full overflow-hidden xl:flex-1">
       {<Logo logoName={(isLastStep ? intent : la) as LogoName} />}
-      <CardContent className="relative z-10">
-        <VStack className="space-between gap-4">
+      <CardContent className="relative z-10 h-full">
+        <VStack className="h-full justify-between gap-4">
           <Heading>
             <Trans>
               {intent && primaryToken && `${capitalizeFirstLetter(i18n._(intentTxt[intent]))} your `}
@@ -86,21 +86,23 @@ export const LinkedActionCard = ({
               {secondaryTagline[la]}
             </Trans>
           </Heading>
-          {la === IntentMapping.REWARDS_INTENT ? (
-            <RewardsRate token={secondaryToken} currentRewardContract={selectedRewardContract} />
-          ) : la === IntentMapping.EXPERT_INTENT ? (
-            <AdvancedRate expertModule={expertModule || undefined} />
-          ) : (
-            <SavingsRate />
-          )}
-          <Link to={urlWithRetainedParams} onClick={handleClick} className="w-fit">
-            <Button
-              variant="light"
-              className="h-auto min-h-10 w-fit max-w-full whitespace-normal text-balance px-5"
-            >
-              {buttonText}
-            </Button>
-          </Link>
+          <VStack className="space-between gap-4">
+            {la === IntentMapping.REWARDS_INTENT ? (
+              <RewardsRate token={secondaryToken} currentRewardContract={selectedRewardContract} />
+            ) : la === IntentMapping.EXPERT_INTENT ? (
+              <AdvancedRate expertModule={expertModule || undefined} />
+            ) : (
+              <SavingsRate />
+            )}
+            <Link to={urlWithRetainedParams} onClick={handleClick} className="w-fit">
+              <Button
+                variant="light"
+                className="h-auto min-h-10 w-fit max-w-full whitespace-normal text-balance px-5"
+              >
+                {buttonText}
+              </Button>
+            </Link>
+          </VStack>
         </VStack>
       </CardContent>
     </Card>

--- a/packages/widgets/src/widgets/StUSDSWidget/index.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/index.tsx
@@ -383,15 +383,15 @@ const StUSDSWidgetWrapped = ({
               </HStack>
             </Button>
           )}
-          <div className="space-y-1">
-            <Heading variant="x-large">
-              <Trans>stUSDS</Trans>
-            </Heading>
-            <Text className="text-textSecondary" variant="small">
-              <Trans>Access a variable reward rate on USDS by participating in SKY-backed borrowing</Trans>
-            </Text>
-          </div>
+          <Heading variant="x-large">
+            <Trans>stUSDS</Trans>
+          </Heading>
         </div>
+      }
+      subHeader={
+        <Text className="text-textSecondary" variant="small">
+          <Trans>Access a variable reward rate on USDS by participating in SKY-backed borrowing</Trans>
+        </Text>
       }
       rightHeader={rightHeaderComponent}
       footer={


### PR DESCRIPTION
### What does this PR do?
- Make text in linked action buttons wrap to avoid them being cut off when space is reduced
- Make the linked action card content expand to full height and add space in the middle so the card contents are aligned on the bottom
- Fix the subtitle size in the expert and stUSDS widgets so they can now expand to the full width of the widgets


### Testing steps:
