### PR TITLE
Add proxy configuration for local API requests

### DIFF
--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -61,13 +61,19 @@ export function sanitizeUrl(url: string | undefined) {
   if (!url) return undefined;
   try {
     const parsedUrl = new URL(url);
-    // Ensure that the url begins with 'https:'
-    if (parsedUrl.protocol !== 'https:') {
+
+    // Allow localhost in development for local API testing
+    const isLocalDev =
+      import.meta.env.DEV && (parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1');
+
+    // Ensure that the url begins with 'https:' (except localhost in dev)
+    if (parsedUrl.protocol !== 'https:' && !isLocalDev) {
       return undefined;
     }
 
-    // Check if the domain is in the allowed list. Check for subdomains too
+    // Check if the domain is in the allowed list. Check for subdomains too (except localhost in dev)
     if (
+      !isLocalDev &&
       !ALLOWED_EXTERNAL_DOMAINS.some(
         domain => parsedUrl.hostname === domain || parsedUrl.hostname.endsWith(`.${domain}`)
       )

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -101,6 +101,16 @@ export default ({ mode }: { mode: modeEnum }) => {
           /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
           'https://app.safe.global'
         ]
+      },
+      proxy: {
+        // Proxy API requests to local api-workers (localhost:8787)
+        // This keeps requests same-origin so cookies (SameSite=None; Secure) work over HTTP
+        '/ip/status': 'http://localhost:8787',
+        '/address/status': 'http://localhost:8787',
+        '/terms-acceptance': 'http://localhost:8787',
+        '/chatbot': 'http://localhost:8787',
+        '/chat': 'http://localhost:8787',
+        '/health': 'http://localhost:8787'
       }
     },
     preview: {


### PR DESCRIPTION
## Summary

* Add a Vite dev server proxy to forward API requests to a locally running `api-workers` instance on `localhost:8787`.
* Update `sanitizeUrl` to allow `localhost` / `127.0.0.1` URLs in development mode (`import.meta.env.DEV`), so environment variables pointing to local APIs are not rejected.

Both changes are development-only:

* The proxy runs only in the Vite dev server.
* The `sanitizeUrl` bypass is eliminated from production builds via dead code elimination.

---

## Local Testing Setup

To test against a local `api-workers` instance, update `apps/webapp/.env`:

```
# Route API traffic through the Vite proxy to local api-workers
VITE_AUTH_URL=http://localhost:3000
VITE_TERMS_ENDPOINT=http://localhost:3000/terms-acceptance
VITE_CHATBOT_DOMAIN=http://localhost:3000
VITE_SKIP_AUTH_CHECK=false
```

Then:

* Run `api-workers` on port `8787`.
* Run the web app on port `3000`.

The Vite proxy automatically forwards the following routes to `localhost:8787`:

* `/ip/status`
* `/address/status`
* `/terms-acceptance`
* `/chatbot`
* `/chat`
* `/health`

---

## Test Plan

* Confirm `sanitizeUrl` allows `localhost` URLs in development and rejects them in a production build.
* Confirm the Vite proxy forwards API requests to `localhost:8787`.
* Verify the terms check and accept flow works end-to-end through the proxy.
* Confirm the production build contains no `localhost` references and behaves as expected.
