### PR TITLE
refactor(pendle): source PT balances on-chain and split price by usdsEquivalence

### DIFF
--- a/packages/hooks/src/pendle/pendle.d.ts
+++ b/packages/hooks/src/pendle/pendle.d.ts
@@ -313,43 +313,6 @@ export type PendleMarketHistoryHook = ReadHook & {
   data?: PendleTransactionRaw[];
 };
 
-// ---------------------------------------------------------------------------
-// Pendle API transport types (/v1/dashboard/positions/database/{userAddress})
-// ---------------------------------------------------------------------------
-
-export type PendleDashboardLegPositionRaw = {
-  valuation: number;
-  balance: string;
-};
-
-export type PendleDashboardLpPositionRaw = PendleDashboardLegPositionRaw & {
-  activeBalance: string;
-};
-
-export type PendleDashboardOpenPositionRaw = {
-  /** "<chainId>-<marketAddress>" — e.g. "1-0xeab7..." */
-  marketId: string;
-  pt: PendleDashboardLegPositionRaw;
-  yt: PendleDashboardLegPositionRaw;
-  lp: PendleDashboardLpPositionRaw;
-  crossPtPositions: unknown[];
-};
-
-export type PendleDashboardChainPositionsRaw = {
-  chainId: number;
-  totalOpen: number;
-  totalClosed: number;
-  totalSy: number;
-  openPositions: PendleDashboardOpenPositionRaw[];
-  closedPositions: unknown[];
-  syPositions: unknown[];
-  updatedAt: string;
-};
-
-export type PendleDashboardPositionsResponseRaw = {
-  positions: PendleDashboardChainPositionsRaw[];
-};
-
 /** Per-market user PT balance + USD valuation, scoped to markets we support. */
 export type PendleMarketUserAsset = {
   /** Market contract address */
@@ -358,7 +321,7 @@ export type PendleMarketUserAsset = {
   ptBalance: bigint;
   /** User's PT balance normalized to 18 decimals (WAD) */
   ptBalanceNormalized: bigint;
-  /** USD valuation of the PT position, as reported by Pendle's dashboard API */
+  /** USD valuation of the PT position (USDS-equivalent peg × USDS price) */
   valuationUsd: number;
 };
 

--- a/packages/hooks/src/pendle/pendleApiClient.ts
+++ b/packages/hooks/src/pendle/pendleApiClient.ts
@@ -4,7 +4,6 @@ import { PENDLE_API_BASE_URL } from './constants';
 import type {
   PendleConvertRequest,
   PendleConvertResponseRaw,
-  PendleDashboardPositionsResponseRaw,
   PendleMarketSummaryRaw,
   PendleMarketsAllResponseRaw,
   PendleMarketTransactionsResponseRaw,
@@ -105,21 +104,3 @@ export async function fetchPendleMarketTransactions(
   return json.results || [];
 }
 
-/**
- * GET /v1/dashboard/positions/database/{userAddress}
- *
- * Returns the user's Pendle positions across every chain Pendle supports.
- * Results are grouped per chain; consumers must filter to the chains and
- * markets they care about. We use this to aggregate the user's PT holdings
- * across our supported markets for the Balances widget.
- */
-export async function fetchPendleDashboardPositions(
-  userAddress: `0x${string}`
-): Promise<PendleDashboardPositionsResponseRaw> {
-  const url = `${PENDLE_API_BASE_URL}/v1/dashboard/positions/database/${userAddress.toLowerCase()}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Pendle /dashboard/positions ${response.status}`);
-  }
-  return (await response.json()) as PendleDashboardPositionsResponseRaw;
-}

