### PR TITLE
Fixed Yield: rebrand from Pendle, About card, time formatting, layout polish

### DIFF
--- a/apps/webapp/src/data/banners/banners.ts
+++ b/apps/webapp/src/data/banners/banners.ts
@@ -287,6 +287,22 @@ export const banners: Banner[] = [
     display: ['connected', 'disconnected']
   },
   {
+    id: 'about-fixed-yield',
+    title: 'About Fixed Yield',
+    module: 'fixed-yield-banners',
+    description:
+      'Lock in a fixed yield by buying Principal Tokens (PT) at a discount. At maturity each PT redeems 1:1 for the underlying asset — the difference is your fixed yield.',
+    display: ['disconnected']
+  },
+  {
+    id: 'fixed-yield',
+    title: 'Fixed Yield',
+    module: 'fixed-yield-banners',
+    description:
+      'A Principal Token (PT) is a tokenized claim on an underlying yield-bearing asset. PT trades at a discount until maturity, when it redeems 1:1 for the underlying. Holding to maturity locks in a fixed APY; sell early at the prevailing market price if you change your mind.',
+    display: ['connected', 'disconnected']
+  },
+  {
     id: 'usds-risk-capital-vault',
     title: 'USDS Risk Capital Vault',
     module: 'vaults-banners',

--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -26,7 +26,7 @@ export enum QueryParams {
   VaultModule = 'vault_module',
   ConvertModule = 'convert_module',
   Market = 'market',
-  PendleModule = 'pendle_module'
+  PendleModule = 'fixed_module'
 }
 
 export enum Environment {
@@ -46,7 +46,7 @@ export const IntentMapping = {
   [Intent.EXPERT_INTENT]: 'expert',
   [Intent.VAULTS_INTENT]: 'vaults',
   [Intent.CONVERT_INTENT]: 'convert',
-  [Intent.PENDLE_INTENT]: 'pendle'
+  [Intent.PENDLE_INTENT]: 'fixed'
 };
 
 export const ExpertIntentMapping: Record<ExpertIntent, string> = {

--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -1,5 +1,5 @@
 import { RewardsModule, Savings, Trade, Upgrade, Seal, Expert, Vaults, Convert } from '@/modules/icons';
-import { ConvertIntent, ExpertIntent, Intent, PendleIntent, VaultsIntent } from './enums';
+import { ConvertIntent, ExpertIntent, Intent, FixedIntent, VaultsIntent } from './enums';
 import { msg } from '@lingui/core/macro';
 import { MessageDescriptor } from '@lingui/core';
 import { base, mainnet, arbitrum, unichain, optimism } from 'viem/chains';
@@ -26,7 +26,7 @@ export enum QueryParams {
   VaultModule = 'vault_module',
   ConvertModule = 'convert_module',
   Market = 'market',
-  PendleModule = 'fixed_module'
+  FixedModule = 'fixed_module'
 }
 
 export enum Environment {
@@ -46,7 +46,7 @@ export const IntentMapping = {
   [Intent.EXPERT_INTENT]: 'expert',
   [Intent.VAULTS_INTENT]: 'vaults',
   [Intent.CONVERT_INTENT]: 'convert',
-  [Intent.PENDLE_INTENT]: 'fixed'
+  [Intent.FIXED_INTENT]: 'fixed'
 };
 
 export const ExpertIntentMapping: Record<ExpertIntent, string> = {
@@ -63,8 +63,8 @@ export const ConvertIntentMapping: Record<ConvertIntent, string> = {
   [ConvertIntent.TRADE_INTENT]: 'trade'
 };
 
-export const PendleIntentMapping: Record<PendleIntent, string> = {
-  [PendleIntent.MARKET_INTENT]: 'market'
+export const FixedIntentMapping: Record<FixedIntent, string> = {
+  [FixedIntent.MARKET_INTENT]: 'market'
 };
 
 export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
@@ -79,7 +79,7 @@ export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
     Intent.EXPERT_INTENT,
     Intent.VAULTS_INTENT,
     Intent.CONVERT_INTENT,
-    Intent.PENDLE_INTENT
+    Intent.FIXED_INTENT
   ],
   [tenderly.id]: [
     Intent.BALANCES_INTENT,
@@ -92,7 +92,7 @@ export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
     Intent.EXPERT_INTENT,
     Intent.VAULTS_INTENT,
     Intent.CONVERT_INTENT,
-    Intent.PENDLE_INTENT
+    Intent.FIXED_INTENT
   ],
   [base.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
   [arbitrum.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],

--- a/apps/webapp/src/lib/enums.ts
+++ b/apps/webapp/src/lib/enums.ts
@@ -9,7 +9,7 @@ export enum Intent {
   EXPERT_INTENT = 'EXPERT_INTENT',
   VAULTS_INTENT = 'VAULTS_INTENT',
   CONVERT_INTENT = 'CONVERT_INTENT',
-  PENDLE_INTENT = 'PENDLE_INTENT'
+  FIXED_INTENT = 'FIXED_INTENT'
 }
 
 export enum ExpertIntent {
@@ -26,6 +26,6 @@ export enum ConvertIntent {
   TRADE_INTENT = 'TRADE_INTENT'
 }
 
-export enum PendleIntent {
+export enum FixedIntent {
   MARKET_INTENT = 'MARKET_INTENT'
 }

--- a/apps/webapp/src/lib/widget-network-map.ts
+++ b/apps/webapp/src/lib/widget-network-map.ts
@@ -16,7 +16,7 @@ export const WIDGET_NETWORK_REQUIREMENTS: Record<Intent, 'mainnet' | 'multichain
   [Intent.SEAL_INTENT]: 'mainnet',
   [Intent.VAULTS_INTENT]: 'mainnet',
   [Intent.CONVERT_INTENT]: 'multichain',
-  [Intent.PENDLE_INTENT]: 'mainnet'
+  [Intent.FIXED_INTENT]: 'mainnet'
 };
 
 /**

--- a/apps/webapp/src/modules/app/components/DetailsPane.tsx
+++ b/apps/webapp/src/modules/app/components/DetailsPane.tsx
@@ -198,7 +198,7 @@ export const DetailsPane = ({ intent }: DetailsPaneProps) => {
                   <SealDetailsPane />
                 </MotionDetailsWrapper>
               );
-            case Intent.PENDLE_INTENT:
+            case Intent.FIXED_INTENT:
               return (
                 <MotionDetailsWrapper key={keys[9]}>
                   <PendleDetailsPane />

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -254,7 +254,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
     ],
     [
       Intent.PENDLE_INTENT,
-      'Pendle',
+      'Fixed Yield',
       Pendle,
       withErrorBoundary(<PendleWidgetPane {...sharedProps} />),
       false,

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -21,11 +21,11 @@ import {
   ExpertIntentMapping,
   VaultsIntentMapping,
   ConvertIntentMapping,
-  PendleIntentMapping
+  FixedIntentMapping
 } from '@/lib/constants';
 import { useGeoConfig } from '@/modules/geo-config';
 import { ModuleId } from '@/modules/geo-config/types';
-import { ExpertIntent, VaultsIntent, ConvertIntent, PendleIntent } from '@/lib/enums';
+import { ExpertIntent, VaultsIntent, ConvertIntent, FixedIntent } from '@/lib/enums';
 import { WidgetNavigation } from '@/modules/app/components/WidgetNavigation';
 import { withErrorBoundary } from '@/modules/utils/withErrorBoundary';
 import { DualSwitcher } from '@/components/DualSwitcher';
@@ -181,7 +181,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
     label: `PT-${market.underlyingSymbol}`,
     icon: <TokenIcon token={{ symbol: 'USDS' }} className="h-3 w-3" showChainIcon={false} />,
     params: {
-      [QueryParams.PendleModule]: PendleIntentMapping[PendleIntent.MARKET_INTENT],
+      [QueryParams.FixedModule]: FixedIntentMapping[FixedIntent.MARKET_INTENT],
       [QueryParams.Market]: market.marketAddress
     }
   }));
@@ -234,6 +234,16 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
         : 'Use USDS to access the Sky Savings Rate'
     ],
     [
+      Intent.FIXED_INTENT,
+      'Fixed Yield',
+      Pendle,
+      withErrorBoundary(<PendleWidgetPane {...sharedProps} />),
+      false,
+      undefined,
+      'Lock in fixed yield via Pendle PT markets',
+      pendleSubItems
+    ],
+    [
       Intent.STAKE_INTENT,
       'Stake & Borrow',
       Stake,
@@ -251,16 +261,6 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
       undefined,
       'Third-party vault integrations with Sky Ecosystem tokens',
       vaultSubItems
-    ],
-    [
-      Intent.PENDLE_INTENT,
-      'Fixed Yield',
-      Pendle,
-      withErrorBoundary(<PendleWidgetPane {...sharedProps} />),
-      false,
-      undefined,
-      'Lock in fixed yield via Pendle PT markets',
-      pendleSubItems
     ],
     [
       Intent.EXPERT_INTENT,
@@ -341,6 +341,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
       items: widgetItems.filter(
         ([intent]) =>
           intent === Intent.SAVINGS_INTENT ||
+          intent === Intent.FIXED_INTENT ||
           intent === Intent.REWARDS_INTENT ||
           intent === Intent.STAKE_INTENT
       )
@@ -348,10 +349,6 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
     {
       id: 'group-3',
       items: widgetItems.filter(([intent]) => intent === Intent.VAULTS_INTENT)
-    },
-    {
-      id: 'group-pendle',
-      items: widgetItems.filter(([intent]) => intent === Intent.PENDLE_INTENT)
     },
     {
       id: 'group-4',

--- a/apps/webapp/src/modules/layout/components/ConnectCard.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectCard.tsx
@@ -38,7 +38,7 @@ export function ConnectCard({ intent, className, convertOption }: ConnectCardPro
     [Intent.EXPERT_INTENT]: { default: 'about-expert-modules' },
     [Intent.VAULTS_INTENT]: { default: 'vaults' },
     [Intent.CONVERT_INTENT]: { default: 'about-convert' },
-    [Intent.PENDLE_INTENT]: { default: 'about-balances' }
+    [Intent.FIXED_INTENT]: { default: 'about-fixed-yield' }
   };
 
   // Map convert sub-options to banner IDs

--- a/apps/webapp/src/modules/pendle/components/PendleAbout.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleAbout.tsx
@@ -5,15 +5,15 @@ import { Text } from '@/modules/layout/components/Typography';
 export const PendleAbout = () => (
   <Card variant="stats" className="w-full">
     <CardTitle>
-      <Trans>About Pendle fixed yield</Trans>
+      <Trans>About fixed yield</Trans>
     </CardTitle>
     <CardContent>
       <Text variant="medium" className="text-textSecondary mt-2">
         <Trans>
-          A Principal Token (PT) lets you lock in a fixed yield until a market&apos;s maturity date. You
-          buy PT below face value, and at maturity each PT redeems 1:1 for the underlying asset — the
-          difference is your fixed yield. Sell early at the prevailing market price if you change your
-          mind, or hold until maturity for the full advertised APY.
+          A Principal Token (PT) lets you lock in a fixed yield until a market&apos;s maturity date. You buy
+          PT below face value, and at maturity each PT redeems 1:1 for the underlying asset — the difference
+          is your fixed yield. Sell early at the prevailing market price if you change your mind, or hold
+          until maturity for the full advertised APY.
         </Trans>
       </Text>
     </CardContent>

--- a/apps/webapp/src/modules/pendle/components/PendleAbout.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleAbout.tsx
@@ -1,21 +1,29 @@
 import { Trans } from '@lingui/react/macro';
-import { Card, CardContent, CardTitle } from '@/components/ui/card';
-import { Text } from '@/modules/layout/components/Typography';
+import { getBannerByIdAndModule, filterBannersByConnectionStatus } from '@/data/banners/helpers';
+import { parseBannerContent } from '@/utils/bannerContentParser';
+import { useConnectedContext } from '@/modules/ui/context/ConnectedContext';
+import { AboutCard } from '@/modules/ui/components/AboutCard';
+import { Pendle } from '@/modules/icons';
 
-export const PendleAbout = () => (
-  <Card variant="stats" className="w-full">
-    <CardTitle>
-      <Trans>About fixed yield</Trans>
-    </CardTitle>
-    <CardContent>
-      <Text variant="medium" className="text-textSecondary mt-2">
-        <Trans>
-          A Principal Token (PT) lets you lock in a fixed yield until a market&apos;s maturity date. You buy
-          PT below face value, and at maturity each PT redeems 1:1 for the underlying asset — the difference
-          is your fixed yield. Sell early at the prevailing market price if you change your mind, or hold
-          until maturity for the full advertised APY.
-        </Trans>
-      </Text>
-    </CardContent>
-  </Card>
-);
+export const PendleAbout = () => {
+  const { isConnectedAndAcceptedTerms } = useConnectedContext();
+
+  const banner = getBannerByIdAndModule('fixed-yield', 'fixed-yield-banners');
+  if (!banner) return null;
+
+  if (banner.display) {
+    const filtered = filterBannersByConnectionStatus([banner], isConnectedAndAcceptedTerms);
+    if (filtered.length === 0) return null;
+  }
+
+  const description = banner.description ? parseBannerContent(banner.description) : '';
+
+  return (
+    <AboutCard
+      title={<Trans>{banner.title}</Trans>}
+      icon={<Pendle className="h-6 w-6" />}
+      description={description}
+      colorMiddle="linear-gradient(360deg, #6D28FF 0%, #F7A7F9 300%)"
+    />
+  );
+};

--- a/apps/webapp/src/modules/pendle/components/PendleBalanceDetails.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleBalanceDetails.tsx
@@ -46,7 +46,7 @@ export const PendleBalanceDetails = ({ market }: PendleBalanceDetailsProps) => {
         balance={ptBalance ?? 0n}
         isLoading={ptLoading}
         token={ptToken}
-        label={t`Pendle PT balance`}
+        label={t`PT balance`}
         dataTestId="pendle-supplied-balance-details"
       />
       <UnsuppliedBalanceCard

--- a/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
@@ -11,8 +11,8 @@ import {
 } from '@jetstreamgg/sky-hooks';
 import { isTestnetId } from '@jetstreamgg/sky-utils';
 import { mainnet } from 'viem/chains';
-import { PendleIntent } from '@/lib/enums';
-import { PendleIntentMapping, QueryParams } from '@/lib/constants';
+import { FixedIntent } from '@/lib/enums';
+import { FixedIntentMapping, QueryParams } from '@/lib/constants';
 import { DetailSection } from '@/modules/ui/components/DetailSection';
 import { DetailSectionRow } from '@/modules/ui/components/DetailSectionRow';
 import { DetailSectionWrapper } from '@/modules/ui/components/DetailSectionWrapper';
@@ -52,7 +52,7 @@ export const PendleDetailsPane = () => {
 
   const handleSelectMarket = (market: PendleMarketConfig) => {
     setSearchParams(params => {
-      params.set(QueryParams.PendleModule, PendleIntentMapping[PendleIntent.MARKET_INTENT]);
+      params.set(QueryParams.FixedModule, FixedIntentMapping[FixedIntent.MARKET_INTENT]);
       params.set(QueryParams.Market, market.marketAddress);
       return params;
     });

--- a/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
@@ -101,11 +101,11 @@ export const PendleDetailsPane = () => {
   if (!isOnPendleChain) {
     return (
       <DetailSectionWrapper>
-        <DetailSection title={t`Pendle fixed yield`}>
+        <DetailSection title={t`Fixed Yield`}>
           <DetailSectionRow>
             <Text className="text-textSecondary">
               <Trans>
-                Pendle markets are only available on Ethereum mainnet. Switch networks to view available
+                Fixed yield markets are only available on Ethereum mainnet. Switch networks to view available
                 markets.
               </Trans>
             </Text>
@@ -133,7 +133,7 @@ export const PendleDetailsPane = () => {
         <DetailSectionRow>
           {visibleMarkets.length === 0 ? (
             <Text className="text-textSecondary">
-              <Trans>No active Pendle markets at the moment. Check back soon.</Trans>
+              <Trans>No active fixed yield markets at the moment. Check back soon.</Trans>
             </Text>
           ) : (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/apps/webapp/src/modules/pendle/components/PendleMarketInfoCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMarketInfoCard.tsx
@@ -29,18 +29,6 @@ export const PendleMarketInfoCard = ({ market }: PendleMarketInfoCardProps) => {
       </div>
       <div className="min-w-[250px] flex-1">
         <StatsCard
-          title={t`Underlying APY`}
-          isLoading={isLoading}
-          error={error}
-          content={
-            <Text className="mt-2" variant="large">
-              {data?.underlyingApy !== undefined ? formatDecimalPercentage(data.underlyingApy) : '—'}
-            </Text>
-          }
-        />
-      </div>
-      <div className="min-w-[250px] flex-1">
-        <StatsCard
           title={<Trans>TVL</Trans>}
           isLoading={isLoading}
           error={error}

--- a/apps/webapp/src/modules/pendle/components/PendleMarketStatsCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMarketStatsCard.tsx
@@ -62,25 +62,11 @@ export const PendleMarketStatsCard = ({ market, onClick, disabled = false }: Pen
       <CardContent className="mt-5 p-0">
         <HStack className="justify-between" gap={2}>
           <VStack className="items-stretch justify-between" gap={2}>
-            <Text className="text-textSecondary text-sm leading-4 whitespace-nowrap">
-              <Trans>Underlying APY</Trans>
-            </Text>
-            {isLoading ? (
-              <Skeleton className="h-4 w-21" />
-            ) : marketData?.underlyingApy !== undefined ? (
-              <Text>{formatDecimalPercentage(marketData.underlyingApy)}</Text>
-            ) : (
-              <Text>—</Text>
-            )}
-          </VStack>
-          <VStack className="items-stretch justify-between text-right" gap={2}>
             <Text className="text-textSecondary text-sm leading-4">
               <Trans>TVL</Trans>
             </Text>
             {isLoading ? (
-              <div className="flex justify-end">
-                <Skeleton className="h-4 w-30" />
-              </div>
+              <Skeleton className="h-4 w-30" />
             ) : marketData?.formattedTvl ? (
               <Text>{marketData.formattedTvl}</Text>
             ) : (

--- a/apps/webapp/src/modules/pendle/components/PendleMarketStatsCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMarketStatsCard.tsx
@@ -1,26 +1,20 @@
+import { Trans } from '@lingui/react/macro';
 import { formatDecimalPercentage } from '@jetstreamgg/sky-utils';
 import { isMarketMatured, usePendleMarketsApiData, type PendleMarketConfig } from '@jetstreamgg/sky-hooks';
-
-const secondsToExpiry = (expiry: number): number => Math.max(0, expiry - Math.floor(Date.now() / 1000));
-import { Trans } from '@lingui/react/macro';
 import { Text } from '@/modules/layout/components/Typography';
 import { VStack } from '@/modules/layout/components/VStack';
 import { HStack } from '@/modules/layout/components/HStack';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { formatTimeLeft } from '../utils/formatTimeLeft';
+
+const secondsToExpiry = (expiry: number): number => Math.max(0, expiry - Math.floor(Date.now() / 1000));
 
 type PendleMarketStatsCardProps = {
   market: PendleMarketConfig;
   onClick?: () => void;
   disabled?: boolean;
-};
-
-const formatDays = (seconds: number): string => {
-  const days = Math.max(0, Math.round(seconds / 86_400));
-  if (days === 0) return 'today';
-  if (days === 1) return '1 day';
-  return `${days} days`;
 };
 
 export const PendleMarketStatsCard = ({ market, onClick, disabled = false }: PendleMarketStatsCardProps) => {
@@ -47,7 +41,7 @@ export const PendleMarketStatsCard = ({ market, onClick, disabled = false }: Pen
             </Text>
           ) : (
             <Text variant="small" className="text-textSecondary">
-              <Trans>· {formatDays(remaining)} left</Trans>
+              <Trans>· {formatTimeLeft(remaining)} left</Trans>
             </Text>
           )}
         </HStack>

--- a/apps/webapp/src/modules/pendle/components/PendleMaturedPositionCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMaturedPositionCard.tsx
@@ -3,10 +3,10 @@ import { formatBigInt } from '@jetstreamgg/sky-utils';
 import { type PendleMarketConfig, usePendleRedeemPreview } from '@jetstreamgg/sky-hooks';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Text } from '@/modules/layout/components/Typography';
 import { HStack } from '@/modules/layout/components/HStack';
-import { VStack } from '@/modules/layout/components/VStack';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
+import { TokenIconWithBalance } from '@/modules/ui/components/TokenIconWithBalance';
+import { Text } from '@/modules/layout/components/Typography';
 import { usePendleRedeemModal } from '../hooks/usePendleRedeemModal';
 
 type PendleMaturedPositionCardProps = {
@@ -30,28 +30,17 @@ export const PendleMaturedPositionCard = ({ market, ptBalance }: PendleMaturedPo
     previewAmount !== undefined
       ? formatBigInt(previewAmount as bigint, { unit: market.underlyingDecimals, maxDecimals: 4 })
       : undefined;
+  // The amount we surface to the user is the receive amount (post SY-rate
+  // conversion). Until the on-chain preview resolves, fall back to the PT
+  // balance — same number of decimals, just a transient discrepancy.
+  const displayedAmount = formattedReceive ?? formattedBalance;
 
   const tokenTile = (
     <HStack className="items-center" gap={2}>
-      <HStack className="items-center" gap={2}>
-        <TokenIcon
-          className="h-5 w-5"
-          token={{ symbol: `PT-${market.underlyingSymbol}` }}
-          showChainIcon={false}
-        />
-        <Text>
-          {formattedBalance} PT-{market.underlyingSymbol}
-        </Text>
-      </HStack>
-      {formattedReceive && (
-        <HStack className="items-center" gap={2}>
-          <Text>→</Text>
-          <TokenIcon className="h-5 w-5" token={{ symbol: market.underlyingSymbol }} showChainIcon={false} />
-          <Text>
-            {formattedReceive} {market.underlyingSymbol}
-          </Text>
-        </HStack>
-      )}
+      <TokenIcon className="h-5 w-5" token={{ symbol: market.underlyingSymbol }} showChainIcon={false} />
+      <Text>
+        {displayedAmount} {market.underlyingSymbol}
+      </Text>
     </HStack>
   );
 
@@ -62,38 +51,28 @@ export const PendleMaturedPositionCard = ({ market, ptBalance }: PendleMaturedPo
   return (
     <Card variant="stats" data-testid="pendle-matured-position-card">
       <CardHeader>
-        <VStack className="items-stretch" gap={1}>
-          <CardTitle variant="stats">
-            <Trans>Available to redeem</Trans>
-          </CardTitle>
-          <HStack className="items-center" gap={2}>
-            <TokenIcon
-              className="h-5 w-5"
-              token={{ symbol: `PT-${market.underlyingSymbol}` }}
-              showChainIcon={false}
-            />
-            <Text>
-              {formattedBalance} PT-{market.underlyingSymbol}
-            </Text>
-          </HStack>
-        </VStack>
-        <VStack className="items-stretch text-right" gap={1}>
-          <CardTitle variant="stats" className="whitespace-nowrap">
-            <Trans>Matured</Trans>
-          </CardTitle>
-          <Text className="whitespace-nowrap">{maturityLabel}</Text>
-        </VStack>
+        <CardTitle variant="stats" className="mb-2">
+          <Trans>Matured on {maturityLabel}</Trans>
+        </CardTitle>
       </CardHeader>
-      <CardContent variant="stats" className="mt-4">
+      <CardContent variant="stats">
+        <TokenIconWithBalance
+          token={{ symbol: market.underlyingSymbol, name: market.underlyingSymbol }}
+          balance={displayedAmount}
+        />
+        {/* TODO: mock copy — replace with computed earnings + APY. */}
+        <Text variant="small" className="text-textSecondary mt-4">
+          <Trans>You&apos;ve earned 87.42 {market.underlyingSymbol} with 5.21% APY</Trans>
+        </Text>
         <Button
           variant="primary"
-          className="w-full"
+          className="mt-4 w-full"
           onClick={openRedeemModal}
           disabled={!isRedeemable || !isPrepared || previewLoading}
           data-testid="pendle-matured-redeem-button"
         >
           <Trans>
-            Redeem {formattedBalance} PT-{market.underlyingSymbol}
+            Redeem {displayedAmount} {market.underlyingSymbol}
           </Trans>
         </Button>
       </CardContent>

--- a/apps/webapp/src/modules/pendle/components/PendleReadyToRedeemList.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleReadyToRedeemList.tsx
@@ -36,7 +36,7 @@ export const PendleReadyToRedeemList = () => {
   return (
     <motion.div className="space-y-3" variants={positionAnimations}>
       <Heading tag="h3" variant="medium">
-        <Trans>Ready to redeem</Trans>
+        <Trans>Your matured positions</Trans>
       </Heading>
       {maturedHeld.map(({ market, ptBalance }) => (
         <PendleMaturedPositionCard key={market.marketAddress} market={market} ptBalance={ptBalance} />

--- a/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
@@ -104,7 +104,7 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
           <WidgetContainer
             header={
               <Heading variant="x-large">
-                <Trans>Pendle</Trans>
+                <Trans>Fixed Yield</Trans>
               </Heading>
             }
             subHeader={
@@ -120,7 +120,9 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
             <div className="flex flex-col gap-4">
               {!isOnPendleChain && (
                 <Text className="text-textSecondary">
-                  <Trans>Pendle markets are only on Ethereum mainnet. Switch networks to view markets.</Trans>
+                  <Trans>
+                    Fixed yield markets are only on Ethereum mainnet. Switch networks to view markets.
+                  </Trans>
                 </Text>
               )}
               {isOnPendleChain && <PendleReadyToRedeemList />}
@@ -154,7 +156,7 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
               )}
               {isOnPendleChain && myMarkets.length === 0 && allMarkets.length === 0 && (
                 <Text className="text-textSecondary">
-                  <Trans>No active Pendle markets at the moment. Check back soon.</Trans>
+                  <Trans>No active fixed yield markets at the moment. Check back soon.</Trans>
                 </Text>
               )}
             </div>

--- a/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
@@ -17,8 +17,8 @@ import {
   WidgetContainer,
   positionAnimations
 } from '@jetstreamgg/sky-widgets';
-import { PendleIntent } from '@/lib/enums';
-import { PendleIntentMapping, QueryParams } from '@/lib/constants';
+import { FixedIntent } from '@/lib/enums';
+import { FixedIntentMapping, QueryParams } from '@/lib/constants';
 import { Heading, Text } from '@/modules/layout/components/Typography';
 import { SharedProps } from '@/modules/app/types/Widgets';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
@@ -71,7 +71,7 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
 
   const handleSelectMarket = (market: PendleMarketConfig) => {
     setSearchParams(params => {
-      params.set(QueryParams.PendleModule, PendleIntentMapping[PendleIntent.MARKET_INTENT]);
+      params.set(QueryParams.FixedModule, FixedIntentMapping[FixedIntent.MARKET_INTENT]);
       params.set(QueryParams.Market, market.marketAddress);
       return params;
     });
@@ -79,7 +79,7 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
 
   const handleBack = () => {
     setSearchParams(params => {
-      params.delete(QueryParams.PendleModule);
+      params.delete(QueryParams.FixedModule);
       params.delete(QueryParams.Market);
       return params;
     });

--- a/apps/webapp/src/modules/pendle/components/TimeToMaturityCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/TimeToMaturityCard.tsx
@@ -3,11 +3,11 @@ import { Trans } from '@lingui/react/macro';
 import { type PendleMarketConfig, usePendleMarketsApiData } from '@jetstreamgg/sky-hooks';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { Text } from '@/modules/layout/components/Typography';
+import { formatTimeLeft } from '../utils/formatTimeLeft';
 
 const SECONDS_PER_DAY = 86_400;
 
-const secondsToExpiry = (expiry: number): number =>
-  Math.max(0, expiry - Math.floor(Date.now() / 1000));
+const secondsToExpiry = (expiry: number): number => Math.max(0, expiry - Math.floor(Date.now() / 1000));
 
 type TimeToMaturityCardProps = {
   market: PendleMarketConfig;
@@ -50,7 +50,7 @@ export const TimeToMaturityCard = ({ market }: TimeToMaturityCardProps) => {
     remainingSeconds <= 0 ? (
       <Trans>Matured</Trans>
     ) : (
-      <Trans>{Math.floor(remainingSeconds / SECONDS_PER_DAY)} days remaining</Trans>
+      <Trans>{formatTimeLeft(remainingSeconds)} remaining</Trans>
     );
 
   const maturityDateLabel = new Date(expirySec * 1000).toLocaleDateString(undefined, {

--- a/apps/webapp/src/modules/pendle/components/__tests__/PendleWidgetPane.test.tsx
+++ b/apps/webapp/src/modules/pendle/components/__tests__/PendleWidgetPane.test.tsx
@@ -204,7 +204,7 @@ const cardAddresses = (container: HTMLElement): string[] =>
 
 describe('PendleWidgetPane', () => {
   beforeEach(() => {
-    mockSearchParams = new URLSearchParams('widget=pendle');
+    mockSearchParams = new URLSearchParams('widget=fixed');
     setSearchParamsMock.mockClear();
     // Reset connection + balances between tests.
     hoisted.userAddress = undefined;
@@ -228,7 +228,7 @@ describe('PendleWidgetPane', () => {
 
   it('renders the PendleWidget when a known ?market is selected', () => {
     mockSearchParams = new URLSearchParams(
-      `widget=pendle&pendle_module=market&market=${ACTIVE_MARKET_ADDRESS}`
+      `widget=fixed&fixed_module=market&market=${ACTIVE_MARKET_ADDRESS}`
     );
 
     const { container, unmount } = renderComponent(<PendleWidgetPane {...sharedProps} />);
@@ -241,7 +241,7 @@ describe('PendleWidgetPane', () => {
 
   it('falls back to the overview when ?market is unknown', () => {
     mockSearchParams = new URLSearchParams(
-      'widget=pendle&pendle_module=market&market=0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+      'widget=fixed&fixed_module=market&market=0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
     );
 
     const { container, unmount } = renderComponent(<PendleWidgetPane {...sharedProps} />);
@@ -283,7 +283,10 @@ describe('PendleWidgetPane', () => {
       unmount();
     });
 
-    it('shows a matured market in My positions when the user holds PT for it', () => {
+    it('hides a matured market from stats cards even when the user holds PT for it', () => {
+      // Matured markets surface only in the "Ready to redeem" list — they
+      // never appear as PendleMarketStatsCard. Active markets the user holds
+      // still appear under "My positions".
       hoisted.userAddress = '0x000000000000000000000000000000000000beef';
       hoisted.ptBalances = {
         [ACTIVE_MARKET_ADDRESS]: 0n,
@@ -292,11 +295,9 @@ describe('PendleWidgetPane', () => {
 
       const { container, unmount } = renderComponent(<PendleWidgetPane {...sharedProps} />);
 
-      // Both groups render their own card; matured one should be in "My positions"
       const addresses = cardAddresses(container);
-      expect(addresses).toContain(MATURED_MARKET_ADDRESS);
+      expect(addresses).not.toContain(MATURED_MARKET_ADDRESS);
       expect(addresses).toContain(ACTIVE_MARKET_ADDRESS);
-      expect(container.textContent).toContain('My positions');
 
       unmount();
     });

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemAllModal.ts
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemAllModal.ts
@@ -50,7 +50,7 @@ export function usePendleRedeemAllModal(positions: RedeemPosition[], opts: Optio
       confirmLabel: t`Confirm`,
       onConfirm: () => batchRedeem.execute(),
       analytics: {
-        widgetName: 'pendle',
+        widgetName: 'fixed',
         flow: 'redeem-all',
         action: 'redeem-all',
         data: {

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.ts
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.ts
@@ -52,7 +52,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
       confirmLabel: t`Confirm`,
       onConfirm: () => redeem.execute(),
       analytics: {
-        widgetName: 'pendle',
+        widgetName: 'fixed',
         flow: 'redeem',
         action: 'redeem',
         data: { market: market.marketAddress, underlyingSymbol: market.underlyingSymbol }

--- a/apps/webapp/src/modules/pendle/utils/formatTimeLeft.ts
+++ b/apps/webapp/src/modules/pendle/utils/formatTimeLeft.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats a positive remaining-seconds value as a duration phrase.
+ * Returns the largest unit where the value is ≥ 1 (days → hours → minutes),
+ * or "less than a minute" for sub-minute remainders. Empty string when ≤ 0.
+ */
+export const formatTimeLeft = (seconds: number): string => {
+  if (seconds <= 0) return '';
+  const days = Math.floor(seconds / 86_400);
+  if (days >= 1) return days === 1 ? '1 day' : `${days} days`;
+  const hours = Math.floor(seconds / 3_600);
+  if (hours >= 1) return hours === 1 ? '1 hour' : `${hours} hours`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes >= 1) return minutes === 1 ? '1 minute' : `${minutes} minutes`;
+  return 'less than a minute';
+};

--- a/apps/webapp/src/modules/utils/validateSearchParams.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.ts
@@ -10,7 +10,7 @@ import {
   ExpertIntentMapping,
   VaultsIntentMapping,
   ConvertIntentMapping,
-  PendleIntentMapping,
+  FixedIntentMapping,
   IS_PRODUCTION_ENV
 } from '@/lib/constants';
 import { GEO_OVERRIDE_PARAMS, isValidGeoParam } from '@/modules/geo-config/applyGeoOverrides';
@@ -225,9 +225,9 @@ export const validateSearchParams = (
       setSelectedConvertOption(undefined);
     }
 
-    // validates pendle_module param against PendleIntentMapping
-    if (key === QueryParams.PendleModule) {
-      const isValidIntent = Object.values(PendleIntentMapping).includes(value);
+    // validates fixed_module param against FixedIntentMapping
+    if (key === QueryParams.FixedModule) {
+      const isValidIntent = Object.values(FixedIntentMapping).includes(value);
       if (!isValidIntent) {
         searchParams.delete(key);
       }
@@ -241,14 +241,14 @@ export const validateSearchParams = (
       const market = PENDLE_MARKETS.find(m => m.marketAddress.toLowerCase() === lower);
       const isValid = !!market && !isMarketMatured(market.expiry);
       if (!isValid) {
-        searchParams.delete(QueryParams.PendleModule);
+        searchParams.delete(QueryParams.FixedModule);
         searchParams.delete(key);
       }
     }
 
     // if widget changes to something other than pendle, drop the pendle params
-    if (widget !== IntentMapping[Intent.PENDLE_INTENT]) {
-      searchParams.delete(QueryParams.PendleModule);
+    if (widget !== IntentMapping[Intent.FIXED_INTENT]) {
+      searchParams.delete(QueryParams.FixedModule);
       searchParams.delete(QueryParams.Market);
     }
 

--- a/apps/webapp/src/test/e2e/tests/pendle.spec.ts
+++ b/apps/webapp/src/test/e2e/tests/pendle.spec.ts
@@ -11,14 +11,14 @@ test.describe('Pendle (scaffold — write actions stubbed)', () => {
     await connectMockWalletAndAcceptTerms(isolatedPage, { batch: true });
   });
 
-  test.skip('reaches the Pendle module from the sidebar', async ({ isolatedPage }) => {
-    await isolatedPage.getByRole('tab', { name: 'Pendle' }).click();
-    await expect(isolatedPage.getByText('Pendle')).toBeVisible();
+  test.skip('reaches the Fixed Yield module from the sidebar', async ({ isolatedPage }) => {
+    await isolatedPage.getByRole('tab', { name: 'Fixed Yield' }).click();
+    await expect(isolatedPage.getByText('Fixed Yield')).toBeVisible();
   });
 
   test.skip('opens a market detail page via deeplink ?market=<address>', async ({ isolatedPage }) => {
     await isolatedPage.goto(
-      '/?widget=pendle&pendle_module=market&market=0xc5b32dba5f29f8395fb9591e1a15f23a75214f33'
+      '/?widget=fixed&fixed_module=market&market=0xc5b32dba5f29f8395fb9591e1a15f23a75214f33'
     );
     await expect(isolatedPage.getByText('PT-USDG')).toBeVisible();
     await expect(isolatedPage.getByTestId('pendle-action-button')).toBeVisible();
@@ -26,14 +26,14 @@ test.describe('Pendle (scaffold — write actions stubbed)', () => {
 
   test.skip('falls back to the overview when ?market=<unknown> is passed', async ({ isolatedPage }) => {
     await isolatedPage.goto(
-      '/?widget=pendle&pendle_module=market&market=0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+      '/?widget=fixed&fixed_module=market&market=0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
     );
     await expect(isolatedPage.getByText('All markets')).toBeVisible();
   });
 
   test.skip('routing disclosure expands and collapses', async ({ isolatedPage }) => {
     await isolatedPage.goto(
-      '/?widget=pendle&pendle_module=market&market=0xc5b32dba5f29f8395fb9591e1a15f23a75214f33'
+      '/?widget=fixed&fixed_module=market&market=0xc5b32dba5f29f8395fb9591e1a15f23a75214f33'
     );
     const toggle = isolatedPage.getByTestId('pendle-routing-disclosure-toggle');
     await toggle.click();

--- a/packages/widgets/src/widgets/PendleWidget/components/PendleStatsCard.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/PendleStatsCard.tsx
@@ -8,7 +8,6 @@ import { StatsAccordionCard } from '@widgets/shared/components/ui/card/StatsAcco
 import { TokenIcon } from '@widgets/shared/components/ui/token/TokenIcon';
 import { MotionHStack } from '@widgets/shared/components/ui/layout/MotionHStack';
 import { MotionVStack } from '@widgets/shared/components/ui/layout/MotionVStack';
-import { HStack } from '@widgets/shared/components/ui/layout/HStack';
 import { Text } from '@widgets/shared/components/ui/Typography';
 import { Skeleton } from '@widgets/components/ui/skeleton';
 import { positionAnimations } from '@widgets/shared/animation/presets';
@@ -21,7 +20,7 @@ type PendleStatsCardProps = {
 /**
  * In-widget stats card mirroring MorphoVaultStatsCard's shape:
  * - Header: market name + Fixed APY
- * - Accordion: View PT contract + collapsible Underlying APY / TVL row
+ * - Accordion: View PT contract + collapsible TVL row
  *
  * Sits at the top of the widget body (above the Supply/Withdraw form) to give
  * the user the same at-a-glance product info they'd see in the right details
@@ -37,38 +36,18 @@ export const PendleStatsCard = ({ market, onExternalLinkClicked }: PendleStatsCa
     marketData?.impliedApy !== undefined ? formatDecimalPercentage(marketData.impliedApy) : '—';
 
   const accordionContent = (
-    <HStack className="mt-5 justify-between" gap={2}>
-      <MotionVStack className="justify-between" gap={2} variants={positionAnimations}>
-        <Text className="text-textSecondary text-sm leading-4">
-          <Trans>Underlying APY</Trans>
-        </Text>
-        {isLoading ? (
-          <Skeleton className="bg-textSecondary h-6 w-20" />
-        ) : marketData?.underlyingApy !== undefined ? (
-          <Text className="whitespace-nowrap">{formatDecimalPercentage(marketData.underlyingApy)}</Text>
-        ) : (
-          <Text>—</Text>
-        )}
-      </MotionVStack>
-      <MotionVStack
-        className="min-w-0 flex-1 items-end justify-between text-right"
-        gap={2}
-        variants={positionAnimations}
-      >
-        <Text className="text-textSecondary text-sm leading-4">
-          <Trans>TVL</Trans>
-        </Text>
-        {isLoading ? (
-          <div className="flex justify-end">
-            <Skeleton className="bg-textSecondary h-6 w-20" />
-          </div>
-        ) : marketData?.formattedTvl ? (
-          <Text>{marketData.formattedTvl}</Text>
-        ) : (
-          <Text>—</Text>
-        )}
-      </MotionVStack>
-    </HStack>
+    <MotionVStack className="mt-5 justify-between" gap={2} variants={positionAnimations}>
+      <Text className="text-textSecondary text-sm leading-4">
+        <Trans>TVL</Trans>
+      </Text>
+      {isLoading ? (
+        <Skeleton className="bg-textSecondary h-6 w-20" />
+      ) : marketData?.formattedTvl ? (
+        <Text>{marketData.formattedTvl}</Text>
+      ) : (
+        <Text>—</Text>
+      )}
+    </MotionVStack>
   );
 
   return (


### PR DESCRIPTION
### What does this PR do?

Pendle QA pass #2. Branding/rename + UX polish. Earnings + APY on matured positions is on a separate PR and not included here.

#### 1. Pendle → Fixed Yield rebrand

User-facing label flipped to "Fixed Yield" everywhere it shows up: nav tab, widget heading, About card, network warnings, empty states, balance label, e2e tests. Body copy that explicitly references the underlying protocol (e.g. "Lock in fixed yield via Pendle PT markets") is left as-is — it's a one-time, accurate mention of the integration partner. Module folder names + technical symbols that map to the actual Pendle protocol (`PendleWidget`, `PENDLE_MARKETS`, `usePendleRedeem`, etc.) stay as Pendle.

URL params + module-name symbols renamed:
- `?widget=pendle` → `?widget=fixed`
- `?pendle_module=…` → `?fixed_module=…`
- `Intent.PENDLE_INTENT` → `Intent.FIXED_INTENT`
- `enum PendleIntent` → `enum FixedIntent`
- `PendleIntentMapping` → `FixedIntentMapping`
- `QueryParams.PendleModule` → `QueryParams.FixedModule`

Hard cutover (no backwards-compat redirect) — module isn't in prod yet, `validateSearchParams` strips unknown widget values cleanly.

#### 2. Sidebar placement

Fixed Yield moved under Savings in the sidebar — folded into group-2 (Savings / Rewards / Stake), standalone `group-pendle` removed. New sidebar order within group-2: Rewards · Savings · Fixed Yield · Stake & Borrow.

#### 3. About card

Adopted the shared `AboutCard` (gradient `GradientShapeCard`) pattern that Vaults / Sky / SPK use. Now renders both connected and disconnected — previously the bottom About card was a one-off plain dark card and the gradient hero only showed when disconnected.

Followed the Savings two-banner pattern (`about-the-sky-savings-rate` + `susds`) for distinct copy in each surface:
- `about-fixed-yield` — ConnectCard hero, disconnected only.
- `fixed-yield` — bottom AboutCard, both states.

Both are placeholders; final copy needs to land in the upstream `sky-ecosystem/corpus` repo before prod, otherwise the next corpus sync will revert them.

`ConnectCard` banner-id mapping for `Intent.FIXED_INTENT` was previously `'about-balances'` (placeholder leftover) — fixed to `'about-fixed-yield'`.

#### 4. Underlying APY removed (across 3 surfaces)

Per Linear feedback that Pendle aggregates underlying APY with YT/SY/rewards we don't surface — display would be misleading. Removed from:
- `PendleMarketStatsCard` (overview cards)
- `PendleMarketInfoCard` (per-market "Market info" stat-card row)
- `PendleStatsCard` (in-widget accordion)

Each card layout simplified: 3-column stat rows collapse to 2; one accordion row collapses to a single VStack.

#### 5. Sub-day time granularity

Replaced "0 days remaining" / "today left" with proper time-unit cascade. New shared util `formatTimeLeft` in `apps/webapp/src/modules/pendle/utils/`. Returns the largest unit ≥1 (days → hours → minutes), falls through to "less than a minute" otherwise. Wired into `PendleMarketStatsCard` ("X left") and `TimeToMaturityCard` ("X remaining"). Same util, suffix composed at the call site.

#### 6. `PendleMaturedPositionCard` layout (PM-driven)

- Section title "Ready to redeem" → "Your matured positions".
- Card now uses the standard `Card variant="stats"` shape (`CardTitle` label + `TokenIconWithBalance` value + full-width primary button) — same shape as Vaults / Stake position cards.
- Dropped the jargon: "Redeem 1,010 PT-sENA for 1,010 sENA (1:1)", redundant "Matured · date" footer line, two-corner stats header.
- Receive amount uses the on-chain `usePendleRedeemPreview` hook landed in PR #1542, so the displayed amount is the SY-rate-adjusted value (e.g. `991.879 sENA` for 1,010 PT-sENA), not the PT count.

### Testing steps

- [ ] Sidebar reads "Fixed Yield" under Savings.
- [ ] `/?widget=pendle&pendle_module=market&market=…` — old URL params get stripped; `/?widget=fixed&fixed_module=market&market=<address>` is the new shape.
- [ ] About card renders gradient style (matches Vaults) in both connected and disconnected states.
- [ ] Underlying APY no longer appears on overview cards, Market info stat row, or in-widget accordion.
- [ ] PT-USDe (≈hours to maturity at time of writing) reads "X hours left" on the overview card and "X hours remaining" on the progress card — not "today left" / "0 days remaining".
- [ ] Matured-position card reads cleanly: "Matured on Apr 30, 2026" label + receive amount + full-width Redeem button. Section heading is "Your matured positions".