### PR TITLE
feat(pendle): sync corpus content and wire Fixed Yield banners, FAQs, and tooltips

### DIFF
--- a/apps/webapp/src/data/banners/banners.ts
+++ b/apps/webapp/src/data/banners/banners.ts
@@ -287,22 +287,6 @@ export const banners: Banner[] = [
     display: ['connected', 'disconnected']
   },
   {
-    id: 'about-fixed-yield',
-    title: 'About Fixed Yield',
-    module: 'fixed-yield-banners',
-    description:
-      'Lock in a fixed yield by buying Principal Tokens (PT) at a discount. At maturity each PT redeems 1:1 for the underlying asset — the difference is your fixed yield.',
-    display: ['disconnected']
-  },
-  {
-    id: 'fixed-yield',
-    title: 'Fixed Yield',
-    module: 'fixed-yield-banners',
-    description:
-      'A Principal Token (PT) is a tokenized claim on an underlying yield-bearing asset. PT trades at a discount until maturity, when it redeems 1:1 for the underlying. Holding to maturity locks in a fixed APY; sell early at the prevailing market price if you change your mind.',
-    display: ['connected', 'disconnected']
-  },
-  {
     id: 'usds-risk-capital-vault',
     title: 'USDS Risk Capital Vault',
     module: 'vaults-banners',
@@ -340,6 +324,14 @@ export const banners: Banner[] = [
     module: 'vaults-banners',
     description:
       'Curated by Sky on Morpho, allocates 80% of deposits into sUSDS earning the Sky Savings Rate, and the remaining 20% to markets with volatile bluechip collateral exposure including stUSDS/USDS, cbBTC/USDS, wstETH/USDS and WETH/USDS.',
+    display: ['connected', 'disconnected']
+  },
+  {
+    id: 'fixed-yield',
+    title: 'Fixed Yield',
+    module: 'fixed-yield-banners',
+    description:
+      'Powered by Pendle, allows USDS deposits to lock in a fixed APY until a set maturity date by converting the deposit into PT-sUSDS. The yield is fixed at the moment of supply and guaranteed if held to maturity; early withdrawal is available but settles at the prevailing PT-sUSDS market price.',
     display: ['connected', 'disconnected']
   }
 ];

--- a/apps/webapp/src/data/faqs/getFixedYieldFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getFixedYieldFaqItems.ts
@@ -1,0 +1,30 @@
+export const getFixedYieldFaqItems = () => {
+  const items = [
+    {
+      question: 'What is Fixed Yield, and how does it work?',
+      answer: `Fixed Yield allows you to lock in a fixed APY on USDS deposits until a set maturity date through Pendle, a third-party yield-trading protocol. When you supply USDS, it is converted into PT-sUSDS, which entitles you to redeem a known amount of USDS at the maturity date.
+
+The yield is fixed at the moment you supply, regardless of how the Sky Savings Rate or PT-sUSDS market price changes afterward. The fixed APY is guaranteed only if you hold PT-sUSDS to or past maturity. You can withdraw at any time before maturity, but early withdrawal settles at the prevailing PT-sUSDS market price, so the realized yield may differ from the advertised fixed APY. Please see the [User Risk Documentation](https://docs.sky.money/user-risks) and [Terms of Use](https://docs.sky.money/legal-terms) for more information.`,
+      index: 0
+    },
+    {
+      question: 'What is PT-sUSDS?',
+      answer:
+        'PT-sUSDS is a Principal Token issued by Pendle that represents the right to redeem an underlying amount of USDS via sUSDS at a specific future maturity date. When you supply USDS through Fixed Yield, it is converted into PT-sUSDS at a discount to its redemption value — that discount is what produces the fixed APY when held to maturity. At maturity, each PT-sUSDS becomes redeemable for its full underlying USDS value.',
+      index: 1
+    },
+    {
+      question: 'What happens if I withdraw before maturity?',
+      answer:
+        'You can withdraw at any time, but early withdrawal requires selling PT-sUSDS on the Pendle market rather than redeeming it. The price depends on prevailing market conditions, so the realized APY may be higher or lower than the fixed APY locked in at supply. The advertised fixed APY is guaranteed only if PT-sUSDS is held to or past maturity.',
+      index: 2
+    },
+    {
+      question: 'What happens at and after maturity?',
+      answer:
+        'At maturity, each PT-sUSDS becomes redeemable for its full underlying USDS value, locking in the fixed APY advertised at the time of supply. You can redeem on or any time after the maturity date — there is no penalty for waiting, but PT-sUSDS does not accrue any additional yield once maturity has passed.',
+      index: 3
+    }
+  ];
+  return items.sort((a, b) => a.index - b.index);
+};

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
@@ -171,7 +171,8 @@ const RATE_TOOLTIP_TYPES: Partial<Record<NonNullable<BalancesAction['rateKey']>,
   rewards: 'str',
   savings: 'ssr',
   stusds: 'stusds',
