### PR TITLE
Adopt eslint-plugin-react-hooks (APP-227)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import testingLibrary from 'eslint-plugin-testing-library';
+import reactHooks from 'eslint-plugin-react-hooks';
 import tanstackEslintPluginQuery from '@tanstack/eslint-plugin-query';
 import globals from 'globals';
 import tsParser from '@typescript-eslint/parser';
@@ -34,6 +35,22 @@ export default [
     'plugin:react/recommended',
     'plugin:@typescript-eslint/recommended'
   ),
+  reactHooks.configs.flat.recommended,
+  {
+    // TODO(APP-227): Demoted react-hooks rules from `error` to `warn` to land the
+    // plugin without a large up-front triage. Promote each rule back to `error`
+    // (delete its line below) as the existing violations are fixed across the
+    // monorepo. `exhaustive-deps` is already `warn` in the recommended preset.
+    rules: {
+      'react-hooks/rules-of-hooks': 'warn',
+      'react-hooks/set-state-in-effect': 'warn',
+      'react-hooks/refs': 'warn',
+      'react-hooks/static-components': 'warn',
+      'react-hooks/preserve-manual-memoization': 'warn',
+      'react-hooks/immutability': 'warn',
+      'react-hooks/purity': 'warn'
+    }
+  },
   {
     plugins: {
       '@typescript-eslint': typescriptEslint,

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "dotenv": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-react": "catalog:",
+    "eslint-plugin-react-hooks": "catalog:",
     "eslint-plugin-testing-library": "catalog:",
     "globals": "catalog:",
     "happy-dom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ catalogs:
     eslint-plugin-react:
       specifier: ^7.37.5
       version: 7.37.5
+    eslint-plugin-react-hooks:
+      specifier: ^7.1.1
+      version: 7.1.1
     eslint-plugin-testing-library:
       specifier: ^7.16.2
       version: 7.16.2
@@ -375,6 +378,9 @@ importers:
       eslint-plugin-react:
         specifier: 'catalog:'
         version: 7.37.5(eslint@10.2.1(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: 'catalog:'
+        version: 7.1.1(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-testing-library:
         specifier: 'catalog:'
         version: 7.16.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
@@ -4813,9 +4819,6 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
-
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -5077,6 +5080,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -5461,6 +5470,12 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
@@ -8062,6 +8077,12 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
@@ -13110,8 +13131,6 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@3.6.0: {}
-
   date-fns@4.1.0: {}
 
   dayjs@1.11.13: {}
@@ -13461,6 +13480,17 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@7.1.1(eslint@10.2.1(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/parser': 7.29.2
+      eslint: 10.2.1(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
@@ -13932,6 +13962,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   he@1.2.0: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -16887,6 +16923,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-validation-error@4.0.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.22.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ catalog:
   embla-carousel-react: ^8.6.0
   eslint: ^10.2.0
   eslint-plugin-react: ^7.37.5
+  eslint-plugin-react-hooks: ^7.1.1
   eslint-plugin-testing-library: ^7.16.2
   ethers: ^6.16.0
   globals: ^17.5.0


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-react-hooks@^7.1.1` (latest stable, satisfies the workspace's 7-day `minimumReleaseAge`) to the catalog and root devDependencies.
- Wires `reactHooks.configs.flat.recommended` into `eslint.config.mjs`. The v7 recommended preset includes the full Rules of React + React Compiler rule set (rules-of-hooks, exhaustive-deps, set-state-in-effect, refs, static-components, immutability, preserve-manual-memoization, purity).
- Demotes the seven new error-level rules to `warn` to land the plugin without a large up-front triage. A `TODO(APP-227)` block in `eslint.config.mjs` documents the intent and instructs promoting each rule back to `error` (by deleting its line) as the existing violations are fixed across the monorepo.

## Why warn, not error?

The recommended preset surfaced **383 problems (159 errors, 224 warnings) across 126 files** on first run — far more than the issue anticipated. Rather than block this PR on a deep triage, this lands the plugin in observe-only mode and creates a punch list for incremental cleanup.

## Triage breakdown (current state: 0 errors, 383 warnings)

| Rule | Count | Notes |
|---|---|---|
| `exhaustive-deps` | 224 | Already `warn` in the preset; often real bugs. |
| `set-state-in-effect` | 79 | Demoted. Many are 'mirror prop into state' / 'detect change to bump' patterns refactorable to render-time `setState` w/ guard. |
| `refs` | 43 | Demoted. Concentrated in 7 files (analytics banner, transaction context, sequential tx flow, etc.). |
| `rules-of-hooks` | 11 | Demoted. ~7 are real bugs (conditional hook calls); 3-4 are false positives in Playwright fixtures (`use` keyword name collision). |
| `static-components` | 9 | Demoted. 3 files defining components inside render. |
| `preserve-manual-memoization` | 8 | Demoted. React Compiler couldn't preserve existing `useMemo` calls. |
| `immutability` | 8 | Demoted. Mix of post-render reassignment, ref-suffix naming, and TDZ issues. |
| `purity` | 1 | Demoted. |

## Test plan

- [x] `pnpm install` — clean, no new peer-dep warnings (`+ eslint-plugin-react-hooks 7.1.1`).
- [x] `pnpm lint` — exits 0 with `383 problems (0 errors, 383 warnings)`.
- [ ] CI green.
- [x] Manual: confirm IDE picks up the new rules (warnings should appear in editor on hook-using files).