### PR TITLE
Add a read-only variant to `TokenInput` for Pendle 'You receive' cards

### DIFF
--- a/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
+++ b/packages/widgets/src/shared/components/ui/token/TokenInput.tsx
@@ -42,6 +42,8 @@ export interface TokenInputProps {
   className?: string;
   disabled?: boolean;
   inputDisabled?: boolean;
+  /** Display-only variant: replaces the editable input with a formatted readout. */
+  readOnly?: boolean;
   error?: string;
   errorTooltip?: string;
   variant?: 'bottom' | 'top';
@@ -72,6 +74,7 @@ export function TokenInput({
   value,
   disabled,
   inputDisabled = false,
+  readOnly = false,
   dataTestId = 'token-input',
   placeholder,
   onChange,
@@ -282,7 +285,8 @@ export function TokenInput({
         <MotionCard
           ref={cardRef}
           className={cn(
-            'hover-in-before pb-4! min-h-16 w-96 overflow-hidden rounded-2xl border-0',
+            'hover-in-before min-h-16 w-96 overflow-hidden rounded-2xl border-0',
+            !readOnly && 'pb-4!',
             className
           )}
           style={{
@@ -310,90 +314,112 @@ export function TokenInput({
                   animate={AnimationLabels.animate}
                 >
                   <motion.div variants={positionAnimations}>
-                    <Input
-                      ref={inputRef}
-                      className="hide-spin-button placeholder:text-white/30"
-                      value={inputValue !== '00' ? inputValue : '0'}
-                      onChange={e => {
-                        updateValue(e.target.value as `${number}`, e);
-                        if (typeof onSetMax === 'function') onSetMax(false);
-                      }}
-                      onInput={() => {
-                        onInput?.();
-                      }}
-                      disabled={disabled || inputDisabled}
-                      //prevent scrolling to change input
-                      onWheel={e => (e.target as HTMLElement).blur()}
-                      type="number"
-                      placeholder={placeholder || 'Enter amount'}
-                      rightElement={
-                        <div ref={tokenSelectorRef}>
+                    {readOnly ? (
+                      <HStack className="items-center justify-between pb-1 pt-4">
+                        <div
+                          className="text-text flex h-6 grow items-center truncate text-base lg:h-7 lg:text-lg"
+                          data-testid={dataTestId}
+                        >
+                          {value && value !== 0n
+                            ? formatBigInt(value, { unit: decimals, maxDecimals: 4 })
+                            : '—'}
+                        </div>
+                        <div ref={tokenSelectorRef} className="shrink-0">
                           <TokenSelector
                             token={token}
                             disabled={disabled || tokenList.length <= 1}
                             showChevron={tokenList.length > 1}
                           />
                         </div>
-                      }
-                      error={shownError}
-                      errorTooltip={errorTooltip}
-                      data-testid={dataTestId}
-                      step={'any'}
-                      min={0}
-                    />
+                      </HStack>
+                    ) : (
+                      <Input
+                        ref={inputRef}
+                        className="hide-spin-button placeholder:text-white/30"
+                        value={inputValue !== '00' ? inputValue : '0'}
+                        onChange={e => {
+                          updateValue(e.target.value as `${number}`, e);
+                          if (typeof onSetMax === 'function') onSetMax(false);
+                        }}
+                        onInput={() => {
+                          onInput?.();
+                        }}
+                        disabled={disabled || inputDisabled}
+                        //prevent scrolling to change input
+                        onWheel={e => (e.target as HTMLElement).blur()}
+                        type="number"
+                        placeholder={placeholder || 'Enter amount'}
+                        rightElement={
+                          <div ref={tokenSelectorRef}>
+                            <TokenSelector
+                              token={token}
+                              disabled={disabled || tokenList.length <= 1}
+                              showChevron={tokenList.length > 1}
+                            />
+                          </div>
+                        }
+                        error={shownError}
+                        errorTooltip={errorTooltip}
+                        data-testid={dataTestId}
+                        step={'any'}
+                        min={0}
+                      />
+                    )}
                   </motion.div>
-                  <motion.div variants={positionAnimations}>
-                    <HStack className="justify-between pt-4">
-                      <HStack
-                        gap={2}
-                        className={`text-selectActive ${'w-full'} items-center overflow-clip`}
-                        title={balanceText}
-                      >
-                        {!hideIcon && limitText && isConnectedAndEnabled ? (
-                          showGauge ? (
-                            <div>
-                              <Gauge height={20} width={20} className="text-textDesaturated" />
-                            </div>
-                          ) : (
+                  {!readOnly && (
+                    <motion.div variants={positionAnimations}>
+                      <HStack className="justify-between pt-4">
+                        <HStack
+                          gap={2}
+                          className={`text-selectActive ${'w-full'} items-center overflow-clip`}
+                          title={balanceText}
+                        >
+                          {!hideIcon && limitText && isConnectedAndEnabled ? (
+                            showGauge ? (
+                              <div>
+                                <Gauge height={20} width={20} className="text-textDesaturated" />
+                              </div>
+                            ) : (
+                              <div>
+                                <Wallet height={20} width={20} className="text-textDesaturated" />
+                              </div>
+                            )
+                          ) : !hideIcon && (!limitText || !isConnectedAndEnabled) ? (
                             <div>
                               <Wallet height={20} width={20} className="text-textDesaturated" />
                             </div>
-                          )
-                        ) : !hideIcon && (!limitText || !isConnectedAndEnabled) ? (
-                          <div>
-                            <Wallet height={20} width={20} className="text-textDesaturated" />
-                          </div>
-                        ) : null}
-                        <Text
-                          className="text-textDesaturated text-nowrap text-sm leading-none"
-                          dataTestId={`${dataTestId}-balance`}
-                        >
-                          {limitText && isConnectedAndEnabled ? limitText : balanceText}
-                        </Text>
+                          ) : null}
+                          <Text
+                            className="text-textDesaturated text-nowrap text-sm leading-none"
+                            dataTestId={`${dataTestId}-balance`}
+                          >
+                            {limitText && isConnectedAndEnabled ? limitText : balanceText}
+                          </Text>
+                        </HStack>
+                        {showPercentageButtons && (
+                          <HStack gap={2} className="text-selectActive items-center">
+                            {buttonsToShow.map(percentage => (
+                              <Button
+                                key={percentage}
+                                size="input"
+                                variant="input"
+                                onClick={e => onPercentageClicked(e, percentage, percentage === 100)}
+                                disabled={disabled}
+                                data-testid={percentage === 100 ? `${dataTestId}-max` : undefined}
+                              >
+                                {`${percentage}%`}
+                              </Button>
+                            ))}
+                          </HStack>
+                        )}
+                        {customActionButtons && (
+                          <HStack gap={2} className="text-selectActive items-center">
+                            {customActionButtons}
+                          </HStack>
+                        )}
                       </HStack>
-                      {showPercentageButtons && (
-                        <HStack gap={2} className="text-selectActive items-center">
-                          {buttonsToShow.map(percentage => (
-                            <Button
-                              key={percentage}
-                              size="input"
-                              variant="input"
-                              onClick={e => onPercentageClicked(e, percentage, percentage === 100)}
-                              disabled={disabled}
-                              data-testid={percentage === 100 ? `${dataTestId}-max` : undefined}
-                            >
-                              {`${percentage}%`}
-                            </Button>
-                          ))}
-                        </HStack>
-                      )}
-                      {customActionButtons && (
-                        <HStack gap={2} className="text-selectActive items-center">
-                          {customActionButtons}
-                        </HStack>
-                      )}
-                    </HStack>
-                  </motion.div>
+                    </motion.div>
+                  )}
                 </motion.div>
               ) : (
                 <motion.div

--- a/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -182,8 +182,7 @@ export const SupplyWithdraw = ({
                 balance={enabled ? outputBalance : undefined}
                 value={quote?.amountOut ?? 0n}
                 onChange={() => null}
-                inputDisabled
-                showPercentageButtons={false}
+                readOnly
                 enabled={enabled}
                 dataTestId="pendle-supply-output"
               />
@@ -220,8 +219,7 @@ export const SupplyWithdraw = ({
                 balance={enabled ? outputBalance : undefined}
                 value={quote?.amountOut ?? 0n}
                 onChange={() => null}
-                inputDisabled
-                showPercentageButtons={false}
+                readOnly
                 enabled={enabled}
                 dataTestId="pendle-withdraw-output"
               />


### PR DESCRIPTION
## Summary

Layered on top of #1547. Adds a `readOnly?: boolean` prop to `TokenInput` and applies it to the two "You receive" cards in `SupplyWithdraw` (BUY-output PT, SELL-output USDS / USDC / underlying).

### Why

#1547 introduced two stacked `TokenInput`s on each Pendle flow with the bottom card frozen via `inputDisabled` + `onChange={() => null}`. The affordance is misleading: the bottom card still renders as a full editable input — percentage buttons, wallet/balance row, big input field — even though the *only* meaningful action there is selecting the output token (or no action at all on the BUY output). It reads as a broken input, not as a result panel.

### What changes

When `readOnly` is set on `TokenInput`:

- The editable `<Input>` is replaced with a static text + token-selector row inside the same `HStack` layout the editable variant uses, so the value sits at the same vertical eye-line as the typed text in a paired editable card above.
- The wallet/balance row, percentage buttons, and custom-action buttons are suppressed — they don't apply when the amount isn't user-driven.
- The card's `pb-4!` override is scoped to `!readOnly`; readout cards fall back to Card default padding.
- The internal row uses asymmetric `pt-4 pb-1` for a visually lighter footprint.
- Empty state renders `—` (em-dash) instead of `0`, to read as "waiting" rather than "the answer is zero".

`PendleWidget/SupplyWithdraw.tsx` swaps `inputDisabled` + `onChange={() => null}` + `showPercentageButtons={false}` for `readOnly` on both output cards.

### Out of scope

- Loading skeleton during quote fetch — the em-dash covers both idle and brief loading states, and the `TransactionOverview` below already shows a skeleton when actually fetching.
- A `loading?: boolean` prop is a natural follow-up if we want a true 3-state (idle / loading / value) display.

<img width="850" height="682" alt="image" src="https://github.com/user-attachments/assets/cc51fa90-d4c1-420c-8c25-a6eb10caf248" />

## Test plan

- [ ] BUY view: output card shows "You receive" + computed PT amount + PT chip; no input field, no percentage buttons, no balance row.
- [ ] SELL view: output card shows "You receive" + computed amount + selectable USDS / USDC / underlying chip.
- [ ] Empty state: with no amount entered, value renders as `—`.
- [ ] Value text and token chip share the same vertical eye-line at base and `lg` breakpoints.
- [ ] Editable input above is unchanged (same padding, balance row, percentage buttons).
- [ ] `pnpm -F @jetstreamgg/sky-widgets typecheck` clean.
- [ ] `pnpm -F @jetstreamgg/sky-widgets test --run` passes (63/63).