### PR TITLE
sentry: fix toSorted, silence error -32601

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -82,9 +82,13 @@ export function initSentry(): void {
         return null;
       }
 
-      // Drop unhandled wallet provider rejections (EIP-1193 code 4001).
-      // These are plain-object rejections from wallet connectors during Wagmi's
-      // auto-reconnect on page load — not actionable on our side (WEBAPP-B).
+      // Drop unhandled wallet provider rejections from EIP-1193 providers.
+      // These are plain-object rejections we can't prevent from our side:
+      //   - 4001: user rejected request during Wagmi auto-reconnect (WEBAPP-B).
+      //   - -32601: JSON-RPC "Method not found" — wagmi/viem/RainbowKit
+      //     speculatively probe optional methods (EIP-5792 capabilities,
+      //     wallet_watchAsset, etc.) and wallets that don't implement them
+      //     reject with this code.
       const extraData = (event.extra as Record<string, unknown> | undefined)?.__serialized__ as
         | Record<string, unknown>
         | undefined;
@@ -92,7 +96,7 @@ export function initSentry(): void {
         event.exception?.values?.some(v =>
           v.value?.includes('Object captured as promise rejection with keys')
         ) &&
-        extraData?.code === 4001
+        (extraData?.code === 4001 || extraData?.code === -32601)
       ) {
         return null;
       }

--- a/packages/widgets/src/widgets/TradeWidget/lib/utils.ts
+++ b/packages/widgets/src/widgets/TradeWidget/lib/utils.ts
@@ -42,7 +42,7 @@ export function getAllowedTargetTokens(
   targetTokenList: TokenForChain[],
   disallowedPairs?: Record<string, SUPPORTED_TOKEN_SYMBOLS[]>
 ) {
-  const sortedTargetTokenList = targetTokenList.toSorted(targetTokensSort);
+  const sortedTargetTokenList = [...targetTokenList].sort(targetTokensSort);
 
   if (!disallowedPairs || !inputTokenSymbol) return sortedTargetTokenList;
 


### PR DESCRIPTION
  - Fix WEBAPP-3X — TypeError: t.toSorted is not a function on iOS Safari 15.x.
  Array.prototype.toSorted (ES2023) is unsupported before Safari 16. Replaced the single call in
  TradeWidget/lib/utils.ts with [...arr].sort(cmp), preserving the non-mutating semantics without
  the runtime dependency.
  - Silence WEBAPP-B — 124 events of UnhandledRejection: Object captured as promise rejection with
  keys: code, message with code: -32601 (JSON-RPC "Method not found"). These are speculative
  EIP-1193 method probes from wagmi/viem/RainbowKit (EIP-5792 capabilities, wallet_watchAsset,
  etc.) rejecting on wallets that don't implement the method. Extended the existing 4001 filter in
  sentry/init.ts beforeSend to also drop -32601 rejections with the same plain-object shape.