### PR TITLE
feat(balances): Fixed Yield cards in Balances widget and details pane

### DIFF
--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -177,6 +177,11 @@ export const getVaultsOverviewUrl = (searchParams: URLSearchParams, chainId: num
     `/?network=${getMainnetChainName(chainId)}&widget=${mapIntentToQueryParam(Intent.VAULTS_INTENT)}`,
     searchParams
   );
+export const getFixedYieldUrl = (searchParams: URLSearchParams, chainId: number) =>
+  getQueryParams(
+    `/?network=${getMainnetChainName(chainId)}&widget=${mapIntentToQueryParam(Intent.FIXED_INTENT)}`,
+    searchParams
+  );
 export const getConvertUrl = (searchParams: URLSearchParams, chainId: number) =>
   getQueryParams(
     `/?network=${getMainnetChainName(chainId)}&widget=${mapIntentToQueryParam(Intent.CONVERT_INTENT)}`,

--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -143,7 +143,8 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
     }
   }, []);
 
-  const { rewardsUrl, savingsUrlMap, sealUrl, stakeUrl, stusdsUrl, vaultsUrl } = useModuleUrls();
+  const { rewardsUrl, savingsUrlMap, sealUrl, stakeUrl, stusdsUrl, vaultsUrl, fixedYieldUrl } =
+    useModuleUrls();
   const rewardContracts = useAvailableTokenRewardContracts(chainId);
   const rewardSubItems = rewardContracts
     .filter(contract => contract.rewardToken.symbol !== 'SKY')
@@ -201,6 +202,7 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
           stakeCardUrl={stakeUrl}
           stusdsCardUrl={isRegionRestricted ? undefined : stusdsUrl}
           vaultsCardUrl={vaultsUrl}
+          fixedYieldCardUrl={fixedYieldUrl}
           chainIds={getSupportedChainIds(chainId)}
           hideZeroBalances={hideZeroBalances}
           setHideZeroBalances={setHideZeroBalances}

