### PR TITLE
Overwrite Sonner's default styles for success and error notifications

### DIFF
--- a/apps/webapp/src/modules/app/hooks/useNotification.tsx
+++ b/apps/webapp/src/modules/app/hooks/useNotification.tsx
@@ -330,13 +330,17 @@ export const useNotification = () => {
       } else if (type && type !== NotificationType.INSUFFICIENT_BALANCE) {
         if (status === TxStatus.SUCCESS) {
           toast.success(title, {
+            unstyled: true,
             description,
-            duration
+            duration,
+            className: 'justify-start'
           });
         } else {
           toast.error(title, {
+            unstyled: true,
             description,
-            duration
+            duration,
+            className: 'justify-start'
           });
         }
         handleTokenReceived(type);


### PR DESCRIPTION
Before:
<img width="446" height="124" alt="Screenshot 2025-10-03 at 3 49 14 PM" src="https://github.com/user-attachments/assets/2cf39b35-82c9-42f3-abd0-088344e6da3d" />

After:
<img width="456" height="137" alt="Screenshot 2025-10-03 at 3 48 43 PM" src="https://github.com/user-attachments/assets/89f545ba-8782-453b-9db8-04ec680835db" />
