### PR TITLE
APP-209: react-markdown 9→10, vite-plugin-node-polyfills 0.25→0.26, audit CI gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,27 @@ jobs:
           pnpm lint
           pnpm typecheck
 
+  audit:
+    name: Audit
+    needs: install
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+        pnpm-version: [10.17.0]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: ${{ matrix.pnpm-version }}
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level high
+
   test:
     name: Test
     needs: install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,14 @@ pnpm build           # Build all packages and webapp
 pnpm build:packages  # Build packages only
 ```
 
+### Security audit
+
+```bash
+pnpm audit --prod --audit-level high   # Audit runtime deps; fails on high/critical
+```
+
+`pnpm audit`'s `dev` flag is unreliable in workspaces. CI uses `pnpm audit --prod --audit-level high` to audit only the runtime dependency trees.
+
 ### i18n
 
 ```bash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     react-markdown:
-      specifier: ^9.1.0
-      version: 9.1.0
+      specifier: ^10.1.0
+      version: 10.1.0
     react-router-dom:
       specifier: ^6.30.3
       version: 6.30.3
@@ -286,8 +286,8 @@ catalogs:
       specifier: ^4.5.4
       version: 4.5.4
     vite-plugin-node-polyfills:
-      specifier: ^0.25.0
-      version: 0.25.0
+      specifier: ^0.26.0
+      version: 0.26.0
     vite-plugin-simple-html:
       specifier: ^1.1.0
       version: 1.1.0
@@ -551,7 +551,7 @@ importers:
         version: 1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-markdown:
         specifier: 'catalog:'
-        version: 9.1.0(@types/react@19.2.7)(react@19.2.4)
+        version: 10.1.0(@types/react@19.2.7)(react@19.2.4)
       react-router-dom:
         specifier: 'catalog:'
         version: 6.30.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -618,7 +618,7 @@ importers:
         version: 5.9.3
       vite-plugin-node-polyfills:
         specifier: 'catalog:'
-        version: 0.25.0(rollup@4.60.1)(vite@7.3.2(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.37.0)(yaml@2.8.3))
+        version: 0.26.0(rollup@4.60.1)(vite@7.3.2(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.37.0)(yaml@2.8.3))
       vite-plugin-simple-html:
         specifier: 'catalog:'
         version: 1.1.0(vite@7.3.2(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.37.0)(yaml@2.8.3))
@@ -6843,8 +6843,8 @@ packages:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
-  react-markdown@9.1.0:
-    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
@@ -7708,10 +7708,10 @@ packages:
       vite:
         optional: true
 
-  vite-plugin-node-polyfills@0.25.0:
-    resolution: {integrity: sha512-rHZ324W3LhfGPxWwQb2N048TThB6nVvnipsqBUJEzh3R9xeK9KI3si+GMQxCuAcpPJBVf0LpDtJ+beYzB3/chg==}
+  vite-plugin-node-polyfills@0.26.0:
+    resolution: {integrity: sha512-BAe5YzJf368XGev02hDvioidx4uVH8dqEJlG73bjQSxM26/AQnGcKFomq9n3vGq5yqpSHKN4h1XQNxx9l98mBg==}
     peerDependencies:
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite-plugin-simple-html@1.1.0:
     resolution: {integrity: sha512-77yBF60RKUWIkmJtKKhGTExV8eW6UvrIcrXHBWNRFfqiH4Bt8MniCeIte1Jv1ef6SkckoIsg5QFG/wafgbm6ZQ==}
