### PR TITLE
restricted balance edge case APP-155

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -167,7 +167,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
       withErrorBoundary(
         <BalancesWidgetPane
           {...sharedProps}
-          hideModuleBalances={isRegionRestricted}
+          hideRestrictedModules={isRegionRestricted}
           rewardsCardUrl={isRegionRestricted ? undefined : rewardsUrl}
           savingsCardUrlMap={isRegionRestricted ? undefined : savingsUrlMap}
           sealCardUrl={sealUrl}

--- a/packages/widgets/src/widgets/BalancesWidget/BalancesWidget.md
+++ b/packages/widgets/src/widgets/BalancesWidget/BalancesWidget.md
@@ -23,7 +23,6 @@ function BalancesPage() {
         rightHeaderComponent={<CustomButton />}
         externalWidgetState={/* initial state */}
         onStateValidated={onStateValidated}
-        hideModuleBalances={false}
         enabled={true}
         actionForToken={actionForToken}
         rewardsCardUrl={rewardsCardUrl}
@@ -40,8 +39,6 @@ In addition to `WidgetProps`, `BalancesWidget` component also accepts the follow
 
 - `customTokenMap?: { [chainId: number]: TokenForChain[]; }`
   - A map of custom tokens to be used in the widget. If provided, this map will override the default list.
-- `hideModuleBalances?: boolean;`
-  - A boolean to hide or show module balances.
 - `actionForToken?: (symbol: string, balance: string, tokenChainId: number) => { label: string; actionUrl: string; image: string } | undefined;`
   - A function to define actions for a specific token.
 - `rewardsCardUrl?: string;`

--- a/packages/widgets/src/widgets/BalancesWidget/components/BalancesContent.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/BalancesContent.tsx
@@ -9,7 +9,6 @@ import { useCallback, useState } from 'react';
 import { useChainId } from 'wagmi';
 
 interface BalancesContentProps {
-  hideModuleBalances?: boolean;
   hideRestrictedModules?: boolean;
   chainIds?: number[];
   rewardsCardUrl?: string;
@@ -27,7 +26,6 @@ interface BalancesContentProps {
 }
 
 export const BalancesContent = ({
-  hideModuleBalances,
   hideRestrictedModules,
   onExternalLinkClicked,
   chainIds,
@@ -75,15 +73,12 @@ export const BalancesContent = ({
               setHideZeroBalances={setHideZeroBalances}
               chainId={chainId}
             />
-            {!hideModuleBalances && (
-              <Heading variant="small" className="mb-3 leading-6">
-                <Trans>Supplied funds</Trans>
-              </Heading>
-            )}
+            <Heading variant="small" className="mb-3 leading-6">
+              <Trans>Supplied funds</Trans>
+            </Heading>
           </>
         )}
         <ModulesBalances
-          hideModuleBalances={hideModuleBalances}
           rewardsCardUrl={rewardsCardUrl}
           savingsCardUrlMap={savingsCardUrlMap}
           sealCardUrl={sealCardUrl}

--- a/packages/widgets/src/widgets/BalancesWidget/components/ModulesBalances.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/ModulesBalances.tsx
@@ -39,7 +39,6 @@ export interface CardProps {
 }
 
 interface ModulesBalancesProps {
-  hideModuleBalances?: boolean;
   rewardsCardUrl?: string;
   savingsCardUrlMap?: Record<number, string>;
   sealCardUrl?: string;
@@ -56,7 +55,6 @@ interface ModulesBalancesProps {
 }
 
 export const ModulesBalances = ({
-  hideModuleBalances: hideModuleBalancesProp,
   rewardsCardUrl,
   savingsCardUrlMap,
   sealCardUrl,
@@ -215,9 +213,6 @@ export const ModulesBalances = ({
     hideRestrictedModules || multichainSavingsBalancesError || (totalSavingsBalance === 0n && hideZeroBalances)
   );
 
-  const hideModuleBalancesLocal = hideSavings && hideRewards && hideSeal;
-  const hideModuleBalances = hideModuleBalancesProp || hideModuleBalancesLocal;
-
   // Fallback display order used while prices are loading to prevent layout shifts
   const fallbackOrder: Record<string, number> = {
     rewards: 0,
@@ -278,11 +273,11 @@ export const ModulesBalances = ({
       id: 'rewards' | 'savings' | 'stusds' | 'staking' | 'seal' | 'vaults';
       hidden: boolean;
     }> = [
-      { id: 'rewards', hidden: hideModuleBalances || hideRewards },
-      { id: 'savings', hidden: hideModuleBalances || hideSavings },
+      { id: 'rewards', hidden: hideRewards },
+      { id: 'savings', hidden: hideSavings },
       { id: 'staking', hidden: hideStake },
       { id: 'vaults', hidden: hideVaults },
-      { id: 'stusds', hidden: hideModuleBalances || hideExpert },
+      { id: 'stusds', hidden: hideExpert },
       { id: 'seal', hidden: hideSeal }
     ];
 
@@ -299,7 +294,6 @@ export const ModulesBalances = ({
     // While loading, use stable fallback order to prevent layout shifts
     return visible.sort((a, b) => fallbackOrder[a.id] - fallbackOrder[b.id]);
   }, [
-    hideModuleBalances,
     hideRewards,
     hideSavings,
     hideExpert,

--- a/packages/widgets/src/widgets/BalancesWidget/index.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/index.tsx
@@ -17,7 +17,6 @@ import { useCallback, useMemo, useState } from 'react';
 
 export type BalancesWidgetProps = WidgetProps & {
   chainIds?: number[];
-  hideModuleBalances?: boolean;
   hideRestrictedModules?: boolean;
   rewardsCardUrl?: string;
   savingsCardUrlMap?: Record<number, string>;
@@ -39,7 +38,6 @@ export const BalancesWidget = ({
   onConnect,
   locale,
   rightHeaderComponent,
-  hideModuleBalances = false,
   hideRestrictedModules = false,
   enabled = true,
   onExternalLinkClicked,
@@ -63,7 +61,6 @@ export const BalancesWidget = ({
         <BalancesWidgetWrapped
           onConnect={onConnect}
           rightHeaderComponent={rightHeaderComponent}
-          hideModuleBalances={hideModuleBalances}
           hideRestrictedModules={hideRestrictedModules}
           enabled={enabled}
           chainIds={chainIds}
@@ -89,7 +86,6 @@ export const BalancesWidget = ({
 const BalancesWidgetWrapped = ({
   onConnect,
   rightHeaderComponent,
-  hideModuleBalances = false,
   hideRestrictedModules = false,
   enabled = true,
   onExternalLinkClicked,
@@ -167,7 +163,6 @@ const BalancesWidgetWrapped = ({
               />
             )}
             <BalancesContent
-              hideModuleBalances={hideModuleBalances}
               hideRestrictedModules={hideRestrictedModules}
               rewardsCardUrl={rewardsCardUrl}
               savingsCardUrlMap={savingsCardUrlMap}


### PR DESCRIPTION
- fix: Show the "no supplied funds" graphic when a region-restricted user's only deposits live in restricted modules. WidgetPane was passing the geo flag via hideModuleBalances, which hid the cards but was ignored by allFundsEmpty — leaving the widget blank. Switch to hideRestrictedModules to match ConnectedModalTabs.
- refactor: Delete the now-unused hideModuleBalances prop from BalancesWidget / BalancesContent / ModulesBalances and drop the vestigial hideSavings && hideRewards && hideSeal gate (dead for rewards/savings, inconsistent for stusds). Module visibility is now driven uniformly by each module's own hide flag.