### PR TITLE
APP-236: Wire Fixed Yield (Pendle) into the shared widget event-callback pattern

### DIFF
--- a/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
@@ -22,6 +22,7 @@ import { FixedIntentMapping, QueryParams } from '@/lib/constants';
 import { Heading, Text } from '@/modules/layout/components/Typography';
 import { SharedProps } from '@/modules/app/types/Widgets';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import { useWidgetAnalytics } from '@/modules/analytics/hooks/useWidgetAnalytics';
 import { PendleMarketStatsCard } from './PendleMarketStatsCard';
 import { PendleReadyToRedeemList } from './PendleReadyToRedeemList';
 
@@ -36,6 +37,7 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
   const chainId = useChainId();
   const isOnPendleChain = isTestnetId(chainId) || chainId === mainnet.id;
   const [batchEnabled, setBatchEnabled] = useBatchToggle();
+  const onAnalyticsEvent = useWidgetAnalytics('fixed', chainId);
 
   const selectedMarketAddress = searchParams.get(QueryParams.Market);
   const selectedMarket = useMemo(() => findMarket(selectedMarketAddress), [selectedMarketAddress]);
@@ -107,6 +109,7 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
             market={selectedMarket!}
             onExternalLinkClicked={sharedProps.onExternalLinkClicked}
             onBackToPendle={handleBack}
+            onAnalyticsEvent={onAnalyticsEvent}
             batchEnabled={batchEnabled}
             setBatchEnabled={setBatchEnabled}
           />

--- a/apps/webapp/src/modules/pendle/components/__tests__/PendleWidgetPane.test.tsx
+++ b/apps/webapp/src/modules/pendle/components/__tests__/PendleWidgetPane.test.tsx
@@ -13,6 +13,10 @@ i18n.activate('en');
 const ACTIVE_MARKET_ADDRESS = '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33' as const;
 const MATURED_MARKET_ADDRESS = '0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1' as const;
 