@@ -15435,7 +15435,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  react-markdown@9.1.0(@types/react@19.2.7)(react@19.2.4):
+  react-markdown@10.1.0(@types/react@19.2.7)(react@19.2.4):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -16497,7 +16497,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-node-polyfills@0.25.0(rollup@4.60.1)(vite@7.3.2(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.37.0)(yaml@2.8.3)):
+  vite-plugin-node-polyfills@0.26.0(rollup@4.60.1)(vite@7.3.2(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.37.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.60.1)
       node-stdlib-browser: 1.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -82,7 +82,7 @@ catalog:
   react-dom: ^19.2.4
   react-intersection-observer: ^9.16.0
   react-jazzicon: ^1.0.4
-  react-markdown: ^9.1.0
+  react-markdown: ^10.1.0
   react-router-dom: ^6.30.3
   recharts: ^2.15.4
   rehype-sanitize: ^6.0.0
@@ -96,7 +96,7 @@ catalog:
   viem: ^2.47.6
   vite: ^7.3.2
   vite-plugin-dts: ^4.5.4
-  vite-plugin-node-polyfills: ^0.25.0
+  vite-plugin-node-polyfills: ^0.26.0
   vite-plugin-simple-html: ^1.1.0
   vite-plugin-static-copy: ^3.2.0
   vitest: ^3.2.4


### PR DESCRIPTION
## Summary

Closes the security-path advisories identified in [APP-209](https://linear.app/skybasestar/issue/APP-209) (Wave 1 of the [APP-206](https://linear.app/skybasestar/issue/APP-206) upgrade sequence) and adds a CI gate so future runtime-path regressions surface immediately.

**Stacked on #1511 (which is stacked on #1508).** Merge order: #1508 → #1511 → this. GitHub will auto-retarget to `development` as the bases land.

### Catalog bumps (`pnpm-workspace.yaml`)

| Package | From | To | Closes |
|---|---|---|---|
| `react-markdown` | `^9.1.0` | `^10.1.0` | CVE-2025-66400 (`mdast-util-to-hast` unsanitized `class` attr → XSS-adjacent) |
| `vite-plugin-node-polyfills` | `^0.25.0` | `^0.26.0` | CVE-2026-2739 (`bn.js`), CVE-2025-15284 / CVE-2026-2391 (`qs`), CVE-2025-14505 (`elliptic`) |

The CVEs this PR was originally written to close are also defensively covered by Wave 2's `pnpm.overrides` block (#1508). Bumping the upstream packages is still the right move — overrides are no longer needed for these once releases catch up.

### CI gate (`.github/workflows/main.yml`)

New `audit` job parallel to `lint` / `test`, depends only on `install` for ordering. Runs `pnpm audit --prod --audit-level high`. Skips the build cache and `pnpm install` (audit reads straight from `pnpm-lock.yaml` via `cache: 'pnpm'`). No nightly schedule — runs on PRs and `push: [main]`. Easy to add `schedule:` later if desired.

### Documentation (`CLAUDE.md`)

Brief note on why CI uses `--prod`: pnpm's `dev: true` flag is unreliable in workspaces, so we scope the audit to runtime dependency trees.

## react-markdown v9 → v10 compatibility

Only known v10 breaking change per the changelog: the `className` prop on `<Markdown>` was removed. Single call site in this repo:

`apps/webapp/src/modules/ui/components/markdown/SafeMarkdownRenderer.tsx` uses only `rehypePlugins` and `components` — no `className`. No code change required.

## Test plan

- [x] `pnpm install` clean (only the 2 catalog packages change)
- [x] `pnpm lint` passes
- [x] `pnpm audit --prod --audit-level high` exits 0 (3 moderates remain, 0 highs)
- [ ] CI green on the stacked base
- [ ] Manually exercise markdown surfaces (chat / `rehype-sanitize` paths) on staging preview
- [ ] E2E pipeline green on staging preview

## Known pre-existing issues (not regressions)

`pnpm typecheck` fails on the `development` baseline with 9 errors in webapp modules (`convert/`, `rewards/`, `savings/`, `vaults/`, `ui/`) referencing exports that aren't present in the current `@jetstreamgg/sky-widgets` / `sky-hooks` versions. #1508's test plan documents the same baseline. Out of scope here.