### PR TITLE
Fix blank MetaMask QR: allow SDK relay + data: in CSP connect-src

### DIFF
--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -38,6 +38,8 @@ export default ({ mode }: { mode: modeEnum }) => {
   const PROXY_ORIGIN = process.env.VITE_PROXY_ORIGIN || '';
 
   // TODO: Update the githubusercontent.com url when the terms document is ready in the right location
+  // connect-src includes `data:` so the MetaMask SDK can fetch its embedded fox-logo SVG, which is
+  // rendered in the center of the connection QR. Without it, the logo fetch fails and the QR renders blank.
   const CONTENT_SECURITY_POLICY = `
     default-src 'self';
     script-src 'self'
@@ -47,7 +49,7 @@ export default ({ mode }: { mode: modeEnum }) => {
     style-src 'self' 'unsafe-inline' https://*.posthog.com https://e.sky.money;
     img-src 'self' data: blob: https://explorer-api.walletconnect.com https://*.posthog.com https://e.sky.money;
     font-src 'self';
-    connect-src 'self'
+    connect-src 'self' data:
       https://proxy.sky.money
       https://staging-proxy.sky.money
       ${PROXY_ORIGIN}
@@ -93,6 +95,7 @@ export default ({ mode }: { mode: modeEnum }) => {
       https://metamask-sdk.api.cx.metamask.io/evt
       https://a.markfi.xyz
       wss://metamask-sdk.api.cx.metamask.io
+      wss://mm-sdk-relay.api.cx.metamask.io
       wss://nbstream.binance.com/wallet-connector
       https://*.jetstream-account.workers.dev
       cloudflareinsights.com


### PR DESCRIPTION
## Summary

Fixes APP-232: users without the MetaMask browser extension see a blank QR when clicking "Connect with MetaMask".

Two additions to `connect-src` in the Vite meta-tag CSP:
- `wss://mm-sdk-relay.api.cx.metamask.io` — the MetaMask SDK websocket that negotiates the session ID encoded into the QR. Without it, the SDK can't generate a session and the QR has nothing to render. This domain is the one called out in MetaMask's own SDK troubleshooting guide.
- `data:` — the SDK fetches its embedded fox-logo SVG via `fetch()` to render in the center of the QR. Without `data:` in `connect-src`, the logo fetch is blocked and the QR component fails, leaving the modal blank.

## On the security of allowing `data:` in `connect-src`

Low-risk allowance. Data URIs are inline payloads that don't reach the network and don't execute — execution is `script-src`'s domain. OWASP and MDN treat `data:` as **dangerous** in `script-src`, `default-src`, `frame-src`, and `object-src` (where it can be used to inject executable content or auto-navigated documents), but **acceptable** in `connect-src`, `img-src` (which we already allow), `font-src`, and `media-src`. Adding it here is comparable to allowing `data:` in `img-src`, which is already standard for our marketing and webapp CSPs. It does not weaken protection against XSS, exfiltration, or framing.

## Related infra change

The Cloudflare-applied CSP needs the same two entries to take effect on `app.sky.money` (preview deploys are covered by this PR's meta-tag CSP only). Companion PR in `skybase-infra` updates `modules/cloudflare-zone/headers.tf`. Both must ship for production users to be unblocked — either CSP alone would still reject the relay/logo.

## Test plan

- [ ] In a browser without the MetaMask extension (fresh profile / private window with extensions off / Safari): Connect Wallet → MetaMask → QR renders with fox icon in the center.
- [ ] DevTools console no longer shows `Refused to connect to wss://mm-sdk-relay.api.cx.metamask.io` or `Refused to connect to data:image/svg+xml` errors.
- [ ] Connection still works as before for users WITH the MetaMask extension installed (skips the QR modal entirely, deep-injects via `window.ethereum`).
- [ ] Other connectors (WalletConnect, Coinbase, Rainbow) are unaffected.