### PR TITLE
pnpm.overrides: prune redundant entry, tighten replacements, document conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,18 +104,22 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
+  "//pnpm.overrides": [
+    "Conventions for entries below:",
+    "1. Prefer range-scoped selectors (pkg@<patched) so the override self-expires once upstreams publish clean versions.",
+    "2. On the replacement side, use a tilde range (~X.Y.Z) pinned to the same minor whenever multiple majors of the package may coexist in the tree - an unbounded >=X.Y.Z can silently bump older-major consumers to a newer major via pnpm's dedup (see picomatch/bn.js/glob)."
+  ],
   "pnpm": {
     "overrides": {
       "esbuild@<=0.24.2": "^0.25.0",
       "@babel/runtime@7.26.7": "7.26.10",
       "axios@>=1.0.0 <1.15.0": "1.15.0",
       "@json-rpc-tools/provider>axios@^0.21.0": "1.15.0",
-      "protobufjs@<7.5.5": "^7.5.5",
-      "dompurify@<3.4.0": ">=3.4.0",
-      "lodash@<4.18.0": ">=4.18.0",
-      "defu@<6.1.5": ">=6.1.5",
-      "h3@<1.15.9": ">=1.15.9",
-      "vite@>=7.0.0 <7.3.2": "^7.3.2"
+      "protobufjs@<7.5.5": "~7.5.5",
+      "dompurify@<3.4.0": "~3.4.0",
+      "lodash@<4.18.0": "~4.18.0",
+      "defu@<6.1.5": "~6.1.5",
+      "h3@<1.15.9": "~1.15.9"
     }
   },
   "packageManager": "pnpm@10.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,12 +312,11 @@ overrides:
   '@babel/runtime@7.26.7': 7.26.10
   axios@>=1.0.0 <1.15.0: 1.15.0
   '@json-rpc-tools/provider>axios@^0.21.0': 1.15.0
-  protobufjs@<7.5.5: ^7.5.5
-  dompurify@<3.4.0: '>=3.4.0'
-  lodash@<4.18.0: '>=4.18.0'
-  defu@<6.1.5: '>=6.1.5'
-  h3@<1.15.9: '>=1.15.9'
-  vite@>=7.0.0 <7.3.2: ^7.3.2
+  protobufjs@<7.5.5: ~7.5.5
+  dompurify@<3.4.0: ~3.4.0
+  lodash@<4.18.0: ~4.18.0
+  defu@<6.1.5: ~6.1.5
+  h3@<1.15.9: ~1.15.9
 
 importers:
 