+const onAnalyticsEventMock = vi.fn();
+
+let capturedWidgetProps: Record<string, any> | undefined;
+
 const hoisted = vi.hoisted(() => ({
   activeMarket: {
     name: 'PT-USDG',
@@ -85,7 +89,10 @@ vi.mock('@jetstreamgg/sky-widgets', async importOriginal => {
   return {
     ...actual,
     CardAnimationWrapper: ({ children }: { children: ReactNode }) => <>{children}</>,
-    PendleWidget: () => <div data-testid="pendle-widget-stub" />,
+    PendleWidget: (props: Record<string, any>) => {
+      capturedWidgetProps = props;
+      return <div data-testid="pendle-widget-stub" />;
+    },
     WidgetContainer: ({
       children,
       header,
@@ -136,6 +143,10 @@ vi.mock('motion/react', async importOriginal => {
 vi.mock('@/modules/layout/components/Typography', () => ({
   Heading: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Text: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}));
+
+vi.mock('@/modules/analytics/hooks/useWidgetAnalytics', () => ({
+  useWidgetAnalytics: () => onAnalyticsEventMock
 }));
 
 vi.mock('@/modules/ui/context/TransactionContext', () => ({
@@ -208,6 +219,8 @@ describe('PendleWidgetPane', () => {
   beforeEach(() => {
     mockSearchParams = new URLSearchParams('widget=fixed');
     setSearchParamsMock.mockClear();
+    onAnalyticsEventMock.mockClear();
+    capturedWidgetProps = undefined;
     // Reset connection + balances between tests.
     hoisted.userAddress = undefined;
     hoisted.ptBalances = undefined;
@@ -237,6 +250,18 @@ describe('PendleWidgetPane', () => {
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('[data-testid="pendle-widget-stub"]')).not.toBeNull();
+
+    unmount();
+  });
+
+  it('passes the useWidgetAnalytics callback through to PendleWidget as onAnalyticsEvent', () => {
+    mockSearchParams = new URLSearchParams(
+      `widget=fixed&fixed_module=market&market=${ACTIVE_MARKET_ADDRESS}`
+    );
+
+    const { unmount } = renderComponent(<PendleWidgetPane {...sharedProps} />);
+
+    expect(capturedWidgetProps?.onAnalyticsEvent).toBe(onAnalyticsEventMock);
 
     unmount();
   });

--- a/apps/webapp/src/modules/pendle/hooks/__tests__/usePendleRedeemModal.test.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/__tests__/usePendleRedeemModal.test.tsx
@@ -1,0 +1,221 @@
+/// <reference types="vite/client" />
+
+import { act, useEffect, type ReactNode } from 'react';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mainnet } from 'viem/chains';
+import { pendleAnalyticsData } from '@jetstreamgg/sky-widgets';
+import type { PendleConvertQuote, PendleMarketConfig } from '@jetstreamgg/sky-hooks';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+i18n.load('en', {});
+i18n.activate('en');
+
+const MATURED_MARKET: PendleMarketConfig = {
+  name: 'PT-USDG',
+  marketAddress: '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33',
+  ptToken: '0x9db38d74a0d29380899ad354121dfb521adb0548',
+  ytToken: '0x4a1294749a70bc32a998b49dd11bf26e9379e3c1',
+  syToken: '0xc1799cab1f201946f7cfafbaf1bcc089b2f08927',
+  underlyingToken: '0xe343167631d89b6ffc58b88d6b7fb0228795491d',
+  underlyingSymbol: 'USDG',
+  underlyingDecimals: 6,
+  expiry: 1_700_000_000 // matured (2023)
+};
+
+const PT_BALANCE = 1_500_000n; // 1.5 PT-USDG (6dp)
+
+const QUOTE: PendleConvertQuote = {
+  method: 'exitPostExpToToken',
+  amountOut: 1_499_500n,
+  apiMinOut: 1_484_505n,
+  effectiveApy: 0.054,
+  impliedApy: 0.06,
+  priceImpact: -0.0012,
+  aggregatorType: 'KYBERSWAP',
+  feeUsd: 1.23,
+  fetchedAt: Date.now(),
+  apiContractParams: [],
+  apiContractParamsName: []
+};
+
+const hoisted = vi.hoisted(() => ({
+  launchMock: vi.fn(),
+  matured: true
+}));
+
+vi.mock('@jetstreamgg/sky-hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@jetstreamgg/sky-hooks')>();
+  return {
+    ...actual,
+    isMarketMatured: () => hoisted.matured,
+    usePendleUserPtBalances: () => ({
+      data: { [MATURED_MARKET.marketAddress]: PT_BALANCE },
+      isLoading: false,
+      error: undefined,
+      mutate: () => undefined,
+      dataSources: []
+    }),
+    useQuotePendleConvert: () => ({
+      data: QUOTE,
+      isLoading: false,
+      error: undefined,
+      mutate: () => undefined,
+      dataSources: []
+    }),
+    useBatchPendleConvert: () => ({
+      execute: () => undefined,
+      reset: () => undefined,
+      prepared: true,
+      isLoading: false,
+      error: undefined,
+      currentCallIndex: 0
+    })
+  };
+});
+
+vi.mock('@jetstreamgg/sky-widgets', async importOriginal => {
+  const actual = await importOriginal<typeof import('@jetstreamgg/sky-widgets')>();
+  return {
+    ...actual,
+    // Heavy components inside the modal — render-irrelevant for these assertions.
+    PendleConfigMenu: () => null,
+    usePendleSlippage: () => ({
+      slippage: 0.01,
+      setSlippage: () => undefined,
+      defaultSlippage: 0.01
+    })
+  };
+});
+
+vi.mock('@/modules/ui/context/TransactionContext', () => ({
+  useTransaction: () => ({
+    launch: hoisted.launchMock,
+    updateModalContent: () => undefined,
+    isModalOpen: false,
+    txCallbacks: {
+      onMutate: () => undefined,
+      onStart: () => undefined,
+      onSuccess: () => undefined,
+      onError: () => undefined
+    },
+    txStatus: 'idle'
+  })
+}));
+
+vi.mock('../../components/PendleRedeem', () => ({
+  PendleRedeem: () => null
+}));
+
+import { usePendleRedeemModal } from '../usePendleRedeemModal';
+
+function renderComponent(ui: ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<I18nProvider i18n={i18n}>{ui}</I18nProvider>);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  };
+}
+
+const TestConsumer = ({ openOnMount = true }: { openOnMount?: boolean }) => {
+  const { openRedeemModal } = usePendleRedeemModal(MATURED_MARKET);
+  useEffect(() => {
+    if (openOnMount) openRedeemModal();
+  }, [openRedeemModal, openOnMount]);
+  return null;
+};
+
+describe('usePendleRedeemModal analytics', () => {
+  beforeEach(() => {
+    hoisted.launchMock.mockClear();
+    hoisted.matured = true;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves widgetName=fixed, flow=redeem, action=redeem on launch()', () => {
+    const { unmount } = renderComponent(<TestConsumer />);
+    expect(hoisted.launchMock).toHaveBeenCalledTimes(1);
+    const config = hoisted.launchMock.mock.calls[0][0];
+    expect(config.analytics.widgetName).toBe('fixed');
+    expect(config.analytics.flow).toBe('redeem');
+    expect(config.analytics.action).toBe('redeem');
+    unmount();
+  });
+
+  it('emits analytics.data shaped identically to pendleAnalyticsData(redeem)', () => {
+    const { unmount } = renderComponent(<TestConsumer />);
+    const config = hoisted.launchMock.mock.calls[0][0];
+
+    // Reconstruct the expected blob from the same inputs the hook used.
+    const ptToken = {
+      name: 'PT-USDG',
+      symbol: 'PT-USDG',
+      decimals: 6,
+      color: '#1BE3C2',
+      address: { [mainnet.id]: MATURED_MARKET.ptToken }
+    };
+    const underlyingToken = {
+      name: 'USDG',
+      symbol: 'USDG',
+      decimals: 6,
+      color: '#00C2A1',
+      address: { [mainnet.id]: MATURED_MARKET.underlyingToken }
+    };
+    const expected = pendleAnalyticsData({
+      market: MATURED_MARKET,
+      side: 'redeem',
+      originToken: ptToken,
+      targetToken: underlyingToken,
+      amountFromBigint: PT_BALANCE,
+      amountToBigint: QUOTE.amountOut,
+      fromDecimals: MATURED_MARKET.underlyingDecimals,
+      toDecimals: MATURED_MARKET.underlyingDecimals,
+      slippage: 0.01,
+      quote: QUOTE,
+      isBatchTx: true
+    });
+
+    // Each key in `expected` must be present on the launched blob with the
+    // same value. `amount` is added on top of that — assert separately below.
+    for (const [key, value] of Object.entries(expected)) {
+      expect(config.analytics.data[key]).toEqual(value);
+    }
+    unmount();
+  });
+
+  it('emits a strictly negative amount in analytics.data with PT-balance magnitude', () => {
+    const { unmount } = renderComponent(<TestConsumer />);
+    const config = hoisted.launchMock.mock.calls[0][0];
+    expect(config.analytics.data.amount).toBeLessThan(0);
+    expect(Math.abs(config.analytics.data.amount)).toBeCloseTo(1.5, 6);
+    unmount();
+  });
+
+  it('includes module=pendle and the consolidated Pendle fields', () => {
+    const { unmount } = renderComponent(<TestConsumer />);
+    const config = hoisted.launchMock.mock.calls[0][0];
+    const data = config.analytics.data;
+    expect(data.module).toBe('pendle');
+    expect(data.productAddress).toBe(MATURED_MARKET.marketAddress);
+    expect(data.ptAddress).toBe(MATURED_MARKET.ptToken);
+    expect(data.expiry).toBe(MATURED_MARKET.expiry);
+    expect(data.aggregatorType).toBe('KYBERSWAP');
+    expect(data.feeUsd).toBe(1.23);
+    unmount();
+  });
+});

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { t } from '@lingui/core/macro';
 import { mainnet } from 'viem/chains';
+import { formatUnits } from 'viem';
 import {
+  getTokenDecimals,
   isMarketMatured,
   PendleConvertSide,
   useBatchPendleConvert,
@@ -10,7 +12,12 @@ import {
   type PendleMarketConfig,
   type Token
 } from '@jetstreamgg/sky-hooks';
-import { PendleConfigMenu, usePendleSlippage, usePendleTokens } from '@jetstreamgg/sky-widgets';
+import {
+  PendleConfigMenu,
+  pendleAnalyticsData,
+  usePendleSlippage,
+  usePendleTokens
+} from '@jetstreamgg/sky-widgets';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { PendleRedeem } from '../components/PendleRedeem';
 
@@ -35,7 +42,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
   const matured = isMarketMatured(market.expiry);
   const isRedeemable = matured && ptBalance > 0n;
 
-  const { underlyingToken, inputTokenList } = usePendleTokens(market);
+  const { underlyingToken, ptToken, inputTokenList } = usePendleTokens(market);
   const [selectedOutputToken, setSelectedOutputToken] = useState<Token>(underlyingToken);
   const outputTokenAddress = selectedOutputToken.address[mainnet.id] as `0x${string}`;
 
@@ -139,6 +146,23 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
   const confirmDisabled = !writeHook.prepared || isFetchingQuote || writeHook.isLoading;
 
   const openRedeemModal = useCallback(() => {
+    const toDecimals = getTokenDecimals(selectedOutputToken, mainnet.id);
+    const data = pendleAnalyticsData({
+      market,
+      side: 'redeem',
+      originToken: ptToken,
+      targetToken: selectedOutputToken,
+      amountFromBigint: ptBalance,
+      amountToBigint: quote?.amountOut ?? 0n,
+      fromDecimals: market.underlyingDecimals,
+      toDecimals,
+      slippage,
+      quote,
+      isBatchTx: true
+    });
+    // `useAppAnalytics` has no sign-flip helper — emit the withdrawal sign
+    // explicitly so dashboard tiles filtering `properties.amount < 0` pick
+    // up redeem as a withdrawal alongside SELL.
     launch({
       title: t`Redeem PT-${market.underlyingSymbol}`,
       transactionContent,
@@ -152,18 +176,20 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
         flow: 'redeem',
         action: 'redeem',
         data: {
-          market: market.marketAddress,
-          underlyingSymbol: market.underlyingSymbol,
-          outputToken: selectedOutputToken.symbol
+          ...data,
+          amount: -Number(formatUnits(ptBalance, market.underlyingDecimals))
         }
       }
     });
   }, [
     launch,
     writeHook,
-    market.underlyingSymbol,
-    market.marketAddress,
-    selectedOutputToken.symbol,
+    market,
+    ptToken,
+    ptBalance,
+    selectedOutputToken,
+    quote,
+    slippage,
     transactionContent,
     rightHeaderComponent,
     confirmDisabled,

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -24,6 +24,11 @@ export type { PendleTokens } from './widgets/PendleWidget/hooks/usePendleTokens'
 export { usePendleSlippage } from './widgets/PendleWidget/hooks/usePendleSlippage';
 export type { PendleSlippageMode } from './widgets/PendleWidget/hooks/usePendleSlippage';
 export { PendleConfigMenu } from './widgets/PendleWidget/components/PendleConfigMenu';
+export { pendleAnalyticsData } from './widgets/PendleWidget/lib/pendleAnalyticsData';
+export type {
+  PendleAnalyticsDataInput,
+  PendleAnalyticsSide
+} from './widgets/PendleWidget/lib/pendleAnalyticsData';
 export { TokenDropdown } from './shared/components/ui/token/TokenDropdown';
 export { TransactionOverview } from './shared/components/ui/transaction/TransactionOverview';
 export { MorphoVaultBadge } from './widgets/MorphoVaultWidget/components/MorphoVaultBadge';

--- a/packages/widgets/src/widgets/PendleWidget/hooks/usePendleTransactionCallbacks.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/hooks/usePendleTransactionCallbacks.tsx
@@ -1,0 +1,170 @@
+import { useRef } from 'react';
+import { formatUnits } from 'viem';
+import { t } from '@lingui/core/macro';
+import { getTransactionLink } from '@jetstreamgg/sky-utils';
+import {
+  PendleConvertSide,
+  type PendleConvertQuote,
+  type PendleMarketConfig,
+  type Token
+} from '@jetstreamgg/sky-hooks';
+import { TxStatus } from '@widgets/shared/constants';
+import { WidgetProps, WidgetState } from '@widgets/shared/types/widgetState';
+import { WidgetAnalyticsEvent, WidgetAnalyticsEventType } from '@widgets/shared/types/analyticsEvents';
+import { PendleFlow, PendleScreen } from '../lib/constants';
+import { pendleAnalyticsData, type PendleAnalyticsSide } from '../lib/pendleAnalyticsData';
+
+type UsePendleTransactionCallbacksParameters = Pick<WidgetProps, 'onNotification' | 'onAnalyticsEvent'> & {
+  flow: PendleFlow;
+  side: PendleConvertSide;
+  market: PendleMarketConfig;
+  originToken: Token;
+  targetToken: Token;
+  amount: bigint;
+  fromDecimals: number;
+  toDecimals: number;
+  slippage: number;
+  quote?: PendleConvertQuote;
+  needsAllowance: boolean;
+  shouldUseBatch: boolean;
+  chainId: number;
+  address?: `0x${string}`;
+  isSafeWallet: boolean;
+  setTxStatus: (status: TxStatus) => void;
+  setExternalLink: (link: string | undefined) => void;
+  setWidgetState: (updater: (prev: WidgetState) => WidgetState) => void;
+  refetchInputBalance: () => void;
+  refetchOutputBalance: () => void;
+  refetchPtBalance: () => void;
+};
+
+export function usePendleTransactionCallbacks({
+  flow,
+  side,
+  market,
+  originToken,
+  targetToken,
+  amount,
+  fromDecimals,
+  toDecimals,
+  slippage,
+  quote,
+  needsAllowance,
+  shouldUseBatch,
+  chainId,
+  address,
+  isSafeWallet,
+  setTxStatus,
+  setExternalLink,
+  setWidgetState,
+  refetchInputBalance,
+  refetchOutputBalance,
+  refetchPtBalance,
+  onNotification,
+  onAnalyticsEvent
+}: UsePendleTransactionCallbacksParameters) {
+  // Tracks which step of a non-batch sequence we're on (approve → main).
+  const supplyStepRef = useRef(0);
+
+  const mainAction: 'supply' | 'withdraw' = side === PendleConvertSide.BUY ? 'supply' : 'withdraw';
+  const analyticsSide: PendleAnalyticsSide = side === PendleConvertSide.BUY ? 'buy' : 'sell';
+  const formattedAmount = Number(formatUnits(amount, fromDecimals));
+
+  const buildData = () =>
+    pendleAnalyticsData({
+      market,
+      side: analyticsSide,
+      originToken,
+      targetToken,
+      amountFromBigint: amount,
+      amountToBigint: quote?.amountOut ?? 0n,
+      fromDecimals,
+      toDecimals,
+      slippage,
+      quote,
+      isBatchTx: shouldUseBatch
+    });
+
+  // Analytics must never break functionality.
+  const fireAnalytics = (event: WidgetAnalyticsEvent) => {
+    try {
+      onAnalyticsEvent?.(event);
+    } catch {
+      // swallow
+    }
+  };
+
+  return {
+    onMutate: () => {
+      const step = supplyStepRef.current;
+      supplyStepRef.current++;
+      const isApproveStep = needsAllowance && !shouldUseBatch && step === 0;
+
+      setTxStatus(TxStatus.INITIALIZED);
+      setExternalLink(undefined);
+      setWidgetState((prev: WidgetState) => ({ ...prev, screen: PendleScreen.TRANSACTION }));
+
+      fireAnalytics({
+        event: WidgetAnalyticsEventType.TRANSACTION_STARTED,
+        action: isApproveStep ? 'approve' : mainAction,
+        flow: mainAction,
+        amount: formattedAmount,
+        data: buildData()
+      });
+    },
+    onStart: (hash: string | undefined) => {
+      setTxStatus(TxStatus.LOADING);
+      if (hash) {
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
+    },
+    onSuccess: (hash: string | undefined) => {
+      supplyStepRef.current = 0;
+      refetchInputBalance();
+      refetchOutputBalance();
+      refetchPtBalance();
+      setTxStatus(TxStatus.SUCCESS);
+      if (hash) {
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
+      onNotification?.({
+        title: flow === PendleFlow.BUY ? t`Supply complete` : t`Withdrawal complete`,
+        description:
+          flow === PendleFlow.BUY
+            ? t`PT-${market.underlyingSymbol} delivered to your wallet.`
+            : t`${targetToken.symbol} delivered to your wallet.`,
+        status: TxStatus.SUCCESS
+      });
+
+      fireAnalytics({
+        event: WidgetAnalyticsEventType.TRANSACTION_COMPLETED,
+        action: mainAction,
+        flow: mainAction,
+        txHash: hash,
+        amount: formattedAmount,
+        data: buildData()
+      });
+    },
+    onError: (err: Error, hash: string | undefined) => {
+      supplyStepRef.current = 0;
+      setTxStatus(TxStatus.ERROR);
+      if (hash) {
+        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
+      }
+      onNotification?.({
+        title: t`Transaction failed`,
+        description: err.message,
+        status: TxStatus.ERROR
+      });
+
+      fireAnalytics({
+        event: WidgetAnalyticsEventType.TRANSACTION_ERROR,
+        action: mainAction,
+        flow: mainAction,
+        txHash: hash,
+        amount: formattedAmount,
+        data: buildData()
+      });
+    }
+  };
+}

--- a/packages/widgets/src/widgets/PendleWidget/index.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/index.tsx
@@ -1,10 +1,12 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
+import { formatUnits } from 'viem';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
 import { useChainId } from 'wagmi';
 import { useConnection } from 'wagmi';
 import {
+  getTokenDecimals,
   PENDLE_ROUTER_V4_ADDRESS,
   PendleConvertSide,
   useBatchPendleConvert,
@@ -15,7 +17,7 @@ import {
   type PendleMarketConfig,
   type Token
 } from '@jetstreamgg/sky-hooks';
-import { isTestnetId, getTransactionLink, useDebounce, useIsSafeWallet } from '@jetstreamgg/sky-utils';
+import { isTestnetId, useDebounce, useIsSafeWallet } from '@jetstreamgg/sky-utils';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@widgets/components/ui/button';
 import { WidgetContainer } from '@widgets/shared/components/ui/widget/WidgetContainer';
@@ -28,10 +30,13 @@ import { AnimatePresence } from 'motion/react';
 import { TxStatus } from '@widgets/shared/constants';
 import { WidgetContext } from '@widgets/context/WidgetContext';
 import { WidgetProps, WidgetState } from '@widgets/shared/types/widgetState';
+import { WidgetAnalyticsEventType } from '@widgets/shared/types/analyticsEvents';
 import { mainnet } from 'viem/chains';
 import { PendleAction, PendleFlow, PendleScreen } from './lib/constants';
 import { usePendleSlippage } from './hooks/usePendleSlippage';
 import { usePendleTokens } from './hooks/usePendleTokens';
+import { usePendleTransactionCallbacks } from './hooks/usePendleTransactionCallbacks';
+import { pendleAnalyticsData } from './lib/pendleAnalyticsData';
 import { SupplyWithdraw } from './components/SupplyWithdraw';
 import { PendleConfigMenu } from './components/PendleConfigMenu';
 import { PendlePoweredBy } from './components/PendlePoweredBy';
@@ -55,6 +60,7 @@ const PendleWidgetWrapped = ({
   onConnect,
   rightHeaderComponent,
   onNotification,
+  onAnalyticsEvent,
   onExternalLinkClicked,
   onBackToPendle,
   enabled = true,
@@ -187,47 +193,34 @@ const PendleWidgetWrapped = ({
     return balance !== undefined && debouncedAmount > balance;
   }, [isConnectedAndEnabled, amount, debouncedAmount, flow, inputBalance, ptBalance]);
 
-  const txCallbacks = {
-    onMutate: () => {
-      setTxStatus(TxStatus.INITIALIZED);
-      setExternalLink(undefined);
-      setWidgetState((prev: WidgetState) => ({ ...prev, screen: PendleScreen.TRANSACTION }));
-    },
-    onStart: (hash: string | undefined) => {
-      setTxStatus(TxStatus.LOADING);
-      if (hash) {
-        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
-      }
-    },
-    onSuccess: (hash: string | undefined) => {
-      refetchInputBalance();
-      refetchOutputBalance();
-      refetchPtBalance();
-      setTxStatus(TxStatus.SUCCESS);
-      if (hash) {
-        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
-      }
-      onNotification?.({
-        title: flow === PendleFlow.BUY ? t`Supply complete` : t`Withdrawal complete`,
-        description:
-          flow === PendleFlow.BUY
-            ? t`PT-${market.underlyingSymbol} delivered to your wallet.`
-            : t`${targetToken.symbol} delivered to your wallet.`,
-        status: TxStatus.SUCCESS
-      });
-    },
-    onError: (err: Error, hash: string | undefined) => {
-      setTxStatus(TxStatus.ERROR);
-      if (hash) {
-        setExternalLink(getTransactionLink(chainId, address, hash, isSafeWallet));
-      }
-      onNotification?.({
-        title: t`Transaction failed`,
-        description: err.message,
-        status: TxStatus.ERROR
-      });
-    }
-  };
+  const fromDecimals = getTokenDecimals(originToken, mainnet.id);
+  const toDecimals = getTokenDecimals(targetToken, mainnet.id);
+
+  const txCallbacks = usePendleTransactionCallbacks({
+    flow,
+    side,
+    market,
+    originToken,
+    targetToken,
+    amount: debouncedAmount,
+    fromDecimals,
+    toDecimals,
+    slippage,
+    quote,
+    needsAllowance,
+    shouldUseBatch,
+    chainId,
+    address,
+    isSafeWallet,
+    setTxStatus,
+    setExternalLink,
+    setWidgetState,
+    refetchInputBalance,
+    refetchOutputBalance,
+    refetchPtBalance,
+    onNotification,
+    onAnalyticsEvent
+  });
 
   const batchConvert = useBatchPendleConvert({
     side,
@@ -276,6 +269,31 @@ const PendleWidgetWrapped = ({
 
   const reviewOnClick = () => {
     setScreen(PendleScreen.REVIEW);
+
+    try {
+      const analyticsFlow = side === PendleConvertSide.BUY ? 'supply' : 'withdraw';
+      onAnalyticsEvent?.({
+        event: WidgetAnalyticsEventType.REVIEW_VIEWED,
+        action: analyticsFlow,
+        flow: analyticsFlow,
+        amount: Number(formatUnits(debouncedAmount, fromDecimals)),
+        data: pendleAnalyticsData({
+          market,
+          side: side === PendleConvertSide.BUY ? 'buy' : 'sell',
+          originToken,
+          targetToken,
+          amountFromBigint: debouncedAmount,
+          amountToBigint: quote?.amountOut ?? 0n,
+          fromDecimals,
+          toDecimals,
+          slippage,
+          quote,
+          isBatchTx: shouldUseBatch
+        })
+      });
+    } catch {
+      // Analytics must never break functionality
+    }
   };
 
   const nextOnClick = () => {

--- a/packages/widgets/src/widgets/PendleWidget/lib/pendleAnalyticsData.test.ts
+++ b/packages/widgets/src/widgets/PendleWidget/lib/pendleAnalyticsData.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest';
+import { mainnet } from 'viem/chains';
+import type { PendleConvertQuote, PendleMarketConfig, Token } from '@jetstreamgg/sky-hooks';
+import { pendleAnalyticsData } from './pendleAnalyticsData';
+
+const MARKET: PendleMarketConfig = {
+  name: 'PT-USDG',
+  marketAddress: '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33',
+  ptToken: '0x9db38d74a0d29380899ad354121dfb521adb0548',
+  ytToken: '0x4a1294749a70bc32a998b49dd11bf26e9379e3c1',
+  syToken: '0xc1799cab1f201946f7cfafbaf1bcc089b2f08927',
+  underlyingToken: '0xe343167631d89b6ffc58b88d6b7fb0228795491d',
+  underlyingSymbol: 'USDG',
+  underlyingDecimals: 6,
+  // 30 days from now — concrete enough to exercise daysToMaturity rounding.
+  expiry: Math.floor(Date.now() / 1000) + 30 * 86_400
+};
+
+const MATURED_MARKET: PendleMarketConfig = {
+  ...MARKET,
+  expiry: 1_700_000_000 // 2023 — already matured
+};
+
+const USDG_TOKEN: Token = {
+  name: 'USDG',
+  symbol: 'USDG',
+  decimals: 6,
+  color: '#00C2A1',
+  address: { [mainnet.id]: MARKET.underlyingToken }
+};
+
+const USDS_TOKEN: Token = {
+  name: 'USDS',
+  symbol: 'USDS',
+  decimals: 18,
+  color: '#000000',
+  address: { [mainnet.id]: '0xdc035d45d973e3ec169d2276ddab16f1e407384f' }
+};
+
+const PT_TOKEN: Token = {
+  name: 'PT-USDG',
+  symbol: 'PT-USDG',
+  decimals: 6,
+  color: '#1BE3C2',
+  address: { [mainnet.id]: MARKET.ptToken }
+};
+
+const QUOTE: PendleConvertQuote = {
+  method: 'exitPostExpToToken',
+  amountOut: 1_500_000n,
+  apiMinOut: 1_485_000n,
+  effectiveApy: 0.054,
+  impliedApy: 0.06,
+  priceImpact: -0.0012,
+  aggregatorType: 'KYBERSWAP',
+  feeUsd: 1.23,
+  fetchedAt: Date.now(),
+  apiContractParams: [],
+  apiContractParamsName: []
+};
+
+describe('pendleAnalyticsData', () => {
+  describe('REDEEM shape', () => {
+    it('emits PT as from-side and selected output as to-side', () => {
+      const data = pendleAnalyticsData({
+        market: MATURED_MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDS_TOKEN,
+        amountFromBigint: 1_500_000n,
+        amountToBigint: 1_499_500n * 10n ** 12n, // ~1.4995 in USDS (18 decimals)
+        fromDecimals: 6,
+        toDecimals: 18,
+        slippage: 0.01,
+        quote: QUOTE,
+        isBatchTx: true
+      });
+
+      expect(data.tokenSymbolFrom).toBe('PT-USDG');
+      expect(data.tokenAddressFrom).toBe(MATURED_MARKET.ptToken);
+      expect(data.amountFrom).toBe(1.5);
+      expect(data.tokenSymbolTo).toBe('USDS');
+      expect(data.tokenAddressTo).toBe(USDS_TOKEN.address[mainnet.id]);
+      expect(data.amountTo).toBeCloseTo(1.4995, 4);
+    });
+
+    it('emits the consolidated Vaults-base + Pendle-specific fields', () => {
+      const data = pendleAnalyticsData({
+        market: MATURED_MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1_500_000n,
+        amountToBigint: 1_500_000n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        quote: QUOTE,
+        isBatchTx: true
+      });
+
+      expect(data.module).toBe('pendle');
+      expect(data.product).toBe(MATURED_MARKET.name);
+      expect(data.productAddress).toBe(MATURED_MARKET.marketAddress);
+      expect(data.assetAddress).toBe(MATURED_MARKET.underlyingToken);
+      expect(data.assetSymbol).toBe('USDG');
+      expect(data.ptAddress).toBe(MATURED_MARKET.ptToken);
+      expect(data.expiry).toBe(MATURED_MARKET.expiry);
+      expect(data.slippage).toBe(0.01);
+    });
+  });
+
+  describe('daysToMaturity', () => {
+    it('returns 0 for a market that has already matured', () => {
+      const data = pendleAnalyticsData({
+        market: MATURED_MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        isBatchTx: true
+      });
+
+      expect(data.daysToMaturity).toBe(0);
+    });
+
+    it('returns ~30 for a market 30 days out', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        isBatchTx: true
+      });
+
+      // Math.ceil((expiry*1000 - now) / 86_400_000) — between 29 and 31 covers
+      // wall-clock drift in the test runner.
+      expect(data.daysToMaturity).toBeGreaterThanOrEqual(29);
+      expect(data.daysToMaturity).toBeLessThanOrEqual(31);
+    });
+  });
+
+  describe('quote fields', () => {
+    it('includes aggregatorType, priceImpact, effectiveApy, feeUsd when quote is present', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        quote: QUOTE,
+        isBatchTx: true
+      });
+
+      expect(data.aggregatorType).toBe('KYBERSWAP');
+      expect(data.priceImpact).toBe(-0.0012);
+      expect(data.effectiveApy).toBe(0.054);
+      expect(data.feeUsd).toBe(1.23);
+    });
+
+    it('omits aggregatorType, priceImpact, effectiveApy, feeUsd when quote is undefined', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        isBatchTx: true
+      });
+
+      expect(data).not.toHaveProperty('aggregatorType');
+      expect(data).not.toHaveProperty('priceImpact');
+      expect(data).not.toHaveProperty('effectiveApy');
+      expect(data).not.toHaveProperty('feeUsd');
+    });
+
+    it('omits a quote field whose value is undefined while keeping the others', () => {
+      const partial: PendleConvertQuote = {
+        ...QUOTE,
+        aggregatorType: undefined,
+        feeUsd: undefined
+      };
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        quote: partial,
+        isBatchTx: true
+      });
+
+      expect(data).not.toHaveProperty('aggregatorType');
+      expect(data).not.toHaveProperty('feeUsd');
+      expect(data.priceImpact).toBe(-0.0012);
+      expect(data.effectiveApy).toBe(0.054);
+    });
+  });
+
+  describe('decimal conversion', () => {
+    it('formats USDC (6 decimals) correctly — 1_000_000n = 1', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1_000_000n,
+        amountToBigint: 1_000_000n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        isBatchTx: true
+      });
+
+      expect(data.amountFrom).toBe(1);
+      expect(data.amountTo).toBe(1);
+    });
+
+    it('handles 18-decimal target alongside 6-decimal origin', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDS_TOKEN,
+        amountFromBigint: 2_500_000n, // 2.5 PT (6dp)
+        amountToBigint: 2_500_000_000_000_000_000n, // 2.5 USDS (18dp)
+        fromDecimals: 6,
+        toDecimals: 18,
+        slippage: 0.01,
+        isBatchTx: true
+      });
+
+      expect(data.amountFrom).toBe(2.5);
+      expect(data.amountTo).toBe(2.5);
+    });
+  });
+
+  describe('isBatchTx', () => {
+    it('round-trips true', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        isBatchTx: true
+      });
+      expect(data.isBatchTx).toBe(true);
+    });
+
+    it('round-trips false', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'redeem',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1n,
+        amountToBigint: 1n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.01,
+        isBatchTx: false
+      });
+      expect(data.isBatchTx).toBe(false);
+    });
+  });
+});

--- a/packages/widgets/src/widgets/PendleWidget/lib/pendleAnalyticsData.test.ts
+++ b/packages/widgets/src/widgets/PendleWidget/lib/pendleAnalyticsData.test.ts
@@ -289,4 +289,98 @@ describe('pendleAnalyticsData', () => {
       expect(data.isBatchTx).toBe(false);
     });
   });