-  staking: 'srr'
+  staking: 'srr',
+  fixedYield: 'fixedYield'
 };
 
 function resolveAction(

--- a/apps/webapp/src/modules/layout/components/ConnectCard.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectCard.tsx
@@ -9,6 +9,7 @@ import { getBannerById } from '@/data/banners/banners';
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { base, arbitrum, optimism, unichain } from 'viem/chains';
 import { Morpho } from '@/widgets';
+import { Pendle as PendleIcon } from '@/widgets/shared/components/icons/Pendle';
 
 // Type for banner configuration
 type BannerConfig = {
@@ -81,6 +82,7 @@ export function ConnectCard({ intent, className, convertOption }: ConnectCardPro
   const contentText = banner?.description ? parseBannerContent(banner.description) : '';
 
   const isMorphoVaults = intent === Intent.VAULTS_INTENT;
+  const isFixedYield = intent === Intent.FIXED_INTENT;
 
   return (
     <GradientShapeCard
@@ -100,13 +102,21 @@ export function ConnectCard({ intent, className, convertOption }: ConnectCardPro
       <div className="w-[80%] space-y-2 self-start xl:w-2/3" data-testid="connect-wallet-card">
         <Heading className="mb-2 flex items-center gap-2">
           {isMorphoVaults && <Morpho className="h-6 w-6 rounded-sm" />}
-          {isMorphoVaults ? <Trans>Vaults</Trans> : heading}
+          {isFixedYield && <PendleIcon className="h-6 w-6 rounded-sm" />}
+          {isMorphoVaults ? <Trans>Vaults</Trans> : isFixedYield ? <Trans>About Fixed Yield</Trans> : heading}
         </Heading>
         {isMorphoVaults ? (
-          <Text variant="small" className="leading-[18px]">
+          <Text variant="small" className="leading-4.5">
             <Trans>
               Connect your wallet to start using Sky-curated Morpho Vaults. Deposit USDS, USDT, or USDC and
               start earning.
+            </Trans>
+          </Text>
+        ) : isFixedYield ? (
+          <Text variant="small" className="leading-4.5">
+            <Trans>
+              Powered by Pendle, deposit USDS to receive PT-sUSDS at a discount and lock in a fixed yield
+              until maturity. The rate is set at deposit and guaranteed if held to maturity.
             </Trans>
           </Text>
         ) : (

--- a/apps/webapp/src/modules/pendle/components/PendleBalanceDetails.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleBalanceDetails.tsx
@@ -5,6 +5,7 @@ import { mainnet } from 'viem/chains';
 import { isTestnetId } from '@/utils';
 import { usePendleUserPtBalances, type PendleMarketConfig } from '@/hooks';
 import { SuppliedBalanceCard, UnsuppliedBalanceCard } from '@/modules/ui/components/BalanceCards';
+import { getTooltipById } from '@/widgets';
 
 type PendleBalanceDetailsProps = {
   market: PendleMarketConfig;
@@ -40,6 +41,8 @@ export const PendleBalanceDetails = ({ market }: PendleBalanceDetailsProps) => {
     decimals: market.underlyingDecimals
   };
 
+  const ptTooltip = getTooltipById('pt-susds');
+
   return (
     <div className="flex w-full flex-col justify-between gap-3 xl:flex-row">
       <SuppliedBalanceCard
@@ -47,6 +50,7 @@ export const PendleBalanceDetails = ({ market }: PendleBalanceDetailsProps) => {
         isLoading={ptLoading}
         token={ptToken}
         label={t`PT balance`}
+        labelTooltip={ptTooltip ? { title: ptTooltip.title, description: ptTooltip.tooltip } : undefined}
         dataTestId="pendle-supplied-balance-details"
       />
       <UnsuppliedBalanceCard

--- a/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleDetailsPane.tsx
@@ -3,12 +3,7 @@ import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useSearchParams } from 'react-router-dom';
 import { useChainId, useConnection } from 'wagmi';
-import {
-  isMarketMatured,
-  PENDLE_MARKETS,
-  usePendleUserPtBalances,
-  type PendleMarketConfig
-} from '@/hooks';
+import { isMarketMatured, PENDLE_MARKETS, usePendleUserPtBalances, type PendleMarketConfig } from '@/hooks';
 import { isTestnetId } from '@/utils';
 import { mainnet } from 'viem/chains';
 import { FixedIntent } from '@/lib/enums';
@@ -25,6 +20,7 @@ import { TimeToMaturityCard } from './TimeToMaturityCard';
 import { PendleMarketHistory } from './PendleMarketHistory';
 import { PendleAllMarketsHistory } from './PendleAllMarketsHistory';
 import { PendleReadyToRedeemTable } from './PendleReadyToRedeemTable';
+import { PendleFaq } from './PendleFaq';
 
 const findMarket = (address: string | null): PendleMarketConfig | undefined => {
   if (!address) return undefined;
@@ -91,6 +87,11 @@ export const PendleDetailsPane = () => {
             <PendleMarketHistory market={selectedMarket!} />
           </DetailSectionRow>
         </DetailSection>
+        <DetailSection title={t`FAQs`}>
+          <DetailSectionRow>
+            <PendleFaq />
+          </DetailSectionRow>
+        </DetailSection>
       </DetailSectionWrapper>
     );
   }
@@ -115,6 +116,11 @@ export const PendleDetailsPane = () => {
         <DetailSection title={t`About`}>
           <DetailSectionRow>
             <PendleAbout />
+          </DetailSectionRow>
+        </DetailSection>
+        <DetailSection title={t`FAQs`}>
+          <DetailSectionRow>
+            <PendleFaq />
           </DetailSectionRow>
         </DetailSection>
       </DetailSectionWrapper>
@@ -157,6 +163,11 @@ export const PendleDetailsPane = () => {
       <DetailSection title={t`About`}>
         <DetailSectionRow>
           <PendleAbout />
+        </DetailSectionRow>
+      </DetailSection>
+      <DetailSection title={t`FAQs`}>
+        <DetailSectionRow>
+          <PendleFaq />
         </DetailSectionRow>
       </DetailSection>
     </DetailSectionWrapper>

--- a/apps/webapp/src/modules/pendle/components/PendleFaq.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleFaq.tsx
@@ -1,0 +1,8 @@
+import { getFixedYieldFaqItems } from '@/data/faqs/getFixedYieldFaqItems';
+import { FaqAccordion } from '@/modules/ui/components/FaqAccordion';
+
+export function PendleFaq() {
+  const faqItems = getFixedYieldFaqItems();
+
+  return <FaqAccordion items={faqItems} />;
+}

--- a/apps/webapp/src/modules/pendle/components/PendleMarketInfoCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMarketInfoCard.tsx
@@ -4,6 +4,7 @@ import { formatDecimalPercentage } from '@/utils';
 import { usePendleMarketsApiData, type PendleMarketConfig } from '@/hooks';
 import { Text } from '@/modules/layout/components/Typography';
 import { StatsCard } from '@/modules/ui/components/StatsCard';
+import { PopoverRateInfo } from '@/widgets';
 
 type PendleMarketInfoCardProps = {
   market: PendleMarketConfig;
@@ -21,9 +22,12 @@ export const PendleMarketInfoCard = ({ market }: PendleMarketInfoCardProps) => {
           isLoading={isLoading}
           error={error}
           content={
-            <Text className="text-bullish mt-2" variant="large">
-              {data?.impliedApy !== undefined ? formatDecimalPercentage(data.impliedApy) : '—'}
-            </Text>
+            <div className="mt-2 flex flex-row items-center gap-2">
+              <Text className="text-bullish" variant="large">
+                {data?.impliedApy !== undefined ? formatDecimalPercentage(data.impliedApy) : '—'}
+              </Text>
+              {data?.impliedApy !== undefined && <PopoverRateInfo type="fixedYield" />}
+            </div>
           }
         />
       </div>

--- a/apps/webapp/src/modules/pendle/components/PendleMarketStatsCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMarketStatsCard.tsx
@@ -8,6 +8,7 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatTimeLeft } from '../utils/formatTimeLeft';
+import { getTooltipById, PopoverInfo, PopoverRateInfo } from '@/widgets';
 
 const secondsToExpiry = (expiry: number): number => Math.max(0, expiry - Math.floor(Date.now() / 1000));
 
@@ -22,6 +23,7 @@ export const PendleMarketStatsCard = ({ market, onClick, disabled = false }: Pen
   const remaining = secondsToExpiry(market.expiry);
   const { data: allMarketsData, isLoading } = usePendleMarketsApiData();
   const marketData = allMarketsData?.[market.marketAddress];
+  const maturityTooltip = getTooltipById('maturity-date');
 
   return (
     <Card
@@ -48,7 +50,10 @@ export const PendleMarketStatsCard = ({ market, onClick, disabled = false }: Pen
         {isLoading ? (
           <Skeleton className="h-4 w-16" />
         ) : marketData?.impliedApy !== undefined ? (
-          <Text className="text-bullish">{formatDecimalPercentage(marketData.impliedApy)}</Text>
+          <HStack className="items-center" gap={2}>
+            <Text className="text-bullish">{formatDecimalPercentage(marketData.impliedApy)}</Text>
+            <PopoverRateInfo type="fixedYield" iconClassName="w-3 h-3" />
+          </HStack>
         ) : (
           <Text>—</Text>
         )}
@@ -68,9 +73,18 @@ export const PendleMarketStatsCard = ({ market, onClick, disabled = false }: Pen
             )}
           </VStack>
           <VStack className="items-stretch justify-between text-right" gap={2}>
-            <Text className="text-textSecondary text-sm leading-4">
-              <Trans>Maturity</Trans>
-            </Text>
+            <HStack className="items-center justify-end" gap={1}>
+              <Text className="text-textSecondary text-sm leading-4">
+                <Trans>Maturity</Trans>
+              </Text>
+              {maturityTooltip && (
+                <PopoverInfo
+                  title={maturityTooltip.title}
+                  description={maturityTooltip.tooltip}
+                  iconClassName="text-textSecondary hover:text-white transition-colors"
+                />
+              )}
+            </HStack>
             <Text className="whitespace-nowrap">
               {new Date(market.expiry * 1000).toLocaleDateString(undefined, {
                 year: 'numeric',

--- a/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
@@ -10,7 +10,7 @@ import {
   type PendleMarketConfig,
   type Token
 } from '@/hooks';
-import { TokenDropdown, TransactionOverview } from '@/widgets';
+import { getTooltipById, TokenDropdown, TransactionOverview } from '@/widgets';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { HStack } from '@/modules/layout/components/HStack';
 import { Text } from '@/modules/layout/components/Typography';
@@ -96,7 +96,9 @@ export const PendleRedeem = ({
               {
                 label: t`Effective APY`,
                 value: formatDecimalPercentage(quote.effectiveApy),
-                className: 'text-bullish'
+                className: 'text-bullish',
+                tooltipTitle: getTooltipById('effective-apy')?.title || '',
+                tooltipText: getTooltipById('effective-apy')?.tooltip || ''
               }
             ]
           : [])

--- a/apps/webapp/src/modules/pendle/components/TimeToMaturityCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/TimeToMaturityCard.tsx
@@ -4,6 +4,7 @@ import { type PendleMarketConfig, usePendleMarketsApiData } from '@/hooks';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { Text } from '@/modules/layout/components/Typography';
 import { formatTimeLeft } from '../utils/formatTimeLeft';
+import { getTooltipById, PopoverInfo } from '@/widgets';
 
 const SECONDS_PER_DAY = 86_400;
 
@@ -68,10 +69,21 @@ export const TimeToMaturityCard = ({ market }: TimeToMaturityCardProps) => {
         })
       : null;
 
+  const maturityTooltip = getTooltipById('maturity-date');
+
   return (
     <Card variant="stats" className="w-full">
-      <CardTitle>
-        <Trans>Time to maturity</Trans>
+      <CardTitle className="flex items-center gap-1">
+        <span>
+          <Trans>Time to maturity</Trans>
+        </span>
+        {maturityTooltip && (
+          <PopoverInfo
+            title={maturityTooltip.title}
+            description={maturityTooltip.tooltip}
+            iconClassName="text-textSecondary hover:text-white transition-colors"
+          />
+        )}
       </CardTitle>
       <CardContent>
         <div className="mt-2 flex items-center justify-between">

--- a/apps/webapp/src/modules/ui/components/BalanceCards.tsx
+++ b/apps/webapp/src/modules/ui/components/BalanceCards.tsx
@@ -11,12 +11,14 @@ import { LoadingErrorWrapper } from './LoadingErrorWrapper';
 import { Text } from '@/modules/layout/components/Typography';
 import { Token } from '@/hooks';
 import { useChainId } from 'wagmi';
+import { PopoverInfo } from '@/widgets';
 
 interface BalanceCardProps {
   balance: bigint | string;
   isLoading: boolean;
   token: Pick<Token, 'symbol' | 'name'> & Partial<Pick<Token, 'decimals'>>;
   label?: string;
+  labelTooltip?: { title: string; description: React.ReactNode };
   toggle?: React.ReactNode;
   error?: Error | null;
   afterBalance?: string;
@@ -34,6 +36,7 @@ interface BaseBalanceCardProps extends BalanceCardProps {
 
 function BaseBalanceCard({
   label,
+  labelTooltip,
   toggle,
   balance,
   icon,
@@ -68,7 +71,7 @@ function BaseBalanceCard({
           error={error ? error : null}
           errorComponent={<ErrorComponent label={label} />}
         >
-          <BaseBalanceCardContent label={label} toggle={toggle}>
+          <BaseBalanceCardContent label={label} labelTooltip={labelTooltip} toggle={toggle}>
             <TokenIconWithBalance
               token={token}
               balance={
@@ -87,10 +90,12 @@ function BaseBalanceCard({
 
 function BaseBalanceCardContent({
   label,
+  labelTooltip,
   toggle,
   children
 }: {
   label: string;
+  labelTooltip?: { title: string; description: React.ReactNode };
   toggle?: React.ReactNode;
   children: React.ReactNode;
 }) {
@@ -103,6 +108,15 @@ function BaseBalanceCardContent({
           </CardTitle>
           {toggle}
         </div>
+      ) : labelTooltip ? (
+        <CardTitle variant="stats" className="mb-2 flex items-center gap-1">
+          <span>{label}</span>
+          <PopoverInfo
+            title={labelTooltip.title}
+            description={labelTooltip.description}
+            iconClassName="text-textSecondary hover:text-white transition-colors"
+          />
+        </CardTitle>
       ) : (
         <CardTitle variant="stats" className="mb-2">
           {label}
@@ -136,6 +150,7 @@ export function SuppliedBalanceCard({
   isLoading,
   token,
   label,
+  labelTooltip,
   error,
   afterBalance,
   dataTestId
@@ -143,6 +158,7 @@ export function SuppliedBalanceCard({
   return (
     <BaseBalanceCard
       label={label || t`Savings balance`}
+      labelTooltip={labelTooltip}
       balance={balance}
       icon={<Supplied />}
       iconEmpty={<SuppliedEmpty />}

--- a/apps/webapp/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/widgets/shared/components/ui/card/InteractiveStatsCardWithMarketAccordion';
 import { Skeleton } from '@/widgets/components/ui/skeleton';
 import { CardProps, ModuleCardVariant } from './ModulesBalances';
+import { RateLineWithArrow } from '@/widgets/shared/components/ui/RateLineWithArrow';
 
 export const FixedYieldBalanceCard = ({
   url,
@@ -110,11 +111,15 @@ export const FixedYieldBalanceCard = ({
         isRateLoading ? (
           <Skeleton className="h-4 w-20" />
         ) : maxRate > 0 ? (
-          <Text variant="small" className="text-bullish">
-            {activeMarketsCount === 1
-              ? t`Rate: ${formatDecimalPercentage(maxRate)}`
-              : t`Rates up to: ${formatDecimalPercentage(maxRate)}`}
-          </Text>
+          <RateLineWithArrow
+            rateText={
+              activeMarketsCount === 1
+                ? t`Rate: ${formatDecimalPercentage(maxRate)}`
+                : t`Rates up to: ${formatDecimalPercentage(maxRate)}`
+            }
+            popoverType="fixedYield"
+            showArrow={false}
+          />
         ) : (
           <></>
         )
@@ -138,9 +143,7 @@ export const FixedYieldBalanceCard = ({
       icon={fixedYieldIcon}
       url={url}
       logoName="fixedYield"
-      content={
-        isBalanceLoading ? <Skeleton className="w-32" /> : <Text>{formatBigInt(total)}</Text>
-      }
+      content={isBalanceLoading ? <Skeleton className="w-32" /> : <Text>{formatBigInt(total)}</Text>}
     />
   );
 };

--- a/apps/webapp/src/widgets/PendleWidget/components/PendleStatsCard.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/components/PendleStatsCard.tsx
@@ -11,6 +11,7 @@ import { MotionVStack } from '@/widgets/shared/components/ui/layout/MotionVStack
 import { Text } from '@/widgets/shared/components/ui/Typography';
 import { Skeleton } from '@/widgets/components/ui/skeleton';
 import { positionAnimations } from '@/widgets/shared/animation/presets';
+import { PopoverRateInfo } from '@/widgets/shared/components/ui/PopoverRateInfo';
 
 type PendleStatsCardProps = {
   market: PendleMarketConfig;
@@ -63,7 +64,10 @@ export const PendleStatsCard = ({ market, onExternalLinkClicked }: PendleStatsCa
           {isLoading ? (
             <Skeleton className="bg-textSecondary h-5 w-16" />
           ) : (
-            <Text className="text-bullish">{apyDisplay}</Text>
+            <>
+              <Text className="text-bullish">{apyDisplay}</Text>
+              <PopoverRateInfo type="fixedYield" onExternalLinkClicked={onExternalLinkClicked} />
+            </>
           )}
         </MotionHStack>
       }

--- a/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -19,6 +19,7 @@ import { positionAnimations } from '@/widgets/shared/animation/presets';
 import { MotionVStack } from '@/widgets/shared/components/ui/layout/MotionVStack';
 import { PendleFlow } from '../lib/constants';
 import { VStack } from '@/widgets/shared/components/ui/layout/VStack';
+import { getTooltipById } from '@/widgets/data/tooltips';
 
 type SupplyWithdrawProps = {
   market: PendleMarketConfig;
@@ -251,12 +252,20 @@ export const SupplyWithdraw = ({
                   },
                   {
                     label: t`You receive`,
-                    value: formattedReceive!
+                    value: formattedReceive!,
+                    ...(flow !== PendleFlow.BUY
+                      ? {
+                          tooltipTitle: getTooltipById('early-withdrawal-impact')?.title || '',
+                          tooltipText: getTooltipById('early-withdrawal-impact')?.tooltip || ''
+                        }
+                      : {})
                   },
                   {
                     label: flow === PendleFlow.BUY ? t`Fixed APY locked` : t`Effective APY`,
                     value: apyDisplay,
-                    className: 'text-bullish'
+                    className: 'text-bullish',
+                    tooltipTitle: getTooltipById('effective-apy')?.title || '',
+                    tooltipText: getTooltipById('effective-apy')?.tooltip || ''
                   },
                   {
                     label: t`Maturity date`,

--- a/apps/webapp/src/widgets/data/tooltips/index.ts
+++ b/apps/webapp/src/widgets/data/tooltips/index.ts
@@ -283,6 +283,36 @@ Bundled transaction: Active`
       'Vault rates are variable and depend on market conditions, borrower demand, and the allocation strategy defined by Sky as vault curator on Morpho. Key factors that influence vault rates include the supply and demand dynamics of the underlying lending markets, the utilization rate of each market the vault allocates to, and the specific allocation strategy and risk profile of the vault. Sky.money does not control or guarantee vault performance. The vault rate provided is an estimated annual rate, updated using data from Morpho, a third-party lending protocol. This estimate is for informational purposes only and does not guarantee future results.'
   },
   {
+    id: 'pt-susds',
+    title: 'PT-sUSDS',
+    tooltip:
+      'PT-sUSDS is a Principal Token issued by Pendle that represents the right to redeem an underlying amount of USDS via sUSDS at a specific future maturity date. It is purchased at a discount to its redemption value, and that discount is what produces the fixed APY when held to maturity. PT-sUSDS is a tradable derivative, not a stablecoin — its market price can fluctuate before maturity.'
+  },
+  {
+    id: 'fixed-yield-rate',
+    title: 'Fixed Yield Rate',
+    tooltip:
+      'The Fixed Yield Rate is the annualized return locked in at the moment USDS is supplied, based on the discount at which PT-sUSDS is purchased on the Pendle market. The rate is guaranteed only if PT-sUSDS is held to or past maturity. Sky.money does not control or guarantee the rate, which is determined by the Pendle market and may differ from the rate displayed before transaction submission.'
+  },
+  {
+    id: 'maturity-date',
+    title: 'Maturity Date',
+    tooltip:
+      'The Maturity Date is the date on which each PT-sUSDS becomes redeemable for its full underlying USDS value, locking in the advertised fixed APY. PT-sUSDS can be redeemed at any time on or after this date and does not accrue any additional yield once maturity has passed. Each Pendle market has a fixed maturity date set when the market is created.'
+  },
+  {
+    id: 'effective-apy',
+    title: 'Effective APY',
+    tooltip:
+      'The Effective APY is the realized annualized yield for a specific order, after accounting for the price impact of trading PT-sUSDS on the Pendle market. Larger orders can move the market price, which may reduce the Effective APY relative to the headline Fixed Yield Rate. The Effective APY shown is an estimate based on current market conditions and may change before the transaction is executed.'
+  },
+  {
+    id: 'early-withdrawal-impact',
+    title: 'Early Withdrawal Impact',
+    tooltip:
+      'Withdrawing before the Maturity Date requires selling PT-sUSDS on the Pendle market rather than redeeming it for the fixed amount. The realized APY on an early withdrawal depends on the prevailing PT-sUSDS market price and may be higher or lower than the Fixed Yield Rate locked in at supply. The advertised fixed APY is guaranteed only if PT-sUSDS is held to or past maturity.'
+  },
+  {
     id: 'rewards-rate',
     title: 'Rewards Rate',
     tooltip:

--- a/apps/webapp/src/widgets/shared/components/ui/PopoverRateInfo.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/PopoverRateInfo.tsx
@@ -33,7 +33,8 @@ const TOOLTIP_ID_MAP = {
   delayedUpgradePenalty: 'delayed-upgrade-penalty',
   remainingCapacity: 'remaining-capacity',
   withdrawalLiquidity: 'withdrawal-liquidity',
-  maximumCapacity: 'maximum-capacity'
+  maximumCapacity: 'maximum-capacity',
+  fixedYield: 'fixed-yield-rate'
 } as const;
 
 type TooltipContent = {

--- a/apps/webapp/src/widgets/shared/components/ui/RateLineWithArrow.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/RateLineWithArrow.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 interface RateLineWithArrowProps {
   rateText: string;
-  popoverType: 'ssr' | 'srr' | 'str' | 'stusds' | 'expert' | 'morpho';
+  popoverType: 'ssr' | 'srr' | 'str' | 'stusds' | 'expert' | 'morpho' | 'fixedYield';
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   showArrow?: boolean;
 }


### PR DESCRIPTION
## Summary
- Sync corpus content
- Add missing Fixed Yield banners, FAQs and tooltips

## Test plan
- [ ] FAQ section renders on Pendle details pane (overview, off-chain fallback, and selected-market views) with content from `getFixedYieldFaqItems`
- [ ] Tooltips appear next to the rate value (not the label) on: balances `Supplied to Fixed Yield` card, `Fixed Yield Markets` suggested action, PT market stats card in `My positions`, in-widget `PT-USDG` stats header, and details-pane `Market info → Fixed APY`
- [ ] Other tooltips render where expected: `PT balance` (PT-sUSDS), `Maturity` column + `Time to maturity` heading (maturity date), `Fixed APY locked` / `Effective APY` transaction overview row (effective APY), and withdraw flow `You receive` row (early withdrawal impact)
- [ ] No regressions to existing rate tooltips (savings, stake, vaults, etc.)