### PR TITLE
Always query mainnet chainId for stake reward contracts

### DIFF
--- a/packages/hooks/src/stake/useStakeRewardContracts.ts
+++ b/packages/hooks/src/stake/useStakeRewardContracts.ts
@@ -96,6 +96,9 @@ export function useStakeRewardContracts({
 } = {}): ReadHook & { data: { contractAddress: `0x${string}` }[] | undefined } {
   const walletChainId = useChainId();
   const chainId = walletChainId === TENDERLY_CHAIN_ID ? walletChainId : mainnet.id;
+  // The indexer only has Reward rows for mainnet, so always query with mainnet's
+  // chainId. Tenderly is a mainnet fork and uses the same reward addresses.
+  const indexerChainId = mainnet.id;
   const config = useConfig();
   const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
 
@@ -109,8 +112,8 @@ export function useStakeRewardContracts({
     refetch: mutate,
     isLoading: isGraphqlLoading
   } = useQuery({
-    queryKey: ['stakeRewardContracts', urlSubgraph, chainId],
-    queryFn: () => fetchStakeRewardContracts(urlSubgraph, chainId),
+    queryKey: ['stakeRewardContracts', urlSubgraph, indexerChainId],
+    queryFn: () => fetchStakeRewardContracts(urlSubgraph, indexerChainId),
     enabled: !!urlSubgraph,
     placeholderData: hardcodedContracts
   });


### PR DESCRIPTION
## Summary
- On staging the stake reward selector was silent-empty: the Envio indexer at `proxy.sky.money/indexer` only has `Reward` rows for chainId=1, but `useStakeRewardContracts` was sending the wallet's chainId (314310 on Tenderly) into the query, so it returned `{rewards: []}`.
- Empty was a successful response, so the on-chain `validateHardcodedContracts` fallback never fired (it's gated on `enabled: !!graphqlError`).
- Tenderly is a mainnet fork and reuses the same reward addresses (`lsSky*RewardAddress[1] === lsSky*RewardAddress[314310]` in `generated.ts`), so the indexer query can safely always run against mainnet's chainId.
- Locally the bug was masked because the indexer call from `localhost` was failing (likely CORS), which triggered the on-chain fallback and surfaced the active SKY reward.

Regression introduced by the 2026-02-26 Envio HyperIndex migration (`5d7880da`), which added the `chainId: { _eq: ${chainId} }` filter to the rewards query.

## Changes
- `useStakeRewardContracts`: introduce `indexerChainId = mainnet.id` for the GraphQL query and its `queryKey`. The on-chain fallback still uses the wallet's `chainId` so `StakeModule.farms()` runs on the correct chain.

## Test plan
- [ ] On staging Tenderly VNet (chainId 314310): open the Stake flow, reward selector shows the active reward set (SKY) instead of being empty.
- [ ] On staging mainnet: reward selector unchanged.
- [ ] Locally on Tenderly: behavior unchanged (indexer still fails locally, on-chain fallback still surfaces SKY).
- [ ] `pnpm -F sky-hooks typecheck` passes (verified locally).