### PR TITLE
APP-211: Bump tailwind-merge to v3

### DIFF
--- a/apps/webapp/src/modules/convert/components/ConvertWidgetPane.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertWidgetPane.tsx
@@ -153,7 +153,7 @@ export function ConvertWidgetPane(sharedProps: SharedProps) {
                 role="button"
                 tabIndex={isPending ? -1 : 0}
                 aria-disabled={isPending}
-                className={`from-primary-start/15 to-primary-end/15 hover:from-primary-start hover:to-primary-end border-primary-start/30 bg-radial-(--gradient-position) transition-[background-color,background-image] lg:p-5 ${cardInteractionClass}`}
+                className={`bg-transparent from-primary-start/15 to-primary-end/15 hover:from-primary-start hover:to-primary-end border-primary-start/30 bg-radial-(--gradient-position) transition-[background-color,background-image] lg:p-5 ${cardInteractionClass}`}
                 onClick={() => handleSelectOption(ConvertIntent.PSM_INTENT)}
                 onKeyDown={e => {
                   if (e.key === 'Enter' || e.key === ' ') {
@@ -182,7 +182,7 @@ export function ConvertWidgetPane(sharedProps: SharedProps) {
                   role="button"
                   tabIndex={isPending ? -1 : 0}
                   aria-disabled={isPending}
-                  className={`from-card to-card hover:from-primary-start hover:to-primary-end bg-radial-(--gradient-position) transition-[background-color,background-image] lg:p-5 ${cardInteractionClass}`}
+                  className={`bg-transparent from-card to-card hover:from-primary-start hover:to-primary-end bg-radial-(--gradient-position) transition-[background-color,background-image] lg:p-5 ${cardInteractionClass}`}
                   onClick={() => handleSelectOption(ConvertIntent.TRADE_INTENT)}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -213,7 +213,7 @@ export function ConvertWidgetPane(sharedProps: SharedProps) {
                   tabIndex={isPending ? -1 : 0}
                   aria-disabled={isPending}
                   data-testid="convert-upgrade-card"
-                  className={`from-card to-card hover:from-primary-start hover:to-primary-end bg-radial-(--gradient-position) transition-[background-color,background-image] lg:p-5 ${cardInteractionClass}`}
+                  className={`bg-transparent from-card to-card hover:from-primary-start hover:to-primary-end bg-radial-(--gradient-position) transition-[background-color,background-image] lg:p-5 ${cardInteractionClass}`}
                   onClick={() => handleSelectOption(ConvertIntent.UPGRADE_INTENT)}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {

--- a/apps/webapp/src/modules/expert/components/MorphoVaultStatsCard.tsx
+++ b/apps/webapp/src/modules/expert/components/MorphoVaultStatsCard.tsx
@@ -46,7 +46,7 @@ export const MorphoVaultStatsCard = ({
 
   return (
     <Card
-      className={`from-card to-card h-full bg-radial-(--gradient-position) transition-[background-color,background-image,opacity] lg:p-5 ${onClick && !disabled ? 'hover:from-primary-start/100 hover:to-primary-end/100 cursor-pointer' : ''} ${disabled ? 'opacity-50' : ''}`}
+      className={`bg-transparent from-card to-card h-full bg-radial-(--gradient-position) transition-[background-color,background-image,opacity] lg:p-5 ${onClick && !disabled ? 'hover:from-primary-start/100 hover:to-primary-end/100 cursor-pointer' : ''} ${disabled ? 'opacity-50' : ''}`}
       onClick={disabled ? undefined : onClick}
       data-testid="morpho-vault-stats-card"
     >

--- a/apps/webapp/src/modules/expert/components/StusdsStatsCard.tsx
+++ b/apps/webapp/src/modules/expert/components/StusdsStatsCard.tsx
@@ -30,7 +30,7 @@ export const StusdsStatsCard = ({ onClick, disabled = false }: StusdsStatsCardPr
 
   return (
     <Card
-      className={`from-card to-card h-full bg-radial-(--gradient-position) transition-[background-color,background-image,opacity] lg:p-5 ${onClick && !disabled ? 'hover:from-primary-start/100 hover:to-primary-end/100 cursor-pointer' : ''} ${disabled ? 'opacity-50' : ''}`}
+      className={`bg-transparent from-card to-card h-full bg-radial-(--gradient-position) transition-[background-color,background-image,opacity] lg:p-5 ${onClick && !disabled ? 'hover:from-primary-start/100 hover:to-primary-end/100 cursor-pointer' : ''} ${disabled ? 'opacity-50' : ''}`}
       onClick={disabled ? undefined : onClick}
       data-testid="stusds-stats-card"
     >

--- a/packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCard.tsx
+++ b/packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCard.tsx
@@ -97,7 +97,7 @@ export const RewardsStatsCard = ({
       rewardContract={rewardContract}
       onClick={onClick}
       isConnectedAndEnabled={isConnectedAndEnabled}
-      className="from-card to-card hover:from-primary-start/100 hover:to-primary-end/100 active:from-primary-start/100 active:to-primary-end/100 bg-radial-(--gradient-position) transition-[background-color,background-image,opacity]"
+      className="bg-transparent from-card to-card hover:from-primary-start/100 hover:to-primary-end/100 active:from-primary-start/100 active:to-primary-end/100 bg-radial-(--gradient-position) transition-[background-color,background-image,opacity]"
       content={
         <VStack gap={0}>
           <HStack className="mt-5 justify-between" gap={2}>

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/SaRewardsCard.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/SaRewardsCard.tsx
@@ -61,7 +61,7 @@ export const SaRewardsCard = ({
     <Card
       variant="pool"
       onClick={handleSelectRewardContract}
-      className={`hover-in-before overflow-hidden bg-radial-(--gradient-position) transition-colors ${
+      className={`hover-in-before overflow-hidden bg-transparent bg-radial-(--gradient-position) transition-colors ${
         selectedRewardContract && getAddress(selectedRewardContract) === getAddress(contractAddress)
           ? 'from-primary-start/100 to-primary-end/100'
           : 'from-card to-card hover:from-primary-start/40 hover:to-primary-end/40'

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/StakeDelegateCardCompact.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/StakeDelegateCardCompact.tsx
@@ -24,7 +24,7 @@ export const StakeDelegateCardCompact = ({
   return (
     <Card
       className={cn(
-        'flex items-center justify-between bg-radial-(--gradient-position) transition-colors',
+        'flex items-center justify-between bg-transparent bg-radial-(--gradient-position) transition-colors',
         isDelegateSelected
           ? 'from-primary-start/100 to-primary-end/100 cursor-default'
           : 'from-card to-card hover:from-primary-start/40 hover:to-primary-end/40 cursor-pointer'

--- a/packages/widgets/src/widgets/StakeModuleWidget/components/StakeRewardsCardCompact.tsx
+++ b/packages/widgets/src/widgets/StakeModuleWidget/components/StakeRewardsCardCompact.tsx
@@ -76,7 +76,7 @@ export const StakeRewardsCardCompact = ({
   return (
     <Card
       className={cn(
-        'flex items-center justify-between bg-radial-(--gradient-position) transition-colors',
+        'flex items-center justify-between bg-transparent bg-radial-(--gradient-position) transition-colors',
         isRewardContractSelected
           ? 'from-primary-start/100 to-primary-end/100 cursor-default'
           : 'from-card to-card hover:from-primary-start/40 hover:to-primary-end/40 cursor-pointer'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ catalogs:
       specifier: ^2.0.7
       version: 2.0.7
     tailwind-merge:
-      specifier: ^2.6.1
-      version: 2.6.1
+      specifier: ^3.5.0
+      version: 3.5.0
     tailwindcss:
       specifier: ^4.1.17
       version: 4.2.1
@@ -606,7 +606,7 @@ importers:
         version: 20.8.9(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       tailwind-merge:
         specifier: 'catalog:'
-        version: 2.6.1
+        version: 3.5.0
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.1
@@ -809,7 +809,7 @@ importers:
         version: 6.30.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: 'catalog:'
-        version: 2.6.1
+        version: 3.5.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -7302,8 +7302,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -15940,7 +15940,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwind-merge@2.6.1: {}
+  tailwind-merge@3.5.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.2.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,7 +88,7 @@ catalog:
   rehype-sanitize: ^6.0.0
   rollup-plugin-visualizer: ^6.0.11
   sonner: ^2.0.7
-  tailwind-merge: ^2.6.1
+  tailwind-merge: ^3.5.0
   tailwindcss: ^4.1.17
   tailwindcss-animate: ^1.0.7
   tiny-invariant: ^1.3.1


### PR DESCRIPTION
## Summary
- Bumps `tailwind-merge` catalog entry from `^2.6.1` to `^3.5.0`. v3 aligns with Tailwind v4's token format (we're on Tailwind v4 already).
- Audited v3 release notes: no `extendTailwindMerge`/`createTailwindMerge`/custom `classGroups`/validators/prefix/separator in the repo, so none of the v3 config-shape breakers apply. Default export signature is unchanged.
- Patches 7 card call sites that relied on a v2 class-merge bug.

## The class-merge behavior change
v2.6.1 incorrectly treated `bg-radial-*` (a background-image utility) as conflicting with `bg-<color>` classes and stripped `bg-card` from the final class list. v3 correctly keeps both (they target different CSS properties). Since `--color-card` is `rgba(128, 117, 255, 0.07)`, the extra `bg-card` layer stacking under the gradient visually doubled the alpha on every `<Card>` that used `from-card to-card` with `bg-radial-(--gradient-position)` as an always-on override — rewards, vaults, expert, convert widgets.

Fix: add an explicit `bg-transparent` next to `bg-radial-(--gradient-position)` so v3 strips `bg-card` via the `bg-color` conflict group, reproducing the v2 look.

## Files touched
- `apps/webapp/src/modules/convert/components/ConvertWidgetPane.tsx` (3 cards)
- `apps/webapp/src/modules/expert/components/StusdsStatsCard.tsx`
- `apps/webapp/src/modules/expert/components/MorphoVaultStatsCard.tsx`
- `packages/widgets/src/widgets/RewardsWidget/components/RewardsStatsCard.tsx`
- `packages/widgets/src/widgets/StakeModuleWidget/components/SaRewardsCard.tsx`
- `packages/widgets/src/widgets/StakeModuleWidget/components/StakeDelegateCardCompact.tsx`
- `packages/widgets/src/widgets/StakeModuleWidget/components/StakeRewardsCardCompact.tsx`

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 2 pre-existing failures on base branch (`BalancesSuggestedActions.test.tsx`, `ConvertWidgetPane.test.tsx`); no new regressions; no className snapshot churn
- [x] Manual spot-check: rewards / vaults / expert / convert cards now match production
- [x] Hover / selected states on stake + seal delegate/rewards cards still look right
- [x] Re-check dialog / modal surfaces

## Linear
https://linear.app/skybasestar/issue/APP-211/dep-upgrade-04-tailwind-merge-2-3