### PR TITLE
Relax COOP to same-origin-allow-popups for wallet popup flows

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
           "key": "Permissions-Policy",
           "value": "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), midi=(), serial=(), hid=()"
         },
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Change `Cross-Origin-Opener-Policy` in `vercel.json` from `same-origin` to `same-origin-allow-popups`.
- Required by Base Account and Coinbase Wallet popup-based auth flows, which need a working `window.opener` to postMessage back to the dapp. `same-origin` severs that link for cross-origin popups and breaks the flow ([Base docs](https://docs.base.org/base-account/more/troubleshooting/usage-details/popups#cross-origin-opener-policy)).
- Security tradeoff is small: we keep cross-origin process isolation for the main document (XS-Leaks / Spectre protection, isolation from malicious openers/embedders). The only relaxation is that popups *we* open to other origins retain opener access — exactly what wallet SDKs need, and we control which popups we open.

COOP doesn't support per-domain allowlisting, so this site-wide value is the tightest setting compatible with Base Account.

## Test plan

- [ ] Deploy preview and verify `Cross-Origin-Opener-Policy: same-origin-allow-popups` is present on the response headers
- [ ] Connect with Base Account — popup completes and returns to the app successfully
- [ ] Connect with Coinbase Wallet (popup mode) — connection completes
- [ ] Smoke-test other wallet connectors (WalletConnect, MetaMask) — no regression
- [ ] No new console warnings related to COOP / opener access