### PR TITLE
fix: correct Sky Ecosystem casing

### DIFF
--- a/apps/webapp/src/data/banners/banners.ts
+++ b/apps/webapp/src/data/banners/banners.ts
@@ -179,7 +179,7 @@ export const banners: Banner[] = [
     title: 'SKY',
     module: 'upgrade-banners',
     description:
-      'SKY is a native governance token of the decentralised Sky ecosystem and the upgraded version of MKR. You can trade SKY for USDS, depending on your location and other criteria, and use SKY to access Staking Rewards and participate in Sky Ecosystem Governance.',
+      'SKY is a native governance token of the decentralised Sky Ecosystem and the upgraded version of MKR. You can trade SKY for USDS, depending on your location and other criteria, and use SKY to access Staking Rewards and participate in Sky Ecosystem Governance.',
     display: ['connected', 'disconnected']
   },
   {

--- a/apps/webapp/src/data/chat/speed-bumps/index.ts
+++ b/apps/webapp/src/data/chat/speed-bumps/index.ts
@@ -5,8 +5,8 @@ import { upgradeSpeedBump } from './upgrade';
 import { tradeSpeedBump } from './trade';
 import { expertModulesSpeedBump } from './expert-modules';
 import { stakingEngineSpeedBump } from './staking-engine';
-import { vaultsSpeedBump } from './vaults';
 import { psmConversionSpeedBump } from './psm-conversion';
+import { vaultsSpeedBump } from './vaults';
 
 export { skyTokenRewardsSpeedBump } from './sky-token-rewards';
 export { skySavingsRateSpeedBump } from './sky-savings-rate';
@@ -14,8 +14,8 @@ export { upgradeSpeedBump } from './upgrade';
 export { tradeSpeedBump } from './trade';
 export { expertModulesSpeedBump } from './expert-modules';
 export { stakingEngineSpeedBump } from './staking-engine';
-export { vaultsSpeedBump } from './vaults';
 export { psmConversionSpeedBump } from './psm-conversion';
+export { vaultsSpeedBump } from './vaults';
 
 export const speedBumps: SpeedBumpContent[] = [
   skyTokenRewardsSpeedBump,

--- a/apps/webapp/src/data/version.ts
+++ b/apps/webapp/src/data/version.ts
@@ -1,5 +1,5 @@
 // Version of the corpus content used to generate FAQs, tooltips, banners, and speed bumps
-export const CORPUS_VERSION = 'v0.48.0';
+export const CORPUS_VERSION = 'v0.49.0';
 
 // Branch name used during content extraction
 export const CORPUS_BRANCH = 'development';

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -222,7 +222,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
       withErrorBoundary(<VaultsWidgetPane {...sharedProps} />),
       false,
       undefined,
-      'Third-party vault integrations with Sky ecosystem tokens',
+      'Third-party vault integrations with Sky Ecosystem tokens',
       vaultSubItems
     ],
     [
@@ -248,7 +248,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
       withErrorBoundary(<ConvertWidgetPane {...sharedProps} />),
       false,
       undefined,
-      'Get Sky ecosystem tokens with best possible rates',
+      'Get Sky Ecosystem tokens with best possible rates',
       [
         {
           label: '1:1 Conversion',

--- a/apps/webapp/src/modules/convert/components/ConvertWidgetPane.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertWidgetPane.tsx
@@ -143,7 +143,7 @@ export function ConvertWidgetPane(sharedProps: SharedProps) {
             }
             subHeader={
               <Text className="text-textSecondary" variant="small">
-                <Trans>Get Sky ecosystem tokens with best possible rates</Trans>
+                <Trans>Get Sky Ecosystem tokens with best possible rates</Trans>
               </Text>
             }
             rightHeader={sharedProps.rightHeaderComponent}

--- a/apps/webapp/src/modules/ui/components/AboutSealModule.tsx
+++ b/apps/webapp/src/modules/ui/components/AboutSealModule.tsx
@@ -20,7 +20,7 @@ export const AboutSealModule = ({ height }: { height?: number | undefined }) => 
         <Trans>
           Seal Rewards can be accessed when you supply MKR or SKY to the Seal Engine of the decentralised,
           non-custodial Sky Protocol. Currently, all Seal Rewards take the form of USDS. Eventually, subject
-          to Sky ecosystem governance approval, Seal Rewards may also be available in the form of Sky Star
+          to Sky Ecosystem governance approval, Seal Rewards may also be available in the form of Sky Star
           tokens.
         </Trans>
       }

--- a/apps/webapp/src/modules/ui/components/AboutSky.tsx
+++ b/apps/webapp/src/modules/ui/components/AboutSky.tsx
@@ -18,9 +18,9 @@ export const AboutSky = ({ height }: { height?: number | undefined }) => {
       tokenSymbol="SKY"
       description={
         <Trans>
-          SKY is a native governance token of the decentralised Sky ecosystem and the upgraded version of MKR.
+          SKY is a native governance token of the decentralised Sky Ecosystem and the upgraded version of MKR.
           You can upgrade your MKR to SKY at the rate of 1:24,000, trade SKY for USDS and, soon, use it to
-          accumulate Activation Token Rewards and participate in Sky ecosystem governance.
+          accumulate Activation Token Rewards and participate in Sky Ecosystem governance.
         </Trans>
       }
       linkHref={skyEtherscanLink}

--- a/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.tsx
+++ b/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.tsx
@@ -94,7 +94,7 @@ export function VaultsWidgetPane(sharedProps: SharedProps) {
             }
             subHeader={
               <Text className="text-textSecondary" variant="small">
-                <Trans>Third-party vault integrations with Sky ecosystem tokens</Trans>
+                <Trans>Third-party vault integrations with Sky Ecosystem tokens</Trans>
               </Text>
             }
             rightHeader={sharedProps.rightHeaderComponent}

--- a/apps/webapp/src/test/e2e/tests/psm-conversion.ts
+++ b/apps/webapp/src/test/e2e/tests/psm-conversion.ts
@@ -113,7 +113,7 @@ export const runPsmConversionTests = async ({ networkName }: { networkName: Netw
       await expect(
         isolatedPage
           .getByTestId('widget-container')
-          .getByText('Get Sky ecosystem tokens with best possible rates')
+          .getByText('Get Sky Ecosystem tokens with best possible rates')
       ).toBeVisible();
     });
 

--- a/packages/hooks/src/shared/useOverallSkyData.md
+++ b/packages/hooks/src/shared/useOverallSkyData.md
@@ -1,6 +1,6 @@
 # useOverallSkyData
 
-Hook for fetching overall Sky ecosystem data.
+Hook for fetching overall Sky Ecosystem data.
 
 ## Import
 
@@ -8,7 +8,7 @@ Import the hook from '@jetstreamgg/sky-hooks'.
 
 ## Usage
 
-Use this hook in your React components to fetch and display overall Sky ecosystem data. The hook provides data, error, and loading states.
+Use this hook in your React components to fetch and display overall Sky Ecosystem data. The hook provides data, error, and loading states.
 
 ```tsx
 import { useOverallSkyData } from '@jetstreamgg/sky-hooks';
@@ -38,7 +38,7 @@ This hook doesn't accept any parameters.
 Returns an object extending ReadHook and containing:
 
 - data: OverallSkyData | undefined
-  - The fetched overall Sky ecosystem data.
+  - The fetched overall Sky Ecosystem data.
 - error: Error | undefined
   - Any error that occurred during the fetch.
 - isLoading: boolean
@@ -67,7 +67,7 @@ The OverallSkyData type includes the following properties:
 ## Notes
 
 - This hook fetches data from the BA Labs API.
-- The data includes various metrics related to the Sky ecosystem, including savings rates, TVL, wallet counts, and token prices.
+- The data includes various metrics related to the Sky Ecosystem, including savings rates, TVL, wallet counts, and token prices.
 - The hook automatically handles API URL construction based on the current chain ID.
 - Data is fetched using React Query, providing caching and automatic refetching capabilities.
 - The trust level for this data source is set to TRUST_LEVELS[TrustLevelEnum.TWO].

--- a/packages/widgets/src/data/tooltips/legacy-tooltips.ts
+++ b/packages/widgets/src/data/tooltips/legacy-tooltips.ts
@@ -28,7 +28,7 @@ export const legacyTooltips: Tooltip[] = [
     id: 'debt-ceiling',
     title: 'Debt ceiling',
     tooltip:
-      'If the debt ceiling utilization reaches 100%, no new USDS can be borrowed. The debt ceiling is a parameter determined by Sky ecosystem governance through a process of decentralized onchain voting.'
+      'If the debt ceiling utilization reaches 100%, no new USDS can be borrowed. The debt ceiling is a parameter determined by Sky Ecosystem governance through a process of decentralized onchain voting.'
   },
   {
     id: 'borrow-rate',
@@ -102,7 +102,7 @@ export const legacyTooltips: Tooltip[] = [
     id: 'debt-ceiling-seal',
     title: 'Debt ceiling',
     tooltip:
-      'If the debt ceiling utilization reaches 100%, no new USDS can be borrowed. The debt ceiling is a parameter determined by Sky ecosystem governance through a process of decentralized onchain voting.'
+      'If the debt ceiling utilization reaches 100%, no new USDS can be borrowed. The debt ceiling is a parameter determined by Sky Ecosystem governance through a process of decentralized onchain voting.'
   },
   {
     id: 'borrow-rate-seal',

--- a/packages/widgets/src/widgets/SealModuleWidget/components/About.tsx
+++ b/packages/widgets/src/widgets/SealModuleWidget/components/About.tsx
@@ -27,7 +27,7 @@ export const About = () => {
               <br />
               <Text>
                 The exit fee is a risk parameter managed and determined (regardless of position duration) by
-                Sky ecosystem governance. The exit fee applies at unsealing, not at sealing, which means that
+                Sky Ecosystem governance. The exit fee applies at unsealing, not at sealing, which means that
                 it is determined the moment you unseal your MKR.
               </Text>
               <br />
@@ -36,7 +36,7 @@ export const About = () => {
           contentClassname="max-w-[400px]"
         />{' '}
         <Trans>
-          in order to provide access to Seal Rewards and encourage a deeper commitment to Sky ecosystem
+          in order to provide access to Seal Rewards and encourage a deeper commitment to Sky Ecosystem
           governance.
         </Trans>
       </Text>


### PR DESCRIPTION
## Summary
- Fixes incorrect lowercase "ecosystem" in "Sky Ecosystem" references across UI components, tooltips, documentation, and E2E tests
- Corpus-synced files (banners, FAQ tooltips) are excluded and will be fixed upstream in the corpus repo

## Test plan
- [ ] Verify UI text displays "Sky Ecosystem" with correct casing
- [ ] E2E tests pass with updated text matcher