### PR TITLE
Keep address and terms checks enabled on private deployments

### DIFF
--- a/apps/webapp/src/modules/ui/context/ConnectedContext.test.tsx
+++ b/apps/webapp/src/modules/ui/context/ConnectedContext.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectedProvider, useConnectedContext } from './ConnectedContext';
+
+const mockUseVpnCheck = vi.fn();
+const mockCheckTermsWithRetry = vi.fn();
+const mockTrackVpnCheckCompleted = vi.fn();
+
+let mockPrivateDeployment = false;
+let mockConnection = {
+  isConnected: true,
+  address: '0x1234567890123456789012345678901234567890'
+};
+let mockRestrictedAddressCheck = {
+  data: { addressAllowed: true },
+  isLoading: false,
+  error: undefined
+};
+let mockVpnCheck = {
+  data: { isConnectedToVpn: false, isRestrictedRegion: false, countryCode: 'SE' },
+  isLoading: false,
+  error: undefined
+};
+
+vi.mock('wagmi', () => ({
+  useChainId: () => 1,
+  useConnection: () => mockConnection
+}));
+
+vi.mock('@/lib/constants', () => ({
+  IS_PRODUCTION_ENV: false
+}));
+
+vi.mock('@jetstreamgg/sky-hooks', () => ({
+  useRestrictedAddressCheck: () => mockRestrictedAddressCheck,
+  useVpnCheck: (args: unknown) => {
+    mockUseVpnCheck(args);
+    return mockVpnCheck;
+  }
+}));
+
+vi.mock('@/lib/isPrivateDeployment', () => ({
+  isPrivateDeployment: () => mockPrivateDeployment
+}));
+
+vi.mock('@/modules/analytics/hooks/useVpnAnalytics', () => ({
+  useVpnAnalytics: () => ({
+    trackVpnCheckCompleted: mockTrackVpnCheckCompleted
+  })
+}));
+
+vi.mock('@/modules/ui/lib/checkTermsWithRetry', () => ({
+  checkTermsWithRetry: (address: string) => mockCheckTermsWithRetry(address)
+}));
+
+function ContextSnapshot() {
+  const { isAuthorized, isConnectedAndAcceptedTerms } = useConnectedContext();
+
+  return (
+    <>
+      <div data-testid="authorized">{String(isAuthorized)}</div>
+      <div data-testid="connected-accepted">{String(isConnectedAndAcceptedTerms)}</div>
+    </>
+  );
+}
+
+describe('ConnectedProvider private deployment handling', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_SKIP_AUTH_CHECK', 'false');
+    mockPrivateDeployment = false;
+    mockConnection = {
+      isConnected: true,
+      address: '0x1234567890123456789012345678901234567890'
+    };
+    mockRestrictedAddressCheck = {
+      data: { addressAllowed: true },
+      isLoading: false,
+      error: undefined
+    };
+    mockVpnCheck = {
+      data: { isConnectedToVpn: false, isRestrictedRegion: false, countryCode: 'SE' },
+      isLoading: false,
+      error: undefined
+    };
+    mockUseVpnCheck.mockClear();
+    mockCheckTermsWithRetry.mockReset();
+    mockTrackVpnCheckCompleted.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps restricted-address enforcement enabled on private deployments', async () => {
+    mockPrivateDeployment = true;
+    mockRestrictedAddressCheck = {
+      data: { addressAllowed: false },
+      isLoading: false,
+      error: undefined
+    };
+    mockCheckTermsWithRetry.mockResolvedValue({ termsAccepted: true, error: false });
+
+    render(
+      <ConnectedProvider>
+        <ContextSnapshot />
+      </ConnectedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('authorized').textContent).toBe('false');
+    });
+
+    expect(mockUseVpnCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: true
+      })
+    );
+    expect(mockCheckTermsWithRetry).toHaveBeenCalledWith(mockConnection.address);
+  });
+
+  it('still requires terms acceptance on private deployments', async () => {
+    mockPrivateDeployment = true;
+    mockCheckTermsWithRetry.mockResolvedValue({ termsAccepted: false, error: false });
+
+    render(
+      <ConnectedProvider>
+        <ContextSnapshot />
+      </ConnectedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connected-accepted').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('authorized').textContent).toBe('true');
+    expect(mockCheckTermsWithRetry).toHaveBeenCalledWith(mockConnection.address);
+  });
+});

