### PR TITLE
fix: handle empty receipts on successful EIP-5792 batch tx

### DIFF
--- a/packages/hooks/src/shared/useSendBatchTransactionFlow.ts
+++ b/packages/hooks/src/shared/useSendBatchTransactionFlow.ts
@@ -62,13 +62,13 @@ export function useSendBatchTransactionFlow<const calls extends readonly unknown
   useEffect(() => {
     if (mutationData?.id) {
       if (isSuccess && data.status === 'success') {
-        onSuccess(data.receipts?.[0].transactionHash);
+        onSuccess(data.receipts?.[0]?.transactionHash);
       } else if (isSuccess && data.status === 'failure') {
         onError(new Error('ERROR: Batch transaction failed'), undefined);
       } else if (miningError) {
-        onError(miningError, data?.receipts?.[0].transactionHash);
+        onError(miningError, data?.receipts?.[0]?.transactionHash);
       } else if (failureReason && txReverted) {
-        onError(toError(failureReason), data?.receipts?.[0].transactionHash);
+        onError(toError(failureReason), data?.receipts?.[0]?.transactionHash);
       }
     }
   }, [isSuccess, miningError, failureReason, mutationData?.id, txReverted, data]);


### PR DESCRIPTION
Guard `receipts[0]?.transactionHash` access in `useSendBatchTransactionFlow` — EIP-5792 wallets can return `status: 'success'` with an empty `receipts` array, which crashed the widget error boundary.

Wallets shouldn't do that but apparently at least one mobile wallet does. With this fix, rather than seeing an error, the user just won't see an etherscan link on the success screen.

Fixes WEBAPP-60.