### PR TITLE
fix: bundle Phosphor icons into single chunk to shrink stale-chunk surface

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -54,7 +54,12 @@ export function initSentry(): void {
       // unhandled rejection. Safe to drop — WalletConnect can't reliably
       // deep-link to wallets from those WebViews anyway (WEBAPP-1Z).
       /Can't find variable: indexedDB/,
-      /indexedDB is not defined/
+      /indexedDB is not defined/,
+      // Stale-chunk after deploy: a long-lived tab has the previous build's
+      // hashed chunk URLs baked into its module graph; the next __vitePreload
+      // 404s. User just needs to refresh — not actionable.
+      /Failed to fetch dynamically imported module.*\/assets\/.+\.js/,
+      /Importing a module script failed.*\/assets\/.+\.js/
     ],
     integrations: [
       Sentry.thirdPartyErrorFilterIntegration({

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -139,7 +139,19 @@ export default ({ mode }: { mode: modeEnum }) => {
       sourcemap: shouldUploadSourcemaps,
       outDir: '../dist',
       emptyOutDir: true,
-      modulePreload: { polyfill: false }
+      modulePreload: { polyfill: false },
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            // Reown's appkit-ui dynamic-imports each Phosphor icon as its own chunk
+            // (50+ per-icon files). Consolidating them shrinks the stale-chunk
+            // surface area after deploys and trades 50 requests for 1.
+            if (id.includes('@phosphor-icons/webcomponents')) {
+              return 'phosphor-icons';
+            }
+          }
+        }
+      }
     },
     test: {
       exclude: [...configDefaults.exclude, '**/test/e2e/**'],

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -140,15 +140,18 @@ export default ({ mode }: { mode: modeEnum }) => {
       outDir: '../dist',
       emptyOutDir: true,
       modulePreload: { polyfill: false },
-      rollupOptions: {
+      rolldownOptions: {
         output: {
-          manualChunks(id) {
-            // Reown's appkit-ui dynamic-imports each Phosphor icon as its own chunk
-            // (50+ per-icon files). Consolidating them shrinks the stale-chunk
-            // surface area after deploys and trades 50 requests for 1.
-            if (id.includes('@phosphor-icons/webcomponents')) {
-              return 'phosphor-icons';
-            }
+          // Reown's appkit-ui dynamic-imports each Phosphor icon as its own chunk
+          // (50+ per-icon files). Consolidating them shrinks the stale-chunk
+          // surface area after deploys and trades 50 requests for 1.
+          codeSplitting: {
+            groups: [
+              {
+                name: 'phosphor-icons',
+                test: /@phosphor-icons[\\/]webcomponents/
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
## Summary

Sentry [WEBAPP-N](https://jetstream-gg.sentry.io/issues/7382743794/) — `TypeError: Failed to fetch dynamically imported module: …/assets/PhCaretRight-….js` (88 events, ongoing) — is the canonical Vite stale-chunk symptom: a user holding an old build hits a 404 on a lazy-loaded chunk after deploy.

Root cause: Reown's `@reown/appkit-ui` transitively pulls in `@phosphor-icons/webcomponents` and dynamic-imports each icon individually. The dist currently ships **52 per-icon `Ph*.js` chunks** (~199KB raw / ~31KB gzipped combined). Each is a potential stale-chunk landmine.

- **`vite.config.ts`** — add `build.rolldownOptions.output.codeSplitting.groups` to coalesce `@phosphor-icons/webcomponents` into a single `phosphor-icons` chunk. Swaps 52 HTTP/2 requests for one ~31KB-gzipped fetch and shrinks the stale-chunk blast radius from "any of 52 icons" to "this one chunk". Uses Vite 8 / Rolldown's current API (`rollupOptions` + `manualChunks` are both deprecated in Vite 8).
- **`src/modules/sentry/init.ts`** — add two regexes to `ignoreErrors` covering the Chromium ("Failed to fetch dynamically imported module") and WebKit ("Importing a module script failed") wordings of the stale-chunk error, scoped to `/assets/*.js` so unrelated fetch failures still report. Users recover by refreshing, so the report adds no signal.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm build` produces a single `phosphor-icons-*.js` chunk in `dist/assets/` and no `Ph*-*.js` per-icon chunks
- [ ] Manually open the connect modal and confirm Phosphor icons (caret, browser, etc.) render correctly
- [ ] Sentry: after deploy, WEBAPP-N stops accruing new events