+
+  describe('BUY shape', () => {
+    it('emits the supply token as from-side and PT as to-side (USDG underlying, 6dp)', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'buy',
+        originToken: USDG_TOKEN,
+        targetToken: PT_TOKEN,
+        amountFromBigint: 1_000_000n, // 1 USDG (6dp)
+        amountToBigint: 1_500_000n, // 1.5 PT-USDG (6dp)
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.002,
+        quote: QUOTE,
+        isBatchTx: false
+      });
+
+      expect(data.tokenSymbolFrom).toBe('USDG');
+      expect(data.tokenAddressFrom).toBe(USDG_TOKEN.address[mainnet.id]);
+      expect(data.amountFrom).toBe(1);
+      expect(data.tokenSymbolTo).toBe('PT-USDG');
+      expect(data.tokenAddressTo).toBe(PT_TOKEN.address[mainnet.id]);
+      expect(data.amountTo).toBe(1.5);
+    });
+
+    it('threads non-underlying supply token decimals correctly (USDS, 18dp)', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'buy',
+        originToken: USDS_TOKEN, // 18dp underlying
+        targetToken: PT_TOKEN,
+        amountFromBigint: 2_500_000_000_000_000_000n, // 2.5 USDS (18dp)
+        amountToBigint: 2_500_000n, // 2.5 PT (6dp)
+        fromDecimals: 18,
+        toDecimals: 6,
+        slippage: 0.002,
+        quote: QUOTE,
+        isBatchTx: false
+      });
+
+      expect(data.tokenSymbolFrom).toBe('USDS');
+      expect(data.amountFrom).toBe(2.5);
+      expect(data.tokenSymbolTo).toBe('PT-USDG');
+      expect(data.amountTo).toBe(2.5);
+    });
+  });
+
+  describe('SELL shape', () => {
+    it('emits PT as from-side and the withdraw token as to-side (swap of BUY)', () => {
+      const data = pendleAnalyticsData({
+        market: MARKET,
+        side: 'sell',
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        amountFromBigint: 1_500_000n, // 1.5 PT (6dp)
+        amountToBigint: 1_000_000n, // 1 USDG (6dp)
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.002,
+        quote: QUOTE,
+        isBatchTx: false
+      });
+
+      expect(data.tokenSymbolFrom).toBe('PT-USDG');
+      expect(data.tokenAddressFrom).toBe(PT_TOKEN.address[mainnet.id]);
+      expect(data.amountFrom).toBe(1.5);
+      expect(data.tokenSymbolTo).toBe('USDG');
+      expect(data.tokenAddressTo).toBe(USDG_TOKEN.address[mainnet.id]);
+      expect(data.amountTo).toBe(1);
+    });
+  });
+
+  describe('BUY batch toggle', () => {
+    it('structurally matches non-batch BUY except for isBatchTx', () => {
+      const common = {
+        market: MARKET,
+        side: 'buy' as const,
+        originToken: USDG_TOKEN,
+        targetToken: PT_TOKEN,
+        amountFromBigint: 1_000_000n,
+        amountToBigint: 1_500_000n,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.002,
+        quote: QUOTE
+      };
+      const nonBatch = pendleAnalyticsData({ ...common, isBatchTx: false });
+      const batch = pendleAnalyticsData({ ...common, isBatchTx: true });
+
+      expect(nonBatch.isBatchTx).toBe(false);
+      expect(batch.isBatchTx).toBe(true);
+      expect({ ...nonBatch, isBatchTx: undefined }).toEqual({ ...batch, isBatchTx: undefined });
+    });
+  });
 });

