### PR TITLE
Pendle: correctness fixes from code review

### DIFF
--- a/apps/webapp/src/hooks/pendle/buildVerifiedArgs.test.ts
+++ b/apps/webapp/src/hooks/pendle/buildVerifiedArgs.test.ts
@@ -91,7 +91,8 @@ const BUY_KNOWN = {
   outputToken: PT_USDG,
   underlyingToken: USDG,
   amountIn: 100_000_000n,
-  pinnedPendleSwap: PINNED_PENDLE_SWAP
+  pinnedPendleSwap: PINNED_PENDLE_SWAP,
+  slippage: 0.002 // matches the default 99.8M/100M apiMinOut/amountOut in makeBuyQuote
 };
 
 describe('buildVerifiedArgs — Buy', () => {
@@ -261,7 +262,8 @@ describe('buildVerifiedArgs — Withdraw', () => {
     outputToken: USDG,
     underlyingToken: USDG,
     amountIn: 100_000_000n,
-    pinnedPendleSwap: PINNED_PENDLE_SWAP
+    pinnedPendleSwap: PINNED_PENDLE_SWAP,
+    slippage: 0.005 // matches 99.5M/100M
   };
 
   function withdrawVerified(quote: PendleConvertQuote, known = WITHDRAW_KNOWN) {
@@ -317,6 +319,7 @@ describe('buildVerifiedArgs — Buy aggregator branch', () => {
     inputToken: USDS, // user-picked, NOT the underlying
     outputToken: PT_USDG,
     underlyingToken: USDG,
+    slippage: 0.002,
     amountIn: 100_000_000_000_000_000_000n, // 100 USDS (18 decimals)
     pinnedPendleSwap: PINNED_PENDLE_SWAP
   };
@@ -424,7 +427,8 @@ describe('buildVerifiedArgs — Withdraw aggregator branch', () => {
     outputToken: USDS, // user-picked, NOT the underlying
     underlyingToken: USDG,
     amountIn: 100_000_000n,
-    pinnedPendleSwap: PINNED_PENDLE_SWAP
+    pinnedPendleSwap: PINNED_PENDLE_SWAP,
+    slippage: 0.005
   };
 
   function makeAggWithdrawParams(
@@ -548,7 +552,8 @@ describe('buildVerifiedArgs — Exit (matured-market withdraw)', () => {
     outputToken: USDG,
     underlyingToken: USDG,
     amountIn: 100_000_000n,
-    pinnedPendleSwap: PINNED_PENDLE_SWAP
+    pinnedPendleSwap: PINNED_PENDLE_SWAP,
+    slippage: 0.002
   };
 
   function exitVerified(quote: PendleConvertQuote, known = EXIT_KNOWN) {
@@ -611,7 +616,8 @@ describe('buildVerifiedArgs — Exit aggregator branch', () => {
     outputToken: USDS, // user-picked, NOT the underlying
     underlyingToken: USDG,
     amountIn: 100_000_000n,
-    pinnedPendleSwap: PINNED_PENDLE_SWAP
+    pinnedPendleSwap: PINNED_PENDLE_SWAP,
+    slippage: 0.005
   };
 
   function makeAggExitParams(
@@ -685,6 +691,174 @@ describe('buildVerifiedArgs — Exit aggregator branch', () => {
   it('forces netLpIn to 0 even on aggregator-branch exit', () => {
     const verified = buildVerifiedArgs(makeAggExitQuote(), EXIT_AGG_KNOWN);
     expect(verified.args[3]).toBe(0n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apiMinOut floor — uniform across buy / withdraw / exit.
+// ---------------------------------------------------------------------------
+
+describe('buildVerifiedArgs — apiMinOut slippage floor', () => {
+  function makeBuyQuoteWithMinOut(apiMinOut: bigint): PendleConvertQuote {
+    return {
+      method: 'swapExactTokenForPt',
+      amountOut: 100_000_000n,
+      apiMinOut,
+      effectiveApy: 0.05,
+      impliedApy: 0.058,
+      priceImpact: -0.0002,
+      fetchedAt: Date.now(),
+      apiContractParams: [
+        RECEIVER,
+        MARKET,
+        apiMinOut.toString(),
+        API_GUESS,
+        {
+          tokenIn: USDG,
+          netTokenIn: '100000000',
+          tokenMintSy: USDG,
+          pendleSwap: ZERO,
+          swapData: API_EMPTY_SWAP
+        },
+        API_EMPTY_LIMIT
+      ],
+      apiContractParamsName: BUY_PARAM_NAMES
+    };
+  }
+
+  it('refuses to sign when apiMinOut is 0 (the original attack)', () => {
+    expect(() => buildVerifiedArgs(makeBuyQuoteWithMinOut(0n), BUY_KNOWN)).toThrow(
+      /below the local slippage floor/
+    );
+  });
+
+  it('refuses to sign when apiMinOut is materially below the floor (50% smuggled in)', () => {
+    expect(() => buildVerifiedArgs(makeBuyQuoteWithMinOut(50_000_000n), BUY_KNOWN)).toThrow(
+      /below the local slippage floor/
+    );
+  });
+
+  // floor at 0.2% slippage + 1 bp tolerance = (100M * 9979) / 10_000 = 99_790_000
+  it('accepts apiMinOut equal to the floor', () => {
+    const verified = buildVerifiedArgs(makeBuyQuoteWithMinOut(99_790_000n), BUY_KNOWN);
+    if (verified.side !== PendleConvertSide.BUY) throw new Error('expected BUY');
+    expect(verified.args[2]).toBe(99_790_000n);
+  });
+
+  it('accepts apiMinOut above the floor', () => {
+    const verified = buildVerifiedArgs(makeBuyQuoteWithMinOut(99_900_000n), BUY_KNOWN);
+    if (verified.side !== PendleConvertSide.BUY) throw new Error('expected BUY');
+    expect(verified.args[2]).toBe(99_900_000n);
+  });
+
+  it('refuses to sign when apiMinOut is 1 wei below the floor', () => {
+    expect(() => buildVerifiedArgs(makeBuyQuoteWithMinOut(99_789_999n), BUY_KNOWN)).toThrow(
+      /below the local slippage floor/
+    );
+  });
+
+  it('absorbs 1 bp of rounding drift via TOLERANCE_BP', () => {
+    const verified = buildVerifiedArgs(makeBuyQuoteWithMinOut(99_795_000n), BUY_KNOWN);
+    if (verified.side !== PendleConvertSide.BUY) throw new Error('expected BUY');
+    expect(verified.args[2]).toBe(99_795_000n);
+  });
+
+  it('refuses to sign when slippage is negative', () => {
+    expect(() =>
+      buildVerifiedArgs(makeBuyQuoteWithMinOut(99_800_000n), { ...BUY_KNOWN, slippage: -0.01 })
+    ).toThrow(/slippage .* outside the allowed/);
+  });
+
+  it('refuses to sign when slippage is NaN', () => {
+    expect(() =>
+      buildVerifiedArgs(makeBuyQuoteWithMinOut(99_800_000n), { ...BUY_KNOWN, slippage: NaN })
+    ).toThrow(/slippage .* outside the allowed/);
+  });
+
+  it('refuses to sign when slippage is >= 1', () => {
+    expect(() =>
+      buildVerifiedArgs(makeBuyQuoteWithMinOut(99_800_000n), { ...BUY_KNOWN, slippage: 1.5 })
+    ).toThrow(/slippage .* outside the allowed/);
+  });
+
+  it('floor check fires on the withdraw path too', () => {
+    const withdrawQuote: PendleConvertQuote = {
+      method: 'swapExactPtForToken',
+      amountOut: 100_000_000n,
+      apiMinOut: 0n,
+      effectiveApy: 0.05,
+      impliedApy: 0.058,
+      priceImpact: -0.0002,
+      fetchedAt: Date.now(),
+      apiContractParams: [
+        RECEIVER,
+        MARKET,
+        '100000000',
+        {
+          tokenOut: USDG,
+          minTokenOut: '0',
+          tokenRedeemSy: USDG,
+          pendleSwap: ZERO,
+          swapData: API_EMPTY_SWAP
+        },
+        API_EMPTY_LIMIT
+      ],
+      apiContractParamsName: ['receiver', 'market', 'exactPtIn', 'output', 'limit']
+    };
+    const WITHDRAW_KNOWN_LOCAL = {
+      side: PendleConvertSide.WITHDRAW,
+      receiver: RECEIVER,
+      market: MARKET,
+      inputToken: PT_USDG,
+      outputToken: USDG,
+      underlyingToken: USDG,
+      amountIn: 100_000_000n,
+      pinnedPendleSwap: PINNED_PENDLE_SWAP,
+      slippage: 0.005
+    };
+    expect(() => buildVerifiedArgs(withdrawQuote, WITHDRAW_KNOWN_LOCAL)).toThrow(
+      /below the local slippage floor/
+    );
+  });
+
+  it('floor check fires on the exit (matured) path too', () => {
+    const exitQuote: PendleConvertQuote = {
+      method: 'exitPostExpToToken',
+      amountOut: 100_000_000n,
+      apiMinOut: 0n,
+      effectiveApy: 0,
+      impliedApy: 0,
+      priceImpact: -0.0045,
+      fetchedAt: Date.now(),
+      apiContractParams: [
+        RECEIVER,
+        MARKET,
+        '100000000',
+        '0',
+        {
+          tokenOut: USDG,
+          minTokenOut: '0',
+          tokenRedeemSy: USDG,
+          pendleSwap: ZERO,
+          swapData: API_EMPTY_SWAP
+        }
+      ],
+      apiContractParamsName: ['receiver', 'market', 'netPtIn', 'netLpIn', 'output']
+    };
+    const EXIT_KNOWN_LOCAL = {
+      side: PendleConvertSide.WITHDRAW,
+      receiver: RECEIVER,
+      market: MARKET,
+      inputToken: PT_USDG,
+      outputToken: USDG,
+      underlyingToken: USDG,
+      amountIn: 100_000_000n,
+      pinnedPendleSwap: PINNED_PENDLE_SWAP,
+      slippage: 0.002
+    };
+    expect(() => buildVerifiedArgs(exitQuote, EXIT_KNOWN_LOCAL)).toThrow(
+      /below the local slippage floor/
+    );
   });
 });
 

--- a/apps/webapp/src/hooks/pendle/buildVerifiedArgs.ts
+++ b/apps/webapp/src/hooks/pendle/buildVerifiedArgs.ts
@@ -131,6 +131,8 @@ export type KnownCallValues = {
    * other address is rejected.
    */
   pinnedPendleSwap: `0x${string}`;
+  /** Decimal (0.002 = 0.2%). Used to floor apiMinOut — see verifyApiMinOut. */
+  slippage: number;
 };
 
 // ---------------------------------------------------------------------------
@@ -208,13 +210,32 @@ function resolveAggregatorFields(
 }
 
 /**
- * Extract the `guessPtOut` solver hint from the API's parsed contract params.
- *
- * Position 3 in `swapExactTokenForPt`'s arg list per Pendle's docs. We pass
- * this through verbatim — bad values cause an on-chain revert (no fund loss)
- * since `minPtOut` is recomputed locally and provides the actual protection.
- *
- * Numeric fields come back as decimal wei strings (JSON has no native bigint).
+ * Floor apiMinOut against `amountOut * (1 - slippage)` so a tampered /convert
+ * response can't sneak a too-low minOut into the signed call. Slippage is
+ * re-validated here too — localStorage can be widened past the UI cap.
+ * 1 bp tolerance absorbs honest API/local rounding drift.
+ */
+function verifyApiMinOut(quote: PendleConvertQuote, slippage: number): void {
+  if (!Number.isFinite(slippage) || slippage < 0 || slippage >= 1) {
+    throw new Error(
+      `Pendle: refusing to sign — slippage ${slippage} is outside the allowed [0, 1) range`
+    );
+  }
+  const slippageBp = BigInt(Math.round(slippage * 10_000));
+  const TOLERANCE_BP = 1n;
+  const floorBp = 10_000n - slippageBp - TOLERANCE_BP;
+  if (floorBp <= 0n) return;
+  const expectedMinOut = (quote.amountOut * floorBp) / 10_000n;
+  if (quote.apiMinOut < expectedMinOut) {
+    throw new Error(
+      `Pendle: refusing to sign — apiMinOut ${quote.apiMinOut} is below the local slippage floor ${expectedMinOut} (amountOut=${quote.amountOut}, slippage=${slippage})`
+    );
+  }
+}
+
+/**
+ * Solver hint at position 3. Passed through verbatim — fund safety comes
+ * from the verifyApiMinOut floor on minPtOut, not from these hints.
  */
 function extractGuessPtOut(params: unknown[]): VerifiedBuyArgs[3] {
   const raw = params[3] as
@@ -273,8 +294,9 @@ function extractGuessPtOut(params: unknown[]): VerifiedBuyArgs[3] {
  * Trust anchors of the aggregator branch:
  *   (a) pendleSwap is pinned (only Pendle's audited forwarder),
  *   (b) tokenMintSy/tokenRedeemSy is pinned to the underlying,
- *   (c) apiMinOut bounds the worst-case output denominated in the user-picked
- *       token, so a malicious aggregator hop can at worst revert the tx.
+ *   (c) apiMinOut is floored against `amountOut * (1 - slippage)` so a
+ *       compromised or buggy quote cannot sneak a too-low minOut into the
+ *       signed calldata — see verifyApiMinOut.
  */
 export function buildVerifiedArgs(quote: PendleConvertQuote, known: KnownCallValues): VerifiedCall {
   // 1. Per-flow allowlist
@@ -285,7 +307,10 @@ export function buildVerifiedArgs(quote: PendleConvertQuote, known: KnownCallVal
     throw new Error(`Pendle: refusing to sign — selector "${quote.method}" not allowed for ${known.side}`);
   }
 
-  // 2 + 3. Rebuild args from known values + force-empty.
+  // 2. apiMinOut floor — uniform across buy / withdraw / exit.
+  verifyApiMinOut(quote, known.slippage);
+
+  // 3 + 4. Rebuild args from known values + force-empty.
   // Dispatch on the API's method (already gated by the allowlist above).
   if (quote.method === 'swapExactTokenForPt') {
     return buildBuyArgs(quote, known);

--- a/apps/webapp/src/hooks/pendle/computePendleAssetValuations.test.ts
+++ b/apps/webapp/src/hooks/pendle/computePendleAssetValuations.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { computePendleAssetValuations, ptDiscount } from './computePendleAssetValuations';
+import type { PendleMarketConfig, PendleMarketStats } from './pendle';
+
+const SECONDS_PER_YEAR = 365.25 * 86400;
+const NOW = 1_700_000_000;
+
+const PT_USDG: PendleMarketConfig = {
+  name: 'PT-USDG',
+  marketAddress: '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33',
+  ptToken: '0x9db38D74a0D29380899aD354121DfB521aDb0548',
+  ytToken: '0x4a1294749A70bc32A998B49dd11Bf26E9379e3C1',
+  syToken: '0xc1799CaB1F201946f7CFaFBaF1BCC089b2F08927',
+  underlyingToken: '0xe343167631d89B6Ffc58B88d6b7fB0228795491D',
+  underlyingSymbol: 'USDG',
+  underlyingDecimals: 6,
+  expiry: NOW + SECONDS_PER_YEAR / 2, // 6 months out
+  usdsEquivalence: 'pegged'
+};
+
+const PT_SUSDS: PendleMarketConfig = {
+  name: 'PT-sUSDS',
+  marketAddress: '0x1111111111111111111111111111111111111111',
+  ptToken: '0x2222222222222222222222222222222222222222',
+  ytToken: '0x3333333333333333333333333333333333333333',
+  syToken: '0x4444444444444444444444444444444444444444',
+  underlyingToken: '0x5555555555555555555555555555555555555555',
+  underlyingSymbol: 'sUSDS',
+  underlyingDecimals: 18,
+  expiry: NOW + SECONDS_PER_YEAR, // 1 year out
+  usdsEquivalence: 'sUSDS'
+};
+
+const PT_MATURED: PendleMarketConfig = {
+  ...PT_USDG,
+  name: 'PT-MATURED',
+  marketAddress: '0x6666666666666666666666666666666666666666',
+  expiry: NOW - 60 // matured a minute ago
+};
+
+function stats(impliedApy: number): PendleMarketStats {
+  return { impliedApy } as PendleMarketStats;
+}
+
+describe('ptDiscount', () => {
+  it('returns 1 at maturity (and after)', () => {
+    expect(ptDiscount(0.05, NOW, NOW)).toBe(1);
+    expect(ptDiscount(0.05, NOW - 1, NOW)).toBe(1);
+  });
+
+  it('returns 1 when impliedApy is undefined (loading) — face-value fallback', () => {
+    expect(ptDiscount(undefined, NOW + SECONDS_PER_YEAR, NOW)).toBe(1);
+  });
+
+  it('returns 1 when impliedApy is NaN — defensive', () => {
+    expect(ptDiscount(NaN, NOW + SECONDS_PER_YEAR, NOW)).toBe(1);
+  });
+
+  it('discounts a 1-year, 5% APY PT to ~0.952', () => {
+    const d = ptDiscount(0.05, NOW + SECONDS_PER_YEAR, NOW);
+    expect(d).toBeCloseTo(1 / 1.05, 6);
+  });
+
+  it('discounts a 6-month, 5% APY PT to ~0.976', () => {
+    const d = ptDiscount(0.05, NOW + SECONDS_PER_YEAR / 2, NOW);
+    expect(d).toBeCloseTo(Math.pow(1.05, -0.5), 6);
+  });
+
+  it('handles negative impliedApy (rare but valid — PT trading above underlying)', () => {
+    const d = ptDiscount(-0.02, NOW + SECONDS_PER_YEAR, NOW);
+    expect(d).toBeGreaterThan(1);
+  });
+});
+
+describe('computePendleAssetValuations', () => {
+  it('returns empty data when ptBalances is undefined', () => {
+    const out = computePendleAssetValuations({
+      ptBalances: undefined,
+      usdsPrice: 1,
+      sUsdsPrice: 1.05,
+      marketsApi: undefined,
+      nowSec: NOW
+    });
+    expect(out).toEqual({ total: 0n, totalUsd: 0, markets: [] });
+  });
+
+  it('skips markets where the user holds 0 PT', () => {
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_USDG.marketAddress]: 0n },
+        usdsPrice: 1,
+        sUsdsPrice: 1.05,
+        marketsApi: { [PT_USDG.marketAddress]: stats(0.05) },
+        nowSec: NOW
+      },
+      [PT_USDG]
+    );
+    expect(out.markets).toEqual([]);
+  });
+
+  it('applies the impliedApy discount to a pegged-USDS market', () => {
+    // 6-month, 5% APY → discount ≈ 0.9759
+    // Balance 1000 USDG (1_000_000_000n with 6 decimals) → MTM ≈ $975.90
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_USDG.marketAddress]: 1_000_000_000n },
+        usdsPrice: 1,
+        sUsdsPrice: 0,
+        marketsApi: { [PT_USDG.marketAddress]: stats(0.05) },
+        nowSec: NOW
+      },
+      [PT_USDG]
+    );
+    expect(out.markets).toHaveLength(1);
+    expect(out.markets[0].valuationUsd).toBeCloseTo(1000 * Math.pow(1.05, -0.5), 4);
+    expect(out.totalUsd).toBeCloseTo(1000 * Math.pow(1.05, -0.5), 4);
+  });
+
+  it('applies the impliedApy discount to a sUSDS market', () => {
+    // 1-year, 4% APY → discount ≈ 0.9615
+    // Balance 1 PT (1e18) × sUsdsPrice 1.05 × discount ≈ $1.0096
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_SUSDS.marketAddress]: 1_000_000_000_000_000_000n },
+        usdsPrice: 0,
+        sUsdsPrice: 1.05,
+        marketsApi: { [PT_SUSDS.marketAddress]: stats(0.04) },
+        nowSec: NOW
+      },
+      [PT_SUSDS]
+    );
+    expect(out.markets[0].valuationUsd).toBeCloseTo(1.05 / 1.04, 4);
+  });
+
+  it('values matured markets at face × underlying spot (discount = 1)', () => {
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_MATURED.marketAddress]: 1_000_000n }, // 1 token at 6 dec
+        usdsPrice: 1,
+        sUsdsPrice: 0,
+        marketsApi: { [PT_MATURED.marketAddress]: stats(0.05) }, // ignored — matured
+        nowSec: NOW
+      },
+      [PT_MATURED]
+    );
+    expect(out.markets[0].valuationUsd).toBe(1);
+  });
+
+  it('falls back to face value when impliedApy is missing (loading state)', () => {
+    // No marketsApi entry for this market → discount = 1 → face value displayed
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_USDG.marketAddress]: 1_000_000_000n },
+        usdsPrice: 1,
+        sUsdsPrice: 0,
+        marketsApi: undefined,
+        nowSec: NOW
+      },
+      [PT_USDG]
+    );
+    expect(out.markets[0].valuationUsd).toBe(1000); // face value
+  });
+
+  it('sums valuations across markets', () => {
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: {
+          [PT_USDG.marketAddress]: 1_000_000_000n,
+          [PT_SUSDS.marketAddress]: 1_000_000_000_000_000_000n
+        },
+        usdsPrice: 1,
+        sUsdsPrice: 1.05,
+        marketsApi: {
+          [PT_USDG.marketAddress]: stats(0.05),
+          [PT_SUSDS.marketAddress]: stats(0.04)
+        },
+        nowSec: NOW
+      },
+      [PT_USDG, PT_SUSDS]
+    );
+    const expectedUsdg = 1000 * Math.pow(1.05, -0.5);
+    const expectedSusds = 1.05 / 1.04;
+    expect(out.totalUsd).toBeCloseTo(expectedUsdg + expectedSusds, 4);
+    expect(out.markets).toHaveLength(2);
+  });
+
+  it('returns 0 valuation when underlying price is 0 (no price feed)', () => {
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_USDG.marketAddress]: 1_000_000_000n },
+        usdsPrice: 0,
+        sUsdsPrice: 0,
+        marketsApi: { [PT_USDG.marketAddress]: stats(0.05) },
+        nowSec: NOW
+      },
+      [PT_USDG]
+    );
+    expect(out.markets[0].valuationUsd).toBe(0);
+  });
+
+  it('normalizes PT balance to 18 decimals for the `total` field regardless of underlying decimals', () => {
+    // PT-USDG balance of 1_000_000 (1 token at 6 decimals) → 1e18 normalized.
+    const out = computePendleAssetValuations(
+      {
+        ptBalances: { [PT_USDG.marketAddress]: 1_000_000n },
+        usdsPrice: 1,
+        sUsdsPrice: 0,
+        marketsApi: { [PT_USDG.marketAddress]: stats(0.05) },
+        nowSec: NOW
+      },
+      [PT_USDG]
+    );
+    expect(out.total).toBe(1_000_000_000_000_000_000n);
+    expect(out.markets[0].ptBalance).toBe(1_000_000n);
+    expect(out.markets[0].ptBalanceNormalized).toBe(1_000_000_000_000_000_000n);
+  });
+});

