### PR TITLE
factor staking engine debt into utilization

### DIFF
--- a/packages/hooks/src/stusds/useStUsdsCapacityData.ts
+++ b/packages/hooks/src/stusds/useStUsdsCapacityData.ts
@@ -25,9 +25,10 @@ export function useStUsdsCapacityData(): StUsdsCapacityDataHook {
     const maxCapacity = stUsdsData.cap;
 
     // Calculate utilization rate as percentage
+    const borrowedAmount = currentCapacity - stUsdsData.availableLiquidity;
     const utilizationRate =
-      maxCapacity > 0n
-        ? Number((currentCapacity * 10000n) / maxCapacity) / 100 // Convert to percentage with 2 decimal places
+      currentCapacity > 0n
+        ? Number((borrowedAmount * 10000n) / currentCapacity) / 100 // Convert to percentage with 2 decimal places
         : 0;
 
     // Calculate remaining capacity


### PR DESCRIPTION
### What does this PR do?
- utilization should factor in the staking engine debt, not total capacity of stUSDS