### PR TITLE
Staging -> main

### DIFF
--- a/apps/webapp/src/data/faqs/getSavingsFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getSavingsFaqItems.ts
@@ -90,7 +90,7 @@ USDS is also currently available on networks other than Ethereum Mainnet, includ
   },
   {
     question: 'Can I trade sUSDS on the open market?',
-    answer: `Yes, eligible sUSDS holders can access the Sky.money web app to trade the tokens via an API integration with the third-party decentralized exchange [CoW Swap](https://swap.cow.fi/#/1/swap/WETH). sUSDS holders are also free to access any other protocol or exchange that supports sUSDS trading; however, users do so at their own risk. Sky.money is not responsible for any losses or damages incurred while using such third-party platforms.
+    answer: `Yes, eligible sUSDS holders can access the Sky.money web app to trade the tokens via an API integration with the third-party decentralized exchange [CoW Swap](https://swap.cow.finance/#/1/swap/WETH). sUSDS holders are also free to access any other protocol or exchange that supports sUSDS trading; however, users do so at their own risk. Sky.money is not responsible for any losses or damages incurred while using such third-party platforms.
 
 Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.`,
     index: 7

--- a/apps/webapp/src/data/faqs/getTradeFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getTradeFaqItems.ts
@@ -34,7 +34,7 @@ const generalFaqItems = [
     question: 'What is a trade?',
     answer: `A trade is the direct exchange of one cryptocurrency token for another. Trading can occur on decentralized exchanges (DEXs) and centralized exchanges (CEXs).
 
-Eligible Sky.money web app users can trade tokens via an API integration with the third-party decentralized exchange [CoW Swap](https://swap.cow.fi/#/1/swap/WETH). The exact trade route is determined by CoW Swap and is not influenced by Sky.money or the Sky Protocol. Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.
+Eligible Sky.money web app users can trade tokens via an API integration with the third-party decentralized exchange [CoW Swap](https://swap.cow.finance/#/1/swap/WETH). The exact trade route is determined by CoW Swap and is not influenced by Sky.money or the Sky Protocol. Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.
 
 Note that price slippage—a change in price between the time of the trade order and its execution on the blockchain—can occur due to market dynamics. When you trade via the Sky.money web app, you can set your slippage tolerance level.`,
     index: 0
@@ -53,7 +53,7 @@ Depending on your location and other criteria, you can use the Sky.money web app
   },
   {
     question: 'Is trading using Sky.money free?',
-    answer: `Accessing the Sky.money web app is free. Trading, however, may involve a fee imposed by the third-party decentralized exchange (i.e., [CoW Swap](https://swap.cow.fi/#/1/swap/WETH)) integrated with the non-custodial Sky Protocol that is used to make the trade. In addition, you will likely pay a blockchain network transaction fee called a [gas fee](#tooltip-gas-fee), which is neither controlled, imposed nor received by Sky.money or the Sky Protocol. This fee is calculated based on current Ethereum network demand and the amount of gas required to process your transaction.
+    answer: `Accessing the Sky.money web app is free. Trading, however, may involve a fee imposed by the third-party decentralized exchange (i.e., [CoW Swap](https://swap.cow.finance/#/1/swap/WETH)) integrated with the non-custodial Sky Protocol that is used to make the trade. In addition, you will likely pay a blockchain network transaction fee called a [gas fee](#tooltip-gas-fee), which is neither controlled, imposed nor received by Sky.money or the Sky Protocol. This fee is calculated based on current Ethereum network demand and the amount of gas required to process your transaction.
 
 Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.`,
     index: 2
@@ -115,7 +115,7 @@ Available tokens may evolve over time as new trading pairs are added. Please see
   },
   {
     question: 'How does trading on supported L2s differ from trading on Ethereum?',
-    answer: `On Ethereum Mainnet, Base, and Arbitrum, the Sky.money web app features a native integration of [CoW Swap](https://swap.cow.fi/#/1/swap/WETH), a third-party decentralized exchange (DEX) aggregator. Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.
+    answer: `On Ethereum Mainnet, Base, and Arbitrum, the Sky.money web app features a native integration of [CoW Swap](https://swap.cow.finance/#/1/swap/WETH), a third-party decentralized exchange (DEX) aggregator. Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.
 
 On Optimism and Unichain, converting between tokens is made possible through a Peg Stability Module [(PSM)](#tooltip-psm).`,
     index: 1

--- a/apps/webapp/src/data/faqs/getUpgradeFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getUpgradeFaqItems.ts
@@ -194,7 +194,7 @@ For details on the risks associated with soft-pegged stablecoins, review the [Us
     },
     {
       question: 'Can I trade USDS on the open market?',
-      answer: `Yes, eligible USDS holders can access the Sky.money web app to trade the tokens via an API integration with the third-party decentralized exchange [CoW Swap](https://swap.cow.fi/#/1/swap/WETH). USDS holders are also free to access any other protocol or exchange that supports USDS trading; however, users do so at their own risk. Sky.money is not responsible for any losses or damages incurred while using such third-party platforms.
+      answer: `Yes, eligible USDS holders can access the Sky.money web app to trade the tokens via an API integration with the third-party decentralized exchange [CoW Swap](https://swap.cow.finance/#/1/swap/WETH). USDS holders are also free to access any other protocol or exchange that supports USDS trading; however, users do so at their own risk. Sky.money is not responsible for any losses or damages incurred while using such third-party platforms.
 
 Please see the [Terms of Use](https://docs.sky.money/legal-terms) for more information on third-party services.`,
       index: 20

--- a/apps/webapp/src/modules/balances/components/modules/TradeCard.tsx
+++ b/apps/webapp/src/modules/balances/components/modules/TradeCard.tsx
@@ -74,7 +74,7 @@ export function TradeCard() {
         chainId === mainnet.id ? (
           <Text className="text-textSecondary">
             Trades are powered by{' '}
-            <ExternalLink href="https://cow.fi/" showIcon={false} className="text-textSecondary underline">
+            <ExternalLink href="https://cow.finance/" showIcon={false} className="text-textSecondary underline">
               CoW Protocol
             </ExternalLink>
             .

--- a/apps/webapp/src/test/e2e/tests/cowswap-trade.ts
+++ b/apps/webapp/src/test/e2e/tests/cowswap-trade.ts
@@ -43,12 +43,12 @@ export const runCowTradeTests = async ({ networkName }: { networkName: NetworkNa
 
   test('Trade is blocked if costs exceed the traded amount', async ({ isolatedPage }) => {
     await isolatedPage.getByTestId('undefined-menu-button').first().click();
-    await isolatedPage.getByRole('button', { name: 'USDC USDC USDC' }).click();
+    await isolatedPage.getByRole('button', { name: 'DAI DAI DAI' }).click();
     await isolatedPage.getByRole('button', { name: 'Select token' }).click();
     await isolatedPage.getByRole('button', { name: 'USDS USDS USDS' }).click();
 
     await isolatedPage.getByTestId('trade-input-origin').click();
-    await isolatedPage.getByTestId('trade-input-origin').fill('0.0001');
+    await isolatedPage.getByTestId('trade-input-origin').fill('0.0002');
 
     await expect(isolatedPage.getByText('Fetching price')).toBeVisible();
     await expect(isolatedPage.getByText('Fetching price')).not.toBeVisible();

--- a/apps/webapp/src/test/e2e/utils/interceptAndMockCowApiCalls.ts
+++ b/apps/webapp/src/test/e2e/utils/interceptAndMockCowApiCalls.ts
@@ -1,6 +1,6 @@
 import { Page, Route, Request } from '@playwright/test';
 
-const BASE_URL = 'https://api.cow.fi/**/api/v1';
+const BASE_URL = 'https://api.cow.finance/**/api/v1';
 
 export const interceptAndMockCowApiCalls = async (page: Page) => {
   await page.route(BASE_URL + '/quote', mockCowQuoteApiResponses);

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -85,7 +85,7 @@ export default ({ mode }: { mode: modeEnum }) => {
       https://api.sky.money
       https://info-sky.blockanalitica.com
       https://sky-tenderly.blockanalitica.com
-      https://api.cow.fi/
+      https://api.cow.finance/
       https://api.morpho.org/
       https://api.merkl.xyz/
       wss://relay.walletconnect.com

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -85,6 +85,7 @@ export default ({ mode }: { mode: modeEnum }) => {
       https://api.sky.money
       https://info-sky.blockanalitica.com
       https://sky-tenderly.blockanalitica.com
+      https://api.cow.fi/
       https://api.morpho.org/
       https://api.merkl.xyz/
       wss://relay.walletconnect.com

--- a/packages/hooks/src/trade/constants.ts
+++ b/packages/hooks/src/trade/constants.ts
@@ -9,9 +9,9 @@ export enum TradeSide {
 }
 
 const COW_API_ENDPOINT = {
-  [mainnet.id]: 'https://api.cow.fi/mainnet',
-  [base.id]: 'https://api.cow.fi/base',
-  [arbitrum.id]: 'https://api.cow.fi/arbitrum_one'
+  [mainnet.id]: 'https://api.cow.finance/mainnet',
+  [base.id]: 'https://api.cow.finance/base',
+  [arbitrum.id]: 'https://api.cow.finance/arbitrum_one'
 } as const;
 
 export enum OrderQuoteSideKind {

--- a/packages/hooks/src/trade/useCowswapTradeHistory.ts
+++ b/packages/hooks/src/trade/useCowswapTradeHistory.ts
@@ -120,7 +120,7 @@ export function useCowswapTradeHistory({
     dataSources: [
       {
         title: 'CoW Protocol API',
-        href: 'https://docs.cow.fi/category/apis',
+        href: 'https://docs.cow.finance/category/apis',
         onChain: false,
         trustLevel: TRUST_LEVELS[TrustLevelEnum.TWO]
       }

--- a/packages/hooks/src/trade/useQuoteTrade.ts
+++ b/packages/hooks/src/trade/useQuoteTrade.ts
@@ -181,7 +181,7 @@ export const useQuoteTrade = ({
     dataSources: [
       {
         title: 'CoW Protocol Order book API',
-        href: 'https://docs.cow.fi/cow-protocol/reference/apis/orderbook',
+        href: 'https://docs.cow.finance/cow-protocol/reference/apis/orderbook',
         onChain: false,
         trustLevel: TRUST_LEVELS[TrustLevelEnum.TWO]
       }

--- a/packages/hooks/src/trade/useQuoteTrade.ts
+++ b/packages/hooks/src/trade/useQuoteTrade.ts
@@ -7,9 +7,6 @@ import { OrderQuoteResponse, OrderQuoteSide } from './trade';
 import { verifySlippageAndDeadline } from './helpers';
 import { isL2ChainId } from '@jetstreamgg/sky-utils';
 
-const COW_QUOTES_TEMPORARILY_DISABLED = true;
-const COW_QUOTES_TEMPORARILY_DISABLED_ERROR = 'CowQuotesTemporarilyDisabled';
-
 type GetTradeQuoteParams = {
   chainId: number;
   sellToken: `0x${string}`;
@@ -35,10 +32,6 @@ const getTradeQuote = async ({
   isEthFlow,
   isSmartContractWallet
 }: GetTradeQuoteParams) => {
-  if (COW_QUOTES_TEMPORARILY_DISABLED) {
-    throw new Error(COW_QUOTES_TEMPORARILY_DISABLED_ERROR);
-  }
-
   const side: OrderQuoteSide =
     kind === OrderQuoteSideKind.BUY
       ? { kind: OrderQuoteSideKind.BUY, buyAmountAfterFee: amount.toString() }
@@ -173,10 +166,7 @@ export const useQuoteTrade = ({
     gcTime: 2 * 60 * 1000,
     retry: (failureCount: number, error: Error) => {
       //don't retry if the error is because the sell amount does not cover the fee
-      if (
-        error.message?.includes('SellAmountDoesNotCoverFee') ||
-        error.message?.includes(COW_QUOTES_TEMPORARILY_DISABLED_ERROR)
-      ) {
+      if (error.message?.includes('SellAmountDoesNotCoverFee')) {
         return false;
       }
       return failureCount < 2;

--- a/packages/hooks/src/trade/useTradeCosts.ts
+++ b/packages/hooks/src/trade/useTradeCosts.ts
@@ -175,7 +175,7 @@ export const useTradeCosts = ({
   const mutate = baPricesError ? mutateCowPrices : mutateBaPrices;
   const title = baPricesError ? 'CoW Protocol Order book API' : 'BA Labs API';
   const href = baPricesError
-    ? 'https://docs.cow.fi/cow-protocol/reference/apis/orderbook'
+    ? 'https://docs.cow.finance/cow-protocol/reference/apis/orderbook'
     : 'https://blockanalitica.com/';
 
   return {

--- a/packages/utils/src/getCowExplorerLink.ts
+++ b/packages/utils/src/getCowExplorerLink.ts
@@ -8,11 +8,11 @@ export function getCowExplorerLink(chainId: number, orderId: string) {
 function getCowPrefix(id: number) {
   switch (id) {
     case chainId.base:
-      return 'explorer.cow.fi/base';
+      return 'explorer.cow.finance/base';
     case chainId.arbitrum:
-      return 'explorer.cow.fi/arb1';
+      return 'explorer.cow.finance/arb1';
     case chainId.mainnet:
     default:
-      return 'explorer.cow.fi';
+      return 'explorer.cow.finance';
   }
 }

--- a/packages/widgets/src/widgets/TradeWidget/components/TradeHeader.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeHeader.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/react/macro';
 import { Dispatch, SetStateAction } from 'react';
 import { TradeConfigMenu } from './TradeConfigMenu';
 import { Heading, Text } from '@widgets/shared/components/ui/Typography';
+import { ExternalLink } from '@widgets/shared/components/ExternalLink';
 import { CoW } from '@widgets/shared/components/icons/CoW';
 
 type PropTypes = {
@@ -10,6 +11,7 @@ type PropTypes = {
   isEthFlow?: boolean;
   ttl: string;
   setTtl: Dispatch<SetStateAction<string>>;
+  onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
 export const TradeHeader = ({
@@ -18,7 +20,7 @@ export const TradeHeader = ({
   isEthFlow = false,
   ttl,
   setTtl
-}: PropTypes): React.ReactElement => {
+}: Omit<PropTypes, 'originToken' | 'onExternalLinkClicked'>): React.ReactElement => {
   return (
     <div className="flex items-baseline justify-between gap-2">
       <Heading variant="x-large">
@@ -41,10 +43,24 @@ export const TradeSubHeader = () => (
   </Text>
 );
 
-export const TradePoweredBy = () => (
+export const TradePoweredBy = ({
+  onExternalLinkClicked
+}: {
+  onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+}) => (
   <div className="mb-4 flex items-center gap-1.5">
-    <Text className="text-text text-sm leading-none font-normal">Powered by CoW Protocol</Text>
+    <Text className="text-text text-sm leading-none font-normal">
+      Powered by{' '}
+      <ExternalLink
+        href="https://cow.fi/"
+        showIcon={true}
+        iconSize={12}
+        wrapperClassName="gap-1"
+        onExternalLinkClicked={onExternalLinkClicked}
+      >
+        CoW Protocol
+      </ExternalLink>
+    </Text>
     <CoW className="rounded-[0.25rem]" />
   </div>
 );
-

--- a/packages/widgets/src/widgets/TradeWidget/components/TradeHeader.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/components/TradeHeader.tsx
@@ -52,7 +52,7 @@ export const TradePoweredBy = ({
     <Text className="text-text text-sm leading-none font-normal">
       Powered by{' '}
       <ExternalLink
-        href="https://cow.fi/"
+        href="https://cow.finance/"
         showIcon={true}
         iconSize={12}
         wrapperClassName="gap-1"

--- a/packages/widgets/src/widgets/TradeWidget/index.tsx
+++ b/packages/widgets/src/widgets/TradeWidget/index.tsx
@@ -1563,7 +1563,7 @@ function TradeWidgetWrapped({
       }
     >
       <div className="mt-[-16px] space-y-0">
-        <TradePoweredBy />
+        <TradePoweredBy onExternalLinkClicked={onExternalLinkClicked} />
       </div>
       <AnimatePresence mode="popLayout" initial={false}>
         {widgetState.screen === TradeScreen.REVIEW && quoteData && originToken && targetToken ? (

--- a/packages/widgets/src/widgets/TradeWidget/lib/utils.ts
+++ b/packages/widgets/src/widgets/TradeWidget/lib/utils.ts
@@ -59,8 +59,6 @@ export function getAllowedTargetTokens(
 
 export function getQuoteErrorForType(errorType: HandledQuoteErrorTypes | string) {
   switch (errorType) {
-    case 'CowQuotesTemporarilyDisabled':
-      return 'Trades via CoW are temporailty disabled';
     case HandledQuoteErrorTypes.NoLiquidity:
       return 'Request declined. Either you’ve entered an amount that does not meet the minimum required to trade, or there is insufficient liquidity available to process the amount you’ve entered.';
     case HandledQuoteErrorTypes.SellAmountDoesNotCoverFee:


### PR DESCRIPTION
## Summary
- Migrates CoW API/docs/explorer/FAQ links from `cow.fi` → `cow.finance` across hooks, widgets, webapp, and e2e tests
- Reverts the temporary CoW quote disablement (restores `useQuoteTrade` flow and removes `CowQuotesTemporarilyDisabled` error path)
- Adds `api.cow.finance/` to the vite CSP connect-src allowlist and wires a click-tracked `ExternalLink` into `TradePoweredBy`

## Test plan
- [ ] `pnpm typecheck` and `pnpm lint` pass
- [ ] `pnpm test` passes
- [ ] `pnpm e2e` cowswap-trade suite passes against the new `api.cow.finance` endpoints
- [ ] Manual: trade quote loads on mainnet/base/arbitrum; CoW explorer link opens correct host; `Powered by CoW Protocol` link navigates to `cow.finance`