--- a/apps/webapp/src/hooks/pendle/computePendleAssetValuations.ts
+++ b/apps/webapp/src/hooks/pendle/computePendleAssetValuations.ts
@@ -1,0 +1,75 @@
+import { formatUnits, parseUnits } from 'viem';
+import { PENDLE_MARKETS } from './constants';
+import type {
+  AllPendleUserAssetsData,
+  PendleMarketConfig,
+  PendleMarketStats,
+  PendleMarketUserAsset
+} from './pendle';
+
+const EMPTY_DATA: AllPendleUserAssetsData = { total: 0n, totalUsd: 0, markets: [] };
+const SECONDS_PER_YEAR = 365.25 * 86400;
+
+/**
+ * Mark-to-market discount: PT trades below the underlying by the time-value of
+ * the locked-in yield. Pendle's impliedApy is derived from the same relation,
+ * so reversing it gives the PT spot price for free. Returns 1 (face value)
+ * at or past maturity, or whenever impliedApy is unavailable — graceful
+ * fallback for the loading and error paths.
+ */
+export function ptDiscount(impliedApy: number | undefined, expirySec: number, nowSec: number): number {
+  if (impliedApy === undefined || !Number.isFinite(impliedApy)) return 1;
+  const secondsToMaturity = expirySec - nowSec;
+  if (secondsToMaturity <= 0) return 1;
+  const yearsToMaturity = secondsToMaturity / SECONDS_PER_YEAR;
+  return Math.pow(1 + impliedApy, -yearsToMaturity);
+}
+
+export type ComputePendleAssetValuationsInput = {
+  ptBalances: Record<`0x${string}`, bigint> | undefined;
+  usdsPrice: number;
+  sUsdsPrice: number;
+  marketsApi: Partial<Record<`0x${string}`, PendleMarketStats>> | undefined;
+  nowSec: number;
+};
+
+export function computePendleAssetValuations(
+  input: ComputePendleAssetValuationsInput,
+  marketConfigs: readonly PendleMarketConfig[] = PENDLE_MARKETS
+): AllPendleUserAssetsData {
+  if (!input.ptBalances) return EMPTY_DATA;
+
+  const markets: PendleMarketUserAsset[] = [];
+  let total = 0n;
+  let totalUsd = 0;
+
+  for (const market of marketConfigs) {
+    const ptBalance = input.ptBalances[market.marketAddress] || 0n;
+    if (ptBalance <= 0n) continue;
+
+    const formatted = formatUnits(ptBalance, market.underlyingDecimals);
+    const normalized = parseUnits(formatted, 18);
+
+    const underlyingSpot =
+      market.usdsEquivalence === 'pegged'
+        ? input.usdsPrice
+        : market.usdsEquivalence === 'sUSDS'
+          ? input.sUsdsPrice
+          : 0;
+
+    const stats = input.marketsApi?.[market.marketAddress];
+    const discount = ptDiscount(stats?.impliedApy, market.expiry, input.nowSec);
+    const valuationUsd = underlyingSpot > 0 ? parseFloat(formatted) * underlyingSpot * discount : 0;
+
+    total += normalized;
+    totalUsd += valuationUsd;
+    markets.push({
+      marketAddress: market.marketAddress,
+      ptBalance,
+      ptBalanceNormalized: normalized,
+      valuationUsd
+    });
+  }
+
+  return { total, totalUsd, markets };
+}

