### PR TITLE
 Bump date-fns 3 → 4 (APP-216)

### DIFF
--- a/packages/utils/src/formatDate.ts
+++ b/packages/utils/src/formatDate.ts
@@ -14,8 +14,7 @@ export const getDateLocale = async (locale: string): Promise<Locale> => {
     console.error('Error importing locale: ', error);
     localeModule = await import('date-fns/locale/en-US');
   }
-  // In date-fns v3, locales export both 'default' and a named export
-  // The named export is the locale object we need
+  // Locale modules may expose both 'default' and a named export; the named export is the locale object we need.
   const localeKey = Object.keys(localeModule).find(
     key => key !== 'default' && typeof localeModule[key] === 'object'
   );

--- a/packages/utils/src/locale.constants.ts
+++ b/packages/utils/src/locale.constants.ts
@@ -11,7 +11,7 @@ type LocaleImport = {
 // This code is needed to dynamically import the locale data for date-fns.
 // It allows us to only load the locales that are actually used, reducing the bundle size.
 // The compiler needs to statically know the import path, we can't just use a variable.
-// In date-fns v3, locales are named exports, not default exports.
+// Locales are named exports, not default exports.
 export const localeImports: LocaleImport = {
   af: () => import('date-fns/locale/af'),
   ar: () => import('date-fns/locale/ar'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ catalogs:
       specifier: ^2.1.1
       version: 2.1.1
     date-fns:
-      specifier: ^3.6.0
-      version: 3.6.0
+      specifier: ^4.1.0
+      version: 4.1.0
     dotenv:
       specifier: ^16.6.1
       version: 16.6.1
@@ -515,7 +515,7 @@ importers:
         version: 2.1.1
       date-fns:
         specifier: 'catalog:'
-        version: 3.6.0
+        version: 4.1.0
       embla-carousel-autoplay:
         specifier: 'catalog:'
         version: 8.6.0(embla-carousel@8.6.0)
@@ -694,7 +694,7 @@ importers:
     dependencies:
       date-fns:
         specifier: 'catalog:'
-        version: 3.6.0
+        version: 4.1.0
       ethers:
         specifier: 'catalog:'
         version: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -4834,6 +4834,9 @@ packages:
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -13204,6 +13207,8 @@ snapshots:
       is-data-view: 1.0.2
 
   date-fns@3.6.0: {}
+
+  date-fns@4.1.0: {}
 
   dayjs@1.11.13: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,7 +55,7 @@ catalog:
   '@walletconnect/ethereum-provider': ~2.23.9
   class-variance-authority: ^0.7.1
   clsx: ^2.1.1
-  date-fns: ^3.6.0
+  date-fns: ^4.1.0
   dotenv: ^16.6.1
   embla-carousel-autoplay: ^8.6.0
   embla-carousel-fade: ^8.6.0


### PR DESCRIPTION
## Summary
- Bumps `date-fns` from `^3.6.0` to `^4.1.0` via the `pnpm-workspace.yaml` catalog.
- No source changes were required — `format`, `subDays`, `subWeeks`, `startOfMinute`, `getUnixTime`, the `Locale` type, and the `date-fns/locale/<code>` subpath imports are all API-compatible v3 → v4.
- Removed two version-pinned doc comments in `packages/utils/src/{formatDate,locale.constants}.ts` so they don't rot at the next bump.

## Why it's safe
- v4's headline change is the new `TZDate` timezone model. We have **zero** `date-fns-tz` usage in the repo (grep confirms), so that surface area doesn't apply.
- The runtime locale loader in `formatDate.ts` was already defensive about named-vs-default export shapes, so v4's tightened ESM exports flow through unchanged.

## Validation
- ✅ `pnpm install` clean (only pre-existing peer warnings unrelated to this bump).
- ✅ `pnpm typecheck` clean across all four workspaces (`utils`, `hooks`, `widgets`, `webapp`).
- ✅ `pnpm -F @jetstreamgg/sky-utils test` — 52/52 pass (the only package that exercises date-fns directly in unit tests).
- ⚠️ `pnpm -F webapp test` — 56/58. The two failures (`BalancesSuggestedActions.test.tsx`, `ConvertWidgetPane.test.tsx`) are **unrelated to date-fns**: neither file imports the library, and the assertions search for missing UI strings (`'Get USDS'`, `/Trade/i`). They appear to be pre-existing regressions from recent merges on `development` (motion 12 / tailwind-merge v3).

## Test plan
- [ ] Savings & rewards charts: x-axis labels render correctly across 1W / 1M / 1Y / All (formats `MMM d` and `MMM y`).
- [ ] Chart card header `EEE, MMM d 'at' h:mm a` timestamp matches system clock.
- [ ] Chart tooltip dates render on hover with no `Invalid Date`.
- [ ] History views (savings, stake, rewards, upgrade): timestamps render correctly.
- [ ] Browser console shows no `date-fns`-related errors while navigating the above.
- [ ] Spot-check non-en-US locale (e.g. `de`, `ja`) and a DST boundary date.