--- a/apps/webapp/src/modules/app/hooks/useModuleUrls.tsx
+++ b/apps/webapp/src/modules/app/hooks/useModuleUrls.tsx
@@ -2,6 +2,7 @@ import { getSupportedChainIds } from '@/data/wagmi/config/config.default';
 import {
   getConvertUrl,
   getExpertOverviewUrl,
+  getFixedYieldUrl,
   getRewardsUrl,
   getSavingsUrl,
   getSealUrl,
@@ -29,6 +30,7 @@ export const useModuleUrls = () => {
   const stusdsUrl = getStUsdsUrl(searchParams, chainId);
   const vaultsUrl = getVaultsOverviewUrl(searchParams, chainId);
   const convertUrl = getConvertUrl(searchParams, chainId);
+  const fixedYieldUrl = getFixedYieldUrl(searchParams, chainId);
 
   return {
     rewardsUrl,
@@ -38,6 +40,7 @@ export const useModuleUrls = () => {
     expertOverviewUrl,
     stusdsUrl,
     vaultsUrl,
-    convertUrl
+    convertUrl,
+    fixedYieldUrl
   };
 };

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
@@ -50,7 +50,16 @@ import type { ModuleId } from '@/modules/geo-config';
 type BalancesAction = {
   label: string;
   tokens: string[];
-  module: 'convert' | 'morpho' | 'rewards' | 'savings' | 'stusds' | 'stake' | 'trade' | 'upgrade' | 'fixedYield';
+  module:
+    | 'convert'
+    | 'morpho'
+    | 'rewards'
+    | 'savings'
+    | 'stusds'
+    | 'stake'
+    | 'trade'
+    | 'upgrade'
+    | 'fixedYield';
   url: string;
   rateKey?: 'vaults' | 'rewards' | 'savings' | 'stusds' | 'staking' | 'fixedYield';
   badge?: string;
@@ -378,7 +387,7 @@ export function BalancesSuggestedActions({
     const activeMarkets = PENDLE_MARKETS.filter(m => !isMarketMatured(m.expiry));
     const activePtSymbols = activeMarkets.map(m => `PT-${m.underlyingSymbol}`);
     return {
-      label: 'Fixed yield markets',
+      label: 'Fixed Yield Markets',
       tokens: activePtSymbols,
       rateKey: 'fixedYield',
       subtitle: activeMarkets.length === 1 ? 'Rate: {rate}' : 'Rates up to {rate}',

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
@@ -18,7 +18,10 @@ import {
   useHighestRateFromChartData,
   filterDeprecatedRewardContracts,
   useStakeRewardContracts,
-  useMultipleRewardsChartInfo
+  useMultipleRewardsChartInfo,
+  PENDLE_MARKETS,
+  isMarketMatured,
+  usePendleMarketsApiData
 } from '@jetstreamgg/sky-hooks';
 import {
   formatDecimalPercentage,
@@ -27,7 +30,17 @@ import {
   isMainnetId,
   chainId as chainIdConstants
 } from '@jetstreamgg/sky-utils';
-import { Savings, Upgrade, RewardsModule, Stake, Expert, Vaults, Trade, Convert } from '@/modules/icons';
+import {
+  Savings,
+  Upgrade,
+  RewardsModule,
+  Stake,
+  Expert,
+  Vaults,
+  Trade,
+  Convert,
+  Pendle
+} from '@/modules/icons';
 import { Skeleton } from '@/components/ui/skeleton';
 import { type IconProps } from '@/modules/icons/Icon';
 import { Morpho, PopoverRateInfo, type PopoverTooltipType } from '@jetstreamgg/sky-widgets';
@@ -37,9 +50,9 @@ import type { ModuleId } from '@/modules/geo-config';
 type BalancesAction = {
   label: string;
   tokens: string[];
-  module: 'convert' | 'morpho' | 'rewards' | 'savings' | 'stusds' | 'stake' | 'trade' | 'upgrade';
+  module: 'convert' | 'morpho' | 'rewards' | 'savings' | 'stusds' | 'stake' | 'trade' | 'upgrade' | 'fixedYield';
   url: string;
-  rateKey?: 'vaults' | 'rewards' | 'savings' | 'stusds' | 'staking';
+  rateKey?: 'vaults' | 'rewards' | 'savings' | 'stusds' | 'staking' | 'fixedYield';
   badge?: string;
   showMorphoIcon?: boolean;
   subtitle?: string;
@@ -140,10 +153,11 @@ const MODULE_ICONS: Record<BalancesAction['module'], (props: IconProps) => React
   rewards: RewardsModule,
   stake: Stake,
   stusds: Expert,
-  morpho: Vaults
+  morpho: Vaults,
+  fixedYield: Pendle
 };
 
-const RATE_TOOLTIP_TYPES: Record<NonNullable<BalancesAction['rateKey']>, PopoverTooltipType> = {
+const RATE_TOOLTIP_TYPES: Partial<Record<NonNullable<BalancesAction['rateKey']>, PopoverTooltipType>> = {
   vaults: 'morpho',
   rewards: 'str',
   savings: 'ssr',
@@ -223,6 +237,16 @@ function useActionRates(
   const stakeHighestRateData = useHighestRateFromChartData(stakeRewardsChartsInfoData || []);
   const stakingLoading = stakeContractsLoading || stakeChartsLoading;
 
+  const { data: pendleMarketsApi, isLoading: pendleMarketsLoading } = usePendleMarketsApiData();
+  const pendleMaxRate = useMemo(() => {
+    if (!pendleMarketsApi) return 0;
+    return PENDLE_MARKETS.reduce((max, market) => {
+      if (isMarketMatured(market.expiry)) return max;
+      const apy = pendleMarketsApi[market.marketAddress]?.impliedApy ?? 0;
+      return apy > max ? apy : max;
+    }, 0);
+  }, [pendleMarketsApi]);
+
   return useMemo(() => {
     if (!hasRates) return { rates: {}, loading: {} };
 
@@ -281,6 +305,11 @@ function useActionRates(
       }
     }
 
+    if (rateKeys.has('fixedYield')) {
+      loading.fixedYield = pendleMarketsLoading;
+      rates.fixedYield = pendleMaxRate > 0 ? formatDecimalPercentage(pendleMaxRate) : '—';
+    }
+
     return { rates, loading };
   }, [
     hasRates,
@@ -294,7 +323,9 @@ function useActionRates(
     stUsdsLoading,
     vaultsLoading,
     rewardsLoading,
-    stakingLoading
+    stakingLoading,
+    pendleMarketsLoading,
+    pendleMaxRate
   ]);
 }
 
@@ -343,8 +374,26 @@ export function BalancesSuggestedActions({
     trade: 'trade'
   };
 
+  const fixedYieldAction = useMemo<BalancesAction>(() => {
+    const activeMarkets = PENDLE_MARKETS.filter(m => !isMarketMatured(m.expiry));
+    const activePtSymbols = activeMarkets.map(m => `PT-${m.underlyingSymbol}`);
+    return {
+      label: 'Fixed yield markets',
+      tokens: activePtSymbols,
+      rateKey: 'fixedYield',
+      subtitle: activeMarkets.length === 1 ? 'Rate: {rate}' : 'Rates up to {rate}',
+      module: 'fixedYield',
+      url: '?widget=fixed'
+    };
+  }, []);
+
   const actions = useMemo(() => {
-    let result = widget === 'stables' ? STABLE_ACTIONS : widget === 'sky' ? SKY_ACTIONS : TOKEN_ACTIONS;
+    let result =
+      widget === 'stables'
+        ? [...STABLE_ACTIONS, fixedYieldAction]
+        : widget === 'sky'
+          ? SKY_ACTIONS
+          : TOKEN_ACTIONS;
     if (restrictedModules) {
       result = result.filter(action => restrictedModules.includes(action.module));
     }
@@ -353,7 +402,7 @@ export function BalancesSuggestedActions({
       return !geoModuleId || isModuleEnabled(geoModuleId);
     });
     return result;
-  }, [widget, restrictedModules, isModuleEnabled]);
+  }, [widget, restrictedModules, isModuleEnabled, fixedYieldAction]);
 
   const { rates: rateMap, loading: rateLoading } = useActionRates(actions, chainId);
 
@@ -414,14 +463,16 @@ export function BalancesSuggestedActions({
                         className={`flex items-center gap-1 ${action.rateKey && rateMap[action.rateKey] !== '—' ? 'text-bullish' : 'text-textSecondary'}`}
                       >
                         {resolved.subtitle}
-                        {action.rateKey && rateMap[action.rateKey] !== '—' && (
-                          <PopoverRateInfo
-                            type={RATE_TOOLTIP_TYPES[action.rateKey]}
-                            width={12}
-                            height={12}
-                            iconClassName="text-textSecondary"
-                          />
-                        )}
+                        {action.rateKey &&
+                          rateMap[action.rateKey] !== '—' &&
+                          RATE_TOOLTIP_TYPES[action.rateKey] && (
+                            <PopoverRateInfo
+                              type={RATE_TOOLTIP_TYPES[action.rateKey]!}
+                              width={12}
+                              height={12}
+                              iconClassName="text-textSecondary"
+                            />
+                          )}
                       </Text>
                     ))}
                 </div>

--- a/apps/webapp/src/modules/icons/Pendle.tsx
+++ b/apps/webapp/src/modules/icons/Pendle.tsx
@@ -1,17 +1,10 @@
 import { Icon, IconProps } from './Icon';
 
 export const Pendle = (props: IconProps) => (
-  <Icon viewBox="0 0 22 22" {...props}>
+  <Icon {...props}>
     <g opacity="0.8">
-      <circle cx="11" cy="11" r="9" fill="none" stroke="currentColor" strokeWidth="2" />
-      <path
-        d="M11 6V11H15"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <rect x="1" y="1" width="20" height="20" rx="3" fill="none" stroke="currentColor" strokeWidth="2" />
+      <path d="M1 15H8V11H14V7H21" fill="none" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
     </g>
   </Icon>
 );

--- a/apps/webapp/src/modules/layout/components/ConnectedModalTabs.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectedModalTabs.tsx
@@ -17,7 +17,8 @@ export function ConnectedModalTabs() {
   const { onExternalLinkClicked } = useConfigContext();
   const { isRegionRestricted } = useGeoConfig();
 
-  const { rewardsUrl, savingsUrlMap, sealUrl, stakeUrl, expertOverviewUrl, vaultsUrl } = useModuleUrls();
+  const { rewardsUrl, savingsUrlMap, sealUrl, stakeUrl, expertOverviewUrl, vaultsUrl, fixedYieldUrl } =
+    useModuleUrls();
 
   return (
     <Tabs defaultValue={ConnectedModalTabsEnum.SUPPLIED_FUNDS} className="flex min-h-0 flex-1 flex-col">
@@ -42,6 +43,7 @@ export function ConnectedModalTabs() {
           stakeCardUrl={stakeUrl}
           stusdsCardUrl={expertOverviewUrl}
           vaultsCardUrl={vaultsUrl}
+          fixedYieldCardUrl={fixedYieldUrl}
           hideRestrictedModules={isRegionRestricted}
           onExternalLinkClicked={onExternalLinkClicked}
         />

--- a/apps/webapp/src/modules/pendle/components/PendleAbout.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleAbout.tsx
@@ -3,7 +3,6 @@ import { getBannerByIdAndModule, filterBannersByConnectionStatus } from '@/data/
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { useConnectedContext } from '@/modules/ui/context/ConnectedContext';
 import { AboutCard } from '@/modules/ui/components/AboutCard';
-import { Pendle } from '@/modules/icons';
 
 export const PendleAbout = () => {
   const { isConnectedAndAcceptedTerms } = useConnectedContext();
@@ -21,7 +20,6 @@ export const PendleAbout = () => {
   return (
     <AboutCard
       title={<Trans>{banner.title}</Trans>}
-      icon={<Pendle className="h-6 w-6" />}
       description={description}
       colorMiddle="linear-gradient(360deg, #6D28FF 0%, #F7A7F9 300%)"
     />

--- a/apps/webapp/src/public/images/pendle_icon_large.svg
+++ b/apps/webapp/src/public/images/pendle_icon_large.svg
@@ -1,0 +1,19 @@
+<svg width="226" height="226" viewBox="0 0 226 226" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_pendle_large)">
+<rect x="10.27" y="10.27" width="205.46" height="205.46" rx="30.82" fill="url(#paint0_linear_pendle_large)"/>
+<path d="M10.27 164.36H78.76V113H147.24V61.64H215.73" stroke="url(#paint1_linear_pendle_large)" stroke-width="20.55" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_pendle_large" x1="113" y1="10.27" x2="113" y2="215.73" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4331E9"/>
+<stop offset="1" stop-color="#A273FF"/>
+</linearGradient>
+<linearGradient id="paint1_linear_pendle_large" x1="10.27" y1="154.09" x2="215.73" y2="71.91" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFCD6B"/>
+<stop offset="1" stop-color="#EB5EDF"/>
+</linearGradient>
+<clipPath id="clip0_pendle_large">
+<rect width="226" height="226" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -147,6 +147,7 @@ export {
 export { isMarketMatured, formatPendleAggregatorName } from './pendle/helpers';
 export { usePendleMarketsApiData } from './pendle/usePendleMarketsApiData';
 export { usePendleUserPtBalances } from './pendle/usePendleUserPtBalances';
+export { useAllPendleUserAssets } from './pendle/useAllPendleUserAssets';
 export { usePendleMarketHistory } from './pendle/usePendleMarketHistory';
 export { useQuotePendleConvert } from './pendle/useQuotePendleConvert';
 export { useBatchPendleConvert } from './pendle/useBatchPendleConvert';
@@ -173,7 +174,10 @@ export type {
   PendleUserPtBalancesHook,
   PendleTransactionRaw,
   PendleMarketTransactionsResponseRaw,
-  PendleMarketHistoryHook
+  PendleMarketHistoryHook,
+  PendleMarketUserAsset,
+  AllPendleUserAssetsData,
+  AllPendleUserAssetsHook
 } from './pendle/pendle';
 
 // Authentication

--- a/packages/hooks/src/pendle/pendle.d.ts
+++ b/packages/hooks/src/pendle/pendle.d.ts
@@ -312,3 +312,65 @@ export type PendleMarketTransactionsResponseRaw = {
 export type PendleMarketHistoryHook = ReadHook & {
   data?: PendleTransactionRaw[];
 };
+
+// ---------------------------------------------------------------------------
+// Pendle API transport types (/v1/dashboard/positions/database/{userAddress})
+// ---------------------------------------------------------------------------
+
+export type PendleDashboardLegPositionRaw = {
+  valuation: number;
+  balance: string;
+};
+
+export type PendleDashboardLpPositionRaw = PendleDashboardLegPositionRaw & {
+  activeBalance: string;
+};
+
+export type PendleDashboardOpenPositionRaw = {
+  /** "<chainId>-<marketAddress>" — e.g. "1-0xeab7..." */
+  marketId: string;
+  pt: PendleDashboardLegPositionRaw;
+  yt: PendleDashboardLegPositionRaw;
+  lp: PendleDashboardLpPositionRaw;
+  crossPtPositions: unknown[];
+};
+
+export type PendleDashboardChainPositionsRaw = {
+  chainId: number;
+  totalOpen: number;
+  totalClosed: number;
+  totalSy: number;
+  openPositions: PendleDashboardOpenPositionRaw[];
+  closedPositions: unknown[];
+  syPositions: unknown[];
+  updatedAt: string;
+};
+
+export type PendleDashboardPositionsResponseRaw = {
+  positions: PendleDashboardChainPositionsRaw[];
+};
+
+/** Per-market user PT balance + USD valuation, scoped to markets we support. */
+export type PendleMarketUserAsset = {
+  /** Market contract address */
+  marketAddress: `0x${string}`;
+  /** User's PT balance in the PT's native decimals (== underlying decimals) */
+  ptBalance: bigint;
+  /** User's PT balance normalized to 18 decimals (WAD) */
+  ptBalanceNormalized: bigint;
+  /** USD valuation of the PT position, as reported by Pendle's dashboard API */
+  valuationUsd: number;
+};
+
+export type AllPendleUserAssetsData = {
+  /** Total PT balance across all supported markets, normalized to 18 decimals (WAD) */
+  total: bigint;
+  /** Sum of per-market USD valuations across all supported markets */
+  totalUsd: number;
+  /** Per-market breakdown — only includes markets we support with a non-zero PT balance */
+  markets: PendleMarketUserAsset[];
+};
+
+export type AllPendleUserAssetsHook = ReadHook & {
+  data: AllPendleUserAssetsData;
+};

--- a/packages/hooks/src/pendle/pendleApiClient.ts
+++ b/packages/hooks/src/pendle/pendleApiClient.ts
@@ -4,6 +4,7 @@ import { PENDLE_API_BASE_URL } from './constants';
 import type {
   PendleConvertRequest,
   PendleConvertResponseRaw,
+  PendleDashboardPositionsResponseRaw,
   PendleMarketSummaryRaw,
   PendleMarketsAllResponseRaw,
   PendleMarketTransactionsResponseRaw,
@@ -102,4 +103,23 @@ export async function fetchPendleMarketTransactions(
   }
   const json = (await response.json()) as PendleMarketTransactionsResponseRaw;
   return json.results || [];
+}
+
+/**
+ * GET /v1/dashboard/positions/database/{userAddress}
+ *
+ * Returns the user's Pendle positions across every chain Pendle supports.
+ * Results are grouped per chain; consumers must filter to the chains and
+ * markets they care about. We use this to aggregate the user's PT holdings
+ * across our supported markets for the Balances widget.
+ */
+export async function fetchPendleDashboardPositions(
+  userAddress: `0x${string}`
+): Promise<PendleDashboardPositionsResponseRaw> {
+  const url = `${PENDLE_API_BASE_URL}/v1/dashboard/positions/database/${userAddress.toLowerCase()}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Pendle /dashboard/positions ${response.status}`);
+  }
+  return (await response.json()) as PendleDashboardPositionsResponseRaw;
 }

--- a/packages/hooks/src/pendle/useAllPendleUserAssets.ts
+++ b/packages/hooks/src/pendle/useAllPendleUserAssets.ts
@@ -1,0 +1,113 @@
+import { useQuery } from '@tanstack/react-query';
+import { formatUnits, parseUnits } from 'viem';
+import { useConnection } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
+import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
+import { PENDLE_MARKETS } from './constants';
+import { fetchPendleDashboardPositions } from './pendleApiClient';
+import {
+  AllPendleUserAssetsData,
+  AllPendleUserAssetsHook,
+  PendleMarketConfig,
+  PendleMarketUserAsset
+} from './pendle';
+
+const EMPTY_DATA: AllPendleUserAssetsData = { total: 0n, totalUsd: 0, markets: [] };
+
+/**
+ * Parse the API's "<chainId>-<marketAddress>" id format and return the
+ * lowercased market address (or null if the id is malformed).
+ */
+function parseMarketAddress(marketId: string): `0x${string}` | null {
+  const parts = marketId.split('-');
+  if (parts.length !== 2 || !parts[1].startsWith('0x')) return null;
+  return parts[1].toLowerCase() as `0x${string}`;
+}
+
+/**
+ * Hook that aggregates the user's PT balances across every Pendle market we
+ * support. Sources its data from Pendle's dashboard API (the same backing data
+ * shown on app.pendle.finance/dashboard).
+ *
+ * Filtering:
+ *   - Only positions in markets present in PENDLE_MARKETS are returned.
+ *   - Only the `pt` leg is included; `yt`, `lp`, `crossPtPositions` are dropped.
+ *   - Only chain 1 (mainnet) positions are considered — our integration adds
+ *     only mainnet markets, and Pendle's API does not serve Tenderly.
+ *
+ * Returns:
+ *   - `total`: sum of PT balances normalized to 18 decimals (WAD).
+ *     PT decimals match the underlying token's decimals.
+ *   - `totalUsd`: sum of per-market `pt.valuation` values from the API.
+ *   - `markets`: per-market breakdown with the matched config, raw PT balance,
+ *     normalized balance, and USD valuation.
+ */
+export function useAllPendleUserAssets(): AllPendleUserAssetsHook {
+  const { address: userAddress } = useConnection();
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['pendle-user-assets', userAddress?.toLowerCase()],
+    enabled: !!userAddress,
+    queryFn: async (): Promise<AllPendleUserAssetsData> => {
+      if (!userAddress) return EMPTY_DATA;
+      const json = await fetchPendleDashboardPositions(userAddress);
+
+      const supported = new Map<string, PendleMarketConfig>();
+      PENDLE_MARKETS.forEach(m => supported.set(m.marketAddress.toLowerCase(), m));
+
+      const mainnetEntry = json.positions?.find(p => p.chainId === mainnet.id);
+      if (!mainnetEntry) return EMPTY_DATA;
+
+      const markets: PendleMarketUserAsset[] = [];
+      let total = 0n;
+      let totalUsd = 0;
+
+      for (const pos of mainnetEntry.openPositions || []) {
+        const addr = parseMarketAddress(pos.marketId);
+        if (!addr) continue;
+        const market = supported.get(addr);
+        if (!market) continue;
+
+        let ptBalance: bigint;
+        try {
+          ptBalance = BigInt(pos.pt.balance);
+        } catch {
+          continue;
+        }
+        if (ptBalance <= 0n) continue;
+
+        const decimals = market.underlyingDecimals;
+        // const normalized = decimals < 18 ? ptBalance * 10n ** BigInt(18 - decimals) : ptBalance;
+        const normalized = parseUnits(formatUnits(ptBalance, decimals), 18);
+        const valuationUsd = pos.pt.valuation || 0;
+
+        total += normalized;
+        totalUsd += valuationUsd;
+        markets.push({
+          marketAddress: market.marketAddress,
+          ptBalance,
+          ptBalanceNormalized: normalized,
+          valuationUsd
+        });
+      }
+      return { total, totalUsd, markets };
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: false
+  });
+
+  return {
+    isLoading,
+    data: data ?? EMPTY_DATA,
+    error: error || null,
+    mutate: refetch,
+    dataSources: [
+      {
+        title: 'Pendle Dashboard API',
+        href: 'https://api-v2.pendle.finance/core/docs',
+        onChain: false,
+        trustLevel: TRUST_LEVELS[TrustLevelEnum.TWO]
+      }
+    ]
+  };
+}

--- a/packages/widgets/src/public/images/pendle_icon_large.svg
+++ b/packages/widgets/src/public/images/pendle_icon_large.svg
@@ -1,0 +1,19 @@
+<svg width="226" height="226" viewBox="0 0 226 226" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_pendle_large)">
+<rect x="10.27" y="10.27" width="205.46" height="205.46" rx="30.82" fill="url(#paint0_linear_pendle_large)"/>
+<path d="M10.27 164.36H78.76V113H147.24V61.64H215.73" stroke="url(#paint1_linear_pendle_large)" stroke-width="20.55" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_pendle_large" x1="113" y1="10.27" x2="113" y2="215.73" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4331E9"/>
+<stop offset="1" stop-color="#A273FF"/>
+</linearGradient>
+<linearGradient id="paint1_linear_pendle_large" x1="10.27" y1="154.09" x2="215.73" y2="71.91" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFCD6B"/>
+<stop offset="1" stop-color="#EB5EDF"/>
+</linearGradient>
+<clipPath id="clip0_pendle_large">
+<rect width="226" height="226" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/widgets/src/shared/components/ModuleLogo.tsx
+++ b/packages/widgets/src/shared/components/ModuleLogo.tsx
@@ -35,6 +35,11 @@ const logoMetadata = [
     name: 'vaults',
     src: '/images/vaults_icon_large.svg',
     alt: 'Vaults logo'
+  },
+  {
+    name: 'fixedYield',
+    src: '/images/pendle_icon_large.svg',
+    alt: 'Fixed Yield logo'
   }
 ] as const;
 

--- a/packages/widgets/src/shared/components/ui/card/InteractiveStatsCardWithMarketAccordion.tsx
+++ b/packages/widgets/src/shared/components/ui/card/InteractiveStatsCardWithMarketAccordion.tsx
@@ -1,0 +1,209 @@
+import { Card, CardContent, CardFooter } from '@widgets/components/ui/card';
+import { Text } from '../Typography';
+import { TokenIcon } from '../token/TokenIcon';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@widgets/components/ui/accordion';
+import { HStack } from '@widgets/shared/components/ui/layout/HStack';
+import { ArrowRight } from 'lucide-react';
+import { formatBigInt, formatNumber } from '@jetstreamgg/sky-utils';
+import { Link } from 'react-router-dom';
+import { InteractiveStatsCard } from './InteractiveStatsCard';
+
+export type MarketBalanceForAccordion = {
+  marketName: string;
+  marketAddress: `0x${string}`;
+  balance: bigint;
+  /** Balance normalized to 18 decimals for cross-asset comparison */
+  balanceNormalized: bigint;
+  /** Symbol used to resolve the row's token icon (e.g. "PT-USDG") */
+  tokenIconSymbol: string;
+  /** Decimals of the `balance` field for display formatting */
+  balanceDecimals: number;
+  valuationUsd: number;
+  /** Implied APY as a decimal (e.g. 0.0725 for 7.25%). Omitted for matured markets. */
+  rate?: number;
+  isMatured: boolean;
+};
+
+export const InteractiveStatsCardWithMarketAccordion = ({
+  title,
+  headerRightContent,
+  footer,
+  footerRightContent,
+  marketBalances,
+  urlMap,
+  icon,
+  url
+}: {
+  title: React.ReactElement | string;
+  headerRightContent: React.ReactElement | string;
+  footer: React.ReactElement | string;
+  footerRightContent?: React.ReactElement | string;
+  marketBalances: MarketBalanceForAccordion[];
+  urlMap: Record<string, string>;
+  icon?: React.ReactNode;
+  url?: string;
+}): React.ReactElement => {
+  const marketsWithBalance = marketBalances.filter(m => m.balance > 0n);
+
+  // If only one market has balance, show simple card
+  if (marketsWithBalance.length <= 1) {
+    const single = marketsWithBalance[0];
+    return (
+      <InteractiveStatsCard
+        title={title}
+        headerRightContent={headerRightContent}
+        footer={footer}
+        footerRightContent={footerRightContent}
+        url={single ? urlMap[single.marketAddress] : url}
+        icon={icon}
+      />
+    );
+  }
+
+  const headerContent = (
+    <div className="flex items-center gap-2">
+      {icon && <div className="flex h-8 w-8 shrink-0 items-center justify-center">{icon}</div>}
+      <div className="grow">
+        <CardContent className="flex items-center justify-between gap-4">
+          <Text>{title}</Text>
+          {headerRightContent}
+        </CardContent>
+        <CardFooter>
+          <div className="flex w-full items-start justify-between">
+            <div className="flex-1">{footer}</div>
+            {footerRightContent}
+          </div>
+        </CardFooter>
+      </div>
+    </div>
+  );
+
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="details" className="accordion-item border-0">
+        <Card
+          variant="stats"
+          className="has-[.header-link:hover]:from-primary-start has-[.header-link:hover]:to-primary-end w-full px-0! transition-colors has-[.header-link:hover]:bg-radial-(--gradient-position)"
+        >
+          <div className="group/header-link relative -mt-3 px-4 pt-3 pb-1 lg:-mt-5 lg:px-5 lg:pt-5">
+            <div>{headerContent}</div>
+            {url && (
+              <Link
+                to={url}
+                aria-label={typeof title === 'string' ? title : undefined}
+                className="header-link absolute inset-0 z-0 h-full w-full"
+              />
+            )}
+          </div>
+          <AccordionTrigger className="-mb-3 w-full px-4 pb-5 hover:no-underline lg:-mb-5 lg:px-5 lg:pb-5 [&>svg]:hidden">
+            <HStack className="w-full justify-between pt-1.5">
+              <HStack className="items-center -space-x-0.5 opacity-100 transition-opacity duration-200 [.accordion-item[data-state=open]_&]:opacity-0">
+                {marketsWithBalance.map(({ marketAddress, tokenIconSymbol }, index) => (
+                  <div key={marketAddress} style={{ zIndex: marketsWithBalance.length - index }}>
+                    <TokenIcon
+                      className="h-4.25 w-4.25"
+                      token={{ symbol: tokenIconSymbol, name: tokenIconSymbol }}
+                      noChain={true}
+                    />
+                  </div>
+                ))}
+              </HStack>
+              <HStack className="text-textSecondary w-full items-center justify-end gap-0.5">
+                <Text variant="small" className="leading-none">
+                  Funds by market
+                </Text>
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="chevron transition-transform duration-200 [.accordion-item[data-state=open]_&]:rotate-180"
+                >
+                  <path
+                    d="M2 4L6 8L10 4"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </HStack>
+            </HStack>
+          </AccordionTrigger>
+          <AccordionContent className="mt-2 p-0">
+            {marketsWithBalance.map(
+              ({
+                marketName,
+                marketAddress,
+                balance,
+                tokenIconSymbol,
+                balanceDecimals,
+                valuationUsd,
+                rate,
+                isMatured
+              }) => {
+                const marketUrl = urlMap[marketAddress];
+
+                const rowContent = (
+                  <div className="group/interactive-card from-primary-start/0 to-primary-end/0 hover:from-primary-start hover:to-primary-end cursor-pointer bg-radial-(--gradient-position) transition-colors">
+                    <div className="flex items-start gap-2 p-2 px-4 lg:px-5">
+                      <TokenIcon
+                        className="h-8 w-8"
+                        token={{ symbol: tokenIconSymbol, name: tokenIconSymbol }}
+                        noChain={true}
+                      />
+                      <div className="grow">
+                        <div className="flex items-start justify-between">
+                          <div className="flex flex-col">
+                            <Text>{marketName}</Text>
+                            <HStack gap={2} className="items-center">
+                              {isMatured ? (
+                                <Text variant="small" className="text-textSecondary">
+                                  Matured
+                                </Text>
+                              ) : rate !== undefined && rate > 0 ? (
+                                <Text variant="small" className="text-bullish">
+                                  Rate: {(rate * 100).toFixed(2)}%
+                                </Text>
+                              ) : null}
+                              {marketUrl && (
+                                <ArrowRight
+                                  size={16}
+                                  className="opacity-0 transition-opacity group-hover/interactive-card:opacity-100"
+                                />
+                              )}
+                            </HStack>
+                          </div>
+                          <div className="flex flex-col items-end">
+                            <Text>{formatBigInt(balance, { unit: balanceDecimals })}</Text>
+                            <Text variant="small" className="text-textSecondary">
+                              ${formatNumber(valuationUsd, { maxDecimals: 2 })}
+                            </Text>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+
+                return marketUrl ? (
+                  <Link to={marketUrl} key={marketAddress}>
+                    {rowContent}
+                  </Link>
+                ) : (
+                  <div key={marketAddress}>{rowContent}</div>
+                );
+              }
+            )}
+          </AccordionContent>
+        </Card>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/packages/widgets/src/widgets/BalancesWidget/components/BalancesContent.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/BalancesContent.tsx
@@ -17,6 +17,7 @@ interface BalancesContentProps {
   stakeCardUrl?: string;
   stusdsCardUrl?: string;
   vaultsCardUrl?: string;
+  fixedYieldCardUrl?: string;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   showAllNetworks?: boolean;
   hideZeroBalances?: boolean;
@@ -35,6 +36,7 @@ export const BalancesContent = ({
   stakeCardUrl,
   stusdsCardUrl,
   vaultsCardUrl,
+  fixedYieldCardUrl,
   showAllNetworks: showAllNetworksProp,
   hideZeroBalances: hideZeroBalancesProp,
   setShowAllNetworks: setShowAllNetworksProp,
@@ -85,6 +87,7 @@ export const BalancesContent = ({
           stakeCardUrl={stakeCardUrl}
           stusdsCardUrl={stusdsCardUrl}
           vaultsCardUrl={vaultsCardUrl}
+          fixedYieldCardUrl={fixedYieldCardUrl}
           onExternalLinkClicked={onExternalLinkClicked}
           chainIds={chainIds}
           hideZeroBalances={hideZeroBalances}

--- a/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
@@ -27,13 +27,21 @@ export const FixedYieldBalanceCard = ({
 
   const { total, totalUsd, markets } = assetsData;
 
-  // Highest implied APY across markets the user actually holds (skip matured ones).
-  const maxRate = markets.reduce((max, m) => {
-    const config = getPendleMarketByAddress(m.marketAddress);
-    if (!config || isMarketMatured(config.expiry)) return max;
-    const rate = marketsApi?.[m.marketAddress]?.impliedApy ?? 0;
-    return rate > max ? rate : max;
-  }, 0);
+  // Highest implied APY across markets the user actually holds (skip matured ones)
+  // plus a count of those active markets so we can switch between "Rate" and
+  // "Rates up to" labelling.
+  const { maxRate, activeMarketsCount } = markets.reduce(
+    (acc, m) => {
+      const config = getPendleMarketByAddress(m.marketAddress);
+      if (!config || isMarketMatured(config.expiry)) return acc;
+      const rate = marketsApi?.[m.marketAddress]?.impliedApy ?? 0;
+      return {
+        maxRate: rate > acc.maxRate ? rate : acc.maxRate,
+        activeMarketsCount: acc.activeMarketsCount + 1
+      };
+    },
+    { maxRate: 0, activeMarketsCount: 0 }
+  );
 
   const isBalanceLoading = loading || assetsLoading;
   const isRateLoading = loading || assetsLoading || ratesLoading;
@@ -48,6 +56,8 @@ export const FixedYieldBalanceCard = ({
       const config = getPendleMarketByAddress(m.marketAddress);
       if (!config) return [];
       const matured = isMarketMatured(config.expiry);
+      // Matured markets are only worth showing if the user still holds PT to redeem.
+      if (matured && m.ptBalance <= 0n) return [];
       return [
         {
           marketName: config.name,
@@ -101,7 +111,9 @@ export const FixedYieldBalanceCard = ({
           <Skeleton className="h-4 w-20" />
         ) : maxRate > 0 ? (
           <Text variant="small" className="text-bullish">
-            {t`Rates up to: ${formatDecimalPercentage(maxRate)}`}
+            {activeMarketsCount === 1
+              ? t`Rate: ${formatDecimalPercentage(maxRate)}`
+              : t`Rates up to: ${formatDecimalPercentage(maxRate)}`}
           </Text>
         ) : (
           <></>
@@ -127,11 +139,7 @@ export const FixedYieldBalanceCard = ({
       url={url}
       logoName="fixedYield"
       content={
-        isBalanceLoading ? (
-          <Skeleton className="w-32" />
-        ) : (
-          <Text>${formatNumber(totalUsd, { maxDecimals: 2 })}</Text>
-        )
+        isBalanceLoading ? <Skeleton className="w-32" /> : <Text>{formatBigInt(total)}</Text>
       }
     />
   );

--- a/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
@@ -1,0 +1,47 @@
+import { Text } from '@widgets/shared/components/ui/Typography';
+import { t } from '@lingui/core/macro';
+import { InteractiveStatsCard } from '@widgets/shared/components/ui/card/InteractiveStatsCard';
+import { InteractiveStatsCardAlt } from '@widgets/shared/components/ui/card/InteractiveStatsCardAlt';
+import { CardProps, ModuleCardVariant } from './ModulesBalances';
+
+export const FixedYieldBalanceCard = ({
+  url,
+  loading,
+  variant = ModuleCardVariant.default,
+  hideZeroBalances = false
+}: CardProps & { hideZeroBalances?: boolean }) => {
+  const dummyBalance = '5.0000';
+  const dummyRate = '7.25%';
+  const dummyUsd = '$5.00';
+
+  const fixedYieldIcon = (
+    <img src="/images/pendle_icon_large.svg" alt="Fixed Yield" className="h-full w-full" />
+  );
+
+  return variant === ModuleCardVariant.default ? (
+    <InteractiveStatsCard
+      title={t`Supplied to Fixed Yield`}
+      icon={fixedYieldIcon}
+      headerRightContent={<Text>{dummyBalance}</Text>}
+      footer={
+        <Text variant="small" className="text-bullish">
+          {t`Rate: ${dummyRate}`}
+        </Text>
+      }
+      footerRightContent={
+        <Text variant="small" className="text-textSecondary">
+          {dummyUsd}
+        </Text>
+      }
+      url={url}
+    />
+  ) : (
+    <InteractiveStatsCardAlt
+      title={t`Supplied to Fixed Yield`}
+      icon={fixedYieldIcon}
+      url={url}
+      logoName="fixedYield"
+      content={<Text>{dummyBalance} USDS</Text>}
+    />
+  );
+};

--- a/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
@@ -1,18 +1,30 @@
+import { useAllPendleUserAssets, usePendleMarketsApiData } from '@jetstreamgg/sky-hooks';
+import { formatBigInt, formatDecimalPercentage, formatNumber } from '@jetstreamgg/sky-utils';
 import { Text } from '@widgets/shared/components/ui/Typography';
 import { t } from '@lingui/core/macro';
 import { InteractiveStatsCard } from '@widgets/shared/components/ui/card/InteractiveStatsCard';
 import { InteractiveStatsCardAlt } from '@widgets/shared/components/ui/card/InteractiveStatsCardAlt';
+import { Skeleton } from '@widgets/components/ui/skeleton';
 import { CardProps, ModuleCardVariant } from './ModulesBalances';
 
 export const FixedYieldBalanceCard = ({
   url,
   loading,
-  variant = ModuleCardVariant.default,
-  hideZeroBalances = false
+  variant = ModuleCardVariant.default
 }: CardProps & { hideZeroBalances?: boolean }) => {
-  const dummyBalance = '5.0000';
-  const dummyRate = '7.25%';
-  const dummyUsd = '$5.00';
+  const { data: assetsData, isLoading: assetsLoading } = useAllPendleUserAssets();
+  const { data: marketsApi, isLoading: ratesLoading } = usePendleMarketsApiData();
+
+  const { total, totalUsd, markets } = assetsData;
+
+  // Highest implied APY across markets the user actually holds.
+  const maxRate = markets.reduce((max, m) => {
+    const rate = marketsApi?.[m.marketAddress]?.impliedApy ?? 0;
+    return rate > max ? rate : max;
+  }, 0);
+
+  const isBalanceLoading = loading || assetsLoading;
+  const isRateLoading = loading || assetsLoading || ratesLoading;
 
   const fixedYieldIcon = (
     <img src="/images/pendle_icon_large.svg" alt="Fixed Yield" className="h-full w-full" />
@@ -22,16 +34,28 @@ export const FixedYieldBalanceCard = ({
     <InteractiveStatsCard
       title={t`Supplied to Fixed Yield`}
       icon={fixedYieldIcon}
-      headerRightContent={<Text>{dummyBalance}</Text>}
+      headerRightContent={
+        isBalanceLoading ? <Skeleton className="w-32" /> : <Text>{formatBigInt(total)}</Text>
+      }
       footer={
-        <Text variant="small" className="text-bullish">
-          {t`Rate: ${dummyRate}`}
-        </Text>
+        isRateLoading ? (
+          <Skeleton className="h-4 w-20" />
+        ) : maxRate > 0 ? (
+          <Text variant="small" className="text-bullish">
+            {t`Rates up to: ${formatDecimalPercentage(maxRate)}`}
+          </Text>
+        ) : (
+          <></>
+        )
       }
       footerRightContent={
-        <Text variant="small" className="text-textSecondary">
-          {dummyUsd}
-        </Text>
+        isBalanceLoading ? (
+          <Skeleton className="h-[13px] w-20" />
+        ) : totalUsd > 0 ? (
+          <Text variant="small" className="text-textSecondary">
+            ${formatNumber(totalUsd, { maxDecimals: 2 })}
+          </Text>
+        ) : undefined
       }
       url={url}
     />
@@ -41,7 +65,13 @@ export const FixedYieldBalanceCard = ({
       icon={fixedYieldIcon}
       url={url}
       logoName="fixedYield"
-      content={<Text>{dummyBalance} USDS</Text>}
+      content={
+        isBalanceLoading ? (
+          <Skeleton className="w-32" />
+        ) : (
+          <Text>${formatNumber(totalUsd, { maxDecimals: 2 })}</Text>
+        )
+      }
     />
   );
 };

--- a/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
@@ -1,24 +1,36 @@
-import { useAllPendleUserAssets, usePendleMarketsApiData } from '@jetstreamgg/sky-hooks';
+import { useMemo } from 'react';
+import {
+  getPendleMarketByAddress,
+  isMarketMatured,
+  useAllPendleUserAssets,
+  usePendleMarketsApiData
+} from '@jetstreamgg/sky-hooks';
 import { formatBigInt, formatDecimalPercentage, formatNumber } from '@jetstreamgg/sky-utils';
 import { Text } from '@widgets/shared/components/ui/Typography';
 import { t } from '@lingui/core/macro';
-import { InteractiveStatsCard } from '@widgets/shared/components/ui/card/InteractiveStatsCard';
 import { InteractiveStatsCardAlt } from '@widgets/shared/components/ui/card/InteractiveStatsCardAlt';
+import {
+  InteractiveStatsCardWithMarketAccordion,
+  MarketBalanceForAccordion
+} from '@widgets/shared/components/ui/card/InteractiveStatsCardWithMarketAccordion';
 import { Skeleton } from '@widgets/components/ui/skeleton';
 import { CardProps, ModuleCardVariant } from './ModulesBalances';
 
 export const FixedYieldBalanceCard = ({
   url,
   loading,
-  variant = ModuleCardVariant.default
+  variant = ModuleCardVariant.default,
+  hideZeroBalances = false
 }: CardProps & { hideZeroBalances?: boolean }) => {
   const { data: assetsData, isLoading: assetsLoading } = useAllPendleUserAssets();
   const { data: marketsApi, isLoading: ratesLoading } = usePendleMarketsApiData();
 
   const { total, totalUsd, markets } = assetsData;
 
-  // Highest implied APY across markets the user actually holds.
+  // Highest implied APY across markets the user actually holds (skip matured ones).
   const maxRate = markets.reduce((max, m) => {
+    const config = getPendleMarketByAddress(m.marketAddress);
+    if (!config || isMarketMatured(config.expiry)) return max;
     const rate = marketsApi?.[m.marketAddress]?.impliedApy ?? 0;
     return rate > max ? rate : max;
   }, 0);
@@ -30,8 +42,55 @@ export const FixedYieldBalanceCard = ({
     <img src="/images/pendle_icon_large.svg" alt="Fixed Yield" className="h-full w-full" />
   );
 
+  // Build per-market accordion rows + per-market URLs.
+  const { marketBalances, urlMap } = useMemo(() => {
+    const balances: MarketBalanceForAccordion[] = markets.flatMap(m => {
+      const config = getPendleMarketByAddress(m.marketAddress);
+      if (!config) return [];
+      const matured = isMarketMatured(config.expiry);
+      return [
+        {
+          marketName: config.name,
+          marketAddress: m.marketAddress,
+          balance: m.ptBalance,
+          balanceNormalized: m.ptBalanceNormalized,
+          tokenIconSymbol: `PT-${config.underlyingSymbol}`,
+          balanceDecimals: config.underlyingDecimals,
+          valuationUsd: m.valuationUsd,
+          rate: matured ? undefined : marketsApi?.[m.marketAddress]?.impliedApy,
+          isMatured: matured
+        }
+      ];
+    });
+
+    const filtered = hideZeroBalances ? balances.filter(b => b.balance > 0n) : balances;
+
+    // Sort by normalized balance descending so the biggest position shows first.
+    const sorted = filtered.sort((a, b) =>
+      b.balanceNormalized > a.balanceNormalized ? 1 : b.balanceNormalized < a.balanceNormalized ? -1 : 0
+    );
+
+    // Matured markets aren't valid deep-link targets (the widget rejects them),
+    // so fall back to the base Fixed Yield URL for those rows.
+    const map: Record<string, string> = {};
+    sorted.forEach(b => {
+      if (!url) {
+        map[b.marketAddress] = '';
+        return;
+      }
+      if (b.isMatured) {
+        map[b.marketAddress] = url;
+        return;
+      }
+      const separator = url.includes('?') ? '&' : '?';
+      map[b.marketAddress] = `${url}${separator}fixed_module=market&market=${b.marketAddress}`;
+    });
+
+    return { marketBalances: sorted, urlMap: map };
+  }, [markets, marketsApi, hideZeroBalances, url]);
+
   return variant === ModuleCardVariant.default ? (
-    <InteractiveStatsCard
+    <InteractiveStatsCardWithMarketAccordion
       title={t`Supplied to Fixed Yield`}
       icon={fixedYieldIcon}
       headerRightContent={
@@ -57,6 +116,8 @@ export const FixedYieldBalanceCard = ({
           </Text>
         ) : undefined
       }
+      marketBalances={marketBalances}
+      urlMap={urlMap}
       url={url}
     />
   ) : (

--- a/packages/widgets/src/widgets/BalancesWidget/components/ModulesBalances.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/components/ModulesBalances.tsx
@@ -7,13 +7,15 @@ import {
   useTotalUserSealed,
   useTotalUserStaked,
   useAllMorphoVaultsUserAssets,
-  usePrices
+  usePrices,
+  useAllPendleUserAssets
 } from '@jetstreamgg/sky-hooks';
 import { RewardsBalanceCard } from './RewardsBalanceCard';
 import { SavingsBalanceCard } from './SavingsBalanceCard';
 import { SealBalanceCard } from './SealBalanceCard';
 import { StakeBalanceCard } from './StakeBalanceCard';
 import { ExpertBalanceCard } from './ExpertBalanceCard';
+import { FixedYieldBalanceCard } from './FixedYieldBalanceCard';
 import { VaultsBalanceCard } from './VaultsBalanceCard';
 import { chainId, isMainnetId, isTestnetId } from '@jetstreamgg/sky-utils';
 import { useChainId, useConnection } from 'wagmi';
@@ -47,6 +49,7 @@ interface ModulesBalancesProps {
   stakeCardUrl?: string;
   stusdsCardUrl?: string;
   vaultsCardUrl?: string;
+  fixedYieldCardUrl?: string;
   variant?: ModuleCardVariant;
   hideZeroBalances?: boolean;
   showAllNetworks?: boolean;
@@ -63,6 +66,7 @@ export const ModulesBalances = ({
   stakeCardUrl,
   stusdsCardUrl,
   vaultsCardUrl,
+  fixedYieldCardUrl,
   variant = ModuleCardVariant.default,
   hideZeroBalances = false,
   showAllNetworks = true,
@@ -144,6 +148,10 @@ export const ModulesBalances = ({
   } = useAllMorphoVaultsUserAssets();
   const totalMorphoUserAssets = morphoAssetsData.total;
 
+  // Get aggregate Pendle market data across all markets
+  const { data: pendleAssetsData, isLoading: pendleLoading, error: pendleError } = useAllPendleUserAssets();
+  const totalPendleUserAssets = pendleAssetsData.total;
+
   // Expert balance = total across expert modules (stUSDS only for now)
   const totalExpertSavingsBalance = stUsdsData?.userSuppliedUsds || 0n;
   const expertLoading = stUsdsLoading;
@@ -215,14 +223,21 @@ export const ModulesBalances = ({
     (totalSavingsBalance === 0n && hideZeroBalances)
   );
 
+  const hideFixedYield = Boolean(
+    pendleError ||
+    (totalPendleUserAssets === 0n && hideZeroBalances) ||
+    (!showAllNetworks && !isMainnetId(currentChainId))
+  );
+
   // Fallback display order used while prices are loading to prevent layout shifts
   const fallbackOrder: Record<string, number> = {
     rewards: 0,
     savings: 1,
-    staking: 2,
-    vaults: 3,
-    stusds: 4,
-    seal: 5
+    fixedYield: 2,
+    staking: 3,
+    vaults: 4,
+    stusds: 5,
+    seal: 6
   };
 
   // Compute USD value for each module to sort by value descending
@@ -230,7 +245,13 @@ export const ModulesBalances = ({
     parseFloat((Number(balance) / 1e18).toString()) * parseFloat(priceStr);
 
   const anyBalanceLoading =
-    rewardsLoading || savingsLoading || stakeLoading || expertLoading || morphoLoading || sealLoading;
+    rewardsLoading ||
+    savingsLoading ||
+    stakeLoading ||
+    expertLoading ||
+    morphoLoading ||
+    pendleLoading ||
+    sealLoading;
   const canSortByValue = !anyBalanceLoading && !pricesLoading && !!pricesData;
 
   const moduleUsdValues = useMemo(() => {
@@ -249,6 +270,7 @@ export const ModulesBalances = ({
       totalMorphoUserAssets && pricesData.USDS
         ? bigintToUsd(totalMorphoUserAssets, pricesData.USDS.price)
         : 0;
+    values.fixedYield = pendleAssetsData.totalUsd;
     values.stusds =
       totalExpertSavingsBalance && pricesData.USDS
         ? bigintToUsd(totalExpertSavingsBalance, pricesData.USDS.price)
@@ -263,17 +285,19 @@ export const ModulesBalances = ({
     totalSavingsBalance,
     totalUserStaked,
     totalMorphoUserAssets,
+    pendleAssetsData.totalUsd,
     totalExpertSavingsBalance,
     totalUserSealed
   ]);
 
   const sortedModules = useMemo(() => {
     const modules: Array<{
-      id: 'rewards' | 'savings' | 'stusds' | 'staking' | 'seal' | 'vaults';
+      id: 'rewards' | 'savings' | 'stusds' | 'staking' | 'seal' | 'vaults' | 'fixedYield';
       hidden: boolean;
     }> = [
       { id: 'rewards', hidden: hideRewards },
       { id: 'savings', hidden: hideSavings },
+      { id: 'fixedYield', hidden: hideFixedYield },
       { id: 'staking', hidden: hideStake },
       { id: 'vaults', hidden: hideVaults },
       { id: 'stusds', hidden: hideExpert },
@@ -299,6 +323,7 @@ export const ModulesBalances = ({
     hideStake,
     hideSeal,
     hideVaults,
+    hideFixedYield,
     canSortByValue,
     moduleUsdValues
   ]);
@@ -306,7 +331,13 @@ export const ModulesBalances = ({
   // Check if all supplied funds are zero (before any filtering)
   const totalRawSavingsBalance = sortedSavingsBalances.reduce((acc, { balance }) => acc + balance, 0n);
   const isAllLoaded =
-    !rewardsLoading && !savingsLoading && !sealLoading && !stakeLoading && !expertLoading && !morphoLoading;
+    !rewardsLoading &&
+    !savingsLoading &&
+    !sealLoading &&
+    !stakeLoading &&
+    !expertLoading &&
+    !morphoLoading &&
+    !pendleLoading;
   const allFundsEmpty =
     isAllLoaded &&
     (hideRestrictedModules || totalUserRewardsSupplied === 0n) &&
@@ -314,7 +345,8 @@ export const ModulesBalances = ({
     (totalUserSealed ?? 0n) === 0n &&
     (totalUserStaked ?? 0n) === 0n &&
     (hideRestrictedModules || totalExpertSavingsBalance === 0n) &&
-    totalMorphoUserAssets === 0n;
+    totalMorphoUserAssets === 0n &&
+    totalPendleUserAssets === 0n;
 
   useEffect(() => {
     onAllFundsEmpty?.(allFundsEmpty);
@@ -325,7 +357,9 @@ export const ModulesBalances = ({
   }
 
   // Render functions for each module type
-  const renderModule = (moduleId: 'rewards' | 'savings' | 'stusds' | 'staking' | 'seal' | 'vaults') => {
+  const renderModule = (
+    moduleId: 'rewards' | 'savings' | 'stusds' | 'staking' | 'seal' | 'vaults' | 'fixedYield'
+  ) => {
     switch (moduleId) {
       case 'rewards':
         return (
@@ -386,6 +420,16 @@ export const ModulesBalances = ({
           <VaultsBalanceCard
             key="vaults"
             url={vaultsCardUrl}
+            onExternalLinkClicked={onExternalLinkClicked}
+            variant={variant}
+            hideZeroBalances={hideZeroBalances}
+          />
+        );
+      case 'fixedYield':
+        return (
+          <FixedYieldBalanceCard
+            key="fixedYield"
+            url={fixedYieldCardUrl}
             onExternalLinkClicked={onExternalLinkClicked}
             variant={variant}
             hideZeroBalances={hideZeroBalances}

--- a/packages/widgets/src/widgets/BalancesWidget/index.tsx
+++ b/packages/widgets/src/widgets/BalancesWidget/index.tsx
@@ -24,6 +24,7 @@ export type BalancesWidgetProps = WidgetProps & {
   stakeCardUrl?: string;
   stusdsCardUrl?: string;
   vaultsCardUrl?: string;
+  fixedYieldCardUrl?: string;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   onWidgetStateChange?: (params: WidgetStateChangeParams) => void;
   showAllNetworks?: boolean;
@@ -47,6 +48,7 @@ export const BalancesWidget = ({
   stakeCardUrl,
   stusdsCardUrl,
   vaultsCardUrl,
+  fixedYieldCardUrl,
   chainIds,
   showAllNetworks,
   hideZeroBalances,
@@ -70,6 +72,7 @@ export const BalancesWidget = ({
           stakeCardUrl={stakeCardUrl}
           stusdsCardUrl={stusdsCardUrl}
           vaultsCardUrl={vaultsCardUrl}
+          fixedYieldCardUrl={fixedYieldCardUrl}
           onExternalLinkClicked={onExternalLinkClicked}
           showAllNetworks={showAllNetworks}
           hideZeroBalances={hideZeroBalances}
@@ -96,6 +99,7 @@ const BalancesWidgetWrapped = ({
   stakeCardUrl,
   stusdsCardUrl,
   vaultsCardUrl,
+  fixedYieldCardUrl,
   showAllNetworks,
   hideZeroBalances,
   setShowAllNetworks,
@@ -170,6 +174,7 @@ const BalancesWidgetWrapped = ({
               stakeCardUrl={stakeCardUrl}
               stusdsCardUrl={stusdsCardUrl}
               vaultsCardUrl={vaultsCardUrl}
+              fixedYieldCardUrl={fixedYieldCardUrl}
               onExternalLinkClicked={onExternalLinkClicked}
               chainIds={chainIds}
               showAllNetworks={showAllNetworks}


### PR DESCRIPTION
## Summary
- Adds a Fixed Yield card to the Balances widget's Supplied Funds list, backed by Pendle's dashboard API. Features a "Funds by market" accordion (modeled on the Vaults one) with PT token icons, per-row rate or "Matured" label, and a "Rate" / "Rates up to" footer that adapts to the number of active markets.
- Adds a "Fixed yield markets" entry to the Earn with your Stables grid (suggested actions) and to the connected account modal, both wired through a new `fixedYieldCardUrl` prop chain.
- New `useAllPendleUserAssets` hook aggregates user PT positions across supported markets via Pendle's dashboard API, filtered to non-zero balances and normalized to 18 decimals.
- Redesigns the small `Pendle` icon (stairs in a rounded square) and ships a gradient `pendle_icon_large.svg` for use in module cards.

## Test plan
- [ ] Connect a wallet with no Pendle positions — Fixed Yield card hides under the Supplied Funds list (zero-balance filter).
- [ ] Connect a wallet with PT in a single active market — header rate reads `Rate: X.XX%`, card collapses (no accordion).
- [ ] Connect a wallet with PT in multiple active markets — header reads `Rates up to: X.XX%`, accordion expands with per-market rates and PT icons.
- [ ] Connect a wallet holding matured PT — row shows the "Matured" label instead of a rate; clicking it navigates to the Fixed Yield root (not the per-market deep link, which the widget rejects).
- [ ] Open the connected account modal — Fixed Yield row appears and links to `?widget=fixed`.
- [ ] Verify the "Earn with your Stables" grid shows "Fixed yield markets" with PT icons for non-matured markets only, and the label switches between "Rate" / "Rates up to" based on active-market count.