### PR TITLE
chore: enforce pnpm v10+ in engines constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Tarmac is a web3 application framework for building decentralized applications",
   "engines": {
-    "pnpm": ">=9",
+    "pnpm": ">=10.17.0",
     "node": ">=20.19.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Restores `engines.pnpm` from `>=9` to `>=10.17.0` to match the `packageManager` field
- This was previously loosened in `09f6084b` for Vercel deployments but is no longer needed

## Test plan
- [x] Verified `pnpm install` fails with pnpm 9 (`ERR_PNPM_UNSUPPORTED_ENGINE`)
- [x] Verified `pnpm install` succeeds with pnpm 10.33.0