### PR TITLE
Add Bug Bounty link to application footer (APP-230)

### DIFF
--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -168,7 +168,8 @@ export const ALLOWED_EXTERNAL_DOMAINS = [
   'docs.sky.money',
   'vote.sky.money',
   'upgrademkrtosky.skyeco.com',
-  'jobs.ashbyhq.com'
+  'jobs.ashbyhq.com',
+  'immunefi.com'
 ];
 
 export const IS_PRODUCTION_ENV = import.meta.env.VITE_ENV_NAME === Environment.Production;

--- a/apps/webapp/src/modules/layout/components/FooterLinks.tsx
+++ b/apps/webapp/src/modules/layout/components/FooterLinks.tsx
@@ -15,7 +15,7 @@ export function FooterLinks() {
 
   return (
     <div className={'flex w-full pt-2'}>
-      <div className="flex w-full justify-end gap-3 md:justify-start">
+      <div className="flex w-full items-center justify-end gap-3 md:justify-start">
         {regularLinks.map((link, i) => {
           const url = sanitizeUrl(link.url);
           if (!url) return null;
@@ -42,7 +42,7 @@ export function FooterLinks() {
               key={url || `highlight-${i}`}
               variant="primaryAlt"
               size="xs"
-              className="px-4 py-2"
+              className="py-2 sm:px-4"
               asChild
             >
               <ExternalLink href={url} showIcon={false}>


### PR DESCRIPTION
## Summary
- Allowlists `immunefi.com` so the Bug Bounty link (configured via `VITE_FOOTER_LINKS`) passes URL sanitization and renders in the footer.
- Adds `items-center` on the footer link row and tightens button padding (`py-2 sm:px-4`) so the new link aligns cleanly across viewports.

Linear: [APP-230](https://linear.app/skybasestar/issue/APP-230/add-bug-bounty-link-to-application-footer)

## Test plan
- [x] Verify the Bug Bounty link appears in the footer and opens https://immunefi.com/bug-bounty/sky/information/ in a new tab.
- [x] Confirm footer layout/alignment looks correct on mobile, tablet, and desktop widths.
- [x] Confirm existing footer links (Privacy, Terms, Jobs, etc.) still render correctly.