### PR TITLE
Prevent reverse-tabnabbing in ExternalLinkModal

### DIFF
--- a/apps/webapp/src/modules/layout/components/ExternalLinkModal.tsx
+++ b/apps/webapp/src/modules/layout/components/ExternalLinkModal.tsx
@@ -32,7 +32,7 @@ export const ExternalLinkModal: React.FC = () => {
 
   const handleConfirm = useCallback(() => {
     setExternalLinkModalOpened(false);
-    window.open(externalLinkModalUrl, '_blank');
+    window.open(externalLinkModalUrl, '_blank', 'noopener,noreferrer');
   }, [externalLinkModalUrl, setExternalLinkModalOpened]);
 
   let termsLink: any[] = [];


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  The "Leaving Our Website" confirmation modal opened external destinations via `window.open(url, '_blank')` without the `noopener,noreferrer` features string. That left `window.opener` populated on the
  destination tab, allowing a malicious third-party page to navigate the Sky app tab to a phishing clone (classic reverse-tabnabbing). It also leaked the full originating URL via the `Referer` header.           
                                                                                                                                                                                                        
  This is the one imperative `window.open` bypass in the webapp — anchor-based external links already set `rel="noopener noreferrer"`. The modal exists *specifically* to handle destinations outside              
  `ALLOWED_EXTERNAL_DOMAINS`, which is exactly the higher-risk path.                                                                                                                                               
                                                                    
  Fix is a one-line change to `handleConfirm` in `ExternalLinkModal.tsx`: pass `'noopener,noreferrer'` as the third argument to `window.open`.                                                                     
                                                                                                                                                                                                                   
  Resolves [APP-185](https://linear.app/skybasestar/issue/APP-185/fix-reverse-tabnabbing-in-externallinkmodal-pass-noopenernoreferrer-to) (security audit finding L-01).
                                                                                                                                                                                                                   
  ## Test plan                                              
                                                                                                                                                                                                                   
  - [x] Click an external link that triggers the modal (destination not in `ALLOWED_EXTERNAL_DOMAINS`, e.g. `docs.sky.money`)
  - [x] Confirm the destination opens in a new tab as before                                                                                                                                                       
  - [x] In the new tab's console, `window.opener` returns `null`
  - [x] In the new tab's Network panel, the initial document request has `Referrer Policy: no-referrer` and no `Referer` header                                                                                    
  - [x] Trusted-domain links (hosts in `ALLOWED_EXTERNAL_DOMAINS`) still navigate normally — modal isn't involved there