### PR TITLE
Pendle QA fixes: PT icons, retry-after-rejection, quote-error handling

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -57,8 +57,7 @@ import {
   useAvailableTokenRewardContracts,
   MORPHO_VAULTS,
   PENDLE_MARKETS,
-  isMarketMatured,
-  usePendleUserPtBalances
+  isMarketMatured
 } from '@jetstreamgg/sky-hooks';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { useAppAnalytics } from '@/modules/analytics/hooks/useAppAnalytics';
@@ -171,16 +170,15 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
     }
   }));
 
-  // Pendle markets are mainnet-only. Matured markets are hidden unless the connected
-  // user holds a non-zero PT balance for them (mirrors deprecated-rewards behavior).
-  const { data: pendlePtBalances } = usePendleUserPtBalances();
-  const pendleSubItems = PENDLE_MARKETS.filter(market => {
-    if (!isMarketMatured(market.expiry)) return true;
-    const heldBalance = pendlePtBalances?.[market.marketAddress];
-    return heldBalance !== undefined && heldBalance > 0n;
-  }).map(market => ({
+  const pendleSubItems = PENDLE_MARKETS.filter(market => !isMarketMatured(market.expiry)).map(market => ({
     label: `PT-${market.underlyingSymbol}`,
-    icon: <TokenIcon token={{ symbol: 'USDS' }} className="h-3 w-3" showChainIcon={false} />,
+    icon: (
+      <TokenIcon
+        token={{ symbol: `PT-${market.underlyingSymbol}` }}
+        className="h-3 w-3"
+        showChainIcon={false}
+      />
+    ),
     params: {
       [QueryParams.FixedModule]: FixedIntentMapping[FixedIntent.MARKET_INTENT],
       [QueryParams.Market]: market.marketAddress

--- a/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -11,9 +11,9 @@ import {
   type Token
 } from '@jetstreamgg/sky-hooks';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@widgets/components/ui/tabs';
-import { Skeleton } from '@widgets/components/ui/skeleton';
 import { TokenInput } from '@widgets/shared/components/ui/token/TokenInput';
 import { TransactionOverview } from '@widgets/shared/components/ui/transaction/TransactionOverview';
+import { Text } from '@widgets/shared/components/ui/Typography';
 import { motion } from 'motion/react';
 import { positionAnimations } from '@widgets/shared/animation/presets';
 import { MotionVStack } from '@widgets/shared/components/ui/layout/MotionVStack';
@@ -47,6 +47,8 @@ type SupplyWithdrawProps = {
   insufficientFunds: boolean;
   /** User-friendly message for simulation/prepare failure (e.g. slippage too tight). */
   prepareErrorMessage?: string;
+  /** User-friendly message for a failed /convert quote request. */
+  quoteErrorMessage?: string;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
@@ -71,6 +73,7 @@ export const SupplyWithdraw = ({
   enabled,
   insufficientFunds,
   prepareErrorMessage,
+  quoteErrorMessage,
   onExternalLinkClicked
 }: SupplyWithdrawProps) => {
   // Pendle PTs share decimals with the underlying SY (which equals the
@@ -223,85 +226,89 @@ export const SupplyWithdraw = ({
         </TabsContent>
       </Tabs>
 
-      {prepareErrorMessage && amount > 0n && !insufficientFunds && (
-        <div
-          className="bg-error/10 text-error mt-3 rounded-xl px-3 py-2 text-sm"
-          data-testid="pendle-prepare-error-banner"
-          role="alert"
+      {(prepareErrorMessage || quoteErrorMessage) && amount > 0n && !insufficientFunds && (
+        <Text
+          variant="medium"
+          className="text-error mt-3"
+          dataTestId={quoteErrorMessage ? 'pendle-quote-error-banner' : 'pendle-prepare-error-banner'}
         >
-          {prepareErrorMessage}
-        </div>
+          {quoteErrorMessage ?? prepareErrorMessage}
+        </Text>
       )}
 
       {amount > 0n && !insufficientFunds && (
         <TransactionOverview
           title={t`Transaction overview`}
-          isFetching={isFetchingQuote || !quote}
+          isFetching={isFetchingQuote || (!quote && !quoteErrorMessage)}
           fetchingMessage={t`Fetching quote from Pendle`}
           onExternalLinkClicked={onExternalLinkClicked}
-          transactionData={[
-            {
-              label: flow === PendleFlow.BUY ? t`You supply` : t`You redeem`,
-              value: `${formatBigInt(amount, { unit: originDecimals, maxDecimals: 4 })} ${originSymbol}`
-            },
-            {
-              label: t`You receive`,
-              value: formattedReceive ?? <Skeleton className="bg-textSecondary h-4 w-20" />
-            },
-            {
-              label: flow === PendleFlow.BUY ? t`Fixed APY locked` : t`Effective APY`,
-              value: apyDisplay,
-              className: 'text-bullish'
-            },
-            {
-              label: t`Maturity date`,
-              value: maturityDisplay
-            },
-            {
-              label: t`Min. received`,
-              value: formattedMin ?? <Skeleton className="bg-textSecondary h-4 w-20" />
-            },
-            {
-              label: t`Slippage tolerance`,
-              value: `${(slippage * 100).toFixed(2)}%`
-            },
-            {
-              label: t`Price impact`,
-              value: priceImpactRow,
-              className: positiveImpactClass
-            },
-            ...(breakdown
+          transactionData={
+            quote
               ? [
                   {
-                    label: t`  · Pendle AMM`,
-                    value: `${(breakdown.internalPriceImpact * 100).toFixed(3)}%`,
-                    className: positiveImpactClass
+                    label: flow === PendleFlow.BUY ? t`You supply` : t`You redeem`,
+                    value: `${formatBigInt(amount, { unit: originDecimals, maxDecimals: 4 })} ${originSymbol}`
                   },
                   {
-                    label: t`  · Aggregator hop`,
-                    value: `${(breakdown.externalPriceImpact * 100).toFixed(3)}%`,
-                    className: positiveImpactClass
-                  }
-                ]
-              : []),
-            ...(aggregatorName
-              ? [
+                    label: t`You receive`,
+                    value: formattedReceive!
+                  },
                   {
-                    label: t`Routed via`,
-                    value: aggregatorName
+                    label: flow === PendleFlow.BUY ? t`Fixed APY locked` : t`Effective APY`,
+                    value: apyDisplay,
+                    className: 'text-bullish'
+                  },
+                  {
+                    label: t`Maturity date`,
+                    value: maturityDisplay
+                  },
+                  {
+                    label: t`Min. received`,
+                    value: formattedMin!
+                  },
+                  {
+                    label: t`Slippage tolerance`,
+                    value: `${(slippage * 100).toFixed(2)}%`
+                  },
+                  {
+                    label: t`Price impact`,
+                    value: priceImpactRow,
+                    className: positiveImpactClass
+                  },
+                  ...(breakdown
+                    ? [
+                        {
+                          label: t`  · Pendle AMM`,
+                          value: `${(breakdown.internalPriceImpact * 100).toFixed(3)}%`,
+                          className: positiveImpactClass
+                        },
+                        {
+                          label: t`  · Aggregator hop`,
+                          value: `${(breakdown.externalPriceImpact * 100).toFixed(3)}%`,
+                          className: positiveImpactClass
+                        }
+                      ]
+                    : []),
+                  ...(aggregatorName
+                    ? [
+                        {
+                          label: t`Routed via`,
+                          value: aggregatorName
+                        }
+                      ]
+                    : []),
+                  {
+                    label: t`Routing fee`,
+                    value:
+                      quote.feeUsd !== undefined ? (
+                        `$${quote.feeUsd.toFixed(quote.feeUsd >= 1 ? 2 : 4)}`
+                      ) : (
+                        <Trans>Included in quote</Trans>
+                      )
                   }
                 ]
-              : []),
-            {
-              label: t`Routing fee`,
-              value:
-                quote?.feeUsd !== undefined ? (
-                  `$${quote.feeUsd.toFixed(quote.feeUsd >= 1 ? 2 : 4)}`
-                ) : (
-                  <Trans>Included in quote</Trans>
-                )
-            }
-          ]}
+              : undefined
+          }
         />
       )}
     </MotionVStack>

--- a/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -236,7 +236,7 @@ export const SupplyWithdraw = ({
       {amount > 0n && !insufficientFunds && (
         <TransactionOverview
           title={t`Transaction overview`}
-          isFetching={isFetchingQuote && !quote}
+          isFetching={isFetchingQuote || !quote}
           fetchingMessage={t`Fetching quote from Pendle`}
           onExternalLinkClicked={onExternalLinkClicked}
           transactionData={[

--- a/packages/widgets/src/widgets/PendleWidget/index.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/index.tsx
@@ -237,10 +237,12 @@ const PendleWidgetWrapped = ({
 
   const writeHook = batchConvert;
 
-  // Map raw viem/Pendle revert messages to user-friendly copy. Returns
-  // undefined when there's no error to show. Keeping this inline (not a
-  // separate util) since it's tightly coupled to the messages we surface.
+  // Map raw viem/Pendle revert messages to user-friendly copy. Only surfaces
+  // prepare-time errors (simulation / quote-verify); write/mining errors —
+  // including wallet rejection — are handled by the txStatus → ERROR screen
+  // flow, so once we have a usable simulation we suppress this message.
   const prepareErrorMessage = useMemo<string | undefined>(() => {
+    if (writeHook.prepared) return undefined;
     const raw = writeHook.error?.message;
     if (!raw) return undefined;
     if (/INSUFFICIENT_TOKEN_OUT|Slippage:/i.test(raw)) {
@@ -250,7 +252,7 @@ const PendleWidgetWrapped = ({
       return t`Quote expired. Refreshing — please wait a moment.`;
     }
     return t`Unable to prepare transaction. Please try again or adjust your inputs.`;
-  }, [writeHook.error]);
+  }, [writeHook.error, writeHook.prepared]);
 
   // Surface prepare/verify errors as a toast (in addition to inline display).
   useEffect(() => {
@@ -373,7 +375,6 @@ const PendleWidgetWrapped = ({
     amount === 0n ||
     insufficientFunds ||
     isAmountWaitingForDebounce ||
-    !!prepareErrorMessage ||
     !writeHook.prepared ||
     writeHook.isLoading;
 

--- a/packages/widgets/src/widgets/PendleWidget/index.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/index.tsx
@@ -176,7 +176,11 @@ const PendleWidgetWrapped = ({
   const shouldUseBatch = !!batchEnabled && !!batchSupported && needsAllowance;
 
   const debounceSettled = amount === debouncedAmount;
-  const { data: quote, isLoading: isFetchingQuote } = useQuotePendleConvert({
+  const {
+    data: quote,
+    isLoading: isFetchingQuote,
+    error: quoteError
+  } = useQuotePendleConvert({
     side,
     marketAddress: market.marketAddress,
     inputToken,
@@ -186,6 +190,34 @@ const PendleWidgetWrapped = ({
     slippage,
     enabled: isConnectedAndEnabled && debouncedAmount > 0n && debounceSettled
   });
+
+  // Map raw Pendle /convert errors (HTTP failures, malformed quotes, no
+  // routes, network errors) to user-friendly copy.
+  const quoteErrorMessage = useMemo<string | undefined>(() => {
+    const raw = quoteError?.message;
+    if (!raw) return undefined;
+    if (/no routes/i.test(raw)) {
+      return t`No route available for this trade size. Try a different amount.`;
+    }
+    if (/malformed quote/i.test(raw)) {
+      return t`Received an invalid quote from Pendle. Please try again.`;
+    }
+    if (/^Pendle \/convert \d+/i.test(raw)) {
+      return t`Pendle's quote service is temporarily unavailable. Please try again.`;
+    }
+    return t`Couldn't fetch a quote from Pendle. Check your connection and try again.`;
+  }, [quoteError]);
+
+  // Surface quote errors as a toast.
+  useEffect(() => {
+    if (quoteErrorMessage) {
+      onNotification?.({
+        title: t`Error fetching quote`,
+        description: quoteErrorMessage,
+        status: TxStatus.ERROR
+      });
+    }
+  }, [quoteErrorMessage, onNotification]);
 
   const insufficientFunds = useMemo(() => {
     if (!isConnectedAndEnabled || amount === 0n) return false;
@@ -375,6 +407,7 @@ const PendleWidgetWrapped = ({
     amount === 0n ||
     insufficientFunds ||
     isAmountWaitingForDebounce ||
+    !!quoteError ||
     !writeHook.prepared ||
     writeHook.isLoading;
 
@@ -488,6 +521,7 @@ const PendleWidgetWrapped = ({
               enabled={isConnectedAndEnabled}
               insufficientFunds={insufficientFunds}
               prepareErrorMessage={prepareErrorMessage}
+              quoteErrorMessage={quoteErrorMessage}
               onExternalLinkClicked={onExternalLinkClicked}
             />
           </CardAnimationWrapper>

--- a/packages/widgets/src/widgets/PendleWidget/index.tsx
+++ b/packages/widgets/src/widgets/PendleWidget/index.tsx
@@ -196,6 +196,12 @@ const PendleWidgetWrapped = ({
   const quoteErrorMessage = useMemo<string | undefined>(() => {
     const raw = quoteError?.message;
     if (!raw) return undefined;
+    // Pendle rejects inputs valued below $0.01 with a 400. Surfacing the
+    // generic "service unavailable" copy would be misleading — the user
+    // just needs to enter a larger amount.
+    if (/input valuation is too low/i.test(raw)) {
+      return t`Minimum input valuation is $0.01`;
+    }
     if (/no routes/i.test(raw)) {
       return t`No route available for this trade size. Try a different amount.`;
     }


### PR DESCRIPTION
## Summary

Round of QA fixes against the Pendle integration feature branch.

- **Fixed Yield tooltip**: use each market's PT token icon (was hardcoded USDS), and hide matured markets (was previously only hidden when the user held no PT balance).
- **Transaction overview flicker**: ready-state no longer briefly renders before the loading spinner when the user enters an amount — `transactionData` is now gated on `quote` (matches the TradeWidget pattern).
- **Retry after wallet rejection**: the Retry button stayed disabled because wallet-rejection errors leaked into `prepareErrorMessage`, which fed `convertDisabled`. `prepareErrorMessage` is now scoped to prepare-time errors only (suppressed once `writeHook.prepared` is true), and the redundant `!!prepareErrorMessage` clause was dropped from `convertDisabled`.
- **Quote API errors**: `error` from `useQuotePendleConvert` was previously discarded — a failed `/convert` left the UI stuck on the loading spinner. We now surface a toast and an inline message, with branches for: Pendle's $0.01 minimum-valuation 400, "no routes", malformed-quote validation, generic 4xx/5xx, and network errors. `convertDisabled` also gates on `quoteError` so the user can't proceed to Review on a failed quote.
- **Inline error styling**: the existing prepare-error banner (and the new quote-error one) used a bespoke `bg-error/10` card. Aligned both to the rest of the codebase — plain `<Text className="text-error ..."/>`, same shape as `TradeInputs.tsx:271`.

## Test plan

- [ ] Open the widget menu — Fixed Yield tooltip shows PT-USDG / PT-USDe / PT-sENA icons (not USDS) and excludes matured markets.
- [ ] Enter an amount: only the loading spinner appears before the quote arrives (no ready-state flicker).
- [ ] Trigger an approve/supply, reject in the wallet — the Retry button on the error screen is enabled and re-fires the transaction.
- [ ] Enter an amount worth < \$0.01 — inline error reads "Minimum input valuation is \$0.01"; the action button is disabled.
- [ ] Simulate a Pendle API failure (e.g. block `api-v2.pendle.finance` in devtools) — toast fires, inline message shows, action button is disabled, no infinite spinner.
- [ ] Sanity-check the slippage-too-tight inline message still renders in the new `<Text/>` style.