### PR TITLE
Remove CoW protocol external link during DNS incident

### DIFF
--- a/packages/widgets/src/widgets/TradeWidget/components/TradeHeader.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeHeader.tsx
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/react/macro';
 import { Dispatch, SetStateAction } from 'react';
 import { TradeConfigMenu } from './TradeConfigMenu';
 import { Heading, Text } from '@widgets/shared/components/ui/Typography';
-import { ExternalLink } from '@widgets/shared/components/ExternalLink';
 import { CoW } from '@widgets/shared/components/icons/CoW';
 
 type PropTypes = {
@@ -11,7 +10,6 @@ type PropTypes = {
   isEthFlow?: boolean;
   ttl: string;
   setTtl: Dispatch<SetStateAction<string>>;
-  onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
 export const TradeHeader = ({
@@ -20,7 +18,7 @@ export const TradeHeader = ({
   isEthFlow = false,
   ttl,
   setTtl
-}: Omit<PropTypes, 'originToken' | 'onExternalLinkClicked'>): React.ReactElement => {
+}: PropTypes): React.ReactElement => {
   return (
     <div className="flex items-baseline justify-between gap-2">
       <Heading variant="x-large">
@@ -43,24 +41,10 @@ export const TradeSubHeader = () => (
   </Text>
 );
 
-export const TradePoweredBy = ({
-  onExternalLinkClicked
-}: {
-  onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
-}) => (
+export const TradePoweredBy = () => (
   <div className="mb-4 flex items-center gap-1.5">
-    <Text className="text-text text-sm leading-none font-normal">
-      Powered by{' '}
-      <ExternalLink
-        href="https://cow.fi/"
-        showIcon={true}
-        iconSize={12}
-        wrapperClassName="gap-1"
-        onExternalLinkClicked={onExternalLinkClicked}
-      >
-        CoW Protocol
-      </ExternalLink>
-    </Text>
+    <Text className="text-text text-sm leading-none font-normal">Powered by CoW Protocol</Text>
     <CoW className="rounded-[0.25rem]" />
   </div>
 );
+

--- a/packages/widgets/src/widgets/TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/index.tsx
@@ -1563,7 +1563,7 @@ function TradeWidgetWrapped({
       }
     >
       <div className="mt-[-16px] space-y-0">
-        <TradePoweredBy onExternalLinkClicked={onExternalLinkClicked} />
+        <TradePoweredBy />
       </div>
       <AnimatePresence mode="popLayout" initial={false}>
         {widgetState.screen === TradeScreen.REVIEW && quoteData && originToken && targetToken ? (


### PR DESCRIPTION
## Summary
- Removes the external link to `cow.fi` from the "Powered by CoW Protocol" section in the trade widget while the CoW DNS hijack is being investigated
- The "Powered by CoW Protocol" text and icon remain visible, just without linking out

## Test plan
- [ ] Verify the trade widget still displays "Powered by CoW Protocol" text and icon
- [ ] Verify there is no clickable link to cow.fi