@@ -1632,7 +1631,7 @@ packages:
     resolution: {integrity: sha512-cKfVCoOJsHssx7OazCb8P/KHn1UqCiod+OGIpGqchtla09xPNSZmfyEp/Of0+S6G5REkOMV/ZGgl+awtGkJ0fA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^3 || ^4 || ^5.0.9 || ^6 || ^7
 
   '@lit-labs/ssr-dom-shim@1.4.0':
     resolution: {integrity: sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==}
@@ -3510,7 +3509,7 @@ packages:
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^5.2.0 || ^6 || ^7
 
   '@tanstack/eslint-plugin-query@5.91.4':
     resolution: {integrity: sha512-8a+GAeR7oxJ5laNyYBQ6miPK09Hi18o5Oie/jx8zioXODv/AUFLZQecKabPdpQSLmuDXEBPKFh+W5DKbWlahjQ==}
@@ -3745,7 +3744,7 @@ packages:
     resolution: {integrity: sha512-QIluDil2prhY1gdA3GGwxZzTAmLdi8cQ2CcuMW4PB/Wu4e/1pzqrwhYWVd09LInCRlDUidQjd0B70QWbjWtLxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -3763,7 +3762,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^7.3.2
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -7671,7 +7670,7 @@ packages:
     resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
     peerDependencies:
       typescript: '*'
-      vite: ^7.3.2
+      vite: '*'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -7679,18 +7678,18 @@ packages:
   vite-plugin-node-polyfills@0.25.0:
     resolution: {integrity: sha512-rHZ324W3LhfGPxWwQb2N048TThB6nVvnipsqBUJEzh3R9xeK9KI3si+GMQxCuAcpPJBVf0LpDtJ+beYzB3/chg==}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite-plugin-simple-html@1.1.0:
     resolution: {integrity: sha512-77yBF60RKUWIkmJtKKhGTExV8eW6UvrIcrXHBWNRFfqiH4Bt8MniCeIte1Jv1ef6SkckoIsg5QFG/wafgbm6ZQ==}
     peerDependencies:
-      vite: ^7.3.2
+      vite: '>=2.3.0 <9.0.0'
 
   vite-plugin-static-copy@3.2.0:
     resolution: {integrity: sha512-g2k9z8B/1Bx7D4wnFjPLx9dyYGrqWMLTpwTtPHhcU+ElNZP2O4+4OsyaficiDClus0dzVhdGvoGFYMJxoXZ12Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}


### PR DESCRIPTION
## Summary

Audit-driven cleanup of `pnpm.overrides` as a follow-up to [Wave 1](https://github.com/jetstreamgg/tarmac/pull/1506) / [Wave 2](https://github.com/jetstreamgg/tarmac/pull/1508). Part of [APP-198](https://linear.app/skybasestar/issue/APP-198).

### Changes

1. **Remove the `vite@>=7.0.0 <7.3.2 → ^7.3.2` override.**  Redundant. The catalog bump to `vite: ^7.3.2` in `pnpm-workspace.yaml` (Wave 1) covers every direct consumer, and `pnpm why -r vite` reports **only** 7.3.2 in the tree — no transitive ever lands in the `<7.3.2` range, so the override is doing nothing.

2. **Tighten Wave 1 replacement values to tilde ranges** for `protobufjs`, `dompurify`, `lodash`, `defu`, `h3`. Unbounded `>=X.Y.Z` replacements let pnpm's deduplication silently lift older-major consumers onto a newer major — the exact failure I hit on picomatch / bn.js / glob during Wave 2, where a `^2.2.1` spec was resolving to `picomatch 4.x`. Today each of these Wave 1 packages has only a single major in the tree, so this is defensive — it stops the failure mode from re-emerging if a future transitive drags in an older major.

3. **Add a `//pnpm.overrides` comment block** above the overrides documenting the two conventions that future additions should follow:
   - Range-scoped selector (`pkg@<patched`) so the override self-expires once upstreams publish clean versions.
   - Tilde-or-tighter replacement value to stay inside the same minor.

### Left in place (deliberate)

- `esbuild@<=0.24.2 → ^0.25.0` and `@babel/runtime@7.26.7 → 7.26.10` — both pre-existing, both currently inert (no matching version in the tree). Zero runtime cost and we don't have the original context. Leaving alone; if someone turns up the reason they can be cleanly removed later.
- `axios@>=1.0.0 <1.15.0 → 1.15.0` and `@json-rpc-tools/provider>axios@^0.21.0 → 1.15.0` — both active security pins for ongoing axios CVEs. The targeted one is the only thing keeping `@json-rpc-tools/provider 1.7.6` (pulled in via `eip1193-provider`) off axios 0.21.x.

### Resolved versions after cleanup (unchanged)

```
protobufjs 7.5.5
dompurify  3.4.0
lodash     4.18.1
defu       6.1.7
h3         1.15.11
vite       7.3.2   (only version in tree)
```

## Test plan

- [x] `pnpm install` succeeds with the cleaned overrides
- [x] `pnpm typecheck` passes across all workspaces
- [x] `pnpm why -r` confirms every previously-patched package is still at its patched version
- [ ] CI green

## Follow-ups

- **Wave 2 PR ([#1508](https://github.com/jetstreamgg/tarmac/pull/1508))** still has some `>=X.Y.Z` replacements that should be tightened to tilde for consistency (`flatted`, `follow-redirects`, `js-yaml`, `qs`, `hono`, `ajv`, `mdast-util-to-hast`, and the minimatch / glob / rollup entries). I'll follow up with either a commit on that branch before merge or a second cleanup PR afterwards — same idea, same convention.
- **Track down the history of `esbuild@<=0.24.2` and `@babel/runtime@7.26.7`** — if the reason they were added no longer applies, drop them in a later cleanup.