### PR TITLE
Add security headers to Vercel configuration for enhanced protection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,24 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), midi=(), serial=(), hid=()"
+        },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
  - Adds HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and Cross-Origin-Opener-Policy headers to `vercel.json`
  - Addresses security audit finding M-03 (immediate-win headers that need no code changes)                                                                                                                                                                                                                                
  - `X-Frame-Options` is intentionally omitted — `DENY` would break Safe wallet integration, and `SAMEORIGIN` doesn't support allowlisting specific origins. The modern replacement is CSP `frame-ancestors`, which allows allowlisting (e.g. `frame-ancestors 'self' https://app.safe.global`). However, `frame-ancestors`
   is silently ignored by browsers when CSP is delivered via a `<meta>` tag (our current setup in Vite). It only works as an HTTP response header. Clickjacking protection will be added in a follow-up when CSP migrates from the Vite meta tag to an HTTP response header via Cloudflare Transform Rules.               

## Claude verification
<img width="837" height="321" alt="image" src="https://github.com/user-attachments/assets/03248de0-fc46-4a29-a0ea-c6812c2d2aec" />

                                                            
  ## Verification                                                                                                                                                                                                                                                                                                          
  - [ ] Grep for `window.opener` usage — none found, COOP is safe to enable
  - [ ] `window.open` in ExternalLinkModal.tsx already uses `noopener,noreferrer`
  - [ ] Deploy to Vercel preview and confirm headers appear in Network tab
  - [ ] Run preview URL through securityheaders.com (use "Hide results")                                                                                                                                                                                                                                                   
  - [ ] Smoke test wallet connect, trade, savings, stake, upgrade flows in preview
                                                                                                                                                                                                                                                                                                                           
  ## Out of scope                                           
  - CSP migration from `<meta>` tag to HTTP response header (follow-up ticket)
  - `frame-ancestors` allowlisting for Safe (requires CSP migration first)  