### PR TITLE
Fix wallet SDK modals being unclickable while connect dialog is open

### DIFF
--- a/apps/webapp/src/modules/ui/components/ConnectModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ConnectModal.tsx
@@ -24,6 +24,38 @@ interface ConnectModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// Detectors for in-page wallet SDK modals that may overlay our own Dialog.
+// Each detector knows the element selector AND how to tell whether the modal
+// is currently open — needed because Reown AppKit keeps `<w3m-modal>` mounted
+// at all times and only toggles a `class="open"` (via `:host(.open)` CSS in
+// its shadow DOM) to show/hide the actual content. MetaMask Connect and
+// Binance, by contrast, add and remove their modal elements from the DOM
+// per-flow.
+//
+// Add new entries as we adopt new connectors that ship a document.body-mounted
+// modal. Extension popups, mobile deep links, and window.open popups (Coinbase
+// Wallet, Base Account) do not render an in-page modal and don't need to be
+// listed.
+const WALLET_OVERLAY_DETECTORS: { selector: string; isOpen: (el: Element) => boolean }[] = [
+  // MetaMask Connect — modal element is added/removed per-flow, existence = open.
+  { selector: 'mm-install-modal', isOpen: () => true },
+  { selector: 'mm-otp-modal', isOpen: () => true },
+  // Reown / WalletConnect AppKit — element stays mounted, signals open via class.
+  { selector: 'wcm-modal', isOpen: el => el.classList.contains('open') },
+  { selector: 'w3m-modal', isOpen: el => el.classList.contains('open') },
+  { selector: 'appkit-modal', isOpen: el => el.classList.contains('open') },
+  // Binance Web3 Wallet — wrapper div added/removed per-flow, existence = open.
+  { selector: '#binanceW3W-wrapper', isOpen: () => true }
+];
+
+function isWalletOverlayVisible(): boolean {
+  for (const { selector, isOpen } of WALLET_OVERLAY_DETECTORS) {
+    const el = document.querySelector(selector);
+    if (el && isOpen(el)) return true;
+  }
+  return false;
+}
+
 export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
   const connectors = useConnectors();
   const { connector: connectedConnector } = useConnection();
@@ -180,8 +212,39 @@ export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
     );
   };
 
+  // Wallet SDKs that render their own modal (MetaMask Connect, WalletConnect)
+  // mount it as a sibling of our Radix Dialog under document.body. With Radix
+  // in modal mode, DismissableLayer globally blocks outside pointer events, so
+  // clicks meant for the SDK modal get swallowed. Rather than fight Radix, we
+  // close our own Dialog while a known SDK modal is on screen and reopen it
+  // when the SDK modal goes away. Flows that don't render an in-page modal
+  // (browser extensions, mobile deep links, popup windows for Coinbase/Base)
+  // don't trigger this — our Dialog stays open through them.
+  const [hasWalletOverlay, setHasWalletOverlay] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setHasWalletOverlay(false);
+      return;
+    }
+
+    const check = () => setHasWalletOverlay(isWalletOverlayVisible());
+
+    check();
+    // Watch DOM mounts AND attribute changes — Reown AppKit reuses its modal
+    // element and toggles visibility via attributes/CSS rather than removal.
+    const observer = new MutationObserver(check);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['open', 'data-state', 'class', 'style', 'aria-hidden']
+    });
+    return () => observer.disconnect();
+  }, [open]);
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open && !hasWalletOverlay} onOpenChange={onOpenChange}>
       <DialogContent
         className="bg-containerDark max-h-[calc(100dvh-32px)] gap-6 overflow-auto p-4 sm:max-w-[490px] sm:min-w-[490px]"
         onOpenAutoFocus={e => e.preventDefault()}


### PR DESCRIPTION
## Summary

Tarmac's connect dialog (Radix Dialog with `modal={true}`) globally blocks pointer events outside its content tree via `DismissableLayer`. When a wallet SDK (MetaMask Connect, Reown / WalletConnect AppKit, Binance Web3 Wallet) opens its own modal in `document.body`, the SDK modal's clicks get swallowed regardless of z-index — making install / scan / cancel buttons inert.

The fix watches `document.body` for known SDK modal elements via `MutationObserver`. While one is detected as visible, our Radix Dialog is held closed (the parent's `open` prop is preserved, but the effective `open` becomes false). When the SDK modal goes away the dialog reopens automatically, so users who cancel an SDK flow can pick a different wallet without re-clicking Connect Wallet.

## Detected SDK overlays

- `mm-install-modal` / `mm-otp-modal` — MetaMask Connect: existence = open (removed from DOM on close).
- `w3m-modal` / `appkit-modal` / `wcm-modal` — Reown / WalletConnect AppKit: stays mounted, signals via `class="open"`.
- `#binanceW3W-wrapper` — Binance Web3 Wallet: existence = open.

Flows that do not render an in-page modal — browser extensions, mobile deep links, and popup windows for Coinbase Wallet and Base Account — don't trigger this, and our dialog stays open through them.

## Why detection is heterogeneous

Different SDKs report "modal is open" differently. Reown AppKit keeps `<w3m-modal>` mounted permanently (full viewport size, `display: block`) and just toggles `class="open"` on the host — `checkVisibility()` and `display`/`visibility` checks both report it visible regardless of state. The only reliable signal is the class. MetaMask Connect and Binance, by contrast, fully add/remove their wrapper elements per-flow, so existence alone is enough.

## Stacked on #1525

This PR builds on top of #1525 (the CSP fixes for the blank QR). When #1525 merges, this PR's base auto-updates to `development`.

## Test plan

- [ ] Browser without MetaMask extension → Connect Wallet → MetaMask → install modal renders with QR + working "Install MetaMask Extension" button → close it → tarmac dialog reopens.
- [ ] Connect Wallet → WalletConnect → Reown QR modal opens → tarmac closes → close Reown → tarmac reopens. Repeat to confirm re-entry works on subsequent clicks.
- [ ] Connect Wallet → Binance Wallet → Binance QR modal opens → tarmac closes → close Binance → tarmac reopens.
- [ ] Connect Wallet → Coinbase Wallet → tarmac stays open while the Coinbase popup window is used.
- [ ] Connect Wallet → Base Account → tarmac stays open while the Base popup window is used.
- [ ] Browser with MetaMask extension installed → Connect Wallet → MetaMask → no in-page modal; tarmac stays open while the extension prompts approval; closes on success.
- [ ] After a successful connect, tarmac dialog closes and stays closed (no flicker from the observer firing on later DOM mutations).