### PR TITLE
APP-201: Dependabot Wave 3 — elliptic watchlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
     "2. On the replacement side, use a tilde range (~X.Y.Z) pinned to the same minor whenever multiple majors of the package may coexist in the tree - an unbounded >=X.Y.Z can silently bump older-major consumers to a newer major via pnpm's dedup (see picomatch/bn.js/glob).",
     "3. When only one major is in play, caret (^X.Y.Z) is fine and lets pnpm pull in bug-fix minors naturally."
   ],
+  "//pnpm.overrides.watchlist": [
+    "Open Dependabot alerts we intentionally do NOT override here, with rationale:",
+    "- elliptic <=6.6.1 (GHSA-848j-6mx2-7j84, alert #53, low): no patched version published upstream as of 2026-04-22, so there is no target range to pin to. Transitive-only via vite-plugin-node-polyfills -> node-stdlib-browser -> crypto-browserify -> browserify-sign/create-ecdh (dev/bundler polyfill path). No direct imports in this repo (confirmed via grep). Action: revisit when upstream ships a fix; if we ever add a direct call site, migrate to @noble/curves instead. Tracked in APP-201."
+  ],
   "pnpm": {
     "overrides": {
       "esbuild@<=0.24.2": "^0.25.0",


### PR DESCRIPTION
## Summary

Closes out the tarmac Dependabot cleanup from [APP-198](https://linear.app/skybasestar/issue/APP-198) as **Wave 3 — elliptic watchlist** ([APP-201](https://linear.app/skybasestar/issue/APP-201)).

- Stacked on #1508 (Wave 2); merge that first. Rebase onto `development` once #1508 lands.
- Adds a `//pnpm.overrides.watchlist` documentation block to root `package.json` recording why alert **#53** (elliptic ≤6.6.1, GHSA-848j-6mx2-7j84) is not patched via `pnpm.overrides`.

## Findings

- `pnpm why elliptic -r` chain: `vite-plugin-node-polyfills` → `node-stdlib-browser` → `crypto-browserify` → `browserify-sign` / `create-ecdh` → `elliptic`. Dev/bundler polyfill path only.
- `grep` for `from 'elliptic'` / `require('elliptic')` across the repo: **no direct imports**.
- Upstream advisory has `first_patched_version: null` as of 2026-04-22 — nothing to pin to.

## Rationale

- Can't be closed with `pnpm up` or `pnpm.overrides` — there is no patched version to force.
- Leaving the finding in-repo (next to the conventions block added in #1509) means the next person looking at the overrides sees *why* this alert is intentionally unaddressed, not just that it's missing.
- If/when we add a direct call site, the note points future work at `@noble/curves` per APP-201.

## Test plan

- [ ] Merge #1508 first.
- [ ] Rebase this branch onto `development` and confirm CI is green (no code paths touched).
- [ ] After merge, verify alert #53 is the only remaining open alert in the GitHub Security tab.