### PR TITLE
detail card layouts

### DIFF
--- a/apps/webapp/src/modules/layout/components/ConnectCard.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectCard.tsx
@@ -66,11 +66,11 @@ export function ConnectCard({ intent, className }: { intent: Intent; className?:
       colorRight="#2A197D"
       className={className}
     >
-      <div className="w-[80%] space-y-2 self-start lg:w-2/3" data-testid="connect-wallet-card">
+      <div className="w-[80%] space-y-2 self-start xl:w-2/3" data-testid="connect-wallet-card">
         <Heading className="mb-2">{heading}</Heading>
         {contentText}
       </div>
-      <div className="mt-auto w-fit pt-3 lg:self-end lg:pt-0">
+      <div className="mt-auto w-fit pt-3 xl:self-end xl:pt-0">
         <Button
           className="border-border"
           variant="outline"

--- a/apps/webapp/src/modules/layout/components/ConnectCard.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectCard.tsx
@@ -66,18 +66,20 @@ export function ConnectCard({ intent, className }: { intent: Intent; className?:
       colorRight="#2A197D"
       className={className}
     >
-      <div className="w-[80%] space-y-2 lg:w-2/3" data-testid="connect-wallet-card">
+      <div className="w-[80%] space-y-2 self-start lg:w-2/3" data-testid="connect-wallet-card">
         <Heading className="mb-2">{heading}</Heading>
         {contentText}
       </div>
-      <Button
-        className="border-border mt-3 w-fit px-6 py-6 lg:mt-0"
-        variant="outline"
-        onClick={connect}
-        data-testid="connect-wallet-card-button"
-      >
-        <Trans>Connect wallet</Trans>
-      </Button>
+      <div className="mt-auto w-fit pt-3 lg:self-end lg:pt-0">
+        <Button
+          className="border-border"
+          variant="outline"
+          onClick={connect}
+          data-testid="connect-wallet-card-button"
+        >
+          <Trans>Connect wallet</Trans>
+        </Button>
+      </div>
     </GradientShapeCard>
   );
 }

--- a/apps/webapp/src/modules/ui/components/AboutCard.tsx
+++ b/apps/webapp/src/modules/ui/components/AboutCard.tsx
@@ -65,11 +65,11 @@ export const AboutCard = ({
       className="mb-6"
       height={height}
     >
-      <div className={cn('w-[80%] space-y-2 self-start', contentWidth === 'w-1/2' ? 'lg:w-1/2' : 'lg:w-2/3')}>
+      <div className={cn('w-[80%] space-y-2 self-start', contentWidth === 'w-1/2' ? 'xl:w-1/2' : 'xl:w-2/3')}>
         {titleContent && <Heading className="flex items-center gap-2">{titleContent}</Heading>}
         <Text variant="small">{description}</Text>
       </div>
-      <ExternalLink href={linkHref} showIcon={false} className="mt-auto w-fit pt-3 lg:self-end lg:pt-0">
+      <ExternalLink href={linkHref} showIcon={false} className="mt-auto w-fit pt-3 xl:self-end xl:pt-0">
         <Button variant="outline" className="border-border gap-2">
           {linkLabel}
           <ExternalLinkIcon size={16} />

--- a/apps/webapp/src/modules/ui/components/GradientShapeCard.tsx
+++ b/apps/webapp/src/modules/ui/components/GradientShapeCard.tsx
@@ -29,18 +29,18 @@ export function GradientShapeCard({
           className="absolute h-full w-[110%] lg:w-[90%]"
           style={{
             background: colorLeft,
-            clipPath: `polygon(100% 0, ${isMobileOrTablet ? '45%' : '65%'} 100%, 0 100%, 0 0)`
+            clipPath: `polygon(100% 0, ${isMobileOrTablet ? '45%' : '70%'} 100%, 0 100%, 0 0)`
           }}
         />
         <div
-          className="absolute left-[48%] h-full w-[138%] lg:left-[57%] lg:w-[35%]"
+          className="absolute left-[48%] h-full w-[138%] lg:left-[62%] lg:w-[35%]"
           style={{
             background: colorMiddle,
-            clipPath: `polygon(100% 0, 10% 100%, 0 100%, ${isMobileOrTablet ? '45%' : '65%'} 0)`
+            clipPath: `polygon(100% 0, 10% 100%, 0 100%, ${isMobileOrTablet ? '45%' : '70%'} 0)`
           }}
         />
         <div
-          className="absolute left-[55%] h-full w-[200%] lg:left-[60%] lg:w-[60%]"
+          className="absolute left-[55%] h-full w-[200%] lg:left-[65%] lg:w-[60%]"
           style={{
             background: colorRight,
             clipPath: 'polygon(100% 0, 100% 100%, 0 100%, 53% 0)'

--- a/apps/webapp/src/modules/ui/components/GradientShapeCard.tsx
+++ b/apps/webapp/src/modules/ui/components/GradientShapeCard.tsx
@@ -18,7 +18,7 @@ export function GradientShapeCard({
   height?: number;
 }) {
   const { bpi } = useBreakpointIndex();
-  const isMobileOrTablet = bpi < BP.lg;
+  const isCompactLayout = bpi < BP.xl;
   return (
     <Card
       className={cn('mb-6 w-full p-0 lg:p-0', className)}
@@ -26,27 +26,27 @@ export function GradientShapeCard({
     >
       <div className="relative h-full w-full overflow-hidden rounded-[20px]">
         <div
-          className="absolute h-full w-[110%] lg:w-[90%]"
+          className="absolute h-full w-[110%] xl:w-[90%]"
           style={{
             background: colorLeft,
-            clipPath: `polygon(100% 0, ${isMobileOrTablet ? '45%' : '70%'} 100%, 0 100%, 0 0)`
+            clipPath: `polygon(100% 0, ${isCompactLayout ? '45%' : '70%'} 100%, 0 100%, 0 0)`
           }}
         />
         <div
-          className="absolute left-[48%] h-full w-[138%] lg:left-[62%] lg:w-[35%]"
+          className="absolute left-[48%] h-full w-[138%] xl:left-[62%] xl:w-[35%]"
           style={{
             background: colorMiddle,
-            clipPath: `polygon(100% 0, 10% 100%, 0 100%, ${isMobileOrTablet ? '45%' : '70%'} 0)`
+            clipPath: `polygon(100% 0, 10% 100%, 0 100%, ${isCompactLayout ? '45%' : '70%'} 0)`
           }}
         />
         <div
-          className="absolute left-[55%] h-full w-[200%] lg:left-[65%] lg:w-[60%]"
+          className="absolute left-[55%] h-full w-[200%] xl:left-[65%] xl:w-[60%]"
           style={{
             background: colorRight,
             clipPath: 'polygon(100% 0, 100% 100%, 0 100%, 53% 0)'
           }}
         />
-        <div className="relative z-10 flex h-full w-full flex-col p-3 py-4 lg:flex-row lg:items-center lg:justify-between lg:px-6">
+        <div className="relative z-10 flex h-full w-full flex-col p-3 py-4 xl:flex-row xl:items-center xl:justify-between xl:px-6">
           {children}
         </div>
       </div>


### PR DESCRIPTION
- Move button to the left side at xl breakpoint, not desktop breakpoint
- match connect wallet button styling and placement to view contract button
- shift the colored middle section to the right slightly on desktop

Before:

<img width="605" height="568" alt="Screenshot 2025-10-03 at 2 46 49 PM" src="https://github.com/user-attachments/assets/7e13005c-79e8-42c7-b903-c3aae27a0d43" />

<img width="1104" height="485" alt="Screenshot 2025-10-03 at 2 46 37 PM" src="https://github.com/user-attachments/assets/650f5cde-8feb-4083-9eb8-1694be64b3d9" />



After:

<img width="576" height="617" alt="Screenshot 2025-10-03 at 2 48 35 PM" src="https://github.com/user-attachments/assets/99fce674-77ef-4de9-9431-cd986d93d793" />

<img width="1068" height="445" alt="Screenshot 2025-10-03 at 2 43 49 PM" src="https://github.com/user-attachments/assets/c7bb14db-a8f1-4c13-88e8-08e93451a652" />

