### PR TITLE
Handle access-denied terms checks and tighten retry behavior

### DIFF
--- a/apps/webapp/src/modules/ui/context/ConnectedContext.tsx
+++ b/apps/webapp/src/modules/ui/context/ConnectedContext.tsx
@@ -103,6 +103,10 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         tags: { endpoint: 'terms-check' }
       });
       setTermsCheckError(true);
+    } else if (result.accessDenied) {
+      // 403 is an intentional access denial (VPN/region or sanctioned address).
+      // The VPN/address hooks handle the blocked UI — just mark terms as not accepted.
+      setHasAcceptedTerms(false);
     } else {
       setHasAcceptedTerms(result.termsAccepted);
     }
@@ -130,10 +134,11 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const isAllowed = useMemo(
     () =>
       !vpnData?.isConnectedToVpn &&
+      !vpnData?.isRestrictedRegion &&
       (!enabled || (enabled && authData?.addressAllowed)) &&
       !authError &&
       !vpnError,
-    [vpnData?.isConnectedToVpn, enabled, authData?.addressAllowed, authError, vpnError]
+    [vpnData?.isConnectedToVpn, vpnData?.isRestrictedRegion, enabled, authData?.addressAllowed, authError, vpnError]
   );
 
   const isAuthorized = isAllowed || skipAuthCheck;

--- a/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.test.ts
+++ b/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.test.ts
@@ -129,6 +129,25 @@ describe('checkTermsWithRetry', () => {
     );
   });
 
+  it('returns accessDenied immediately on 403 without retrying', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 403 });
+
+    const result = await checkTermsWithRetry(TEST_ADDRESS);
+
+    expect(result).toEqual({ termsAccepted: false, error: false, accessDenied: true });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns error immediately on 400 without retrying', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 400 });
+
+    const result = await checkTermsWithRetry(TEST_ADDRESS);
+
+    expect(result.error).toBe(true);
+    expect(result.termsAccepted).toBe(false);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('handles mixed failure types across retries', async () => {
     global.fetch = vi
       .fn()

--- a/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.ts
+++ b/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.ts
@@ -6,6 +6,7 @@ const RETRY_DELAY_MS = 1000;
 export interface TermsCheckResult {
   termsAccepted: boolean;
   error: false;
+  accessDenied?: boolean;
 }
 
 export interface TermsCheckError {
@@ -39,8 +40,20 @@ export async function checkTermsWithRetry(address: string): Promise<TermsCheckOu
         return { termsAccepted: res.termsAccepted, error: false };
       }
 
+      // 403 is a deliberate access denial (VPN/restricted region or sanctioned address) — not an error
+      if (response.status === 403) {
+        return { termsAccepted: false, error: false, accessDenied: true };
+      }
+
+      // Other 4xx are deterministic client errors — don't retry
+      if (response.status >= 400 && response.status < 500) {
+        return { termsAccepted: false, error: true, lastError: new Error(`Terms check failed with status ${response.status}`) };
+      }
+
+      // 5xx are server errors — worth retrying
       lastError = new Error(`Terms check failed with status ${response.status}`);
     } catch (error) {
+      // Network errors — worth retrying
       lastError = error;
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the terms check flow to distinguish intentional access denials from transient failures and align auth state handling with VPN and region restrictions.

#### Highlights

- Treats `403` responses from `VITE_TERMS_ENDPOINT/check` as intentional access denial instead of a retryable error
- Stops retrying deterministic `4xx` client errors and only retries network failures and `5xx` responses
- Adds an `accessDenied` result to `checkTermsWithRetry` so blocked users can be handled without surfacing a generic terms-check error
- Updates `ConnectedContext` to clear `hasAcceptedTerms` on access denial
- Updates `ConnectedContext` to include `vpnData.isRestrictedRegion` in `isAllowed`, so restricted-region users are not considered authorized
- Adds test coverage for immediate `403` handling without retries
- Adds test coverage for immediate `400` error handling without retries

### Why

- Prevents geo-blocked or otherwise denied users from getting stuck in a retry-driven error flow
- Makes retry behavior stricter so only transient failures are retried
- Ensures region-restricted users follow the blocked auth path consistently

### Testing steps

1. `pnpm test`
2. Verify a `403` response is handled immediately as access denied with no retries
3. Verify a `400` response is handled immediately as an error with no retries
4. Verify network failures and `5xx` responses still retry as expected
5. Smoke test the blocked-access flow and confirm restricted users are not treated as authorized
6. Smoke test the generic terms-check failure path and confirm real failures still surface correctly