### PR TITLE
fix upgrade token dropdown in linked action

### DIFF
--- a/apps/webapp/src/modules/upgrade/components/UpgradeWidgetPane.tsx
+++ b/apps/webapp/src/modules/upgrade/components/UpgradeWidgetPane.tsx
@@ -249,6 +249,13 @@ export function UpgradeWidgetPane(sharedProps: SharedProps) {
       ? UpgradeFlow.REVERT // If in linked action, disallow revert
       : undefined;
 
+  const linkedSourceSymbol =
+    linkedActionConfig.showLinkedAction && linkedActionConfig.sourceToken
+      ? linkedActionConfig.sourceToken.toLowerCase()
+      : undefined;
+  const linkedSourceToken = linkedSourceSymbol ? TOKENS[linkedSourceSymbol] : undefined;
+  const upgradeOptions = linkedSourceToken ? [linkedSourceToken] : [TOKENS.dai, TOKENS.mkr];
+
   return (
     <UpgradeWidget
       {...sharedProps}
@@ -266,11 +273,7 @@ export function UpgradeWidgetPane(sharedProps: SharedProps) {
       onAnalyticsEvent={onAnalyticsEvent}
       customNavigationLabel={customNavLabel}
       onCustomNavigation={onNavigate}
-      upgradeOptions={
-        linkedActionConfig.showLinkedAction && linkedActionConfig.sourceToken
-          ? [linkedActionConfig.sourceToken]
-          : [TOKENS.dai, TOKENS.mkr]
-      }
+      upgradeOptions={upgradeOptions}
       disallowedFlow={disallowedFlow}
       batchEnabled={batchEnabled}
       setBatchEnabled={setBatchEnabled}


### PR DESCRIPTION
  Fixes WEBAPP-52.

  Summary

  UpgradeWidgetPane was passing [linkedActionConfig.sourceToken] (a string) as upgradeOptions, which expects Token[]. Downstream, getTokenDecimals accessed token.decimals[chainId] on the
   string and threw. Fix: map the symbol to a real Token via TOKENS[symbol.toLowerCase()], falling back to defaults if unknown.

Why this bug wasn't caught before:
It only happens when the token input is open in a upgrade linked action. If you start an upgrade linked action normally, there is no option to open the token input. It only happens if you initiate the linked action with the token input already open.

Test plan
  - Got to Upgrade widget, open the token dropdown, click the button for a linked action.