### PR TITLE
Update token symbols for savings and stUSDS cards

### DIFF
--- a/packages/widgets/src/widgets/BalancesWidget/components/SavingsBalanceCard.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/SavingsBalanceCard.tsx
@@ -24,7 +24,7 @@ export const SavingsBalanceCard = ({
   return (
     <InteractiveStatsCardWithAccordion
       title={t`Savings balance`}
-      tokenSymbol="USDS"
+      tokenSymbol="sUSDS"
       headerRightContent={
         loading ? (
           <Skeleton className="w-32" />

--- a/packages/widgets/src/widgets/BalancesWidget/components/StUSDSBalanceCard.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/StUSDSBalanceCard.tsx
@@ -18,7 +18,7 @@ export const StUSDSBalanceCard = ({ url, onExternalLinkClicked, loading }: CardP
   return (
     <InteractiveStatsCard
       title={t`USDS supplied to stUSDS`}
-      tokenSymbol="USDS"
+      tokenSymbol="stUSDS"
       headerRightContent={
         loading || stUsdsLoading ? (
           <Skeleton className="w-32" />


### PR DESCRIPTION
### What does this PR do?

This PR corrects the token symbols displayed on the Savings and stUSDS balance cards. It updates the `SavingsBalanceCard` to show `sUSDS` and the `StUSDSBalanceCard` to show `stUSDS`.

### Testing steps:

1.  Navigate to the page containing the Balances widget.
2.  Verify that the "Savings balance" card correctly displays the token symbol as "sUSDS".
3.  Verify that the "USDS supplied to stUSDS" card correctly displays the token symbol as "stUSDS".