### PR TITLE
Support supplying / withdrawing with USDS / USDC in Pendle

### DIFF
--- a/packages/hooks/src/pendle/buildVerifiedArgs.test.ts
+++ b/packages/hooks/src/pendle/buildVerifiedArgs.test.ts
@@ -18,6 +18,10 @@ const MARKET = '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33' as const;
 const USDG = '0xe343167631d89B6Ffc58B88d6b7fB0228795491D' as const;
 const PT_USDG = '0x9db38D74a0D29380899aD354121DfB521aDb0548' as const;
 const ZERO = '0x0000000000000000000000000000000000000000' as const;
+const PINNED_PENDLE_SWAP = '0xd4f480965d2347d421f1bec7f545682e5ec2151d' as const;
+// USDS — used as the non-underlying input/output for aggregator-branch tests
+const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F' as const;
+const KYBER_ROUTER = '0x6131B5fae19EA4f9D964eAc0408E4408b66337b5' as const;
 
 const API_GUESS = {
   guessMin: '50000000',
@@ -93,7 +97,9 @@ const BUY_KNOWN = {
   market: MARKET,
   inputToken: USDG,
   outputToken: PT_USDG,
-  amountIn: 100_000_000n
+  underlyingToken: USDG,
+  amountIn: 100_000_000n,
+  pinnedPendleSwap: PINNED_PENDLE_SWAP
 };
 
 describe('buildVerifiedArgs — Buy', () => {
@@ -263,7 +269,9 @@ describe('buildVerifiedArgs — Withdraw', () => {
     market: MARKET,
     inputToken: PT_USDG,
     outputToken: USDG,
-    amountIn: 100_000_000n
+    underlyingToken: USDG,
+    amountIn: 100_000_000n,
+    pinnedPendleSwap: PINNED_PENDLE_SWAP
   };
 
   function withdrawVerified(quote: PendleConvertQuote, known = WITHDRAW_KNOWN) {
@@ -293,6 +301,201 @@ describe('buildVerifiedArgs — Withdraw', () => {
   it('throws on an unknown method (selector allowlist)', () => {
     const quote = makeWithdrawQuote({ method: 'redeemPyToToken' });
     expect(() => buildVerifiedArgs(quote, WITHDRAW_KNOWN)).toThrow(/selector .* not allowed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregator branch — input/output token differs from underlying. Pendle's
+// API returns a non-zero pendleSwap (the pinned PendleSwap forwarder) and a
+// populated swapData; tokenMintSy / tokenRedeemSy must equal the underlying.
+// ---------------------------------------------------------------------------
+
+const KYBER_SWAP_DATA = {
+  swapType: 1,
+  extRouter: KYBER_ROUTER,
+  extCalldata: ('0x' + 'ab'.repeat(120)) as `0x${string}`,
+  needScale: false
+};
+
+describe('buildVerifiedArgs — Buy aggregator branch', () => {
+  // User supplies USDS (not the underlying USDG). The API returns a route
+  // through Pendle's PendleSwap → KyberSwap → USDG → SY.
+  const BUY_AGG_KNOWN = {
+    side: PendleConvertSide.BUY,
+    receiver: RECEIVER,
+    market: MARKET,
+    inputToken: USDS, // user-picked, NOT the underlying
+    outputToken: PT_USDG,
+    underlyingToken: USDG,
+    amountIn: 100_000_000_000_000_000_000n, // 100 USDS (18 decimals)
+    pinnedPendleSwap: PINNED_PENDLE_SWAP
+  };
+
+  function makeAggBuyParams(opts: {
+    pendleSwap?: string;
+    swapType?: string;
+    extRouter?: string;
+    extCalldata?: string;
+    inputTokenMintSy?: string;
+  } = {}): unknown[] {
+    return [
+      RECEIVER,
+      MARKET,
+      '99000000',
+      API_GUESS,
+      {
+        tokenIn: USDS,
+        netTokenIn: '100000000000000000000',
+        tokenMintSy: opts.inputTokenMintSy ?? USDG,
+        pendleSwap: opts.pendleSwap ?? PINNED_PENDLE_SWAP,
+        swapData: {
+          swapType: opts.swapType ?? '1',
+          extRouter: opts.extRouter ?? KYBER_ROUTER,
+          extCalldata: opts.extCalldata ?? KYBER_SWAP_DATA.extCalldata,
+          needScale: false
+        }
+      },
+      API_EMPTY_LIMIT
+    ];
+  }
+
+  function makeAggBuyQuote(overrides: Partial<PendleConvertQuote> = {}): PendleConvertQuote {
+    return {
+      method: 'swapExactTokenForPt',
+      amountOut: 100_000_000n,
+      apiMinOut: 99_800_000n,
+      effectiveApy: 0.05,
+      impliedApy: 0.058,
+      priceImpact: -0.0002,
+      aggregatorType: 'KYBERSWAP',
+      aggregatorRoute: {
+        pendleSwap: PINNED_PENDLE_SWAP,
+        swapData: KYBER_SWAP_DATA
+      },
+      fetchedAt: Date.now(),
+      apiContractParams: makeAggBuyParams(),
+      apiContractParamsName: BUY_PARAM_NAMES,
+      ...overrides
+    };
+  }
+
+  it('forwards pendleSwap and swapData when input ≠ underlying', () => {
+    const verified = buildVerifiedArgs(makeAggBuyQuote(), BUY_AGG_KNOWN);
+    if (verified.side !== PendleConvertSide.BUY) throw new Error('expected BUY');
+    expect(verified.args[4].pendleSwap).toBe(PINNED_PENDLE_SWAP);
+    expect(verified.args[4].swapData).toEqual(KYBER_SWAP_DATA);
+  });
+
+  it('pins tokenMintSy to the underlying (not the user-picked input)', () => {
+    const verified = buildVerifiedArgs(makeAggBuyQuote(), BUY_AGG_KNOWN);
+    if (verified.side !== PendleConvertSide.BUY) throw new Error('expected BUY');
+    expect(verified.args[4].tokenIn).toBe(USDS); // user-picked, kept as tokenIn
+    expect(verified.args[4].tokenMintSy).toBe(USDG); // pinned to underlying
+  });
+
+  it('rejects when the API returns a non-pinned pendleSwap', () => {
+    const ATTACKER = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const;
+    const quote = makeAggBuyQuote({
+      aggregatorRoute: { pendleSwap: ATTACKER, swapData: KYBER_SWAP_DATA }
+    });
+    expect(() => buildVerifiedArgs(quote, BUY_AGG_KNOWN)).toThrow(/not the pinned forwarder/);
+  });
+
+  it('rejects when input ≠ underlying but the quote has no aggregatorRoute', () => {
+    const quote = makeAggBuyQuote({ aggregatorRoute: undefined });
+    expect(() => buildVerifiedArgs(quote, BUY_AGG_KNOWN)).toThrow(/aggregator required/);
+  });
+
+  it('uses the no-aggregator path when input === underlying even if aggregatorRoute is present', () => {
+    // Sanity: BUY_KNOWN has inputToken == USDG (the underlying); presence of
+    // aggregatorRoute on the quote should be ignored.
+    const quote = makeAggBuyQuote({
+      aggregatorRoute: { pendleSwap: PINNED_PENDLE_SWAP, swapData: KYBER_SWAP_DATA }
+    });
+    quote.method = 'swapExactTokenForPt';
+    quote.apiContractParams = makeBuyParams();
+    const verified = buildVerifiedArgs(quote, BUY_KNOWN);
+    if (verified.side !== PendleConvertSide.BUY) throw new Error('expected BUY');
+    expect(verified.args[4].pendleSwap).toBe(ZERO);
+    expect(verified.args[4].swapData).toEqual(PENDLE_EMPTY_SWAP_DATA);
+    expect(verified.args[4].tokenMintSy).toBe(USDG);
+  });
+});
+
+describe('buildVerifiedArgs — Withdraw aggregator branch', () => {
+  // User wants USDS out (not the underlying USDG).
+  const WITHDRAW_AGG_KNOWN = {
+    side: PendleConvertSide.WITHDRAW,
+    receiver: RECEIVER,
+    market: MARKET,
+    inputToken: PT_USDG,
+    outputToken: USDS, // user-picked, NOT the underlying
+    underlyingToken: USDG,
+    amountIn: 100_000_000n,
+    pinnedPendleSwap: PINNED_PENDLE_SWAP
+  };
+
+  function makeAggWithdrawParams(opts: { pendleSwap?: string; outputTokenRedeemSy?: string } = {}): unknown[] {
+    return [
+      RECEIVER,
+      MARKET,
+      '100000000',
+      {
+        tokenOut: USDS,
+        minTokenOut: '99000000000000000000',
+        tokenRedeemSy: opts.outputTokenRedeemSy ?? USDG,
+        pendleSwap: opts.pendleSwap ?? PINNED_PENDLE_SWAP,
+        swapData: {
+          swapType: '1',
+          extRouter: KYBER_ROUTER,
+          extCalldata: KYBER_SWAP_DATA.extCalldata,
+          needScale: false
+        }
+      },
+      API_EMPTY_LIMIT
+    ];
+  }
+
+  function makeAggWithdrawQuote(overrides: Partial<PendleConvertQuote> = {}): PendleConvertQuote {
+    return {
+      method: 'swapExactPtForToken',
+      amountOut: 100_000_000n,
+      apiMinOut: 99_500_000_000_000_000_000n,
+      effectiveApy: 0.05,
+      impliedApy: 0.058,
+      priceImpact: -0.0002,
+      aggregatorType: 'KYBERSWAP',
+      aggregatorRoute: {
+        pendleSwap: PINNED_PENDLE_SWAP,
+        swapData: KYBER_SWAP_DATA
+      },
+      fetchedAt: Date.now(),
+      apiContractParams: makeAggWithdrawParams(),
+      apiContractParamsName: ['receiver', 'market', 'exactPtIn', 'output', 'limit'],
+      ...overrides
+    };
+  }
+
+  it('pins tokenRedeemSy to the underlying when output ≠ underlying', () => {
+    const verified = buildVerifiedArgs(makeAggWithdrawQuote(), WITHDRAW_AGG_KNOWN);
+    if (verified.functionName !== 'swapExactPtForToken') throw new Error('expected swapExactPtForToken');
+    expect(verified.args[3].tokenOut).toBe(USDS); // user-picked, kept as tokenOut
+    expect(verified.args[3].tokenRedeemSy).toBe(USDG); // pinned to underlying
+    expect(verified.args[3].pendleSwap).toBe(PINNED_PENDLE_SWAP);
+    expect(verified.args[3].swapData).toEqual(KYBER_SWAP_DATA);
+  });
+
+  it('rejects when the API returns a non-pinned pendleSwap', () => {
+    const ATTACKER = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const;
+    const quote = makeAggWithdrawQuote({
+      aggregatorRoute: { pendleSwap: ATTACKER, swapData: KYBER_SWAP_DATA }
+    });
+    expect(() => buildVerifiedArgs(quote, WITHDRAW_AGG_KNOWN)).toThrow(/not the pinned forwarder/);
+  });
+
+  it('rejects when output ≠ underlying but quote has no aggregatorRoute', () => {
+    const quote = makeAggWithdrawQuote({ aggregatorRoute: undefined });
+    expect(() => buildVerifiedArgs(quote, WITHDRAW_AGG_KNOWN)).toThrow(/aggregator required/);
   });
 });
 
@@ -347,7 +550,9 @@ describe('buildVerifiedArgs — Exit (matured-market withdraw)', () => {
     market: MARKET,
     inputToken: PT_USDG,
     outputToken: USDG,
-    amountIn: 100_000_000n
+    underlyingToken: USDG,
+    amountIn: 100_000_000n,
+    pinnedPendleSwap: PINNED_PENDLE_SWAP
   };
 
   function exitVerified(quote: PendleConvertQuote, known = EXIT_KNOWN) {

--- a/packages/hooks/src/pendle/buildVerifiedArgs.ts
+++ b/packages/hooks/src/pendle/buildVerifiedArgs.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData } from 'viem';
+import { encodeFunctionData, isAddressEqual } from 'viem';
 import { ZERO_ADDRESS } from '../constants';
 import {
   PENDLE_ALLOWED_SELECTORS,
@@ -7,13 +7,24 @@ import {
   PENDLE_ROUTER_V4_ABI,
   PendleConvertSide
 } from './constants';
-import type { PendleConvertQuote } from './pendle';
+import type { PendleAggregatorRoute, PendleConvertQuote } from './pendle';
 
 // ---------------------------------------------------------------------------
 // Verified-args output (typed for the ABI)
 // ---------------------------------------------------------------------------
 
-type VerifiedSwapData = typeof PENDLE_EMPTY_SWAP_DATA;
+/**
+ * The on-chain swapData struct shape. When no aggregator is used this is
+ * byte-equivalent to PENDLE_EMPTY_SWAP_DATA; when an aggregator hop is taken
+ * (input/output token differs from the underlying), the fields come from the
+ * API after passing the pinned-pendleSwap check.
+ */
+type VerifiedSwapData = {
+  swapType: number;
+  extRouter: `0x${string}`;
+  extCalldata: `0x${string}`;
+  needScale: boolean;
+};
 type VerifiedLimit = {
   limitRouter: `0x${string}`;
   epsSkipMarket: bigint;
@@ -97,11 +108,25 @@ export type KnownCallValues = {
   side: PendleConvertSide;
   receiver: `0x${string}`;
   market: `0x${string}`;
-  /** For BUY: underlying token. For WITHDRAW: PT token. */
+  /** For BUY: user-selected input token. For WITHDRAW: PT token. */
   inputToken: `0x${string}`;
-  /** For BUY: PT token. For WITHDRAW: underlying token. */
+  /** For BUY: PT token. For WITHDRAW: user-selected output token. */
   outputToken: `0x${string}`;
+  /**
+   * The market's underlying token (the SY's accepted token). Equals
+   * inputToken on BUY / outputToken on WITHDRAW when the user picked the
+   * underlying directly; differs when the user picked USDS / USDC and the
+   * route therefore goes through an aggregator hop.
+   */
+  underlyingToken: `0x${string}`;
   amountIn: bigint;
+  /**
+   * The pinned PendleSwap forwarder address for the active chain. The caller
+   * resolves this from `PENDLE_PINNED_PENDLESWAP_ADDRESSES[chainId]`. When an
+   * aggregator route is taken, the API's `pendleSwap` MUST equal this — any
+   * other address is rejected.
+   */
+  pinnedPendleSwap: `0x${string}`;
 };
 
 // ---------------------------------------------------------------------------
@@ -110,6 +135,73 @@ export type KnownCallValues = {
 
 const verifiedEmptySwapData: VerifiedSwapData = PENDLE_EMPTY_SWAP_DATA;
 const verifiedEmptyLimit: VerifiedLimit = PENDLE_EMPTY_LIMIT;
+
+/**
+ * Resolve the (pendleSwap, swapData, tokenMintSyOrRedeem) triplet for a Buy
+ * or Withdraw call. There are exactly two valid cases:
+ *
+ *   1. **No aggregator** — the user-picked side equals the underlying. The
+ *      SY accepts the input/output directly; pendleSwap is forced to 0x0
+ *      and swapData to its empty form. tokenMintSy / tokenRedeemSy = the
+ *      user-picked token (which equals the underlying).
+ *
+ *   2. **Aggregator** — the user picked USDS / USDC (or any non-underlying).
+ *      The route must therefore pass through Pendle's PendleSwap forwarder,
+ *      which proxies to the external aggregator. We assert the API's
+ *      `pendleSwap` equals our pinned address; otherwise we refuse to sign.
+ *      tokenMintSy / tokenRedeemSy must be the underlying — that's what the
+ *      SY actually accepts after the aggregator hop produces it.
+ *
+ * @param userSideToken inputToken on BUY, outputToken on WITHDRAW
+ */
+function resolveAggregatorFields(
+  userSideToken: `0x${string}`,
+  underlyingToken: `0x${string}`,
+  pinnedPendleSwap: `0x${string}`,
+  aggregatorRoute: PendleAggregatorRoute | undefined,
+  side: PendleConvertSide
+): {
+  pendleSwap: `0x${string}`;
+  swapData: VerifiedSwapData;
+  tokenMintSyOrRedeem: `0x${string}`;
+} {
+  const usesAggregator = !isAddressEqual(userSideToken, underlyingToken);
+
+  // tokenMintSy / tokenRedeemSy is always the underlying — that's what the SY
+  // contract accepts. In the no-aggregator branch userSideToken === underlying
+  // by precondition, so the two are equivalent on the wire, but pinning to
+  // underlyingToken makes the invariant explicit and self-documenting.
+  if (!usesAggregator) {
+    return {
+      pendleSwap: ZERO_ADDRESS,
+      swapData: verifiedEmptySwapData,
+      tokenMintSyOrRedeem: underlyingToken
+    };
+  }
+
+  // Aggregator path — require the API to have returned a route.
+  if (!aggregatorRoute) {
+    throw new Error(
+      `Pendle: refusing to sign — aggregator required (${side} with non-underlying token) but the quote has no aggregatorRoute`
+    );
+  }
+  // The single trust anchor: pendleSwap MUST be the pinned PendleSwap
+  // forwarder. Anything else means the API is steering us at an unaudited
+  // contract — refuse to sign.
+  if (!isAddressEqual(aggregatorRoute.pendleSwap, pinnedPendleSwap)) {
+    throw new Error(
+      `Pendle: refusing to sign — pendleSwap "${aggregatorRoute.pendleSwap}" is not the pinned forwarder "${pinnedPendleSwap}"`
+    );
+  }
+  return {
+    pendleSwap: aggregatorRoute.pendleSwap,
+    swapData: aggregatorRoute.swapData,
+    // After the aggregator hop, what reaches the SY is the underlying. The
+    // tokenMintSy / tokenRedeemSy field describes what the SY interacts with,
+    // not what the user supplied.
+    tokenMintSyOrRedeem: underlyingToken
+  };
+}
 
 /**
  * Extract the `guessPtOut` solver hint from the API's parsed contract params.
@@ -161,14 +253,24 @@ function extractGuessPtOut(params: unknown[]): VerifiedBuyArgs[3] {
  *   1. Per-flow selector allowlist (`quote.method` ∈ allowed selectors)
  *   2. Override every user-controllable field with values WE know
  *      (receiver, market, amounts, minOut)
- *   3. Force every dangerous field to its empty form
- *      (pendleSwap, swapData, limit) — see Pendle's StructGen.sol
- *
- * The resulting struct is byte-equivalent to what
- * `createTokenInputStruct(token, amount)` + `emptyLimit` would produce.
+ *   3. Resolve (pendleSwap, swapData, tokenMintSy/tokenRedeemSy) based on
+ *      whether the user-picked token equals the underlying:
+ *        - Equal → no-aggregator: empty pendleSwap/swapData, SY field = user
+ *          token (byte-equivalent to `createTokenInputStruct + emptyLimit`).
+ *        - Differs → aggregator: pendleSwap from the API after a strict
+ *          equality check against PENDLE_PINNED_PENDLESWAP_ADDRESSES;
+ *          swapData forwarded; SY field = underlying.
+ *   4. `limit` is always forced to its empty form — limit-orders are out of
+ *      scope.
  *
  * The pinned-router guard is enforced upstream by usePendleConvert which
  * always submits to PENDLE_ROUTER_V4_ADDRESS — never to `quote.tx.to`.
+ *
+ * Trust anchors of the aggregator branch:
+ *   (a) pendleSwap is pinned (only Pendle's audited forwarder),
+ *   (b) tokenMintSy/tokenRedeemSy is pinned to the underlying,
+ *   (c) apiMinOut bounds the worst-case output denominated in the user-picked
+ *       token, so a malicious aggregator hop can at worst revert the tx.
  */
 export function buildVerifiedArgs(quote: PendleConvertQuote, known: KnownCallValues): VerifiedCall {
   // 1. Per-flow allowlist
@@ -200,6 +302,13 @@ export function buildVerifiedArgs(quote: PendleConvertQuote, known: KnownCallVal
 
 function buildBuyArgs(quote: PendleConvertQuote, known: KnownCallValues): VerifiedCall {
   const guessPtOut = extractGuessPtOut(quote.apiContractParams);
+  const { pendleSwap, swapData, tokenMintSyOrRedeem } = resolveAggregatorFields(
+    known.inputToken, // BUY's user-picked side is the input
+    known.underlyingToken,
+    known.pinnedPendleSwap,
+    quote.aggregatorRoute,
+    PendleConvertSide.BUY
+  );
 
   const args: VerifiedBuyArgs = [
     known.receiver,
@@ -209,9 +318,9 @@ function buildBuyArgs(quote: PendleConvertQuote, known: KnownCallValues): Verifi
     {
       tokenIn: known.inputToken,
       netTokenIn: known.amountIn,
-      tokenMintSy: known.inputToken, // the no-aggregator invariant
-      pendleSwap: ZERO_ADDRESS,
-      swapData: verifiedEmptySwapData
+      tokenMintSy: tokenMintSyOrRedeem,
+      pendleSwap,
+      swapData
     },
     verifiedEmptyLimit
   ] as const;
@@ -224,6 +333,14 @@ function buildBuyArgs(quote: PendleConvertQuote, known: KnownCallValues): Verifi
 // ---------------------------------------------------------------------------
 
 function buildWithdrawArgs(quote: PendleConvertQuote, known: KnownCallValues): VerifiedCall {
+  const { pendleSwap, swapData, tokenMintSyOrRedeem } = resolveAggregatorFields(
+    known.outputToken, // WITHDRAW's user-picked side is the output
+    known.underlyingToken,
+    known.pinnedPendleSwap,
+    quote.aggregatorRoute,
+    PendleConvertSide.WITHDRAW
+  );
+
   const args: VerifiedWithdrawArgs = [
     known.receiver,
     known.market,
@@ -231,9 +348,9 @@ function buildWithdrawArgs(quote: PendleConvertQuote, known: KnownCallValues): V
     {
       tokenOut: known.outputToken,
       minTokenOut: quote.apiMinOut,
-      tokenRedeemSy: known.outputToken, // the no-aggregator invariant
-      pendleSwap: ZERO_ADDRESS,
-      swapData: verifiedEmptySwapData
+      tokenRedeemSy: tokenMintSyOrRedeem,
+      pendleSwap,
+      swapData
     },
     verifiedEmptyLimit
   ] as const;

--- a/packages/hooks/src/pendle/constants.ts
+++ b/packages/hooks/src/pendle/constants.ts
@@ -64,6 +64,21 @@ export const PENDLE_ROUTER_V4_ADDRESS: Record<number, `0x${string}`> = {
 };
 
 /**
+ * Pinned Pendle SwapAggregatorRouter (a.k.a. PendleSwap) — the only contract
+ * we permit as the `pendleSwap` field when an aggregator route is taken. This
+ * Pendle-deployed forwarder is the audited bridge between the Router V4 and
+ * external aggregators (KyberSwap, Odos, OKX, Paraswap, …). If the API ever
+ * returns a different `pendleSwap`, buildVerifiedArgs refuses to sign — that
+ * is the single trust anchor of the multi-token / aggregator path.
+ *
+ * Tenderly fork mirrors mainnet state, so the same address applies.
+ */
+export const PENDLE_PINNED_PENDLESWAP_ADDRESSES: Record<number, `0x${string}`> = {
+  [mainnet.id]: '0xd4f480965d2347d421f1bec7f545682e5ec2151d',
+  [TENDERLY_CHAIN_ID]: '0xd4f480965d2347d421f1bec7f545682e5ec2151d'
+};
+
+/**
  * Minimal Pendle Router V4 ABI — only the selectors v1 allows for PT trading.
  *
  * IMPORTANT: this ABI is intentionally minimal. `decodeFunctionData` against

--- a/packages/hooks/src/pendle/pendle.d.ts
+++ b/packages/hooks/src/pendle/pendle.d.ts
@@ -47,6 +47,43 @@ export type PendleMarketConfig = {
  * only API value the call actually depends on is `amountOut` (used to derive
  * minOut) and `apiContractParams[3]` (the `guessPtOut` solver hint, Buy only).
  */
+/**
+ * Pendle's on-chain SwapData struct (matches `swapData` arg in
+ * swapExactTokenForPt / swapExactPtForToken). Populated by the API when an
+ * aggregator hop is needed; empty otherwise (see PENDLE_EMPTY_SWAP_DATA).
+ */
+export type PendleSwapData = {
+  /** Pendle's SwapType enum — non-zero indicates an aggregator route */
+  swapType: number;
+  /** External aggregator router address (KyberSwap, Odos, OKX, Paraswap, …) */
+  extRouter: `0x${string}`;
+  /** Encoded calldata to forward to the external aggregator */
+  extCalldata: `0x${string}`;
+  /** Whether output amounts must be scaled (Pendle internal) */
+  needScale: boolean;
+};
+
+/**
+ * Aggregator route returned by /convert when the input/output token differs
+ * from the SY's accepted token (i.e. when `enableAggregator: true` is set on
+ * the request). buildVerifiedArgs validates `pendleSwap` against
+ * PENDLE_PINNED_PENDLESWAP_ADDRESSES before allowing the call.
+ */
+export type PendleAggregatorRoute = {
+  /** MUST equal a Pendle-deployed PendleSwap forwarder; rejected otherwise. */
+  pendleSwap: `0x${string}`;
+  /** Aggregator forwarding payload */
+  swapData: PendleSwapData;
+};
+
+/** Pendle's price-impact breakdown — present only when an aggregator hop is in the route. */
+export type PendlePriceImpactBreakdown = {
+  /** Slippage from Pendle's own AMM (decimal, signed) */
+  internalPriceImpact: number;
+  /** Slippage from the external aggregator hop (decimal, signed) */
+  externalPriceImpact: number;
+};
+
 export type PendleConvertQuote = {
   /** Function name as reported by Pendle's contractParamInfo */
   method: string;
@@ -66,6 +103,18 @@ export type PendleConvertQuote = {
   impliedApy: number;
   /** Price impact (decimal, signed) */
   priceImpact: number;
+  /** Internal/external price-impact split — present only on aggregator routes */
+  priceImpactBreakdown?: PendlePriceImpactBreakdown;
+  /** Aggregator name as reported by Pendle ("KYBERSWAP", "ODOS", …); display only */
+  aggregatorType?: string;
+  /**
+   * Aggregator forwarding payload — present iff the route uses an aggregator.
+   * When present, buildVerifiedArgs takes the aggregator branch:
+   * `tokenMintSy`/`tokenRedeemSy` is set to the underlying token (not the
+   * user-selected input/output), and `pendleSwap` + `swapData` are forwarded
+   * after the pinned-pendleSwap check.
+   */
+  aggregatorRoute?: PendleAggregatorRoute;
   /** Routing fee in USD as reported by the API (undefined if API omits it) */
   feeUsd?: number;
   /** ms epoch when this quote was fetched (for staleness check) */
@@ -132,6 +181,13 @@ export type PendleConvertRequest = {
   inputs: Array<{ token: `0x${string}`; amount: string }>;
   outputs: Array<`0x${string}`>;
   additionalData?: string;
+  /**
+   * When true, Pendle's API may return a route that uses an external
+   * aggregator (KyberSwap, Odos, …) in front of / behind the SY conversion.
+   * Set only when the user-selected input/output token differs from the
+   * market's underlying token.
+   */
+  enableAggregator?: boolean;
 };
 
 /**
@@ -154,6 +210,11 @@ export type PendleConvertRouteRaw = {
   data: {
     aggregatorType: string;
     priceImpact: number;
+    /** Present only on aggregator routes (when enableAggregator was true and a hop was needed). */
+    priceImpactBreakDown?: {
+      internalPriceImpact: number;
+      externalPriceImpact: number;
+    };
     impliedApy?: { before: number; after: number };
     effectiveApy?: number;
     fee?: { usd: number };

--- a/packages/hooks/src/pendle/useBatchPendleConvert.ts
+++ b/packages/hooks/src/pendle/useBatchPendleConvert.ts
@@ -7,6 +7,7 @@ import { getWriteContractCall } from '../shared/getWriteContractCall';
 import { useTransactionFlow } from '../shared/useTransactionFlow';
 import { useTokenAllowance } from '../tokens/useTokenAllowance';
 import {
+  PENDLE_PINNED_PENDLESWAP_ADDRESSES,
   PENDLE_QUOTE_TTL_MS,
   PENDLE_ROUTER_V4_ABI,
   PENDLE_ROUTER_V4_ADDRESS,
@@ -18,11 +19,18 @@ import { buildVerifiedArgs } from './buildVerifiedArgs';
 type UseBatchPendleConvertParams = BatchWriteHookParams & {
   side: PendleConvertSide;
   marketAddress?: `0x${string}`;
-  /** For BUY: underlying token. For WITHDRAW: PT token. */
+  /** For BUY: user-selected input token. For WITHDRAW: PT token. */
   inputToken?: `0x${string}`;
-  /** For BUY: PT token. For WITHDRAW: underlying token. */
+  /** For BUY: PT token. For WITHDRAW: user-selected output token. */
   outputToken?: `0x${string}`;
-  /** For BUY: underlying amount in wei. For WITHDRAW: PT amount in wei. */
+  /**
+   * The market's underlying token (the SY's accepted token). When the user-
+   * picked side equals this, the call goes through the no-aggregator path;
+   * otherwise buildVerifiedArgs takes the aggregator branch and pins
+   * tokenMintSy / tokenRedeemSy to this address.
+   */
+  underlyingToken?: `0x${string}`;
+  /** For BUY: input amount in wei. For WITHDRAW: PT amount in wei. */
   amountIn?: bigint;
   /** The latest quote from useQuotePendleConvert */
   quote?: PendleConvertQuote;
@@ -51,6 +59,7 @@ export function useBatchPendleConvert({
   marketAddress,
   inputToken,
   outputToken,
+  underlyingToken,
   amountIn,
   quote,
   enabled: activeTabEnabled = true,
@@ -64,6 +73,7 @@ export function useBatchPendleConvert({
   const connectedChainId = useChainId();
   const chainIdToUse = isTestnetId(connectedChainId) ? chainId.tenderly : chainId.mainnet;
   const routerAddress = PENDLE_ROUTER_V4_ADDRESS[chainIdToUse];
+  const pinnedPendleSwap = PENDLE_PINNED_PENDLESWAP_ADDRESSES[chainIdToUse];
 
   // Allowance for the input token (underlying for Buy, PT for Withdraw) → router
   const { data: allowance, error: allowanceError } = useTokenAllowance({
@@ -78,7 +88,16 @@ export function useBatchPendleConvert({
   // Verify the quote and rebuild args. Memoised so the verification only runs
   // when an input changes — guards otherwise re-throw on every render.
   const { verified, verifyError } = useMemo(() => {
-    if (!quote || !marketAddress || !inputToken || !outputToken || !amountIn || !connectedAddress) {
+    if (
+      !quote ||
+      !marketAddress ||
+      !inputToken ||
+      !outputToken ||
+      !underlyingToken ||
+      !pinnedPendleSwap ||
+      !amountIn ||
+      !connectedAddress
+    ) {
       return { verified: undefined, verifyError: null as Error | null };
     }
     if (Date.now() - quote.fetchedAt > PENDLE_QUOTE_TTL_MS) {
@@ -94,13 +113,25 @@ export function useBatchPendleConvert({
         market: marketAddress,
         inputToken,
         outputToken,
-        amountIn
+        underlyingToken,
+        amountIn,
+        pinnedPendleSwap
       });
       return { verified: v, verifyError: null };
     } catch (e) {
       return { verified: undefined, verifyError: e as Error };
     }
-  }, [quote, marketAddress, inputToken, outputToken, amountIn, connectedAddress, side]);
+  }, [
+    quote,
+    marketAddress,
+    inputToken,
+    outputToken,
+    underlyingToken,
+    pinnedPendleSwap,
+    amountIn,
+    connectedAddress,
+    side
+  ]);
 
   // Build the call list: optional approve, then convert.
   const calls: Call[] = [];

--- a/packages/hooks/src/pendle/useQuotePendleConvert.ts
+++ b/packages/hooks/src/pendle/useQuotePendleConvert.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { isAddressEqual } from 'viem';
 import { useConnection } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
-import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
+import { TRUST_LEVELS, TrustLevelEnum, ZERO_ADDRESS } from '../constants';
 import { PENDLE_QUOTE_REFETCH_MS, PendleConvertSide } from './constants';
-import type { PendleQuoteHook, PendleConvertQuote } from './pendle';
+import type { PendleAggregatorRoute, PendleConvertQuote, PendleQuoteHook } from './pendle';
 import { fetchPendleConvert } from './pendleApiClient';
 
 /**
@@ -40,13 +41,99 @@ function extractApiMinOut(method: string, params: unknown[]): bigint {
   return fail(`unknown method "${method}"`);
 }
 
+/**
+ * Pull the aggregator route (`pendleSwap` + `swapData`) out of the API's
+ * parsed contract params. Returns `undefined` if the route is the default
+ * no-aggregator path (`pendleSwap = 0x0` and empty swapData).
+ *
+ * Position depends on the method:
+ *   - swapExactTokenForPt: input struct at params[4]
+ *   - swapExactPtForToken: output struct at params[3]
+ *   - exitPostExpToToken: not used (post-maturity exit stays on the no-aggregator path)
+ *
+ * Throws on a malformed shape so a tampered quote becomes a query error
+ * instead of silently producing a bad signing payload.
+ */
+function extractAggregatorRoute(method: string, params: unknown[]): PendleAggregatorRoute | undefined {
+  // Pendle's API returns numeric fields as decimal strings (JSON has no
+  // native bigint / uint8). `swapType` arrives as e.g. "1", not 1 — we coerce
+  // here. Other numeric scalars in the contract args follow the same shape;
+  // see extractApiMinOut for the precedent.
+  type RawSwapData = {
+    swapType?: number | string;
+    extRouter?: `0x${string}`;
+    extCalldata?: `0x${string}`;
+    needScale?: boolean;
+  };
+  type RawSlot = { pendleSwap?: `0x${string}`; swapData?: RawSwapData };
+
+  let slot: RawSlot | undefined;
+  if (method === 'swapExactTokenForPt') {
+    slot = params[4] as RawSlot | undefined;
+  } else if (method === 'swapExactPtForToken') {
+    slot = params[3] as RawSlot | undefined;
+  } else {
+    return undefined;
+  }
+
+  if (!slot || typeof slot !== 'object') {
+    throw new Error(`Pendle: malformed quote — missing input/output struct for "${method}"`);
+  }
+
+  const pendleSwap = slot.pendleSwap;
+  const swapData = slot.swapData;
+
+  // No-aggregator route: API returns ZERO_ADDRESS / empty swapData.
+  if (!pendleSwap || isAddressEqual(pendleSwap, ZERO_ADDRESS)) {
+    return undefined;
+  }
+
+  const swapTypeRaw = swapData?.swapType;
+  const swapTypeNum =
+    typeof swapTypeRaw === 'number'
+      ? swapTypeRaw
+      : typeof swapTypeRaw === 'string' && /^\d+$/.test(swapTypeRaw)
+        ? Number(swapTypeRaw)
+        : NaN;
+
+  if (
+    !swapData ||
+    !Number.isFinite(swapTypeNum) ||
+    !swapData.extRouter ||
+    typeof swapData.extCalldata !== 'string' ||
+    typeof swapData.needScale !== 'boolean'
+  ) {
+    throw new Error(
+      `Pendle: malformed quote — pendleSwap is set but swapData is missing/invalid for "${method}"`
+    );
+  }
+
+  return {
+    pendleSwap,
+    swapData: {
+      swapType: swapTypeNum,
+      extRouter: swapData.extRouter,
+      extCalldata: swapData.extCalldata,
+      needScale: swapData.needScale
+    }
+  };
+}
+
 type UseQuotePendleConvertParams = {
   side: PendleConvertSide;
   marketAddress?: `0x${string}`;
-  /** The token going IN to /convert (underlying for Buy, PT for Withdraw) */
+  /** The token going IN to /convert (user-selected for Buy, PT for Withdraw) */
   inputToken?: `0x${string}`;
-  /** The token coming OUT of /convert (PT for Buy, underlying for Withdraw) */
+  /** The token coming OUT of /convert (PT for Buy, user-selected for Withdraw) */
   outputToken?: `0x${string}`;
+  /**
+   * The market's underlying token (the one the SY accepts directly). Used to
+   * decide whether to ask the API for an aggregator route: when the user's
+   * non-PT-side token differs from the underlying, we set
+   * `enableAggregator: true` and the API may return a KyberSwap / Odos / OKX /
+   * Paraswap hop wrapped via Pendle's PendleSwap forwarder.
+   */
+  underlyingToken?: `0x${string}`;
   /** Input amount in wei */
   amountIn?: bigint;
   /** Slippage tolerance (decimal, e.g. 0.002 = 0.2%) */
@@ -77,6 +164,7 @@ export function useQuotePendleConvert({
   marketAddress,
   inputToken,
   outputToken,
+  underlyingToken,
   amountIn,
   slippage,
   enabled: enabledParam = true
@@ -88,9 +176,17 @@ export function useQuotePendleConvert({
     !!marketAddress &&
     !!inputToken &&
     !!outputToken &&
+    !!underlyingToken &&
     !!amountIn &&
     amountIn !== 0n &&
     !!connectedAddress;
+
+  // Aggregator is needed iff the user's non-PT-side token differs from the
+  // SY's accepted (underlying) token. PT itself is never the underlying, so
+  // we look at the input on Buy and the output on Withdraw.
+  const nonPtToken = side === PendleConvertSide.BUY ? inputToken : outputToken;
+  const enableAggregator =
+    !!nonPtToken && !!underlyingToken && !isAddressEqual(nonPtToken, underlyingToken);
 
   const { data, isLoading, error, refetch } = useQuery({
     enabled,
@@ -100,6 +196,8 @@ export function useQuotePendleConvert({
       side,
       inputToken,
       outputToken,
+      underlyingToken,
+      enableAggregator,
       // React Query hashes the queryKey via JSON.stringify, which throws on
       // BigInt values. Serialize amountIn to string so the cache key is stable
       // and unique without crashing the renderer.
@@ -116,7 +214,8 @@ export function useQuotePendleConvert({
         slippage,
         inputs,
         outputs: [outputToken!],
-        additionalData: 'impliedApy,effectiveApy'
+        additionalData: 'impliedApy,effectiveApy',
+        ...(enableAggregator ? { enableAggregator: true } : {})
       });
 
       const route = response.routes[0];
@@ -125,6 +224,20 @@ export function useQuotePendleConvert({
         route.contractParamInfo.method,
         route.contractParamInfo.contractCallParams
       );
+      const aggregatorRoute = extractAggregatorRoute(
+        route.contractParamInfo.method,
+        route.contractParamInfo.contractCallParams
+      );
+      const breakdownRaw = route.data.priceImpactBreakDown;
+      const priceImpactBreakdown =
+        breakdownRaw &&
+        typeof breakdownRaw.internalPriceImpact === 'number' &&
+        typeof breakdownRaw.externalPriceImpact === 'number'
+          ? {
+              internalPriceImpact: breakdownRaw.internalPriceImpact,
+              externalPriceImpact: breakdownRaw.externalPriceImpact
+            }
+          : undefined;
 
       return {
         method: route.contractParamInfo.method,
@@ -133,6 +246,9 @@ export function useQuotePendleConvert({
         effectiveApy: route.data.effectiveApy ?? 0,
         impliedApy: route.data.impliedApy?.after ?? route.data.impliedApy?.before ?? 0,
         priceImpact: route.data.priceImpact,
+        priceImpactBreakdown,
+        aggregatorType: aggregatorRoute ? route.data.aggregatorType : undefined,
+        aggregatorRoute,
         feeUsd: route.data.fee?.usd,
         fetchedAt: Date.now(),
         apiContractParams: route.contractParamInfo.contractCallParams,

--- a/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
+++ b/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
@@ -42,6 +42,8 @@ export interface TokenInputProps {
   className?: string;
   disabled?: boolean;
   inputDisabled?: boolean;
+  /** Display-only variant: replaces the editable input with a formatted readout. */
+  readOnly?: boolean;
   error?: string;
   errorTooltip?: string;
   variant?: 'bottom' | 'top';
@@ -72,6 +74,7 @@ export function TokenInput({
   value,
   disabled,
   inputDisabled = false,
+  readOnly = false,
   dataTestId = 'token-input',
   placeholder,
   onChange,
@@ -282,7 +285,8 @@ export function TokenInput({
         <MotionCard
           ref={cardRef}
           className={cn(
-            'hover-in-before pb-4! min-h-16 w-96 overflow-hidden rounded-2xl border-0',
+            'hover-in-before min-h-16 w-96 overflow-hidden rounded-2xl border-0',
+            !readOnly && 'pb-4!',
             className
           )}
           style={{
@@ -310,90 +314,112 @@ export function TokenInput({
                   animate={AnimationLabels.animate}
                 >
                   <motion.div variants={positionAnimations}>
-                    <Input
-                      ref={inputRef}
-                      className="hide-spin-button placeholder:text-white/30"
-                      value={inputValue !== '00' ? inputValue : '0'}
-                      onChange={e => {
-                        updateValue(e.target.value as `${number}`, e);
-                        if (typeof onSetMax === 'function') onSetMax(false);
-                      }}
-                      onInput={() => {
-                        onInput?.();
-                      }}
-                      disabled={disabled || inputDisabled}
-                      //prevent scrolling to change input
-                      onWheel={e => (e.target as HTMLElement).blur()}
-                      type="number"
-                      placeholder={placeholder || 'Enter amount'}
-                      rightElement={
-                        <div ref={tokenSelectorRef}>
+                    {readOnly ? (
+                      <HStack className="items-center justify-between pb-1 pt-4">
+                        <div
+                          className="text-text flex h-6 grow items-center truncate text-base lg:h-7 lg:text-lg"
+                          data-testid={dataTestId}
+                        >
+                          {value && value !== 0n
+                            ? formatBigInt(value, { unit: decimals, maxDecimals: 4 })
+                            : '—'}
+                        </div>
+                        <div ref={tokenSelectorRef} className="shrink-0">
                           <TokenSelector
                             token={token}
                             disabled={disabled || tokenList.length <= 1}
                             showChevron={tokenList.length > 1}
                           />
                         </div>
-                      }
-                      error={shownError}
-                      errorTooltip={errorTooltip}
-                      data-testid={dataTestId}
-                      step={'any'}
-                      min={0}
-                    />
+                      </HStack>
+                    ) : (
+                      <Input
+                        ref={inputRef}
+                        className="hide-spin-button placeholder:text-white/30"
+                        value={inputValue !== '00' ? inputValue : '0'}
+                        onChange={e => {
+                          updateValue(e.target.value as `${number}`, e);
+                          if (typeof onSetMax === 'function') onSetMax(false);
+                        }}
+                        onInput={() => {
+                          onInput?.();
+                        }}
+                        disabled={disabled || inputDisabled}
+                        //prevent scrolling to change input
+                        onWheel={e => (e.target as HTMLElement).blur()}
+                        type="number"
+                        placeholder={placeholder || 'Enter amount'}
+                        rightElement={
+                          <div ref={tokenSelectorRef}>
+                            <TokenSelector
+                              token={token}
+                              disabled={disabled || tokenList.length <= 1}
+                              showChevron={tokenList.length > 1}
+                            />
+                          </div>
+                        }
+                        error={shownError}
+                        errorTooltip={errorTooltip}
+                        data-testid={dataTestId}
+                        step={'any'}
+                        min={0}
+                      />
+                    )}
                   </motion.div>
-                  <motion.div variants={positionAnimations}>
-                    <HStack className="justify-between pt-4">
-                      <HStack
-                        gap={2}
-                        className={`text-selectActive ${'w-full'} items-center overflow-clip`}
-                        title={balanceText}
-                      >
-                        {!hideIcon && limitText && isConnectedAndEnabled ? (
-                          showGauge ? (
-                            <div>
-                              <Gauge height={20} width={20} className="text-textDesaturated" />
-                            </div>
-                          ) : (
+                  {!readOnly && (
+                    <motion.div variants={positionAnimations}>
+                      <HStack className="justify-between pt-4">
+                        <HStack
+                          gap={2}
+                          className={`text-selectActive ${'w-full'} items-center overflow-clip`}
+                          title={balanceText}
+                        >
+                          {!hideIcon && limitText && isConnectedAndEnabled ? (
+                            showGauge ? (
+                              <div>
+                                <Gauge height={20} width={20} className="text-textDesaturated" />
+                              </div>
+                            ) : (
+                              <div>
+                                <Wallet height={20} width={20} className="text-textDesaturated" />
+                              </div>
+                            )
+                          ) : !hideIcon && (!limitText || !isConnectedAndEnabled) ? (
                             <div>
                               <Wallet height={20} width={20} className="text-textDesaturated" />
                             </div>
-                          )
-                        ) : !hideIcon && (!limitText || !isConnectedAndEnabled) ? (
-                          <div>
-                            <Wallet height={20} width={20} className="text-textDesaturated" />
-                          </div>
-                        ) : null}
-                        <Text
-                          className="text-textDesaturated text-nowrap text-sm leading-none"
-                          dataTestId={`${dataTestId}-balance`}
-                        >
-                          {limitText && isConnectedAndEnabled ? limitText : balanceText}
-                        </Text>
+                          ) : null}
+                          <Text
+                            className="text-textDesaturated text-nowrap text-sm leading-none"
+                            dataTestId={`${dataTestId}-balance`}
+                          >
+                            {limitText && isConnectedAndEnabled ? limitText : balanceText}
+                          </Text>
+                        </HStack>
+                        {showPercentageButtons && (
+                          <HStack gap={2} className="text-selectActive items-center">
+                            {buttonsToShow.map(percentage => (
+                              <Button
+                                key={percentage}
+                                size="input"
+                                variant="input"
+                                onClick={e => onPercentageClicked(e, percentage, percentage === 100)}
+                                disabled={disabled}
+                                data-testid={percentage === 100 ? `${dataTestId}-max` : undefined}
+                              >
+                                {`${percentage}%`}
+                              </Button>
+                            ))}
+                          </HStack>
+                        )}
+                        {customActionButtons && (
+                          <HStack gap={2} className="text-selectActive items-center">
+                            {customActionButtons}
+                          </HStack>
+                        )}
                       </HStack>
-                      {showPercentageButtons && (
-                        <HStack gap={2} className="text-selectActive items-center">
-                          {buttonsToShow.map(percentage => (
-                            <Button
-                              key={percentage}
-                              size="input"
-                              variant="input"
-                              onClick={e => onPercentageClicked(e, percentage, percentage === 100)}
-                              disabled={disabled}
-                              data-testid={percentage === 100 ? `${dataTestId}-max` : undefined}
-                            >
-                              {`${percentage}%`}
-                            </Button>
-                          ))}
-                        </HStack>
-                      )}
-                      {customActionButtons && (
-                        <HStack gap={2} className="text-selectActive items-center">
-                          {customActionButtons}
-                        </HStack>
-                      )}
-                    </HStack>
-                  </motion.div>
+                    </motion.div>
+                  )}
                 </motion.div>
               ) : (
                 <motion.div

--- a/packages/widgets/src/widgets/PendleWidget/components/PendleTransactionReview.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/PendleTransactionReview.tsx
@@ -95,6 +95,12 @@ export const PendleTransactionReview = ({
   ]);
 
   // Push title/subtitle/stepper copy.
+  // Multi-token: copy that names the user-side token comes from the selected
+  // token's symbol (originToken on BUY, targetToken on SELL), not from
+  // market.underlyingSymbol — those can differ now (e.g. user supplies USDC
+  // into a PT-USDG market). The matured-redeem branch still uses the market's
+  // underlying since redeem is single-token only.
+  const userSideSymbol = flow === PendleFlow.BUY ? originToken.symbol : targetToken.symbol;
   useEffect(() => {
     const batchStatus =
       !!batchSupported && batchEnabled ? BatchStatus.ENABLED : BatchStatus.DISABLED;
@@ -105,7 +111,7 @@ export const PendleTransactionReview = ({
         i18n._(
           getPendleBuyReviewSubtitle({
             batchStatus,
-            symbol: market.underlyingSymbol,
+            symbol: userSideSymbol,
             needsAllowance
           })
         )
@@ -124,7 +130,7 @@ export const PendleTransactionReview = ({
           getPendleWithdrawReviewSubtitle({
             batchStatus,
             ptSymbol: `PT-${market.underlyingSymbol}`,
-            underlyingSymbol: market.underlyingSymbol,
+            underlyingSymbol: userSideSymbol,
             needsAllowance
           })
         )
@@ -139,7 +145,7 @@ export const PendleTransactionReview = ({
           txStatus,
           isRedeem: isRedeemMode,
           needsAllowance,
-          underlyingSymbol: market.underlyingSymbol
+          underlyingSymbol: isRedeemMode ? market.underlyingSymbol : userSideSymbol
         })
       )
     );
@@ -155,6 +161,7 @@ export const PendleTransactionReview = ({
     txStatus,
     i18n.locale,
     market.underlyingSymbol,
+    userSideSymbol,
     setTxTitle,
     setTxSubtitle,
     setStepTwoTitle,

--- a/packages/widgets/src/widgets/PendleWidget/components/PendleTransactionStatus.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/PendleTransactionStatus.tsx
@@ -3,6 +3,7 @@ import { useLingui } from '@lingui/react';
 import { t } from '@lingui/core/macro';
 import { useChainId } from 'wagmi';
 import { formatBigInt } from '@jetstreamgg/sky-utils';
+import { getTokenDecimals } from '@jetstreamgg/sky-hooks';
 import type { PendleConvertQuote, PendleMarketConfig, Token } from '@jetstreamgg/sky-hooks';
 import { BatchTransactionStatus } from '@widgets/shared/components/ui/transaction/BatchTransactionStatus';
 import type { TxCardCopyText } from '@widgets/shared/types/txCardCopyText';
@@ -107,7 +108,14 @@ export const PendleTransactionStatus = ({
       !isBatchTransaction;
     const flowTxStatus: TxStatus = isWaitingForSecondTransaction ? TxStatus.LOADING : txStatus;
 
-    const amountStr = formatBigInt(amount, { unit: market.underlyingDecimals });
+    // Decimals follow the input side: BUY input is the user-selected supply
+    // token; SELL input is PT (which inherits market.underlyingDecimals via
+    // the SY). Symbol for the user-selected side comes from the matching
+    // Token object, not from market.underlyingSymbol.
+    const inputDecimals =
+      flow === PendleFlow.BUY ? getTokenDecimals(originToken, chainId) : market.underlyingDecimals;
+    const amountStr = formatBigInt(amount, { unit: inputDecimals });
+    const userSideSymbol = flow === PendleFlow.BUY ? originToken.symbol : targetToken.symbol;
 
     if (flow === PendleFlow.BUY) {
       setStepTwoTitle(t`Supply`);
@@ -117,7 +125,7 @@ export const PendleTransactionStatus = ({
           getPendleSupplySubtitle({
             txStatus: flowTxStatus,
             amount: amountStr,
-            symbol: market.underlyingSymbol,
+            symbol: userSideSymbol,
             needsAllowance: flowNeedsAllowance
           })
         )
@@ -127,7 +135,7 @@ export const PendleTransactionStatus = ({
           getPendleSupplyLoadingButtonText({
             txStatus: flowTxStatus,
             amount: amountStr,
-            symbol: market.underlyingSymbol
+            symbol: userSideSymbol
           })
         )
       );
@@ -140,7 +148,7 @@ export const PendleTransactionStatus = ({
             txStatus: flowTxStatus,
             amount: amountStr,
             ptSymbol: `PT-${market.underlyingSymbol}`,
-            underlyingSymbol: market.underlyingSymbol,
+            underlyingSymbol: isRedeemMode ? market.underlyingSymbol : userSideSymbol,
             needsAllowance: flowNeedsAllowance,
             isRedeem: isRedeemMode
           })
@@ -166,7 +174,7 @@ export const PendleTransactionStatus = ({
           txStatus: flowTxStatus,
           isRedeem: isRedeemMode,
           needsAllowance: flowNeedsAllowance,
-          underlyingSymbol: market.underlyingSymbol
+          underlyingSymbol: isRedeemMode ? market.underlyingSymbol : userSideSymbol
         })
       )
     );
@@ -197,6 +205,8 @@ export const PendleTransactionStatus = ({
     amount,
     market.underlyingSymbol,
     market.underlyingDecimals,
+    originToken,
+    targetToken,
     chainId,
     i18n.locale,
     setTxTitle,

--- a/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -1,8 +1,10 @@
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { formatUnits } from 'viem';
+import { mainnet } from 'viem/chains';
 import { formatBigInt, formatDecimalPercentage } from '@jetstreamgg/sky-utils';
 import {
+  getTokenDecimals,
   isMarketMatured,
   type PendleConvertQuote,
   type PendleMarketConfig,
@@ -16,16 +18,27 @@ import { motion } from 'motion/react';
 import { positionAnimations } from '@widgets/shared/animation/presets';
 import { MotionVStack } from '@widgets/shared/components/ui/layout/MotionVStack';
 import { PendleFlow } from '../lib/constants';
+import { VStack } from '@widgets/shared/components/ui/layout/VStack';
 
 type SupplyWithdrawProps = {
   market: PendleMarketConfig;
-  underlyingToken: Token;
   ptToken: Token;
+  /** USDS / USDC / underlying — selectable on BUY input and SELL output. */
+  inputTokenList: Token[];
+  /** Currently-selected BUY input token. */
+  selectedSupplyToken: Token;
+  onSupplyTokenChange: (token: Token) => void;
+  /** Currently-selected SELL output token. */
+  selectedWithdrawOutToken: Token;
+  onWithdrawOutTokenChange: (token: Token) => void;
   flow: PendleFlow;
   onFlowChange: (flow: PendleFlow) => void;
   amount: bigint;
   onAmountChange: (val: bigint) => void;
-  underlyingBalance?: bigint;
+  /** Balance of the input token: BUY → user-selected supply token; SELL → PT. */
+  inputBalance?: bigint;
+  /** Balance of the output token: BUY → PT; SELL → user-selected output token. */
+  outputBalance?: bigint;
   ptBalance?: bigint;
   quote?: PendleConvertQuote;
   isFetchingQuote: boolean;
@@ -37,15 +50,35 @@ type SupplyWithdrawProps = {
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
+/**
+ * Display name for an aggregator. Pendle currently routes through KyberSwap,
+ * Odos, OKX, and Paraswap; we render those with canonical brand casing. Any
+ * other value (e.g. a future addition) passes through unchanged.
+ */
+function formatAggregatorName(raw: string): string {
+  const known: Record<string, string> = {
+    KYBERSWAP: 'KyberSwap',
+    ODOS: 'Odos',
+    OKX: 'OKX',
+    PARASWAP: 'Paraswap'
+  };
+  return known[raw.toUpperCase()] ?? raw;
+}
+
 export const SupplyWithdraw = ({
   market,
-  underlyingToken,
   ptToken,
+  inputTokenList,
+  selectedSupplyToken,
+  onSupplyTokenChange,
+  selectedWithdrawOutToken,
+  onWithdrawOutTokenChange,
   flow,
   onFlowChange,
   amount,
   onAmountChange,
-  underlyingBalance,
+  inputBalance,
+  outputBalance,
   ptBalance,
   quote,
   isFetchingQuote,
@@ -58,18 +91,26 @@ export const SupplyWithdraw = ({
   const matured = isMarketMatured(market.expiry);
   const isRedeemMode = flow === PendleFlow.WITHDRAW && matured;
 
-  // Pendle PTs inherit decimals from the underlying SY, which inherits from the
-  // underlying token. So a PT-USDG (USDG = 6 dec) is 6 dec — input and output
-  // share decimals on both flow directions.
-  const decimals = market.underlyingDecimals;
-  const outputSymbol = flow === PendleFlow.BUY ? `PT-${market.underlyingSymbol}` : market.underlyingSymbol;
-  const inputBalance = flow === PendleFlow.BUY ? underlyingBalance : ptBalance;
+  // Pendle PTs share decimals with the underlying SY (which equals the
+  // underlying token's decimals). The user-side token may be USDS (18) or
+  // USDC (6), so we resolve decimals per-token rather than hardcoding to
+  // market.underlyingDecimals.
+  const ptDecimals = market.underlyingDecimals;
+  const supplyTokenDecimals = getTokenDecimals(selectedSupplyToken, mainnet.id);
+  const withdrawOutTokenDecimals = getTokenDecimals(selectedWithdrawOutToken, mainnet.id);
+
+  // Origin = the editable input (top). Target = the read-only output (bottom).
+  const originDecimals = flow === PendleFlow.BUY ? supplyTokenDecimals : ptDecimals;
+  const targetDecimals = flow === PendleFlow.BUY ? ptDecimals : withdrawOutTokenDecimals;
+  const originSymbol = flow === PendleFlow.BUY ? selectedSupplyToken.symbol : `PT-${market.underlyingSymbol}`;
+  const targetSymbol =
+    flow === PendleFlow.BUY ? `PT-${market.underlyingSymbol}` : selectedWithdrawOutToken.symbol;
 
   const formattedReceive = quote
-    ? `${formatBigInt(quote.amountOut, { unit: decimals, maxDecimals: 4 })} ${outputSymbol}`
+    ? `${formatBigInt(quote.amountOut, { unit: targetDecimals, maxDecimals: 4 })} ${targetSymbol}`
     : undefined;
   const formattedMin = quote
-    ? `${formatBigInt(quote.apiMinOut, { unit: decimals, maxDecimals: 4 })} ${outputSymbol}`
+    ? `${formatBigInt(quote.apiMinOut, { unit: targetDecimals, maxDecimals: 4 })} ${targetSymbol}`
     : undefined;
   const apyDisplay = quote ? formatDecimalPercentage(quote.effectiveApy) : '—';
   const maturityDisplay = new Date(market.expiry * 1000).toLocaleDateString(undefined, {
@@ -79,8 +120,20 @@ export const SupplyWithdraw = ({
   });
 
   const errorText = insufficientFunds
-    ? t`Insufficient funds. Your balance is ${formatUnits(inputBalance ?? 0n, decimals)}.`
+    ? t`Insufficient funds. Your balance is ${formatUnits(inputBalance ?? 0n, originDecimals)}.`
     : undefined;
+
+  // Output (target) Token used purely for the read-only TokenInput.
+  // BUY → PT. SELL → user-selected output token.
+  const targetToken = flow === PendleFlow.BUY ? ptToken : selectedWithdrawOutToken;
+
+  const priceImpactRow = quote?.priceImpact !== undefined ? `${(quote.priceImpact * 100).toFixed(3)}%` : '—';
+
+  const aggregatorName = quote?.aggregatorType ? formatAggregatorName(quote.aggregatorType) : undefined;
+  // Pendle's API returns priceImpactBreakDown even on no-aggregator routes
+  // (with externalPriceImpact = 0). Only surface it when an aggregator is
+  // actually used — otherwise the breakdown is misleading noise.
+  const breakdown = aggregatorName ? quote?.priceImpactBreakdown : undefined;
 
   return (
     <MotionVStack gap={0} className="w-full" variants={positionAnimations}>
@@ -101,58 +154,96 @@ export const SupplyWithdraw = ({
         </motion.div>
 
         <TabsContent value={PendleFlow.BUY}>
-          <motion.div className="flex w-full flex-col" variants={positionAnimations}>
-            <TokenInput
-              className="w-full"
-              label={t`How much ${market.underlyingSymbol} would you like to supply?`}
-              placeholder={t`Enter amount`}
-              token={underlyingToken}
-              tokenList={[underlyingToken]}
-              balance={enabled ? underlyingBalance : undefined}
-              value={amount}
-              onChange={(newValue: bigint) => onAmountChange(newValue)}
-              error={errorText}
-              showPercentageButtons={enabled}
-              enabled={enabled}
-              dataTestId="pendle-supply-input"
-            />
-          </motion.div>
+          <VStack className="items-stretch" gap={3}>
+            <motion.div className="flex w-full flex-col" variants={positionAnimations}>
+              <TokenInput
+                key={`pendle-supply-${selectedSupplyToken.symbol}`}
+                className="w-full"
+                label={t`How much would you like to supply?`}
+                placeholder={t`Enter amount`}
+                token={selectedSupplyToken}
+                tokenList={inputTokenList}
+                onTokenSelected={t => onSupplyTokenChange(t)}
+                balance={enabled ? inputBalance : undefined}
+                value={amount}
+                onChange={(newValue: bigint) => onAmountChange(newValue)}
+                error={errorText}
+                showPercentageButtons={enabled}
+                enabled={enabled}
+                dataTestId="pendle-supply-input"
+              />
+            </motion.div>
+            <motion.div className="flex w-full flex-col" variants={positionAnimations}>
+              <TokenInput
+                className="w-full"
+                label={t`You receive`}
+                token={ptToken}
+                tokenList={[ptToken]}
+                balance={enabled ? outputBalance : undefined}
+                value={quote?.amountOut ?? 0n}
+                onChange={() => null}
+                inputDisabled
+                showPercentageButtons={false}
+                enabled={enabled}
+                dataTestId="pendle-supply-output"
+              />
+            </motion.div>
+          </VStack>
         </TabsContent>
 
         <TabsContent value={PendleFlow.WITHDRAW}>
-          <motion.div className="flex w-full flex-col" variants={positionAnimations}>
-            <TokenInput
-              className="w-full"
-              label={t`How much PT-${market.underlyingSymbol} would you like to withdraw?`}
-              placeholder={t`Enter amount`}
-              token={ptToken}
-              tokenList={[ptToken]}
-              balance={enabled ? ptBalance : undefined}
-              value={amount}
-              onChange={(newValue: bigint) => onAmountChange(newValue)}
-              error={errorText}
-              showPercentageButtons={enabled}
-              enabled={enabled}
-              dataTestId="pendle-withdraw-input"
-            />
-            {!matured && (
-              <div
-                className="mt-3 rounded-xl bg-amber-500/10 px-3 py-2 text-sm text-amber-300"
-                data-testid="pendle-early-withdraw-banner"
-              >
-                <Trans>
-                  Withdrawing before maturity uses the current market price, not the originally locked APY.
-                </Trans>
-              </div>
-            )}
-            {isRedeemMode && (
-              <div className="bg-bullish/10 text-bullish mt-3 rounded-xl px-3 py-2 text-sm">
-                <Trans>
-                  Maturity reached — redeem 1 PT-{market.underlyingSymbol} for 1 {market.underlyingSymbol}.
-                </Trans>
-              </div>
-            )}
-          </motion.div>
+          <VStack className="items-stretch" gap={3}>
+            <motion.div className="flex w-full flex-col" variants={positionAnimations}>
+              <TokenInput
+                className="w-full"
+                label={t`How much PT-${market.underlyingSymbol} would you like to withdraw?`}
+                placeholder={t`Enter amount`}
+                token={ptToken}
+                tokenList={[ptToken]}
+                balance={enabled ? ptBalance : undefined}
+                value={amount}
+                onChange={(newValue: bigint) => onAmountChange(newValue)}
+                error={errorText}
+                showPercentageButtons={enabled}
+                enabled={enabled}
+                dataTestId="pendle-withdraw-input"
+              />
+            </motion.div>
+            <motion.div className="flex w-full flex-col" variants={positionAnimations}>
+              <TokenInput
+                key={`pendle-withdraw-out-${selectedWithdrawOutToken.symbol}`}
+                className="w-full"
+                label={t`You receive`}
+                token={targetToken}
+                tokenList={inputTokenList}
+                onTokenSelected={t => onWithdrawOutTokenChange(t)}
+                balance={enabled ? outputBalance : undefined}
+                value={quote?.amountOut ?? 0n}
+                onChange={() => null}
+                inputDisabled
+                showPercentageButtons={false}
+                enabled={enabled}
+                dataTestId="pendle-withdraw-output"
+              />
+            </motion.div>
+          </VStack>
+          {!matured && (
+            <div
+              className="mt-3 rounded-xl bg-amber-500/10 px-3 py-2 text-sm text-amber-300"
+              data-testid="pendle-early-withdraw-banner"
+            >
+              <Trans>
+                Withdrawing before maturity uses the current market price, not the originally locked APY.
+              </Trans>
+            </div>
+          )}
+          {isRedeemMode && (
+            <div className="bg-bullish/10 text-bullish mt-3 rounded-xl px-3 py-2 text-sm">
+              <Trans>
+                Maturity reached — redeem 1 PT-{market.underlyingSymbol} for 1 {market.underlyingSymbol}.
+              </Trans>
+            </div>
+          )}
         </TabsContent>
       </Tabs>
 
@@ -175,9 +266,7 @@ export const SupplyWithdraw = ({
           transactionData={[
             {
               label: flow === PendleFlow.BUY ? t`You supply` : t`You redeem`,
-              value: `${formatBigInt(amount, { unit: decimals, maxDecimals: 4 })} ${
-                flow === PendleFlow.BUY ? market.underlyingSymbol : `PT-${market.underlyingSymbol}`
-              }`
+              value: `${formatBigInt(amount, { unit: originDecimals, maxDecimals: 4 })} ${originSymbol}`
             },
             {
               label: t`You receive`,
@@ -205,11 +294,28 @@ export const SupplyWithdraw = ({
                   },
                   {
                     label: t`Price impact`,
-                    value:
-                      quote?.priceImpact !== undefined
-                        ? `${(quote.priceImpact * 100).toFixed(3)}%`
-                        : '—'
-                  }
+                    value: priceImpactRow
+                  },
+                  ...(breakdown
+                    ? [
+                        {
+                          label: t`  · Pendle AMM`,
+                          value: `${(breakdown.internalPriceImpact * 100).toFixed(3)}%`
+                        },
+                        {
+                          label: t`  · Aggregator hop`,
+                          value: `${(breakdown.externalPriceImpact * 100).toFixed(3)}%`
+                        }
+                      ]
+                    : []),
+                  ...(aggregatorName
+                    ? [
+                        {
+                          label: t`Routed via`,
+                          value: aggregatorName
+                        }
+                      ]
+                    : [])
                 ]),
             {
               label: t`Routing fee`,
@@ -224,7 +330,6 @@ export const SupplyWithdraw = ({
           ]}
         />
       )}
-
     </MotionVStack>
   );
 };

--- a/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -182,8 +182,7 @@ export const SupplyWithdraw = ({
                 balance={enabled ? outputBalance : undefined}
                 value={quote?.amountOut ?? 0n}
                 onChange={() => null}
-                inputDisabled
-                showPercentageButtons={false}
+                readOnly
                 enabled={enabled}
                 dataTestId="pendle-supply-output"
               />
@@ -220,8 +219,7 @@ export const SupplyWithdraw = ({
                 balance={enabled ? outputBalance : undefined}
                 value={quote?.amountOut ?? 0n}
                 onChange={() => null}
-                inputDisabled
-                showPercentageButtons={false}
+                readOnly
                 enabled={enabled}
                 dataTestId="pendle-withdraw-output"
               />

--- a/packages/widgets/src/widgets/PendleWidget/hooks/usePendleTokens.ts
+++ b/packages/widgets/src/widgets/PendleWidget/hooks/usePendleTokens.ts
@@ -1,10 +1,17 @@
 import { useMemo } from 'react';
-import { type PendleMarketConfig, type Token } from '@jetstreamgg/sky-hooks';
+import { TOKENS, type PendleMarketConfig, type Token } from '@jetstreamgg/sky-hooks';
 import { mainnet } from 'viem/chains';
 
 export type PendleTokens = {
   underlyingToken: Token;
   ptToken: Token;
+  /**
+   * The selectable token list for the user-picked side of the convert flow:
+   * BUY input or SELL output. Always begins with the market's underlying
+   * (default selection) and appends USDS / USDC if they aren't already the
+   * underlying. Reuses the global TOKENS registry — no inline definitions.
+   */
+  inputTokenList: Token[];
 };
 
 // Pendle markets are dynamic (per-market PT address + arbitrary underlying),
@@ -32,5 +39,19 @@ export const usePendleTokens = (market: PendleMarketConfig): PendleTokens => {
     [market.underlyingSymbol, market.underlyingDecimals, market.ptToken]
   );
 
-  return { underlyingToken, ptToken };
+  const inputTokenList = useMemo<Token[]>(() => {
+    const seen = new Set<string>([market.underlyingToken.toLowerCase()]);
+    const list: Token[] = [underlyingToken];
+    for (const candidate of [TOKENS.usds, TOKENS.usdc]) {
+      const addr = candidate.address[mainnet.id];
+      if (!addr) continue;
+      const key = addr.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      list.push(candidate);
+    }
+    return list;
+  }, [market.underlyingToken, underlyingToken]);
+
+  return { underlyingToken, ptToken, inputTokenList };
 };

--- a/packages/widgets/src/widgets/PendleWidget/index.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/index.tsx
@@ -14,7 +14,8 @@ import {
   useQuotePendleConvert,
   useTokenAllowance,
   useTokenBalance,
-  type PendleMarketConfig
+  type PendleMarketConfig,
+  type Token
 } from '@jetstreamgg/sky-hooks';
 import { isTestnetId, getTransactionLink, useDebounce, useIsSafeWallet } from '@jetstreamgg/sky-utils';
 import { ArrowLeft } from 'lucide-react';
@@ -122,10 +123,41 @@ const PendleWidgetWrapped = ({
 
   const balanceChainId = isTestnetId(chainId) ? chainId : mainnet.id;
 
-  const { data: underlyingBalance, refetch: refetchUnderlyingBalance } = useTokenBalance({
+  const { underlyingToken, ptToken, inputTokenList } = usePendleTokens(market);
+
+  const [selectedSupplyToken, setSelectedSupplyToken] = useState<Token>(underlyingToken);
+  const [selectedWithdrawOutToken, setSelectedWithdrawOutToken] = useState<Token>(underlyingToken);
+
+  const handleSupplyTokenChange = (next: Token) => {
+    setAmount(0n);
+    setSelectedSupplyToken(next);
+  };
+
+  // The "user-side" token for the active flow — input on BUY, output on SELL.
+  const userSideToken = flow === PendleFlow.BUY ? selectedSupplyToken : selectedWithdrawOutToken;
+  const userSideTokenAddress = userSideToken.address[mainnet.id] as `0x${string}`;
+
+  const inputToken = flow === PendleFlow.BUY ? userSideTokenAddress : market.ptToken;
+  const outputToken = flow === PendleFlow.BUY ? market.ptToken : userSideTokenAddress;
+  const side = flow === PendleFlow.BUY ? PendleConvertSide.BUY : PendleConvertSide.WITHDRAW;
+
+  const originToken = flow === PendleFlow.BUY ? selectedSupplyToken : ptToken;
+  const targetToken = flow === PendleFlow.BUY ? ptToken : selectedWithdrawOutToken;
+
+  // Balance for the input side: BUY → user-selected supply token; SELL → PT.
+  const { data: inputBalance, refetch: refetchInputBalance } = useTokenBalance({
     chainId: balanceChainId,
     address,
-    token: market.underlyingToken
+    token: inputToken
+  });
+
+  // Balance for the output side: BUY → PT; SELL → user-selected output token.
+  // Read-only TokenInputs render "No wallet connected" when balance is
+  // undefined, so we query this even though the user isn't editing it.
+  const { data: outputBalance, refetch: refetchOutputBalance } = useTokenBalance({
+    chainId: balanceChainId,
+    address,
+    token: outputToken
   });
 
   const { data: ptBalance, refetch: refetchPtBalance } = useTokenBalance({
@@ -143,14 +175,6 @@ const PendleWidgetWrapped = ({
     }
   }, [matured, txStatus, ptBalance?.value]);
 
-  const inputToken = flow === PendleFlow.BUY ? market.underlyingToken : market.ptToken;
-  const outputToken = flow === PendleFlow.BUY ? market.ptToken : market.underlyingToken;
-  const side = flow === PendleFlow.BUY ? PendleConvertSide.BUY : PendleConvertSide.WITHDRAW;
-
-  const { underlyingToken, ptToken } = usePendleTokens(market);
-  const originToken = flow === PendleFlow.BUY ? underlyingToken : ptToken;
-  const targetToken = flow === PendleFlow.BUY ? ptToken : underlyingToken;
-
   // Allowance for the input token (underlying for Buy, PT for Withdraw) → router.
   // Mirrors the check inside useBatchPendleConvert; React Query cache dedupes.
   const { data: allowance } = useTokenAllowance({
@@ -167,21 +191,23 @@ const PendleWidgetWrapped = ({
   // (PT → SY 1:1, then SY → underlying via SY exchange rate). The convert API
   // is unreliable post-maturity (most market info is dropped) and would route
   // a withdraw through the dead AMM with heavy price impact.
+  const debounceSettled = amount === debouncedAmount;
   const { data: quote, isLoading: isFetchingQuote } = useQuotePendleConvert({
     side,
     marketAddress: market.marketAddress,
     inputToken,
     outputToken,
+    underlyingToken: market.underlyingToken,
     amountIn: debouncedAmount > 0n ? debouncedAmount : undefined,
     slippage,
-    enabled: !matured && isConnectedAndEnabled && debouncedAmount > 0n
+    enabled: !matured && isConnectedAndEnabled && debouncedAmount > 0n && debounceSettled
   });
 
   const insufficientFunds = useMemo(() => {
     if (!isConnectedAndEnabled || amount === 0n) return false;
-    const balance = flow === PendleFlow.BUY ? underlyingBalance?.value : ptBalance?.value;
+    const balance = flow === PendleFlow.BUY ? inputBalance?.value : ptBalance?.value;
     return balance !== undefined && debouncedAmount > balance;
-  }, [isConnectedAndEnabled, amount, debouncedAmount, flow, underlyingBalance, ptBalance]);
+  }, [isConnectedAndEnabled, amount, debouncedAmount, flow, inputBalance, ptBalance]);
 
   // -------- WRITE WIRING --------
   // Two hooks, but only one is live per render (the other is gated by `enabled`):
@@ -206,7 +232,8 @@ const PendleWidgetWrapped = ({
       }
     },
     onSuccess: (hash: string | undefined) => {
-      refetchUnderlyingBalance();
+      refetchInputBalance();
+      refetchOutputBalance();
       refetchPtBalance();
       setTxStatus(TxStatus.SUCCESS);
       if (hash) {
@@ -222,7 +249,7 @@ const PendleWidgetWrapped = ({
         description:
           flow === PendleFlow.BUY
             ? t`PT-${market.underlyingSymbol} delivered to your wallet.`
-            : t`${market.underlyingSymbol} delivered to your wallet.`,
+            : t`${targetToken.symbol} delivered to your wallet.`,
         status: TxStatus.SUCCESS
       });
     },
@@ -244,6 +271,7 @@ const PendleWidgetWrapped = ({
     marketAddress: market.marketAddress,
     inputToken,
     outputToken,
+    underlyingToken: market.underlyingToken,
     amountIn: debouncedAmount > 0n ? debouncedAmount : undefined,
     quote,
     enabled: !matured && isConnectedAndEnabled && debouncedAmount > 0n,
@@ -273,6 +301,7 @@ const PendleWidgetWrapped = ({
     if (/quote/i.test(raw) && /stale|expired/i.test(raw)) {
       return t`Quote expired. Refreshing — please wait a moment.`;
     }
+    console.log({ writeHook });
     return t`Unable to prepare transaction. Please try again or adjust your inputs.`;
   }, [writeHook.error]);
 
@@ -508,13 +537,18 @@ const PendleWidgetWrapped = ({
           <CardAnimationWrapper key="pendle-action" className="h-full">
             <SupplyWithdraw
               market={market}
-              underlyingToken={underlyingToken}
               ptToken={ptToken}
+              inputTokenList={inputTokenList}
+              selectedSupplyToken={selectedSupplyToken}
+              onSupplyTokenChange={handleSupplyTokenChange}
+              selectedWithdrawOutToken={selectedWithdrawOutToken}
+              onWithdrawOutTokenChange={setSelectedWithdrawOutToken}
               flow={flow}
               onFlowChange={setFlow}
               amount={amount}
               onAmountChange={setAmount}
-              underlyingBalance={underlyingBalance?.value}
+              inputBalance={inputBalance?.value}
+              outputBalance={outputBalance?.value}
               ptBalance={ptBalance?.value}
               quote={quote}
               isFetchingQuote={isFetchingQuote}

--- a/packages/widgets/src/widgets/PendleWidget/index.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/index.tsx
@@ -301,7 +301,6 @@ const PendleWidgetWrapped = ({
     if (/quote/i.test(raw) && /stale|expired/i.test(raw)) {
       return t`Quote expired. Refreshing — please wait a moment.`;
     }
-    console.log({ writeHook });
     return t`Unable to prepare transaction. Please try again or adjust your inputs.`;
   }, [writeHook.error]);
 


### PR DESCRIPTION
## Summary

Lets users buy and sell PT using **USDS, USDC, or the market's underlying token**. When the selected token differs from the underlying, the route flows through Pendle's PendleSwap forwarder + an external aggregator (KyberSwap / Odos / OKX / Paraswap).

### Hooks layer

- `useQuotePendleConvert` accepts `underlyingToken`, sends `enableAggregator: true` only when the user-side token isn't the underlying, and extracts `aggregatorType`, `priceImpactBreakdown`, and the aggregator route (`pendleSwap` + `swapData`) from the response.
- `buildVerifiedArgs` adds a controlled aggregator branch:
  - the no-aggregator path is preserved verbatim (byte-equivalent struct);
  - the aggregator path requires `aggregatorRoute` on the quote, asserts `pendleSwap` equals the pinned `PENDLE_PINNED_PENDLESWAP_ADDRESSES[chainId]` (the Pendle-deployed forwarder), pins `tokenMintSy` / `tokenRedeemSy` to the underlying (the SY's accepted token), and forwards `pendleSwap` + `swapData`. Anything else throws and the user never sees a sign prompt.
- `useBatchPendleConvert` forwards `underlyingToken` and the resolved pinned forwarder address into the verified-args call.
- New unit tests cover the aggregator branch (pinned-forwarder rejection, missing-route rejection, `tokenMintSy = underlying` invariant) alongside the existing no-aggregator coverage.

**Trust model on the aggregator path:**
1. `pendleSwap` is pinned (audited Pendle forwarder is the only contract we delegate to).
2. `tokenMintSy` / `tokenRedeemSy` is pinned to the underlying.
3. `apiMinOut` (output-token denominated) bounds the worst-case output — a malicious aggregator can at worst revert the tx.
4. `PENDLE_QUOTE_TTL_MS` keeps stale routes out of signing.

There is intentionally no aggregator-type allowlist — the four currently-supported aggregators are accepted via the pinned forwarder, and future additions (better quotes) aren't blocked.

### Widget

- Two stacked `TokenInput`s on both BUY and SELL: origin editable, output read-only. Selectable side flips per flow:
  - **BUY** — origin: `[underlying, USDS, USDC]` (default underlying); output: PT (fixed).
  - **SELL** — origin: PT (fixed); output: `[underlying, USDS, USDC]` (default underlying).
- Token list reuses the existing global `TOKENS` registry — no new token definitions.
- Selected-token symbol + decimals everywhere (overview, review, status copy).
- Transaction overview adds a price-impact breakdown (Pendle AMM / Aggregator hop) and a "Routed via …" row, but **only when an aggregator is actually used** (otherwise the breakdown rows are misleading noise).
- Switching the BUY input token resets `amount` and the input remounts via `key={token.symbol}` so the bigint can't get reinterpreted at new decimals (e.g. `5_000_000n` USDG → `5e-12` USDS).
- The quote hook is gated on `amount === debouncedAmount` so a token switch doesn't trigger a stale request with the previous bigint at the new token's decimals.

### Out of scope

**Redeeming to non-underlying tokens.** Matured-market redeem still goes 1:1 to the underlying via `buildMaturedRedeemVerifiedArgs`. Adding USDS / USDC redeem will require switching that path back through the `/convert` API and is intentionally deferred to a follow-up PR.

## Test plan

- [ ] BUY with underlying — quote does NOT include `enableAggregator`; no "Routed via" row; no breakdown rows; tx succeeds.
- [ ] BUY with USDS / USDC — quote includes `enableAggregator: true`; "Routed via &lt;KyberSwap | Odos | OKX | Paraswap&gt;" + breakdown rows shown; allowance prompt is for the selected token; tx succeeds.
- [ ] SELL to underlying — no aggregator UI; tx succeeds.
- [ ] SELL to USDS / USDC — aggregator UI shown; tx succeeds.
- [ ] Switching BUY input token clears the amount field and does NOT fire a quote request with the stale bigint.
- [ ] Review and status screens display the user-selected token's symbol throughout (not the market underlying).
- [ ] Matured redeem unchanged: still goes 1:1 to the underlying.
- [ ] Unit tests pass: `pnpm -F hooks test buildVerifiedArgs`.
- [ ] (Manual) Force a non-pinned `pendleSwap` via a network mock and confirm the verified-args throw surfaces as a user-facing error rather than a silent fallback.