--- a/apps/webapp/src/hooks/pendle/useAllPendleUserAssets.ts
+++ b/apps/webapp/src/hooks/pendle/useAllPendleUserAssets.ts
@@ -1,28 +1,21 @@
 import { useMemo } from 'react';
-import { formatUnits, parseUnits } from 'viem';
 import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
 import { usePrices } from '../prices/usePrices';
-import { PENDLE_MARKETS } from './constants';
 import { usePendleUserPtBalances } from './usePendleUserPtBalances';
-import {
-  AllPendleUserAssetsData,
-  AllPendleUserAssetsHook,
-  PendleMarketUserAsset
-} from './pendle';
-
-const EMPTY_DATA: AllPendleUserAssetsData = { total: 0n, totalUsd: 0, markets: [] };
+import { usePendleMarketsApiData } from './usePendleMarketsApiData';
+import { computePendleAssetValuations } from './computePendleAssetValuations';
+import { AllPendleUserAssetsData, AllPendleUserAssetsHook } from './pendle';
 
 /**
- * Hook that aggregates the user's PT balances across every Pendle market we
- * support. Reads balances on-chain via PT `balanceOf` (matching the widget) and
- * values them against the price implied by each market's `usdsEquivalence`:
- *   - 'pegged' markets use the USDS price
- *   - 'sUSDS'  markets use the sUSDS price
- *   - markets without `usdsEquivalence` (dev-only) fall back to 0.
+ * Aggregates the user's PT balances across every Pendle market we support.
+ * Reads balances via PT `balanceOf` and values each position mark-to-market
+ * (underlying spot × impliedApy-derived discount), matching Pendle's UI and
+ * the rest of the Balances widget. Falls back to face value (discount = 1)
+ * when impliedApy is still loading.
  *
  * Returns:
  *   - `total`: sum of PT balances normalized to 18 decimals (WAD).
- *   - `totalUsd`: sum of per-market USD valuations.
+ *   - `totalUsd`: sum of per-market mark-to-market USD valuations.
  *   - `markets`: per-market breakdown with raw and normalized balance + USD.
  */
 export function useAllPendleUserAssets(): AllPendleUserAssetsHook {
@@ -33,43 +26,19 @@ export function useAllPendleUserAssets(): AllPendleUserAssetsHook {
     mutate: refetchBalances
   } = usePendleUserPtBalances();
   const { data: pricesData, isLoading: pricesLoading, error: pricesError } = usePrices();
+  const { data: marketsApi } = usePendleMarketsApiData();
 
-  const data = useMemo<AllPendleUserAssetsData>(() => {
-    if (!ptBalances) return EMPTY_DATA;
-    const usdsPrice = pricesData?.USDS ? parseFloat(pricesData.USDS.price) : 0;
-    const sUsdsPrice = pricesData?.sUSDS ? parseFloat(pricesData.sUSDS.price) : 0;
-
-    const markets: PendleMarketUserAsset[] = [];
-    let total = 0n;
-    let totalUsd = 0;
-
-    for (const market of PENDLE_MARKETS) {
-      const ptBalance = ptBalances[market.marketAddress] || 0n;
-      if (ptBalance <= 0n) continue;
-
-      const formatted = formatUnits(ptBalance, market.underlyingDecimals);
-      const normalized = parseUnits(formatted, 18);
-
-      const price =
-        market.usdsEquivalence === 'pegged'
-          ? usdsPrice
-          : market.usdsEquivalence === 'sUSDS'
-            ? sUsdsPrice
-            : 0;
-      const valuationUsd = price > 0 ? parseFloat(formatted) * price : 0;
-
-      total += normalized;
-      totalUsd += valuationUsd;
-      markets.push({
-        marketAddress: market.marketAddress,
-        ptBalance,
-        ptBalanceNormalized: normalized,
-        valuationUsd
-      });
-    }
-
-    return { total, totalUsd, markets };
-  }, [ptBalances, pricesData]);
+  const data = useMemo<AllPendleUserAssetsData>(
+    () =>
+      computePendleAssetValuations({
+        ptBalances,
+        usdsPrice: pricesData?.USDS ? parseFloat(pricesData.USDS.price) : 0,
+        sUsdsPrice: pricesData?.sUSDS ? parseFloat(pricesData.sUSDS.price) : 0,
+        marketsApi,
+        nowSec: Math.floor(Date.now() / 1000)
+      }),
+    [ptBalances, pricesData, marketsApi]
+  );
 
   return {
     isLoading: balancesLoading || pricesLoading,

--- a/apps/webapp/src/hooks/pendle/useBatchPendleConvert.ts
+++ b/apps/webapp/src/hooks/pendle/useBatchPendleConvert.ts
@@ -34,6 +34,12 @@ type UseBatchPendleConvertParams = BatchWriteHookParams & {
   amountIn?: bigint;
   /** The latest quote from useQuotePendleConvert */
   quote?: PendleConvertQuote;
+  /**
+   * The same slippage value passed to useQuotePendleConvert. Threaded into
+   * buildVerifiedArgs so it can floor `apiMinOut` against
+   * `amountOut * (1 - slippage)` and reject quotes that fall below.
+   */
+  slippage: number;
 };
 
 /**
@@ -62,6 +68,7 @@ export function useBatchPendleConvert({
   underlyingToken,
   amountIn,
   quote,
+  slippage,
   enabled: activeTabEnabled = true,
   shouldUseBatch = true,
   onMutate = () => null,
@@ -115,7 +122,8 @@ export function useBatchPendleConvert({
         outputToken,
         underlyingToken,
         amountIn,
-        pinnedPendleSwap
+        pinnedPendleSwap,
+        slippage
       });
       return { verified: v, verifyError: null };
     } catch (e) {
@@ -130,7 +138,8 @@ export function useBatchPendleConvert({
     pinnedPendleSwap,
     amountIn,
     connectedAddress,
-    side
+    side,
+    slippage
   ]);
 
   // Build the call list: optional approve, then convert.

--- a/apps/webapp/src/hooks/pendle/usePendleAllPnlTransactions.test.ts
+++ b/apps/webapp/src/hooks/pendle/usePendleAllPnlTransactions.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePendlePnlRows } from './usePendleAllPnlTransactions';
+import { PendleHistoryAction } from './constants';
+import type { PendlePnlTransactionRaw } from './pendle';
+
+// PT-USDG is the test market wired into PENDLE_MARKETS — resolveMarket() picks
+// it up from its address. Anything else would be filtered as "unsupported."
+const PT_USDG_ADDRESS = '0xc5b32dba5f29f8395fb9591e1a15f23a75214f33';
+
+function row(overrides: Partial<PendlePnlTransactionRaw> = {}): PendlePnlTransactionRaw {
+  return {
+    txHash: '0xabc',
+    timestamp: '2026-04-01T00:00:00Z',
+    market: PT_USDG_ADDRESS,
+    action: 'buyPt',
+    txValueAsset: 100,
+    assetUsd: 1,
+    effectivePtExchangeRate: 0.995,
+    ...overrides
+  } as PendlePnlTransactionRaw;
+}
+
+describe('normalizePendlePnlRows', () => {
+  it('emits a single normalized row for a healthy buyPt', () => {
+    const out = normalizePendlePnlRows([row()]);
+    expect(out).toHaveLength(1);
+    expect(out[0].action).toBe(PendleHistoryAction.BUY_PT);
+    // ptAmount = txValueAsset * effectivePtExchangeRate
+    expect(out[0].ptAmount).toBeCloseTo(99.5, 10);
+    expect(out[0].valueUsd).toBeCloseTo(100, 10);
+  });
+
+  it('emits one row per supported action', () => {
+    const out = normalizePendlePnlRows([
+      row({ action: 'buyPt', txHash: '0x1' }),
+      row({ action: 'sellPt', txHash: '0x2' }),
+      row({ action: 'redeemPy', txHash: '0x3' })
+    ]);
+    expect(out.map(r => r.action)).toEqual([
+      PendleHistoryAction.BUY_PT,
+      PendleHistoryAction.SELL_PT,
+      PendleHistoryAction.REDEEM_PY
+    ]);
+  });
+
+  it('drops rows with NaN txValueAsset', () => {
+    const out = normalizePendlePnlRows([row({ txValueAsset: NaN }), row({ txHash: '0xok' })]);
+    expect(out).toHaveLength(1);
+    expect(out[0].txHash).toBe('0xok');
+  });
+
+  it('drops rows with missing/null effectivePtExchangeRate on a buy/sell', () => {
+    const out = normalizePendlePnlRows([
+      row({ effectivePtExchangeRate: null as unknown as number }),
+      row({ effectivePtExchangeRate: undefined as unknown as number, txHash: '0xb' }),
+      row({ txHash: '0xok' })
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].txHash).toBe('0xok');
+  });
+
+  it('drops rows with NaN assetUsd', () => {
+    const out = normalizePendlePnlRows([row({ assetUsd: NaN })]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('keeps a redeemPy row even with missing effectivePtExchangeRate (not used for redeems)', () => {
+    const out = normalizePendlePnlRows([
+      row({
+        action: 'redeemPy',
+        effectivePtExchangeRate: undefined as unknown as number,
+        txValueAsset: 6143.99,
+        assetUsd: 1
+      })
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].ptAmount).toBe(6143.99);
+  });
+
+  it('drops redeemPy rows with non-positive txValueAsset (YT-only redeem)', () => {
+    const out = normalizePendlePnlRows([row({ action: 'redeemPy', txValueAsset: 0 })]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('drops rows from markets not in PENDLE_MARKETS', () => {
+    const out = normalizePendlePnlRows([row({ market: '0x0000000000000000000000000000000000000000' })]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('drops rows for actions we do not surface (mintPy, addLiquidity, …)', () => {
+    const out = normalizePendlePnlRows([row({ action: 'mintPy' }), row({ action: 'addLiquidity' })]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('sorts surviving rows descending by timestamp', () => {
+    const out = normalizePendlePnlRows([
+      row({ timestamp: '2026-01-01T00:00:00Z', txHash: '0xold' }),
+      row({ timestamp: '2026-03-01T00:00:00Z', txHash: '0xnew' }),
+      row({ timestamp: '2026-02-01T00:00:00Z', txHash: '0xmid' })
+    ]);
+    expect(out.map(r => r.txHash)).toEqual(['0xnew', '0xmid', '0xold']);
+  });
+
+  it('accepts the alternate "<chainId>-<address>" market wire form', () => {
+    const out = normalizePendlePnlRows([row({ market: `1-${PT_USDG_ADDRESS}` })]);
+    expect(out).toHaveLength(1);
+    expect(out[0].market.marketAddress.toLowerCase()).toBe(PT_USDG_ADDRESS);
+  });
+});

--- a/apps/webapp/src/hooks/pendle/usePendleAllPnlTransactions.ts
+++ b/apps/webapp/src/hooks/pendle/usePendleAllPnlTransactions.ts
@@ -36,15 +36,20 @@ function resolveMarket(wireMarket: string): PendleMarketConfig | undefined {
 /**
  * Pure transformer: PnL wire rows → normalized rows tagged with their source
  * market, filtered to PENDLE_MARKETS and surfaced actions, sorted desc by
- * timestamp.
+ * timestamp. Rows with missing or non-finite numeric fields are dropped — the
+ * /v1/pnl/transactions feed has been observed to omit values for in-flight or
+ * just-matured markets, and NaN downstream corrupts both display and the
+ * matured-earnings reconciliation gate (NaN <= 0 is false).
  */
-function normalizePendlePnlRows(rows: PendlePnlTransactionRaw[]): PendleCombinedHistoryRow[] {
+export function normalizePendlePnlRows(rows: PendlePnlTransactionRaw[]): PendleCombinedHistoryRow[] {
   const out: PendleCombinedHistoryRow[] = [];
   for (const tx of rows) {
     const action = mapWireAction(tx.action);
     if (action === undefined) continue;
     const market = resolveMarket(tx.market);
     if (!market) continue;
+    if (!Number.isFinite(tx.txValueAsset) || !Number.isFinite(tx.assetUsd)) continue;
+    if (action !== PendleHistoryAction.REDEEM_PY && !Number.isFinite(tx.effectivePtExchangeRate)) continue;
     // YT-only redeems where no underlying actually moved would render as a
     // confusing "0 USDe Redeem" row; drop them.
     if (action === PendleHistoryAction.REDEEM_PY && !(tx.txValueAsset > 0)) continue;

--- a/apps/webapp/src/hooks/pendle/usePendleCombinedHistory.test.tsx
+++ b/apps/webapp/src/hooks/pendle/usePendleCombinedHistory.test.tsx
@@ -87,6 +87,37 @@ describe('usePendleCombinedHistory', () => {
     expect(result.current.data!.every(r => r.chainId === 1)).toBe(true);
   });
 
+  it('truncates excess fractional digits on the long-product path', () => {
+    // PT-USDG has 6-decimal underlying. txValueAsset * effectivePtExchangeRate
+    // can produce more than 6 fractional digits (e.g. 100.5 * 0.987654321 =
+    // 99.2592292605). The pre-fix code crashed parseUnits on this row.
+    vi.mocked(useAllPendleMarketsHistory).mockReturnValue({
+      data: [row(PT_USDG, PendleHistoryAction.BUY_PT, '2026-04-01T00:00:00Z', 99.2592292605, '0x1')],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+      dataSources: []
+    });
+
+    const { result } = renderHook(() => usePendleCombinedHistory());
+    // Truncated to 6 fractional digits: "99.259229" → 99_259_229n.
+    expect(result.current.data![0].assets).toBe(99_259_229n);
+  });
+
+  it('falls back to toFixed for scientific-notation values', () => {
+    // 1e-7 parses to 0.0000001 — toFixed(18) gives "0.000000100000000000".
+    vi.mocked(useAllPendleMarketsHistory).mockReturnValue({
+      data: [row(PT_USDE, PendleHistoryAction.BUY_PT, '2026-04-01T00:00:00Z', 1e-7, '0x1')],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+      dataSources: []
+    });
+
+    const { result } = renderHook(() => usePendleCombinedHistory());
+    expect(result.current.data![0].assets).toBe(100_000_000_000n); // 1e-7 * 1e18
+  });
+
   it('converts ptAmount float to assets bigint using the source market decimals', () => {
     // PT-USDe has 18-decimal underlying. 6143.99 → 6143_990000000000000000n.
     // PT-USDG has 6-decimal underlying. 100.5 → 100_500_000n.

--- a/apps/webapp/src/hooks/pendle/usePendleCombinedHistory.ts
+++ b/apps/webapp/src/hooks/pendle/usePendleCombinedHistory.ts
@@ -11,13 +11,28 @@ function mapAction(action: PendleHistoryAction): PendleHistoryItem['type'] {
   return TransactionTypeEnum.PENDLE_REDEEM;
 }
 
+/**
+ * toString preserves the user-intended form for short values (6143.99 →
+ * "6143.99", parses to 6143_990000000000000000n at 18 decimals) — toFixed
+ * would expose IEEE-754 noise. But toString also emits scientific notation
+ * for extremes, and `txValueAsset * effectivePtExchangeRate` can produce more
+ * fractional digits than the underlying's precision; both crash parseUnits.
+ * Fall back to toFixed for scientific notation; truncate excess fractional
+ * digits otherwise.
+ */
+function safeStringifyForParse(value: number, decimals: number): string {
+  const str = value.toString();
+  if (/e/i.test(str)) return value.toFixed(decimals);
+  const dot = str.indexOf('.');
+  if (dot < 0) return str;
+  // slice(0, dot + decimals + 1) is a no-op when the fractional part is
+  // already short enough; otherwise it truncates to the underlying's precision.
+  return str.slice(0, dot + decimals + 1);
+}
+
 function rowToItem(row: PendleCombinedHistoryRow): PendleHistoryItem {
-  // toString gives the shortest round-tripping form (6143.99 → "6143.99",
-  // not toFixed's "6143.989999999..."). Fall back to toFixed only when
-  // toString emits scientific notation, which parseUnits rejects.
   const decimals = row.market.underlyingDecimals;
-  const str = row.ptAmount.toString();
-  const assets = parseUnits(/e/i.test(str) ? row.ptAmount.toFixed(decimals) : str, decimals);
+  const assets = parseUnits(safeStringifyForParse(row.ptAmount, decimals) as `${number}`, decimals);
   return {
     blockTimestamp: new Date(row.timestamp),
     transactionHash: row.txHash,

--- a/apps/webapp/src/hooks/shared/useSequentialTransactionFlow.tsx
+++ b/apps/webapp/src/hooks/shared/useSequentialTransactionFlow.tsx
@@ -24,15 +24,9 @@ export function useSequentialTransactionFlow(
   const [isExecuting, setIsExecuting] = useState(false);
   const [hasWriteError, setHasWriteError] = useState(false);
 
-  // Store initial transactions to prevent issues with changing array references
+  // Snapshot of `calls` frozen at execute() time — keeps a refetching quote
+  // from swapping in different args after the user clicked Confirm.
   const transactionsRef = useRef(calls);
-
-  // Only update the ref when execution starts
-  useEffect(() => {
-    if (isExecuting && currentIndex === 0) {
-      transactionsRef.current = calls;
-    }
-  }, [isExecuting, currentIndex, calls]);
 
   // Use the stored transactions during execution
   const stableTransactions = isExecuting ? transactionsRef.current : calls;
@@ -203,7 +197,7 @@ export function useSequentialTransactionFlow(
 
   // Memoize execute function to prevent recreation on every render
   const execute = useCallback(() => {
-    if (currentIndex >= stableTransactions.length) {
+    if (currentIndex >= calls.length) {
       console.log('ERROR: All transactions have been executed');
       return;
     }
@@ -214,6 +208,7 @@ export function useSequentialTransactionFlow(
     }
 
     if (simulationData?.request) {
+      transactionsRef.current = calls; // freeze args for the whole sequence
       setIsExecuting(true);
       writeContract(simulationData.request as Parameters<typeof writeContract>[0]);
     } else {
@@ -228,7 +223,7 @@ export function useSequentialTransactionFlow(
   }, [
     enabled,
     currentIndex,
-    stableTransactions.length,
+    calls,
     currentTransaction,
     simulationData,
     writeContract,

--- a/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
@@ -73,7 +73,7 @@ export const PendleRedeem = ({
         ...(breakdown
           ? [
               {
-                label: t`Pendle pool`,
+                label: t`Pendle redeem`,
                 value: `${formatNumber(-breakdown.internalPriceImpact * 100, { maxDecimals: 3 })}%`,
                 labelClassName: 'pl-4 opacity-70',
                 className: 'opacity-70',
@@ -91,10 +91,10 @@ export const PendleRedeem = ({
           : []),
         {
           label: t`Routed via`,
-          // Redeem direction: PT is always burned via the Pendle pool first;
-          // when an aggregator is in the route, it then swaps the underlying
-          // into the user's chosen output token.
-          value: aggregatorName ? `Pendle pool → ${aggregatorName}` : 'Pendle pool'
+          // Post-maturity, PT is burned via SY at the expiry-frozen rate — no
+          // AMM pool. When an aggregator is in the route, it then swaps the
+          // underlying into the user's chosen output token.
+          value: aggregatorName ? `Pendle redeem → ${aggregatorName}` : 'Pendle redeem'
         },
         {
           label: t`Pendle fee`,

--- a/apps/webapp/src/modules/pendle/hooks/__tests__/usePendleRedeemModal.test.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/__tests__/usePendleRedeemModal.test.tsx
@@ -43,7 +43,9 @@ const QUOTE: PendleConvertQuote = {
 
 const hoisted = vi.hoisted(() => ({
   launchMock: vi.fn(),
-  matured: true
+  matured: true,
+  // Swappable execute fn so tests can prove the latest one fires through onConfirm.
+  currentExecute: (() => undefined) as () => void
 }));
 
 vi.mock('@/hooks', async importOriginal => {
@@ -65,14 +67,20 @@ vi.mock('@/hooks', async importOriginal => {
       mutate: () => undefined,
       dataSources: []
     }),
-    useBatchPendleConvert: () => ({
-      execute: () => undefined,
-      reset: () => undefined,
-      prepared: true,
-      isLoading: false,
-      error: undefined,
-      currentCallIndex: 0
-    })
+    useBatchPendleConvert: () => {
+      // Snapshot the current execute at render time so each render's writeHook
+      // closes over the args from that render — matches the real hook's
+      // semantics (a fresh execute closure per render).
+      const captured = hoisted.currentExecute;
+      return {
+        execute: () => captured(),
+        reset: () => undefined,
+        prepared: true,
+        isLoading: false,
+        error: undefined,
+        currentCallIndex: 0
+      };
+    }
   };
 });
 
@@ -120,6 +128,11 @@ function renderComponent(ui: ReactNode) {
   });
   return {
     container,
+    rerender: (next: ReactNode) => {
+      act(() => {
+        root.render(<I18nProvider i18n={i18n}>{next}</I18nProvider>);
+      });
+    },
     unmount: () => {
       act(() => {
         root.unmount();
@@ -216,6 +229,48 @@ describe('usePendleRedeemModal analytics', () => {
     expect(data.expiry).toBe(MATURED_MARKET.expiry);
     expect(data.aggregatorType).toBe('KYBERSWAP');
     expect(data.feeUsd).toBe(1.23);
+    unmount();
+  });
+});
+
+describe('usePendleRedeemModal onConfirm freshness', () => {
+  beforeEach(() => {
+    hoisted.launchMock.mockClear();
+    // currentExecute is reassigned per test below, so no clear needed here.
+    hoisted.matured = true;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('onConfirm invokes the latest writeHook.execute, not the one captured at launch', () => {
+    // Modal opens with the user's initial selection (e.g. underlying as output).
+    // writeHook.execute closes over that render's args.
+    const executeAtLaunch = vi.fn();
+    hoisted.currentExecute = executeAtLaunch;
+
+    const { rerender, unmount } = renderComponent(<TestConsumer />);
+
+    expect(hoisted.launchMock).toHaveBeenCalledTimes(1);
+    const storedOnConfirm = hoisted.launchMock.mock.calls[0][0].onConfirm;
+
+    // User changes something after launch (output token, slippage, or a
+    // background quote refetch lands). The next render of useBatchPendleConvert
+    // produces a new execute closure referencing the new args. Force the
+    // re-render and swap the hoisted execute to model it.
+    const executeAfterChange = vi.fn();
+    hoisted.currentExecute = executeAfterChange;
+    rerender(<TestConsumer openOnMount={false} />);
+
+    // User clicks Confirm. The stored onConfirm — captured at launch — must
+    // route through the ref and call the latest execute, not the stale one.
+    act(() => {
+      storedOnConfirm();
+    });
+
+    expect(executeAtLaunch).not.toHaveBeenCalled();
+    expect(executeAfterChange).toHaveBeenCalledTimes(1);
     unmount();
   });
 });

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { t } from '@lingui/core/macro';
 import { mainnet } from 'viem/chains';
 import { formatUnits } from 'viem';
@@ -146,6 +146,14 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
 
   const confirmDisabled = !writeHook.prepared || isFetchingQuote || writeHook.isLoading;
 
+  // Stored `onConfirm` closes over the writeHook captured at launch() time;
+  // updateModalContent can't refresh it (its API only updates content fields).
+  // Indirect through a ref so the modal's Confirm button always invokes the
+  // latest execute — picks up output-token / slippage / quote changes the
+  // user made after the modal opened.
+  const executeRef = useRef<() => void>(() => undefined);
+  executeRef.current = () => writeHook.execute();
+
   const openRedeemModal = useCallback(() => {
     const toDecimals = getTokenDecimals(selectedOutputToken, mainnet.id);
     const data = pendleAnalyticsData({
@@ -170,7 +178,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
       rightHeaderComponent,
       confirmLabel: t`Confirm`,
       confirmDisabled,
-      onConfirm: () => writeHook.execute(),
+      onConfirm: () => executeRef.current(),
       sessionId,
       analytics: {
         widgetName: 'fixed',
@@ -184,7 +192,6 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
     });
   }, [
     launch,
-    writeHook,
     market,
     ptToken,
     ptBalance,

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
@@ -71,6 +71,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
     underlyingToken: market.underlyingToken,
     amountIn: isRedeemable ? ptBalance : undefined,
     quote,
+    slippage,
     enabled: isRedeemable,
     shouldUseBatch: true,
     onMutate: () => txCallbacks.onMutate(),

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
@@ -146,11 +146,8 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
 
   const confirmDisabled = !writeHook.prepared || isFetchingQuote || writeHook.isLoading;
 
-  // Stored `onConfirm` closes over the writeHook captured at launch() time;
-  // updateModalContent can't refresh it (its API only updates content fields).
-  // Indirect through a ref so the modal's Confirm button always invokes the
-  // latest execute — picks up output-token / slippage / quote changes the
-  // user made after the modal opened.
+  // Indirect onConfirm through a ref — the stored onConfirm can't be
+  // live-updated, but the ref always points at the latest writeHook.execute.
   const executeRef = useRef<() => void>(() => undefined);
   executeRef.current = () => writeHook.execute();
 

--- a/apps/webapp/src/widgets/PendleWidget/index.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/index.tsx
@@ -269,6 +269,7 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
     underlyingToken: market.underlyingToken,
     amountIn: debouncedAmount > 0n ? debouncedAmount : undefined,
     quote,
+    slippage,
     enabled: isConnectedAndEnabled && debouncedAmount > 0n,
     shouldUseBatch,
     ...txCallbacks


### PR DESCRIPTION
## Summary

Seven targeted fixes to the Pendle integration surfaced by a code review. All are bug fixes — no new features — and each ships with regression tests. Touches Pendle code only, except `6f983b08` which fixes a latent issue in the shared `useSequentialTransactionFlow` hook (no-op for non-Pendle callers).

## Fixes

| Commit | Severity | Fix |
|---|---|---|
| `2b9b5440` | High | Floor `apiMinOut` against `amountOut * (1 - slippage)` in `buildVerifiedArgs`. The verified-args pattern was passing through whatever `minOut` the `/convert` API returned, undermining slippage protection if the API ever returned an unexpected value. +10 tests. |
| `6f983b08` | High | Freeze sequential-tx args at `execute()` time instead of re-snapshotting while `currentIndex === 0`. Otherwise a quote refetch during the ~15s approve window could swap args between what the user reviewed and what the wallet asks them to sign. Affects Pendle + Curve stUSDS, no-op for other callers. |
| `7378eb81` | Medium | Drop NaN rows from `normalizePendlePnlRows` at the API boundary; tolerate `ptAmount` values with more fractional digits than the underlying's decimals via a safe stringifier. Previously a malformed PnL row would crash the activity modal inside `useMemo` with `parseUnits('NaN', n)`. +13 tests. |
| `83543a4e` | Medium | Value PT positions mark-to-market in the Balances widget using the impliedApy-derived discount. Previously displayed face-value-at-maturity, overstating positions by ~2–10% depending on time-to-maturity. Matches Pendle's UI and the rest of the Balances widget. +15 tests. |
| `aeb80900` | Medium | Keep the redeem-modal's stored `onConfirm` fresh across re-renders via a ref. Previously the closure captured `writeHook` at launch time, so a post-launch output-token change would still sign the original token. +1 regression test. |
| `50284f3d` | Low | Label matured-PT redemption as "Pendle redeem" instead of "Pendle pool" — post-expiry there's no AMM pool in the path. |
| `f9adee98` | — | Comment polish on the `executeRef` indirection. |

## Test plan

- [ ] `pnpm typecheck` from repo root
- [ ] `pnpm exec vitest run src/hooks/pendle src/modules/pendle src/widgets/PendleWidget` from `apps/webapp` — all green
- [ ] On Tenderly: open redeem modal on a matured PT, switch output between underlying / USDS / USDC — verify the displayed numbers and wallet popup args track the selection
- [ ] On Tenderly: open the Pendle buy/sell flow, advance to REVIEW, approve — verify the swap-tx args don't shift between review and the wallet popup

## Known but deferred

Two real but low-impact items intentionally left unfixed:

1. **`usePendleSlippage` doesn't sync state across sibling hook instances.** A user adjusting slippage on one matured-redeem card doesn't see it reflected in another card until that card's modal is reopened and the gear is touched. Self-healing per card; the displayed slippage in each modal still matches what's signed (no fund-safety implication). Mostly affects users with PT in multiple matured markets, which is uncommon.

2. **Slippage input is not debounced.** Typing in the custom slippage field fires a `/convert` per keystroke. Trade widget has the same pattern and hasn't been flagged as a problem in practice. Easy to add a debounce or commit-on-blur if telemetry shows excessive API hits.

## Architectural notes (non-blocking, worth knowing)

- **TransactionContext stores JSX + callbacks in state with an asymmetric `updateModalContent` API.** The redeem-modal `onConfirm` bug stemmed directly from `onConfirm` not being in the update set. Locally fixed via an `executeRef` ref-indirection; a render-prop refactor of `TransactionContext` would eliminate the smell at its source.
- **Pendle could adopt Trade's local-slippage-computation pattern.** Trade computes `sellAmountToSign` / `buyAmountToSign` client-side from the API's raw quote. Doing the same for Pendle (`minOut = amountOut * (1 - slippage)`) would obsolete the `apiMinOut` floor check, eliminate slippage-keystroke API hammering, and match Trade's architecture.