--- a/packages/hooks/src/pendle/useAllPendleUserAssets.ts
+++ b/packages/hooks/src/pendle/useAllPendleUserAssets.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { formatUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
 import { usePrices } from '../prices/usePrices';
 import { PENDLE_MARKETS } from './constants';
@@ -15,9 +15,10 @@ const EMPTY_DATA: AllPendleUserAssetsData = { total: 0n, totalUsd: 0, markets: [
 /**
  * Hook that aggregates the user's PT balances across every Pendle market we
  * support. Reads balances on-chain via PT `balanceOf` (matching the widget) and
- * values them against the USDS price — every market in PENDLE_MARKETS we ship
- * to prod has `usdsEquivalence` set, so USDS price is a sufficient peg. For any
- * non-USDS-equivalent market (dev-only), valuation falls back to 0.
+ * values them against the price implied by each market's `usdsEquivalence`:
+ *   - 'pegged' markets use the USDS price
+ *   - 'sUSDS'  markets use the sUSDS price
+ *   - markets without `usdsEquivalence` (dev-only) fall back to 0.
  *
  * Returns:
  *   - `total`: sum of PT balances normalized to 18 decimals (WAD).
@@ -36,6 +37,7 @@ export function useAllPendleUserAssets(): AllPendleUserAssetsHook {
   const data = useMemo<AllPendleUserAssetsData>(() => {
     if (!ptBalances) return EMPTY_DATA;
     const usdsPrice = pricesData?.USDS ? parseFloat(pricesData.USDS.price) : 0;
+    const sUsdsPrice = pricesData?.sUSDS ? parseFloat(pricesData.sUSDS.price) : 0;
 
     const markets: PendleMarketUserAsset[] = [];
     let total = 0n;
@@ -45,18 +47,16 @@ export function useAllPendleUserAssets(): AllPendleUserAssetsHook {
       const ptBalance = ptBalances[market.marketAddress] || 0n;
       if (ptBalance <= 0n) continue;
 
-      const decimals = market.underlyingDecimals;
-      const normalized =
-        decimals < 18
-          ? ptBalance * 10n ** BigInt(18 - decimals)
-          : decimals > 18
-            ? ptBalance / 10n ** BigInt(decimals - 18)
-            : ptBalance;
+      const formatted = formatUnits(ptBalance, market.underlyingDecimals);
+      const normalized = parseUnits(formatted, 18);
 
-      const valuationUsd =
-        market.usdsEquivalence && usdsPrice > 0
-          ? parseFloat(formatUnits(normalized, 18)) * usdsPrice
-          : 0;
+      const price =
+        market.usdsEquivalence === 'pegged'
+          ? usdsPrice
+          : market.usdsEquivalence === 'sUSDS'
+            ? sUsdsPrice
+            : 0;
+      const valuationUsd = price > 0 ? parseFloat(formatted) * price : 0;
 
       total += normalized;
       totalUsd += valuationUsd;

--- a/packages/hooks/src/pendle/useAllPendleUserAssets.ts
+++ b/packages/hooks/src/pendle/useAllPendleUserAssets.ts
@@ -1,112 +1,87 @@
-import { useQuery } from '@tanstack/react-query';
-import { formatUnits, parseUnits } from 'viem';
-import { useConnection } from 'wagmi';
-import { mainnet } from 'wagmi/chains';
+import { useMemo } from 'react';
+import { formatUnits } from 'viem';
 import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
+import { usePrices } from '../prices/usePrices';
 import { PENDLE_MARKETS } from './constants';
-import { fetchPendleDashboardPositions } from './pendleApiClient';
+import { usePendleUserPtBalances } from './usePendleUserPtBalances';
 import {
   AllPendleUserAssetsData,
   AllPendleUserAssetsHook,
-  PendleMarketConfig,
   PendleMarketUserAsset
 } from './pendle';
 
 const EMPTY_DATA: AllPendleUserAssetsData = { total: 0n, totalUsd: 0, markets: [] };
 
 /**
- * Parse the API's "<chainId>-<marketAddress>" id format and return the
- * lowercased market address (or null if the id is malformed).
- */
-function parseMarketAddress(marketId: string): `0x${string}` | null {
-  const parts = marketId.split('-');
-  if (parts.length !== 2 || !parts[1].startsWith('0x')) return null;
-  return parts[1].toLowerCase() as `0x${string}`;
-}
-
-/**
  * Hook that aggregates the user's PT balances across every Pendle market we
- * support. Sources its data from Pendle's dashboard API (the same backing data
- * shown on app.pendle.finance/dashboard).
- *
- * Filtering:
- *   - Only positions in markets present in PENDLE_MARKETS are returned.
- *   - Only the `pt` leg is included; `yt`, `lp`, `crossPtPositions` are dropped.
- *   - Only chain 1 (mainnet) positions are considered — our integration adds
- *     only mainnet markets, and Pendle's API does not serve Tenderly.
+ * support. Reads balances on-chain via PT `balanceOf` (matching the widget) and
+ * values them against the USDS price — every market in PENDLE_MARKETS we ship
+ * to prod has `usdsEquivalence` set, so USDS price is a sufficient peg. For any
+ * non-USDS-equivalent market (dev-only), valuation falls back to 0.
  *
  * Returns:
  *   - `total`: sum of PT balances normalized to 18 decimals (WAD).
- *     PT decimals match the underlying token's decimals.
- *   - `totalUsd`: sum of per-market `pt.valuation` values from the API.
- *   - `markets`: per-market breakdown with the matched config, raw PT balance,
- *     normalized balance, and USD valuation.
+ *   - `totalUsd`: sum of per-market USD valuations.
+ *   - `markets`: per-market breakdown with raw and normalized balance + USD.
  */
 export function useAllPendleUserAssets(): AllPendleUserAssetsHook {
-  const { address: userAddress } = useConnection();
+  const {
+    data: ptBalances,
+    isLoading: balancesLoading,
+    error: balancesError,
+    mutate: refetchBalances
+  } = usePendleUserPtBalances();
+  const { data: pricesData, isLoading: pricesLoading, error: pricesError } = usePrices();
 
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['pendle-user-assets', userAddress?.toLowerCase()],
-    enabled: !!userAddress,
-    queryFn: async (): Promise<AllPendleUserAssetsData> => {
-      if (!userAddress) return EMPTY_DATA;
-      const json = await fetchPendleDashboardPositions(userAddress);
+  const data = useMemo<AllPendleUserAssetsData>(() => {
+    if (!ptBalances) return EMPTY_DATA;
+    const usdsPrice = pricesData?.USDS ? parseFloat(pricesData.USDS.price) : 0;
 
-      const supported = new Map<string, PendleMarketConfig>();
-      PENDLE_MARKETS.forEach(m => supported.set(m.marketAddress.toLowerCase(), m));
+    const markets: PendleMarketUserAsset[] = [];
+    let total = 0n;
+    let totalUsd = 0;
 
-      const mainnetEntry = json.positions?.find(p => p.chainId === mainnet.id);
-      if (!mainnetEntry) return EMPTY_DATA;
+    for (const market of PENDLE_MARKETS) {
+      const ptBalance = ptBalances[market.marketAddress] || 0n;
+      if (ptBalance <= 0n) continue;
 
-      const markets: PendleMarketUserAsset[] = [];
-      let total = 0n;
-      let totalUsd = 0;
+      const decimals = market.underlyingDecimals;
+      const normalized =
+        decimals < 18
+          ? ptBalance * 10n ** BigInt(18 - decimals)
+          : decimals > 18
+            ? ptBalance / 10n ** BigInt(decimals - 18)
+            : ptBalance;
 
-      for (const pos of mainnetEntry.openPositions || []) {
-        const addr = parseMarketAddress(pos.marketId);
-        if (!addr) continue;
-        const market = supported.get(addr);
-        if (!market) continue;
+      const valuationUsd =
+        market.usdsEquivalence && usdsPrice > 0
+          ? parseFloat(formatUnits(normalized, 18)) * usdsPrice
+          : 0;
 
-        let ptBalance: bigint;
-        try {
-          ptBalance = BigInt(pos.pt.balance);
-        } catch {
-          continue;
-        }
-        if (ptBalance <= 0n) continue;
+      total += normalized;
+      totalUsd += valuationUsd;
+      markets.push({
+        marketAddress: market.marketAddress,
+        ptBalance,
+        ptBalanceNormalized: normalized,
+        valuationUsd
+      });
+    }
 
-        const decimals = market.underlyingDecimals;
-        // const normalized = decimals < 18 ? ptBalance * 10n ** BigInt(18 - decimals) : ptBalance;
-        const normalized = parseUnits(formatUnits(ptBalance, decimals), 18);
-        const valuationUsd = pos.pt.valuation || 0;
-
-        total += normalized;
-        totalUsd += valuationUsd;
-        markets.push({
-          marketAddress: market.marketAddress,
-          ptBalance,
-          ptBalanceNormalized: normalized,
-          valuationUsd
-        });
-      }
-      return { total, totalUsd, markets };
-    },
-    staleTime: 60_000,
-    refetchOnWindowFocus: false
-  });
+    return { total, totalUsd, markets };
+  }, [ptBalances, pricesData]);
 
   return {
-    isLoading,
-    data: data ?? EMPTY_DATA,
-    error: error || null,
-    mutate: refetch,
+    isLoading: balancesLoading || pricesLoading,
+    data,
+    error: balancesError || pricesError || null,
+    mutate: refetchBalances,
     dataSources: [
       {
-        title: 'Pendle Dashboard API',
-        href: 'https://api-v2.pendle.finance/core/docs',
-        onChain: false,
-        trustLevel: TRUST_LEVELS[TrustLevelEnum.TWO]
+        title: 'PT contracts',
+        href: '',
+        onChain: true,
+        trustLevel: TRUST_LEVELS[TrustLevelEnum.ONE]
       }
     ]
   };


### PR DESCRIPTION
## Summary
- Replace the Pendle dashboard API as the source for `useAllPendleUserAssets` with on-chain PT `balanceOf` reads (via `usePendleUserPtBalances`), matching how the widget already reads balances.
- Value each market by its `usdsEquivalence`: `'pegged'` → USDS price, `'sUSDS'` → sUSDS price, undefined → 0. Drops the assumption that USDS price is a sufficient peg for every market.
- Use viem's `formatUnits` + `parseUnits` for decimal normalization instead of manual `10n ** BigInt(...)` shifting.
- Removes the now-unused `fetchPendleDashboardPositions` API client and its transport types.

## Test plan
- [ ] Connect a wallet holding PT-USDG (or other pegged market) and confirm the Fixed Yield card shows the same `totalUsd` and per-market breakdown it did before.
- [ ] Verify markets with `usdsEquivalence: 'sUSDS'` value at the sUSDS price when present (or 0 if the prices endpoint omits sUSDS — worth confirming live).
- [ ] Verify markets without `usdsEquivalence` still report `valuationUsd: 0`.
- [ ] `pnpm typecheck` and `pnpm test` pass.