### PR TITLE
filter mobile metamask issue from sentry

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -36,6 +36,9 @@ export function initSentry(): void {
     ignoreErrors: [
       // Errors thrown by wallet browser extensions / in-app browsers, not by our code.
       /not found rainbowkit/i,
+      // WebSocket race condition in MetaMask mobile wallet SDK (centrifuge lib).
+      // Not actionable on our side (WEBAPP-2F).
+      /null is not an object \(evaluating 'this\._transport\.close'\)/,
       // DOM mutation errors caused by browser extensions modifying nodes outside
       // React's control. These surface as React reconciliation failures and are
       // not actionable.


### PR DESCRIPTION
  - Filter out TypeError: null is not an object (evaluating 'this._transport.close') from Sentry (WEBAPP-2F)
  - This is a race condition in the centrifuge WebSocket library, a transitive dependency of @metamask/mobile-wallet-protocol-core. A connection timeout fires after the transport is already torn down.
- Happens when a user tries to connect via MetaMask mobile wallet and the WebSocket connection is slow or drops
- Not actionable on our side
