### PR TITLE
fix lingui race condition

### DIFF
--- a/apps/webapp/src/pages/main.tsx
+++ b/apps/webapp/src/pages/main.tsx
@@ -1,6 +1,7 @@
 import { initSentry } from '../modules/sentry/init';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { i18n } from '@lingui/core';
 import { ConfigProvider } from '../modules/config/context/ConfigProvider';
 import { App } from './App';
 import { ErrorBoundary } from '../modules/layout/components/ErrorBoundary';
@@ -9,6 +10,10 @@ import '../modules/analytics/gtag';
 import '../globals.css';
 
 initSentry();
+
+// Prime Lingui synchronously so `<I18nProvider>`'s first render has a non-null
+// context. ConfigProvider's async dynamicActivate loads the real catalog after.
+i18n.loadAndActivate({ locale: 'en', messages: {} });
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/packages/widgets/src/widgets/StUSDSWidget/index.tsx
+++ b/packages/widgets/src/widgets/StUSDSWidget/index.tsx
@@ -285,6 +285,7 @@ const StUSDSWidgetWrapped = ({
   const withdrawDisabled =
     [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
     isWithdrawBalanceError ||
+    providerSelection.isLoading ||
     (txStatus === TxStatus.IDLE && !stUsdsWithdraw.prepared) ||
     isAmountWaitingForDebounce ||
     debouncedAmount === 0n;
@@ -292,6 +293,7 @@ const StUSDSWidgetWrapped = ({
   const batchSupplyDisabled =
     [TxStatus.INITIALIZED, TxStatus.LOADING].includes(txStatus) ||
     isSupplyBalanceError ||
+    providerSelection.isLoading ||
     !batchStUsdsDeposit.prepared ||
     batchStUsdsDeposit.isLoading ||
     isAmountWaitingForDebounce ||


### PR DESCRIPTION
## Summary

Fixes error on app boot caused by a race between Lingui catalog loading and the first render.

## Root cause

`ConfigProvider` calls `dynamicActivate(i18n, 'en')` during render, but the underlying dynamic `import('./locales/en.ts')` is async. `<I18nProvider>` mounts before activation finishes, seeds its context with `null` (per Lingui's `i18n.isActive ? ... : null` logic), and any `<Trans>` in the first paint calls `useLingui() → null` → `TransNoContext` destructures `lingui: { i18n }` from `null` → throws.

The render error escapes the top-level `ErrorBoundary` (Sentry tags: `handled: no`, `mechanism: auto.browser.global_handlers.onerror`), so affected users see a blank page until they refresh.

## Fix

One line in `main.tsx`, before `ReactDOM.createRoot(...).render(...)`:

```ts
i18n.loadAndActivate({ locale: 'en', messages: {} });
```

This flips `i18n.isActive` to `true` with an empty catalog, so `<I18nProvider>`'s first render seeds a non-null context. `ConfigProvider`'s async `dynamicActivate` still loads the real catalog and triggers a re-render via Lingui's change event.

Safe because the app is hardcoded to `locale: 'en'` — source strings are already English, so the empty-catalog window is invisible.

## Follow-on: stUSDS button gating

The Lingui prime above removed an incidental boot delay that had been masking a pre-existing race in `StUSDSWidget`. `useStUsdsProviderSelection` defaults `selectedProvider` to `NATIVE` while its native/curve data loads, and `useStUsdsTransactions` re-exports the tx impl based on `isCurve`. If `batchStUsdsDeposit.prepared` became true before provider data finished loading, the button could enable with the NATIVE impl — so a click submitted a native tx even when native was blocked (capacity full) and curve would have been selected once data resolved. Surfaced as e2e failures in `expert-stusds` and `stusds-provider-switching`.

Added `providerSelection.isLoading` to `batchSupplyDisabled` and `withdrawDisabled` in `StUSDSWidget/index.tsx` so the button only enables once selection has resolved and the correct tx impl is wired up.

Fixes WEBAPP-45
Fixes WEBAPP-3Q