### PR TITLE
Hotfix: Correct sUSDS preview on withdraw tab

### DIFF
--- a/packages/widgets/src/widgets/SavingsWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/SavingsWidget/components/SupplyWithdraw.tsx
@@ -100,7 +100,7 @@ export const SupplyWithdraw = ({
   });
 
   const { data: sUsdsWithdrawAmount } = useReadSavingsUsds({
-    functionName: 'previewRedeem',
+    functionName: 'previewWithdraw',
     args: [amount],
     chainId: chainId as keyof typeof sUsdsAddress,
     query: {


### PR DESCRIPTION
### What does this PR do?                                                                                                                                                                                        
                                                                                                                                                                                                                   
  Hotfix for a display bug on the Savings **Withdraw** tab: the "You will supply" row in the transaction overview was showing an incorrect (inflated) sUSDS amount.                                                
                                                                                                                                                                                                                   
  **Root cause.** `SupplyWithdraw.tsx` was calling `previewRedeem(amount)`, but `amount` in this component is the USDS the user wants to withdraw. `previewRedeem` is an ERC-4626 read that takes **sUSDS shares** 
  and returns USDS — the inverse of what we need. Passing a USDS amount to it returns `assets × chi` instead of `assets / chi`, overstating the sUSDS the user sees by roughly 19.5% at current rates.
                                                                                                                                                                                                                   
  Switched to `previewWithdraw(assets)`, which is the correct ERC-4626 function for a UI where the user specifies the asset amount and we want the share amount that will be burned.                               
   
  **Scope of impact.** Display-only. The actual withdraw transaction (`useSavingsWithdraw`) calls `sUsds.withdraw(amount, receiver, owner)` with the USDS amount, so the vault always burned the correct share     
  amount and users always received exactly the USDS they asked for. No funds were ever at risk — but the overview was alarming (e.g. a 500k USDS withdrawal showed "546.62k sUSDS" when the true burn was
  ~457.35k).                                                                                                                                                                                                       
                                                            
  **Example from reported bug (rate 3.75%, chi ≈ 1.0932):**                                                                                                                                                        
  | Input | Before (buggy) | After (fixed) |
  |---|---|---|                                                                                                                                                                                                    
  | Withdraw 500,000 USDS | 546.62k sUSDS shown | 457.35k sUSDS shown |
                                                                                                                                                                                                                   
  **Regression source.** Introduced by #946 ("Show stUsds and sUsds amounts in token overview sections"), merged to `development` on 2025-10-20 and reaching `main` via #1032 on 2025-10-31. The bug has been live 
  ~5.5 months. Same copy-paste pattern exists in `StUSDSWidget` and `L2SavingsWidget` but **uses `previewWithdraw` already** — only the mainnet `SavingsWidget` had the wrong function.                            
                                                                                                                                                                                                                   
  **Why CI didn't catch it.** The E2E savings test (`mainnet-savings.spec.ts`) withdraws 0.01 USDS and asserts only on the final success message and balances — never on the "You will supply" overview row. At    
  0.01 USDS the buggy and correct values both round to "0.01 sUSDS" under `formatBigInt({ maxDecimals: 2, compact: true })`, so even a text assertion wouldn't have caught it at that amount. Follow-up: add an
  integration test that mocks `useReadSavingsUsds` and asserts the rendered overview value. Not in this PR to keep the hotfix minimal.                                                                             
                                                            
  **Files changed:** 1 file, 1 line.                                                                                                                                                                               
   
  ### Testing steps:                                                                                                                                                                                               
                                                            
  1. Check out this branch and run `pnpm dev` + `pnpm dev:packages`.                                                                                                                                               
  2. Connect a wallet with a Savings position (or use mock wallet with `pnpm dev:mock`).
  3. Go to **Savings → Withdraw**.                                                                                                                                                                                 
  4. Enter a large withdraw amount (e.g. 500,000 or use the `100%` button on a sizable balance).
  5. Expand **Transaction overview**.                                                                                                                                                                              
  6. Verify:                                                                                                                                                                                                       
     - [ ] "You will withdraw: N USDS" matches the input                                                                                                                                                           
     - [ ] "You will supply: M sUSDS" is **less than** the USDS amount (since 1 sUSDS > 1 USDS at current chi)                                                                                                     
     - [ ] Ratio ≈ USDS ÷ (share price from the `Savings balance` / `TVL` line above), i.e. roughly `N / 1.09` at current rate                                                                                     
     - [ ] Executing the withdrawal still succeeds and the wallet receives exactly the USDS amount entered                                                                                                         
  7. Sanity-check the **Supply** tab still shows the correct sUSDS to receive (this path was not touched but shares the same file).                                                                                
  8. `pnpm typecheck` passes (verified locally).                                                                                                                                                                   
                                                                                                                                                                                                                   
  ### Rollout note                                                                                                                                                                                                 
                                                                                                                                                                                                                   
  After this merges to `main`, forward-merge `main → preprod → staging → development` (or cherry-pick) so the next release train doesn't reintroduce `previewRedeem`.