--- a/packages/widgets/src/widgets/PendleWidget/lib/pendleAnalyticsData.ts
+++ b/packages/widgets/src/widgets/PendleWidget/lib/pendleAnalyticsData.ts
@@ -1,0 +1,65 @@
+import { formatUnits } from 'viem';
+import { mainnet } from 'viem/chains';
+import type { PendleConvertQuote, PendleMarketConfig, Token } from '@jetstreamgg/sky-hooks';
+
+export type PendleAnalyticsSide = 'buy' | 'sell' | 'redeem';
+
+export type PendleAnalyticsDataInput = {
+  market: PendleMarketConfig;
+  side: PendleAnalyticsSide;
+  originToken: Token;
+  targetToken: Token;
+  amountFromBigint: bigint;
+  amountToBigint: bigint;
+  fromDecimals: number;
+  toDecimals: number;
+  slippage: number;
+  quote?: PendleConvertQuote;
+  isBatchTx: boolean;
+};
+
+const MS_PER_DAY = 86_400_000;
+
+// `amount` in the consolidated blob (and the top-level event property where
+// applicable) is in `formatUnits` decimals — BUY's is underlying-token decimals,
+// SELL/REDEEM's is PT-token decimals. PT ≈ underlying at maturity, so
+// cross-direction aggregate sums are approximate. Same approximation PSM makes.
+export function pendleAnalyticsData(input: PendleAnalyticsDataInput): Record<string, unknown> {
+  const {
+    market,
+    isBatchTx,
+    originToken,
+    targetToken,
+    amountFromBigint,
+    amountToBigint,
+    fromDecimals,
+    toDecimals,
+    slippage,
+    quote
+  } = input;
+
+  const daysToMaturity = Math.max(0, Math.ceil((market.expiry * 1000 - Date.now()) / MS_PER_DAY));
+
+  return {
+    module: 'pendle',
+    product: market.name,
+    productAddress: market.marketAddress,
+    assetAddress: market.underlyingToken,
+    assetSymbol: market.underlyingSymbol,
+    isBatchTx,
+    tokenSymbolFrom: originToken.symbol,
+    tokenAddressFrom: originToken.address[mainnet.id],
+    amountFrom: Number(formatUnits(amountFromBigint, fromDecimals)),
+    tokenSymbolTo: targetToken.symbol,
+    tokenAddressTo: targetToken.address[mainnet.id],
+    amountTo: Number(formatUnits(amountToBigint, toDecimals)),
+    slippage,
+    ptAddress: market.ptToken,
+    expiry: market.expiry,
+    daysToMaturity,
+    ...(quote?.aggregatorType !== undefined && { aggregatorType: quote.aggregatorType }),
+    ...(quote?.priceImpact !== undefined && { priceImpact: quote.priceImpact }),
+    ...(quote?.effectiveApy !== undefined && { effectiveApy: quote.effectiveApy }),
+    ...(quote?.feeUsd !== undefined && { feeUsd: quote.feeUsd })
+  };
+}

