### PR TITLE
Use liquidity tooltips when the user supply and withdraw amounts are limited

### DIFF
--- a/packages/widgets/src/widgets/StUSDSWidget/components/StUSDSSupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/components/StUSDSSupplyWithdraw.tsx
@@ -205,14 +205,14 @@ export const StUSDSSupplyWithdraw = ({
             />
             {!isStUsdsDataLoading && remainingCapacityBuffered === 0n ? (
               <div className="ml-3 mt-2 flex items-start text-amber-400">
-                <PopoverRateInfo type="stusds" iconClassName="mt-1 shrink-0" />
+                <PopoverRateInfo type="remainingCapacity" iconClassName="mt-1 shrink-0" />
                 <Text variant="small" className="ml-2 flex gap-2">
                   Supply capacity reached. Deposits are temporarily unavailable.
                 </Text>
               </div>
             ) : !isStUsdsDataLoading && userBalanceExceedsCapacity ? (
               <div className="ml-3 mt-2 flex items-start text-white">
-                <PopoverRateInfo type="stusds" iconClassName="mt-1 shrink-0" />
+                <PopoverRateInfo type="remainingCapacity" iconClassName="mt-1 shrink-0" />
                 <Text variant="small" className="ml-2 flex gap-2">
                   You cannot supply your full balance due to current capacity limits.
                 </Text>
@@ -255,14 +255,14 @@ export const StUSDSSupplyWithdraw = ({
             />
             {!isStUsdsDataLoading && availableLiquidityBuffered === 0n ? (
               <div className="ml-3 mt-2 flex items-start text-amber-400">
-                <PopoverRateInfo type="stusds" iconClassName="mt-1 shrink-0" />
+                <PopoverRateInfo type="withdrawalLiquidity" iconClassName="mt-1 shrink-0" />
                 <Text variant="small" className="ml-2 flex gap-2">
                   Withdrawal liquidity exhausted. Withdrawals are temporarily unavailable.
                 </Text>
               </div>
             ) : !isStUsdsDataLoading && userSuppliedExceedsLiquidity ? (
               <div className="ml-3 mt-2 flex items-start text-white">
-                <PopoverRateInfo type="stusds" iconClassName="mt-1 shrink-0" />
+                <PopoverRateInfo type="withdrawalLiquidity" iconClassName="mt-1 shrink-0" />
                 <Text variant="small" className="ml-2 flex gap-2">
                   You cannot withdraw your full balance due to current liquidity limits.
                 </Text>


### PR DESCRIPTION
### What does this PR do?
Replaces the rate tooltips for the `remaining capacity` and `withdrawal liquidity` ones when the user is notified that they can't supply or withdraw their full amount
