### PR TITLE
Add chainId path param to indexer URL

### DIFF
--- a/apps/webapp/src/modules/app/hooks/useSubgraphUrl.tsx
+++ b/apps/webapp/src/modules/app/hooks/useSubgraphUrl.tsx
@@ -1,3 +1,6 @@
+import { useChainId } from 'wagmi';
+
 export function useSubgraphUrl() {
-  return `${import.meta.env.VITE_PROXY_ORIGIN || ''}/indexer`;
+  const chainId = useChainId();
+  return `${import.meta.env.VITE_PROXY_ORIGIN || 'https://staging-proxy.sky.money'}/indexer/${chainId}`;
 }

--- a/packages/hooks/src/delegates/useDelegates.ts
+++ b/packages/hooks/src/delegates/useDelegates.ts
@@ -78,7 +78,7 @@ export function useDelegates({
   version?: 1 | 2 | 3;
   enabled?: boolean;
 }): ReadHook & { data?: DelegateInfo[] } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const orderByFields = [
     'blockTimestamp',

--- a/packages/hooks/src/delegates/useUserDelegates.ts
+++ b/packages/hooks/src/delegates/useUserDelegates.ts
@@ -85,7 +85,7 @@ export function useUserDelegates({
   search?: string;
   version?: 1 | 2 | 3;
 }): ReadHook & { data?: DelegateInfo[] } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data: subgraphDelegates,

--- a/packages/hooks/src/helpers/getSubgraphUrl.ts
+++ b/packages/hooks/src/helpers/getSubgraphUrl.ts
@@ -1,7 +1,7 @@
 import { URL_SKY_SUBGRAPH, URL_BA_LABS_API_MAINNET } from '../constants';
 
-export function getSubgraphUrl(): string {
-  return URL_SKY_SUBGRAPH;
+export function getSubgraphUrl(chainId: number): string {
+  return `${URL_SKY_SUBGRAPH}/${chainId}`;
 }
 
 export function getBaLabsApiUrl(): string {

--- a/packages/hooks/src/psm/useL2SavingsHistory.ts
+++ b/packages/hooks/src/psm/useL2SavingsHistory.ts
@@ -135,7 +135,7 @@ export function useL2SavingsHistory({
   const { address } = useConnection();
   const currentChainId = useChainId();
   const chainIdToUse = chainId ?? currentChainId;
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainIdToUse) || '';
   const tokenAddressMap = useTokenAddressMap(chainIdToUse);
   const {
     data,

--- a/packages/hooks/src/psm/usePsmTradeHistory.ts
+++ b/packages/hooks/src/psm/usePsmTradeHistory.ts
@@ -127,7 +127,7 @@ export function usePsmTradeHistory({
   const { address } = useConnection();
   const currentChainId = useChainId();
   const chainIdToUse = chainId || currentChainId;
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainIdToUse) || '';
   const tokenAddressMap = useTokenAddressMap(chainIdToUse);
 
   const {

--- a/packages/hooks/src/rewards/useAllRewardsUserHistory.ts
+++ b/packages/hooks/src/rewards/useAllRewardsUserHistory.ts
@@ -95,7 +95,7 @@ export function useAllRewardsUserHistory({
 } = {}): ReadHook & { data?: RewardUserHistoryItem[] } {
   const { address: userAddress } = useConnection();
   const currentChainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   //this hook is only used for mainnet, update this if this ever changes
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
   const rewardContracts = useAvailableTokenRewardContracts(chainIdToUse);

--- a/packages/hooks/src/rewards/useRewardContractInfo.ts
+++ b/packages/hooks/src/rewards/useRewardContractInfo.ts
@@ -45,7 +45,7 @@ export function useRewardContractInfo({
   chainId: number;
   rewardContractAddress: string;
 }): ReadHook & { data?: RewardContractInfo | null } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/rewards/useRewardContractsInfo.ts
+++ b/packages/hooks/src/rewards/useRewardContractsInfo.ts
@@ -43,7 +43,7 @@ export function useRewardContractsInfo({
   chainId: number;
   rewardContracts: RewardContract[];
 }): ReadHook & { data?: RewardContractInfo[] } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/rewards/useRewardsUserHistory.ts
+++ b/packages/hooks/src/rewards/useRewardsUserHistory.ts
@@ -84,7 +84,7 @@ export function useRewardsUserHistory({
 }): ReadHook & { data?: RewardUserHistoryItem[] } {
   const currentChainId = useChainId();
   const { address: userAddress } = useConnection();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   //this hook is only used for mainnet, update this if this ever changes
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
 

--- a/packages/hooks/src/savings/useEthereumSavingsHistory.ts
+++ b/packages/hooks/src/savings/useEthereumSavingsHistory.ts
@@ -70,7 +70,7 @@ export function useEthereumSavingsHistory({
 } = {}): ReadHook & { data?: SavingsHistory } {
   const { address } = useConnection();
   const currentChainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
 
   const {

--- a/packages/hooks/src/savings/useTotalSavingsSuppliers.ts
+++ b/packages/hooks/src/savings/useTotalSavingsSuppliers.ts
@@ -25,7 +25,7 @@ export function useTotalSavingsSuppliers({
   subgraphUrl?: string;
 } = {}): ReadHook & { data?: number } {
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/seal/useSaRewardContracts.ts
+++ b/packages/hooks/src/seal/useSaRewardContracts.ts
@@ -31,7 +31,7 @@ export function useSaRewardContracts({
   subgraphUrl?: string;
 } = {}): ReadHook & { data: { contractAddress: `0x${string}` }[] | undefined } {
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/seal/useSaUserDelegates.ts
+++ b/packages/hooks/src/seal/useSaUserDelegates.ts
@@ -22,7 +22,7 @@ export function useSaUserDelegates({
   random?: boolean;
   search?: string;
 }): ReadHook & { data?: DelegateInfo[] } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data: userDelegatesData,

--- a/packages/hooks/src/seal/useSealHistory.ts
+++ b/packages/hooks/src/seal/useSealHistory.ts
@@ -260,7 +260,7 @@ export function useSealHistory({
 } = {}): ReadHook & { data?: SealHistory } {
   const { address } = useConnection();
   const currentChainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
 
   const {

--- a/packages/hooks/src/seal/useSealPosition.ts
+++ b/packages/hooks/src/seal/useSealPosition.ts
@@ -71,7 +71,7 @@ export function useSealPosition({
 }): ReadHook & { data?: SealPosition } {
   const { address } = useConnection();
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/seal/useTotalUserSealed.ts
+++ b/packages/hooks/src/seal/useTotalUserSealed.ts
@@ -32,7 +32,7 @@ export function useTotalUserSealed({
 } = {}): ReadHook & { data?: bigint } {
   const { address } = useConnection();
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/seal/useUrnsInfo.ts
+++ b/packages/hooks/src/seal/useUrnsInfo.ts
@@ -61,7 +61,7 @@ export function useUrnsInfo({
   chainId: number;
   user: `0x${string}`;
 }): ReadHook & { data?: UrnInfo[] } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/stake/useStakeHistory.ts
+++ b/packages/hooks/src/stake/useStakeHistory.ts
@@ -224,7 +224,7 @@ export function useStakeHistory({
 } = {}): ReadHook & { data?: StakeHistory } {
   const { address } = useConnection();
   const currentChainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
 
   const {

--- a/packages/hooks/src/stake/useStakePosition.ts
+++ b/packages/hooks/src/stake/useStakePosition.ts
@@ -72,7 +72,7 @@ export function useStakePosition({
 }): ReadHook & { data?: StakePosition } {
   const { address } = useConnection();
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/stake/useStakeRewardContracts.ts
+++ b/packages/hooks/src/stake/useStakeRewardContracts.ts
@@ -97,7 +97,7 @@ export function useStakeRewardContracts({
   const walletChainId = useChainId();
   const chainId = walletChainId === TENDERLY_CHAIN_ID ? walletChainId : mainnet.id;
   const config = useConfig();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   // Get chainId-specific hardcoded contracts for placeholder
   const hardcodedContracts = getHardcodedRewardContracts(chainId);

--- a/packages/hooks/src/stake/useStakeUserDelegates.ts
+++ b/packages/hooks/src/stake/useStakeUserDelegates.ts
@@ -60,7 +60,7 @@ export function useStakeUserDelegates({
   sortType?: 'totalDelegated' | 'aligned';
 }): ReadHook & { data?: DelegateInfoWithTotal[] } {
   const hasInitiallyOrdered = useRef(false);
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data: userDelegatesData,

--- a/packages/hooks/src/stake/useTotalUserStaked.ts
+++ b/packages/hooks/src/stake/useTotalUserStaked.ts
@@ -32,7 +32,7 @@ export function useTotalUserStaked({
 } = {}): ReadHook & { data?: bigint } {
   const { address } = useConnection();
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/stake/useUrnsInfo.ts
+++ b/packages/hooks/src/stake/useUrnsInfo.ts
@@ -61,7 +61,7 @@ export function useUrnsInfo({
   chainId: number;
   user: `0x${string}`;
 }): ReadHook & { data?: UrnInfo[] } {
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,

--- a/packages/hooks/src/stusds/useStUsdsHistory.ts
+++ b/packages/hooks/src/stusds/useStUsdsHistory.ts
@@ -131,7 +131,7 @@ export function useStUsdsHistory({
 } = {}): StUsdsHistoryHook {
   const { address } = useConnection();
   const currentChainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
 
   const {

--- a/packages/hooks/src/upgrade/useUpgradeHistory.ts
+++ b/packages/hooks/src/upgrade/useUpgradeHistory.ts
@@ -121,7 +121,7 @@ export function useUpgradeHistory({
 } = {}): ReadHook & { data?: UpgradeHistory } {
   const { address } = useConnection();
   const currentChainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(currentChainId) || '';
   const chainIdToUse = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
 
   const {

--- a/packages/hooks/src/upgrade/useUpgradeTotals.ts
+++ b/packages/hooks/src/upgrade/useUpgradeTotals.ts
@@ -47,7 +47,7 @@ export function useUpgradeTotals({
   subgraphUrl?: string;
 } = {}): ReadHook & { data?: UpgradeTotals } {
   const chainId = useChainId();
-  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl() || '';
+  const urlSubgraph = subgraphUrl ? subgraphUrl : getSubgraphUrl(chainId) || '';
 
   const {
     data,


### PR DESCRIPTION
## Summary

Adds support for an optional chainId path segment on the indexer endpoint (`/indexer/:chainId`) so requests can be routed to the chain-specific indexer (e.g. Tenderly envio). Mirrors the existing `/rpc/:chainId` pattern.

- `useSubgraphUrl()` now reads the active chainId from wagmi and appends it to the URL.
- `useSubgraphUrl()` also falls back to `https://staging-proxy.sky.money` when `VITE_PROXY_ORIGIN` is unset (previously fell back to an empty origin).
- `getSubgraphUrl(chainId)` now requires the chainId argument.
- All call sites in `packages/hooks` pass the chainId already in scope (`useChainId()` / `currentChainId` / `chainIdToUse` / prop).

Non-breaking on the server: the proxy still serves the bare `/indexer` path.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (no new warnings)
- [ ] `pnpm test` (CI)
- [ ] Dev smoke against mainnet: history panels (Upgrade, Savings, Rewards, Stake, Seal) request `/indexer/1` and load
- [ ] Dev smoke against Tenderly (chainId 314310): requests hit `/indexer/314310` and pull data from the Tenderly envio indexer
- [ ] Regression check on an L2 (e.g. Base 8453): `/indexer/8453` returns data