--- a/packages/widgets/src/widgets/PendleWidget/tests/usePendleTransactionCallbacks.test.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/tests/usePendleTransactionCallbacks.test.tsx
@@ -1,0 +1,347 @@
+/// <reference types="vite/client" />
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { i18n } from '@lingui/core';
+import { mainnet } from 'viem/chains';
+import { PendleConvertSide } from '@jetstreamgg/sky-hooks';
+import type { PendleConvertQuote, PendleMarketConfig, Token } from '@jetstreamgg/sky-hooks';
+import { WidgetAnalyticsEventType } from '@widgets/shared/types/analyticsEvents';
+import { PendleFlow } from '../lib/constants';
+import { pendleAnalyticsData } from '../lib/pendleAnalyticsData';
+import { usePendleTransactionCallbacks } from '../hooks/usePendleTransactionCallbacks';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const MARKET: PendleMarketConfig = {
+  name: 'PT-USDG',
+  marketAddress: '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33',
+  ptToken: '0x9db38d74a0d29380899ad354121dfb521adb0548',
+  ytToken: '0x4a1294749a70bc32a998b49dd11bf26e9379e3c1',
+  syToken: '0xc1799cab1f201946f7cfafbaf1bcc089b2f08927',
+  underlyingToken: '0xe343167631d89b6ffc58b88d6b7fb0228795491d',
+  underlyingSymbol: 'USDG',
+  underlyingDecimals: 6,
+  expiry: Math.floor(Date.now() / 1000) + 30 * 86_400
+};
+
+const USDG_TOKEN: Token = {
+  name: 'USDG',
+  symbol: 'USDG',
+  decimals: 6,
+  color: '#00C2A1',
+  address: { [mainnet.id]: MARKET.underlyingToken }
+};
+
+const PT_TOKEN: Token = {
+  name: 'PT-USDG',
+  symbol: 'PT-USDG',
+  decimals: 6,
+  color: '#1BE3C2',
+  address: { [mainnet.id]: MARKET.ptToken }
+};
+
+const QUOTE: PendleConvertQuote = {
+  method: 'addLiquidityDualSyAndPt',
+  amountOut: 1_500_000n,
+  apiMinOut: 1_485_000n,
+  effectiveApy: 0.054,
+  impliedApy: 0.06,
+  priceImpact: -0.0012,
+  aggregatorType: 'KYBERSWAP',
+  feeUsd: 1.23,
+  fetchedAt: Date.now(),
+  apiContractParams: [],
+  apiContractParamsName: []
+};
+
+type BuildParams = Parameters<typeof usePendleTransactionCallbacks>[0];
+
+const baseParams = (overrides: Partial<BuildParams>): BuildParams => ({
+  flow: PendleFlow.BUY,
+  side: PendleConvertSide.BUY,
+  market: MARKET,
+  originToken: USDG_TOKEN,
+  targetToken: PT_TOKEN,
+  amount: 1_000_000n, // 1 USDG (6 decimals)
+  fromDecimals: 6,
+  toDecimals: 6,
+  slippage: 0.002,
+  quote: QUOTE,
+  needsAllowance: true,
+  shouldUseBatch: false,
+  chainId: mainnet.id,
+  address: '0x000000000000000000000000000000000000beef',
+  isSafeWallet: false,
+  setTxStatus: vi.fn(),
+  setExternalLink: vi.fn(),
+  setWidgetState: vi.fn(),
+  refetchInputBalance: vi.fn(),
+  refetchOutputBalance: vi.fn(),
+  refetchPtBalance: vi.fn(),
+  onNotification: vi.fn(),
+  onAnalyticsEvent: vi.fn(),
+  ...overrides
+});
+
+describe('usePendleTransactionCallbacks', () => {
+  describe('BUY non-batch with allowance needed', () => {
+    it('fires TRANSACTION_STARTED with action="approve" then action="supply" across two onMutate calls', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+      });
+      act(() => {
+        result.current.onMutate();
+      });
+
+      expect(onAnalyticsEvent).toHaveBeenCalledTimes(2);
+
+      const first = onAnalyticsEvent.mock.calls[0][0];
+      expect(first.event).toBe(WidgetAnalyticsEventType.TRANSACTION_STARTED);
+      expect(first.action).toBe('approve');
+      expect(first.flow).toBe('supply');
+
+      const second = onAnalyticsEvent.mock.calls[1][0];
+      expect(second.event).toBe(WidgetAnalyticsEventType.TRANSACTION_STARTED);
+      expect(second.action).toBe('supply');
+      expect(second.flow).toBe('supply');
+    });
+
+    it('emits a data blob matching pendleAnalyticsData() called with the same inputs', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+      });
+
+      const expectedData = pendleAnalyticsData({
+        market: MARKET,
+        side: 'buy',
+        originToken: USDG_TOKEN,
+        targetToken: PT_TOKEN,
+        amountFromBigint: 1_000_000n,
+        amountToBigint: QUOTE.amountOut,
+        fromDecimals: 6,
+        toDecimals: 6,
+        slippage: 0.002,
+        quote: QUOTE,
+        isBatchTx: false
+      });
+
+      expect(onAnalyticsEvent.mock.calls[0][0].data).toEqual(expectedData);
+    });
+  });
+
+  describe('BUY batch mode', () => {
+    it('fires TRANSACTION_STARTED once with action="supply"', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({
+        onAnalyticsEvent,
+        shouldUseBatch: true
+      });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+      });
+
+      expect(onAnalyticsEvent).toHaveBeenCalledTimes(1);
+      const evt = onAnalyticsEvent.mock.calls[0][0];
+      expect(evt.event).toBe(WidgetAnalyticsEventType.TRANSACTION_STARTED);
+      expect(evt.action).toBe('supply');
+      expect(evt.flow).toBe('supply');
+      expect(evt.data.isBatchTx).toBe(true);
+    });
+  });
+
+  describe('SELL non-batch with allowance needed', () => {
+    it('fires TRANSACTION_STARTED with action="approve" then action="withdraw"', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({
+        onAnalyticsEvent,
+        flow: PendleFlow.WITHDRAW,
+        side: PendleConvertSide.WITHDRAW,
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN
+      });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+      });
+      act(() => {
+        result.current.onMutate();
+      });
+
+      expect(onAnalyticsEvent).toHaveBeenCalledTimes(2);
+      expect(onAnalyticsEvent.mock.calls[0][0].action).toBe('approve');
+      expect(onAnalyticsEvent.mock.calls[0][0].flow).toBe('withdraw');
+      expect(onAnalyticsEvent.mock.calls[1][0].action).toBe('withdraw');
+      expect(onAnalyticsEvent.mock.calls[1][0].flow).toBe('withdraw');
+    });
+  });
+
+  describe('SELL batch mode', () => {
+    it('fires TRANSACTION_STARTED once with action="withdraw"', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({
+        onAnalyticsEvent,
+        flow: PendleFlow.WITHDRAW,
+        side: PendleConvertSide.WITHDRAW,
+        originToken: PT_TOKEN,
+        targetToken: USDG_TOKEN,
+        shouldUseBatch: true
+      });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+      });
+
+      expect(onAnalyticsEvent).toHaveBeenCalledTimes(1);
+      expect(onAnalyticsEvent.mock.calls[0][0].action).toBe('withdraw');
+    });
+  });
+
+  describe('onSuccess', () => {
+    it('fires exactly one TRANSACTION_COMPLETED with main action and txHash propagated', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onSuccess('0xabc' as `0x${string}`);
+      });
+
+      const completed = onAnalyticsEvent.mock.calls.filter(
+        c => c[0].event === WidgetAnalyticsEventType.TRANSACTION_COMPLETED
+      );
+      expect(completed).toHaveLength(1);
+      expect(completed[0][0].action).toBe('supply');
+      expect(completed[0][0].flow).toBe('supply');
+      expect(completed[0][0].txHash).toBe('0xabc');
+    });
+  });
+
+  describe('onError at step 0 (approve failure)', () => {
+    it('fires TRANSACTION_ERROR with the main action, not "approve"', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      // Simulate the approve step failing immediately (no prior onMutate completing the sequence)
+      act(() => {
+        result.current.onMutate();
+      });
+      act(() => {
+        result.current.onError(new Error('User rejected'), undefined);
+      });
+
+      const errors = onAnalyticsEvent.mock.calls.filter(
+        c => c[0].event === WidgetAnalyticsEventType.TRANSACTION_ERROR
+      );
+      expect(errors).toHaveLength(1);
+      // Matches Vaults inheritance: TRANSACTION_ERROR always carries main action
+      expect(errors[0][0].action).toBe('supply');
+      expect(errors[0][0].flow).toBe('supply');
+    });
+  });
+
+  describe('analytics resilience', () => {
+    it('does not throw when onAnalyticsEvent throws', () => {
+      const onAnalyticsEvent = vi.fn(() => {
+        throw new Error('analytics broke');
+      });
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      expect(() => {
+        act(() => {
+          result.current.onMutate();
+        });
+      }).not.toThrow();
+      expect(() => {
+        act(() => {
+          result.current.onSuccess('0xabc' as `0x${string}`);
+        });
+      }).not.toThrow();
+      expect(() => {
+        act(() => {
+          result.current.onError(new Error('boom'), undefined);
+        });
+      }).not.toThrow();
+    });
+
+    it('does not throw when onAnalyticsEvent is undefined', () => {
+      const params = baseParams({ onAnalyticsEvent: undefined });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      expect(() => {
+        act(() => {
+          result.current.onMutate();
+          result.current.onStart('0xabc' as `0x${string}`);
+          result.current.onSuccess('0xabc' as `0x${string}`);
+          result.current.onError(new Error('boom'), '0xabc' as `0x${string}`);
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('supplyStepRef reset', () => {
+    it('resets to 0 after onSuccess so the next sequence starts at approve again', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+        result.current.onMutate();
+        result.current.onSuccess('0xabc' as `0x${string}`);
+      });
+      onAnalyticsEvent.mockClear();
+
+      act(() => {
+        result.current.onMutate();
+      });
+
+      // The next onMutate after a completed sequence should again be the approve step.
+      expect(onAnalyticsEvent.mock.calls[0][0].action).toBe('approve');
+    });
+
+    it('resets to 0 after onError', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+
+      act(() => {
+        result.current.onMutate();
+        result.current.onError(new Error('boom'), undefined);
+      });
+      onAnalyticsEvent.mockClear();
+
+      act(() => {
+        result.current.onMutate();
+      });
+
+      expect(onAnalyticsEvent.mock.calls[0][0].action).toBe('approve');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixed Yield (Pendle) was the only in-pane widget that hadn't adopted the shared `onAnalyticsEvent` / `WidgetAnalyticsEvent` contract used by Savings, Morpho Vaults, Trade, PSM, Rewards, Stake, Upgrade, and StUSDS. This PR closes that gap and aligns the matured-PT redeem modal with the same event-data shape so all three Fixed Yield operations (buy / sell / redeem) emit a consistent payload.

### What changed

- **New `pendleAnalyticsData` utility** (`packages/widgets/src/widgets/PendleWidget/lib/`) — pure function that builds the consolidated event `data` payload (module/product/asset base mirroring `MorphoVault`, plus the trade-style from/to/amount pair from `useTradeAnalytics`, plus the Pendle-specific fields: PT address, expiry, aggregator type, effective APY, fee). Importable from both the widget package and the webapp so redeem and buy/sell share one schema.
- **New `usePendleTransactionCallbacks` hook** — Pendle's counterpart to `useMorphoVaultTransactionCallbacks`. Wraps the shared transaction callbacks, owns a `supplyStepRef` to distinguish the approve step from the main action in non-batch flows, and threads `onAnalyticsEvent` through every lifecycle event.
- **`PendleWidget`** now accepts `onAnalyticsEvent`, replaces its inline `txCallbacks` with the new hook, and fires the review event on every entry into the review screen (matching Savings / Vaults precedent).
- **`PendleWidgetPane`** picks up `useWidgetAnalytics('fixed', chainId)` and threads it through, mirroring every other widget pane.
- **`usePendleRedeemModal`** aligns its existing event metadata with the new shape and signs its top-level amount so the redeem rolls into cross-direction aggregates the same way `MorphoVault` withdrawals do.

### What didn't change

- No new dependencies in any `package.json`.
- Zero modifications to the shared `useWidgetAnalytics` / `useAppAnalytics` / `TransactionContext` contracts — Pendle conforms to them, doesn't extend them.
- No transaction-logic changes in `useBatchPendleConvert`, `useQuotePendleConvert`, slippage handling, or the error-message mapper. Purely additive instrumentation.
- No dashboard / cron worker / webapp config changes. Those are separate follow-up tickets.

## Test plan

Unit and component test coverage added in the diff:

- `pendleAnalyticsData.test.ts` — pure-function shape coverage across buy / sell / redeem with and without quote, batch toggle, and non-18-decimal underlyings (USDC).
- `usePendleTransactionCallbacks.test.tsx` — lifecycle event firing, approve-step detection, error-event inheritance from the main action, step-counter reset between sequences.
- `usePendleRedeemModal.test.tsx` — confirms the redeem modal launches with the new event metadata shape and signed amount.
- `PendleWidgetPane.test.tsx` — asserts `onAnalyticsEvent` is threaded to `<PendleWidget />`.

Manual:

- [ ] BUY PT happy path with batch — one combined transaction
- [ ] BUY PT happy path without batch — approve then supply
- [ ] SELL PT happy path with batch
- [ ] SELL PT happy path without batch — approve PT then withdraw
- [ ] REDEEM happy path on a matured PT card
- [ ] REDEEM modal dismissed mid-flow — produces the expected cancellation status (modal flow only; in-pane flows match every other widget)
- [ ] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm prettier:check` all green

## Related

- Closes APP-236
- Follow-ups (separate tickets, intentionally out of scope here): dashboard query updates, analytics-cron module support, cross-widget wallet-rejection detection refactor