--- a/apps/webapp/src/modules/ui/context/ConnectedContext.tsx
+++ b/apps/webapp/src/modules/ui/context/ConnectedContext.tsx
@@ -52,8 +52,8 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const [termsCheckError, setTermsCheckError] = useState(false);
   const [enabled, setEnabled] = useState(false);
 
-  const skipAuthCheck =
-    (!IS_PRODUCTION_ENV && import.meta.env.VITE_SKIP_AUTH_CHECK === 'true') || isPrivateDeployment();
+  const fullAuthBypass = !IS_PRODUCTION_ENV && import.meta.env.VITE_SKIP_AUTH_CHECK === 'true';
+  const skipVpnCheck = fullAuthBypass || isPrivateDeployment();
 
   const authUrl = import.meta.env.VITE_AUTH_URL || 'https://staging-api.sky.money';
   const {
@@ -66,7 +66,7 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     data: vpnData,
     isLoading: vpnIsLoading,
     error: vpnError
-  } = useVpnCheck({ authUrl, skip: skipAuthCheck });
+  } = useVpnCheck({ authUrl, skip: skipVpnCheck });
 
   // Track VPN check result once when data or error resolves
   const { trackVpnCheckCompleted } = useVpnAnalytics();
@@ -125,7 +125,7 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   }, [isConnected, address, checkTermsAcceptance]);
 
   useEffect(() => {
-    if (skipAuthCheck) {
+    if (fullAuthBypass) {
       setHasAcceptedTerms(true);
       return;
     }
@@ -135,7 +135,7 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       setHasAcceptedTerms(false);
       setTermsCheckError(false);
     }
-  }, [isConnected, address, skipAuthCheck, checkTermsAcceptance]);
+  }, [isConnected, address, fullAuthBypass, checkTermsAcceptance]);
 
   const isAllowed = useMemo(
     () =>
@@ -154,11 +154,11 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     ]
   );
 
-  const isAuthorized = isAllowed || skipAuthCheck;
+  const isAuthorized = isAllowed || fullAuthBypass;
   const isConnectedAndAcceptedTerms = isConnected && hasAcceptedTerms;
 
   useEffect(() => {
-    if (skipAuthCheck || vpnIsLoading || vpnTrackedRef.current) return;
+    if (skipVpnCheck || vpnIsLoading || vpnTrackedRef.current) return;
     if (!vpnData && !vpnError) return;
     vpnTrackedRef.current = true;
     const result = vpnError
@@ -176,7 +176,7 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       countryCode: vpnData?.countryCode ?? null,
       result
     });
-  }, [skipAuthCheck, vpnIsLoading, vpnData, vpnError, isAllowed, trackVpnCheckCompleted]);
+  }, [skipVpnCheck, vpnIsLoading, vpnData, vpnError, isAllowed, trackVpnCheckCompleted]);
 
   return (
     <ConnectedContext.Provider


### PR DESCRIPTION
  ## Summary

  This stacked PR narrows the private-deployment bypass added in `feature/app-private-bypass`.

  Private hostnames should bypass VPN/geo checks only. They should not inherit the full
  development auth bypass, because that also skips restricted-address enforcement and terms
  acceptance.

  ## Changes

  - split the existing `skipAuthCheck` behavior into:
    - a dev-only full auth bypass for `VITE_SKIP_AUTH_CHECK`
    - a separate VPN-only bypass for private deployments
  - keep restricted-address enforcement active on private hostnames
  - keep terms acceptance checks active on private hostnames
  - add `ConnectedContext` regression tests covering both cases

  ## Why

  The previous wiring let private deployments:
  - authorize wallets even when `addressAllowed === false`
  - mark users as having accepted terms without calling the terms endpoint

  That was broader than the intended private-hostname behavior and created both functional and
  compliance regressions.