### PR TITLE
fix(webapp): prevent fixed yield menu item from pushing items off-screen

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetNavigation.tsx
@@ -3,7 +3,7 @@ import { Intent } from '../../../lib/enums';
 import { IntentMapping } from '@/lib/constants';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/tabs';
 import { BP, useBreakpointIndex } from '@/modules/ui/hooks/useBreakpointIndex';
-import { Heading, Text } from '@/modules/layout/components/Typography';
+import { Text } from '@/modules/layout/components/Typography';
 import { Trans } from '@lingui/react/macro';
 import { WidgetContent } from '../types/Widgets';
 import { AnimatePresence, motion } from 'motion/react';
@@ -13,7 +13,7 @@ import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { LinkedActionWrapper } from '@/modules/ui/components/LinkedActionWrapper';
 import { cn } from '@/lib/utils';
 import { Menu, ChevronDown, Loader2 } from 'lucide-react';
-import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { DualSwitcher } from '@/components/DualSwitcher';
 import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
@@ -221,13 +221,6 @@ export function WidgetNavigation({
               closeIconClassName="size-[22px]"
             >
               <div className="flex h-full flex-col">
-                <div className="p-6 pb-4">
-                  <SheetTitle asChild>
-                    <Heading>
-                      <Trans>Menu</Trans>
-                    </Heading>
-                  </SheetTitle>
-                </div>
                 <div className="mt-10 flex-1 overflow-y-auto px-3 pb-6">
                   {widgetContent.map(group =>
                     group.items.map(([widgetIntent, label, icon, , comingSoon, options]) => (
@@ -367,7 +360,13 @@ export function WidgetNavigation({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                   transition={{ duration: 0.3, ease: 'easeOut' }}
-                  className="bg-textSecondary/20 absolute bottom-4 left-1/2 translate-x-[-21px] rounded-full p-2"
+                  onClick={() => {
+                    tabsListRef.current?.scrollTo({
+                      top: tabsListRef.current.scrollHeight,
+                      behavior: 'smooth'
+                    });
+                  }}
+                  className="bg-textSecondary/20 hover:bg-textSecondary/30 absolute bottom-4 left-1/2 translate-x-[-21px] cursor-pointer rounded-full p-2"
                 >
                   <ChevronDown
                     className="scroll-hint-indicator text-textSecondary"

--- a/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
@@ -3,21 +3,14 @@ import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useSearchParams } from 'react-router-dom';
 import { useChainId, useConnection } from 'wagmi';
-import {
-  isMarketMatured,
-  PENDLE_MARKETS,
-  usePendleUserPtBalances,
-  type PendleMarketConfig
-} from '@/hooks';
+import { isMarketMatured, PENDLE_MARKETS, usePendleUserPtBalances, type PendleMarketConfig } from '@/hooks';
 import { isTestnetId } from '@/utils';
 import { mainnet } from 'viem/chains';
-import { FixedIntent } from '@/lib/enums';
-import { FixedIntentMapping, QueryParams } from '@/lib/constants';
+import { QueryParams } from '@/lib/constants';
 import { DetailSection } from '@/modules/ui/components/DetailSection';
 import { DetailSectionRow } from '@/modules/ui/components/DetailSectionRow';
 import { DetailSectionWrapper } from '@/modules/ui/components/DetailSectionWrapper';
 import { Text } from '@/modules/layout/components/Typography';
-import { PendleMarketStatsCard } from './PendleMarketStatsCard';
 import { PendleAbout } from './PendleAbout';
 import { PendleBalanceDetails } from './PendleBalanceDetails';
 import { PendleMarketInfoCard } from './PendleMarketInfoCard';
@@ -33,7 +26,7 @@ const findMarket = (address: string | null): PendleMarketConfig | undefined => {
 };
 
 export const PendleDetailsPane = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const chainId = useChainId();
   const { address: userAddress } = useConnection();
   const isOnPendleChain = isTestnetId(chainId) || chainId === mainnet.id;
@@ -41,23 +34,8 @@ export const PendleDetailsPane = () => {
   const selectedMarketAddress = searchParams.get(QueryParams.Market);
   const selectedMarket = useMemo(() => findMarket(selectedMarketAddress), [selectedMarketAddress]);
 
-  // A market URL is only valid when it points at an active (non-matured)
-  // entry in PENDLE_MARKETS. Matured markets only surface as redeem rows on
-  // the overview, never as a detail view. Unknown addresses (typo/old
-  // deployment) likewise fall through to overview.
   const showSelectedMarket = !!selectedMarket && !isMarketMatured(selectedMarket.expiry);
 
-  // URL cleanup for matured/unknown markets is centralized in PendleWidgetPane
-  // (sibling pane). Doing it here too caused both setSearchParams calls to
-  // race on the same render, with one stomping on the other.
-
-  const handleSelectMarket = (market: PendleMarketConfig) => {
-    setSearchParams(params => {
-      params.set(QueryParams.FixedModule, FixedIntentMapping[FixedIntent.MARKET_INTENT]);
-      params.set(QueryParams.Market, market.marketAddress);
-      return params;
-    });
-  };
   const { data: ptBalances } = usePendleUserPtBalances();
 
   // Whether the user holds matured PT in any market — gates the overview
@@ -95,10 +73,6 @@ export const PendleDetailsPane = () => {
     );
   }
 
-  // Overview. Available markets excludes matured — those live in
-  // PendleReadyToRedeemTable, not as stats cards.
-  const visibleMarkets = PENDLE_MARKETS.filter(market => !isMarketMatured(market.expiry));
-
   if (!isOnPendleChain) {
     return (
       <DetailSectionWrapper>
@@ -130,25 +104,6 @@ export const PendleDetailsPane = () => {
           </DetailSectionRow>
         </DetailSection>
       )}
-      <DetailSection title={t`Available markets`}>
-        <DetailSectionRow>
-          {visibleMarkets.length === 0 ? (
-            <Text className="text-textSecondary">
-              <Trans>No active fixed yield markets at the moment. Check back soon.</Trans>
-            </Text>
-          ) : (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {visibleMarkets.map(market => (
-                <PendleMarketStatsCard
-                  key={market.marketAddress}
-                  market={market}
-                  onClick={() => handleSelectMarket(market)}
-                />
-              ))}
-            </div>
-          )}
-        </DetailSectionRow>
-      </DetailSection>
       <DetailSection title={t`Your transaction history`}>
         <DetailSectionRow>
           <PendleAllMarketsHistory />


### PR DESCRIPTION
## Summary
- Remove the "Menu" title from the mobile/tablet drawer layout to reclaim space.
- Make the scroll hint chevron clickable so users can jump to the bottom of the widget navigation.
- Remove the "Available markets" section from the Fixed Yield details pane.

## Test plan
- [ ] On desktop, when the vertical widget navigation overflows, the scroll hint chevron appears and clicking it scrolls the list to the bottom.
- [ ] On mobile/tablet, opening the drawer no longer shows the "Menu" title.
- [ ] On the Fixed Yield overview, the "Available markets" section is gone; other sections (balances, history) still render correctly.