### PR TITLE
Temporarily disable CoW trade quotes

### DIFF
--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -85,7 +85,6 @@ export default ({ mode }: { mode: modeEnum }) => {
       https://api.sky.money
       https://info-sky.blockanalitica.com
       https://sky-tenderly.blockanalitica.com
-      https://api.cow.fi/
       https://api.morpho.org/
       https://api.merkl.xyz/
       wss://relay.walletconnect.com

--- a/packages/hooks/src/trade/useQuoteTrade.ts
+++ b/packages/hooks/src/trade/useQuoteTrade.ts
@@ -7,6 +7,9 @@ import { OrderQuoteResponse, OrderQuoteSide } from './trade';
 import { verifySlippageAndDeadline } from './helpers';
 import { isL2ChainId } from '@jetstreamgg/sky-utils';
 
+const COW_QUOTES_TEMPORARILY_DISABLED = true;
+const COW_QUOTES_TEMPORARILY_DISABLED_ERROR = 'CowQuotesTemporarilyDisabled';
+
 type GetTradeQuoteParams = {
   chainId: number;
   sellToken: `0x${string}`;
@@ -32,6 +35,10 @@ const getTradeQuote = async ({
   isEthFlow,
   isSmartContractWallet
 }: GetTradeQuoteParams) => {
+  if (COW_QUOTES_TEMPORARILY_DISABLED) {
+    throw new Error(COW_QUOTES_TEMPORARILY_DISABLED_ERROR);
+  }
+
   const side: OrderQuoteSide =
     kind === OrderQuoteSideKind.BUY
       ? { kind: OrderQuoteSideKind.BUY, buyAmountAfterFee: amount.toString() }
@@ -166,7 +173,10 @@ export const useQuoteTrade = ({
     gcTime: 2 * 60 * 1000,
     retry: (failureCount: number, error: Error) => {
       //don't retry if the error is because the sell amount does not cover the fee
-      if (error.message?.includes('SellAmountDoesNotCoverFee')) {
+      if (
+        error.message?.includes('SellAmountDoesNotCoverFee') ||
+        error.message?.includes(COW_QUOTES_TEMPORARILY_DISABLED_ERROR)
+      ) {
         return false;
       }
       return failureCount < 2;

--- a/packages/widgets/src/widgets/TradeWidget/lib/utils.ts
+++ b/packages/widgets/src/widgets/TradeWidget/lib/utils.ts
@@ -59,6 +59,8 @@ export function getAllowedTargetTokens(
 
 export function getQuoteErrorForType(errorType: HandledQuoteErrorTypes | string) {
   switch (errorType) {
+    case 'CowQuotesTemporarilyDisabled':
+      return 'Trades via CoW are temporailty disabled';
     case HandledQuoteErrorTypes.NoLiquidity:
       return 'Request declined. Either you’ve entered an amount that does not meet the minimum required to trade, or there is insufficient liquidity available to process the amount you’ve entered.';
     case HandledQuoteErrorTypes.SellAmountDoesNotCoverFee:


### PR DESCRIPTION
## Summary
- Short-circuit `getTradeQuote` to throw a `CowQuotesTemporarilyDisabled` error so no quote requests are sent to CoW while the integration is paused.
- Skip retries on this error in `useQuoteTrade` and surface a user-facing message via `getQuoteErrorForType` in the Trade widget.

## Test plan
- [ ] Open the Trade widget and confirm the disabled message is shown instead of a live CoW quote
- [ ] Verify no quote retries occur for the disabled error
- [ ] `pnpm lint` / `pnpm typecheck`