### PR TITLE
fix: lowercase reward contract address in rewards history query

### DIFF
--- a/packages/hooks/src/rewards/useRewardsUserHistory.ts
+++ b/packages/hooks/src/rewards/useRewardsUserHistory.ts
@@ -16,7 +16,7 @@ async function fetchRewardsUserHistory(
   if (!rewardContractAddress || !userAddress) return [];
   const query = gql`
     {
-      reward: Reward_by_pk(id: "${chainId}-${rewardContractAddress}") {
+      reward: Reward_by_pk(id: "${chainId}-${rewardContractAddress.toLowerCase()}") {
         supplyInstances(where: { user: { _ilike: "${userAddress}" } }) {
           blockTimestamp
           transactionHash


### PR DESCRIPTION
## Summary
- Lowercase the reward contract address when querying `Reward_by_pk` so the frontend casing matches the address stored in Envio.

## Test plan
- [ ] Verify rewards user history loads correctly