### PR TITLE
Clean up production console errors and warnings APP-195

### DIFF
--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -37,7 +37,8 @@ const connectors = [
   metaMask(),
   baseAccount({
     appName: 'sky.money',
-    appLogoUrl: 'https://app.sky.money/images/sky.svg'
+    appLogoUrl: 'https://app.sky.money/images/sky.svg',
+    preference: { telemetry: false }
   }),
   coinbaseWallet({
     appName: 'sky.money',

--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -13,7 +13,7 @@ import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { LinkedActionWrapper } from '@/modules/ui/components/LinkedActionWrapper';
 import { cn } from '@/lib/utils';
 import { Menu, ChevronDown, Loader2 } from 'lucide-react';
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { DualSwitcher } from '@/components/DualSwitcher';
 import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
@@ -215,15 +215,18 @@ export function WidgetNavigation({
             </SheetTrigger>
             <SheetContent
               side="left"
+              aria-describedby={undefined}
               className="border-borderPrimary w-[280px] bg-black/10 p-0 backdrop-blur-xl"
               closeButtonClassName="text-white"
               closeIconClassName="size-[22px]"
             >
               <div className="flex h-full flex-col">
                 <div className="p-6 pb-4">
-                  <Heading>
-                    <Trans>Menu</Trans>
-                  </Heading>
+                  <SheetTitle asChild>
+                    <Heading>
+                      <Trans>Menu</Trans>
+                    </Heading>
+                  </SheetTitle>
                 </div>
                 <div className="mt-10 flex-1 overflow-y-auto px-3 pb-6">
                   {widgetContent.map(group =>

--- a/apps/webapp/src/modules/auth/components/UnauthorizedPage.tsx
+++ b/apps/webapp/src/modules/auth/components/UnauthorizedPage.tsx
@@ -151,7 +151,7 @@ export const UnauthorizedPage = ({ authData, vpnData, children }: UnauthorizedPa
     <>
       <Dialog open={true}>
         {isLoading ? (
-          <DialogContent className="bg-containerDark max-w-[300px]">
+          <DialogContent aria-describedby={undefined} className="bg-containerDark max-w-[300px]">
             <div className="flex items-center justify-center p-4">
               <DialogTitle asChild>
                 <Text className="text-text mr-2 text-center">
@@ -162,7 +162,7 @@ export const UnauthorizedPage = ({ authData, vpnData, children }: UnauthorizedPa
             </div>
           </DialogContent>
         ) : (
-          <DialogContent className="bg-containerDark max-w-[640px] p-10">
+          <DialogContent aria-describedby={undefined} className="bg-containerDark max-w-[640px] p-10">
             <div className="flex flex-col gap-5 sm:flex-row">
               <Unavailable className="shrink-0" />
               <div className="">

--- a/apps/webapp/src/modules/layout/components/ConnectedModal.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectedModal.tsx
@@ -47,6 +47,7 @@ export function ConnectedModal({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
+        aria-describedby={undefined}
         className="bg-containerDark flex max-h-[calc(100dvh-32px)] flex-col gap-6 overflow-hidden p-4 sm:max-w-[490px] sm:min-w-[490px]"
         onOpenAutoFocus={e => e.preventDefault()}
         onCloseAutoFocus={e => e.preventDefault()}

--- a/apps/webapp/src/modules/layout/components/UnsupportedNetworkPage.tsx
+++ b/apps/webapp/src/modules/layout/components/UnsupportedNetworkPage.tsx
@@ -25,6 +25,7 @@ export const UnsupportedNetworkPage = ({ children }: { children: React.ReactNode
     <>
       <Dialog open={true} modal={true}>
         <DialogContent
+          aria-describedby={undefined}
           className="bg-containerDark max-w-[640px] p-10"
           onOpenAutoFocus={e => e.preventDefault()} //don't automatically focus the first button
         >

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -87,6 +87,7 @@ export function ChainModal({
         )}
       </DialogTrigger>
       <DialogContent
+        aria-describedby={undefined}
         className={cn('bg-containerDark p-4 sm:min-w-[400px] sm:p-4', isSafeWallet && 'sm:max-w-[400px]')}
         onOpenAutoFocus={e => e.preventDefault()}
         onCloseAutoFocus={e => e.preventDefault()}

--- a/apps/webapp/src/modules/ui/components/ConnectModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ConnectModal.tsx
@@ -262,6 +262,7 @@ export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
   return (
     <Dialog open={open && !hasWalletOverlay} onOpenChange={onOpenChange}>
       <DialogContent
+        aria-describedby={undefined}
         className="bg-containerDark max-h-[calc(100dvh-32px)] gap-6 overflow-auto p-4 sm:max-w-[490px] sm:min-w-[490px]"
         onOpenAutoFocus={e => e.preventDefault()}
         onCloseAutoFocus={e => e.preventDefault()}

--- a/apps/webapp/src/modules/ui/components/FaqAccordion.tsx
+++ b/apps/webapp/src/modules/ui/components/FaqAccordion.tsx
@@ -7,8 +7,7 @@ import {
   PopoverRateInfo,
   PopoverInfo,
   getTooltipById,
-  POPOVER_TOOLTIP_TYPES,
-  type PopoverTooltipType
+  resolvePopoverTooltipKey
 } from '@jetstreamgg/sky-widgets';
 
 interface Item {
@@ -35,17 +34,18 @@ export function FaqAccordion({ items }: { items: Item[] }): React.ReactElement {
                     if (href?.startsWith('#tooltip-')) {
                       const tooltipId = href.replace('#tooltip-', '');
 
-                      // Check if it's a hardcoded PopoverRateInfo tooltip type
-                      if (POPOVER_TOOLTIP_TYPES.includes(tooltipId as PopoverTooltipType)) {
+                      const popoverKey = resolvePopoverTooltipKey(tooltipId);
+                      if (popoverKey) {
                         return (
                           <span className="inline-flex items-center gap-1">
                             {children}
-                            <PopoverRateInfo type={tooltipId as PopoverTooltipType} />
+                            <PopoverRateInfo type={popoverKey} />
                           </span>
                         );
                       }
 
-                      // Otherwise, try to get it from the dynamic tooltip system
+                      // Fall back to the dynamic tooltip system for ids without
+                      // a PopoverRateInfo equivalent (e.g. gas-fee, sealed).
                       const tooltip = getTooltipById(tooltipId);
                       if (tooltip) {
                         return (

--- a/apps/webapp/src/modules/ui/components/TermsDialog.tsx
+++ b/apps/webapp/src/modules/ui/components/TermsDialog.tsx
@@ -63,7 +63,7 @@ export const TermsDialog: React.FC<TermsDialogProps> = ({
   };
 
   const dialogContent = showLoadingState ? (
-    <DialogContent className="bg-containerDark max-w-[300px]">
+    <DialogContent aria-describedby={undefined} className="bg-containerDark max-w-[300px]">
       {loadingContent || (
         <div className="flex items-center justify-center p-4">
           <DialogTitle asChild>
@@ -76,7 +76,7 @@ export const TermsDialog: React.FC<TermsDialogProps> = ({
       )}
     </DialogContent>
   ) : (
-    <DialogContent className="bg-containerDark max-h-[95dvh] overflow-y-auto">
+    <DialogContent aria-describedby={undefined} className="bg-containerDark max-h-[95dvh] overflow-y-auto">
       <DialogTitle className="sr-only">{title}</DialogTitle>
       {termsVersion && (
         <Text className="text-center text-xs text-white/50">

--- a/apps/webapp/src/modules/ui/components/TransactionModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TransactionModal.tsx
@@ -138,6 +138,7 @@ export function TransactionModal({
   return (
     <Dialog open={open} onOpenChange={val => !val && handleClose()}>
       <DialogContent
+        aria-describedby={undefined}
         className="bg-containerDark flex flex-col gap-6 p-4 sm:max-w-122.5 sm:min-w-122.5"
         onPointerDownOutside={e => isTransacting && e.preventDefault()}
         onEscapeKeyDown={e => isTransacting && e.preventDefault()}

--- a/apps/webapp/src/utils/bannerContentParser.tsx
+++ b/apps/webapp/src/utils/bannerContentParser.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import { Text } from '@/modules/layout/components/Typography';
-import {
-  PopoverRateInfo as PopoverInfo,
-  POPOVER_TOOLTIP_TYPES,
-  type PopoverTooltipType
-} from '@jetstreamgg/sky-widgets';
+import { PopoverRateInfo, resolvePopoverTooltipKey } from '@jetstreamgg/sky-widgets';
 import { Trans } from '@lingui/react/macro';
-
-// Use the exported constant from the widgets package for runtime validation
-// Create a set for O(1) lookup performance
-const TOOLTIP_TYPE_SET = new Set<string>(POPOVER_TOOLTIP_TYPES);
 
 /**
  * Parses banner description text and replaces tooltip placeholders with React components
- * Supports patterns like [(PSM)](#tooltip-psm) which get replaced with <PopoverInfo type="psm" />
+ * Supports patterns like [(PSM)](#tooltip-psm) which get replaced with <PopoverRateInfo type="psm" />
  */
 export function parseBannerContent(description: string | React.ReactNode): React.ReactNode {
   // If it's already a React element, return as is
@@ -57,19 +49,14 @@ export function parseBannerContent(description: string | React.ReactNode): React
     const label = match[1]; // e.g., "PSM"
     const tooltipTypeRaw = match[2]; // e.g., "psm"
 
-    // Validate that the tooltip type is valid
-    if (TOOLTIP_TYPE_SET.has(tooltipTypeRaw)) {
-      // TypeScript knows this is safe because we validated it exists in the set
-      const tooltipType = tooltipTypeRaw as PopoverTooltipType;
-
-      // Add the label text followed by the tooltip
+    const tooltipKey = resolvePopoverTooltipKey(tooltipTypeRaw);
+    if (tooltipKey) {
       parts.push(
         <React.Fragment key={`tooltip-${match.index}`}>
-          {label} <PopoverInfo type={tooltipType} />
+          {label} <PopoverRateInfo type={tooltipKey} />
         </React.Fragment>
       );
     } else {
-      // If tooltip type is not recognized, just add the label without tooltip
       console.warn(`Unknown tooltip type: ${tooltipTypeRaw}`);
       parts.push(label);
     }

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -45,9 +45,10 @@ export default ({ mode }: { mode: modeEnum }) => {
     script-src 'self'
       https://static.cloudflareinsights.com
       https://challenges.cloudflare.com
+      https://*.googletagmanager.com
       https://*.posthog.com https://e.sky.money;
     style-src 'self' 'unsafe-inline' https://*.posthog.com https://e.sky.money;
-    img-src 'self' data: blob: https://explorer-api.walletconnect.com https://*.posthog.com https://e.sky.money;
+    img-src 'self' data: blob: https://explorer-api.walletconnect.com https://*.google-analytics.com https://*.googletagmanager.com https://*.posthog.com https://e.sky.money;
     font-src 'self';
     connect-src 'self' data:
       https://proxy.sky.money
@@ -82,6 +83,9 @@ export default ({ mode }: { mode: modeEnum }) => {
       https://api.cow.fi/
       https://api.morpho.org/
       https://api.merkl.xyz/
+      https://*.google-analytics.com
+      https://*.analytics.google.com
+      https://*.googletagmanager.com
       wss://relay.walletconnect.com
       wss://relay.walletconnect.org
       https://pulse.walletconnect.org

--- a/packages/utils/src/hooks/useIsSafeWallet.ts
+++ b/packages/utils/src/hooks/useIsSafeWallet.ts
@@ -22,6 +22,7 @@ export const useIsSafeWallet = () => {
   const { address, connector } = useConnection();
   const chainId = useChainId();
 
+  const isSafeConnector = connector?.id === SAFE_CONNECTOR_ID;
   const baseUrl = SAFE_TRANSACTION_SERVICE_URL[chainId];
   let url: URL | undefined;
   if (baseUrl) {
@@ -29,11 +30,15 @@ export const useIsSafeWallet = () => {
     url = new URL(endpoint);
   }
 
+  // Safe-ness of an address doesn't change — cache the answer for the session
+  // and skip the call when we already know the wallet is a Safe via the connector.
   const { data: isAddressSafeWallet } = useQuery({
-    enabled: Boolean(url && address),
+    enabled: Boolean(url && address) && !isSafeConnector,
     queryKey: ['is-safe-wallet-found', address, chainId],
-    queryFn: () => isSafeWalletFound(url!)
+    queryFn: () => isSafeWalletFound(url!),
+    staleTime: Infinity,
+    gcTime: Infinity
   });
 
-  return connector?.id === SAFE_CONNECTOR_ID || !!isAddressSafeWallet;
+  return isSafeConnector || !!isAddressSafeWallet;
 };

--- a/packages/utils/src/hooks/useIsSafeWallet.ts
+++ b/packages/utils/src/hooks/useIsSafeWallet.ts
@@ -22,7 +22,7 @@ export const useIsSafeWallet = () => {
   const { address, connector } = useConnection();
   const chainId = useChainId();
 
-  const isSafeConnector = connector?.id === SAFE_CONNECTOR_ID;
+  const isSafeConnector = connector?.id === SAFE_CONNECTOR_ID && !!address;
   const baseUrl = SAFE_TRANSACTION_SERVICE_URL[chainId];
   let url: URL | undefined;
   if (baseUrl) {

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -48,6 +48,7 @@ export { NoResults } from './shared/components/icons/NoResults';
 export {
   PopoverRateInfo,
   POPOVER_TOOLTIP_TYPES,
+  resolvePopoverTooltipKey,
   type PopoverTooltipType
 } from './shared/components/ui/PopoverRateInfo';
 export { PopoverInfo } from './shared/components/ui/PopoverInfo';

--- a/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
+++ b/packages/widgets/src/shared/components/ui/PopoverRateInfo.tsx
@@ -78,6 +78,14 @@ export const POPOVER_TOOLTIP_TYPES = Object.keys(TOOLTIP_ID_MAP) as (keyof typeo
 // Derive the type from the map
 export type PopoverTooltipType = keyof typeof TOOLTIP_ID_MAP;
 
+// Accepts short keys ("ssr") or full ids ("sky-savings-rate").
+export function resolvePopoverTooltipKey(raw: string): PopoverTooltipType | undefined {
+  if (raw in TOOLTIP_ID_MAP) return raw as PopoverTooltipType;
+  return Object.entries(TOOLTIP_ID_MAP).find(([, fullId]) => fullId === raw)?.[0] as
+    | PopoverTooltipType
+    | undefined;
+}
+
 export const PopoverRateInfo = ({
   type,
   onExternalLinkClicked,


### PR DESCRIPTION
  Fixes

  - GA / GTM blocked by CSP — added Google Tag Manager / Analytics domains to script-src, img-src, connect-src per Google's CSP guide. GA loader script can now actually run.
  - Inline-script CSP block from getProvider — passed preference: { telemetry: false } to the Base Account connector. Stops @base-org/account from injecting an inline telemetry script that our CSP blocks.
  - Radix Missing Description dialog warnings — added aria-describedby={undefined} to dialogs without a <DialogDescription>
  - Radix Missing DialogTitle warning on the mobile widget nav — WidgetNavigation's <SheetContent> rendered the "Menu" heading as a plain <Heading>, so Radix's accessibility check fired (Sheet is built on @radix-ui/react-dialog). Wrapped it in <SheetTitle asChild> and added aria-describedby={undefined} to match the suppression pattern used on the Dialogs.
  - Unknown tooltip type: sky-savings-rate / stusds-rate — added a resolvePopoverTooltipKey helper in widgets that reverse-resolves a full id back to its short key. Banner parser and FAQ accordion now both render through PopoverRateInfo regardless of which form authors write.
  - Repeated safe-transaction-*.safe.global 404s — useIsSafeWallet now caches the result for the session (staleTime: Infinity, gcTime: Infinity), skips the call entirely when connector.id === 'safe', and the isSafeConnector flag is gated on address so it can't flip true mid-connecting.

  Test plan

  - Open /savings and /stusds — confirm no Unknown tooltip type warning, tooltip popovers open with correct content
  - Open Connect / Chain / Connected / Transaction modals — confirm no Radix dialog warning
  - Open the mobile widget nav (hamburger) — confirm no Radix DialogTitle / Description warning
  - Connect via Base Account — confirm no inline-script CSP error
  - Connect a non-Safe wallet — confirm exactly one /api/v1/safes/{address} 404 per session, not one per modal open / focus
  - GA fix can only be tested on prod, since its only used on prod