### PR TITLE
Exclude sUSDS from withdraw in fixed module

### DIFF
--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
@@ -42,8 +42,8 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
   const matured = isMarketMatured(market.expiry);
   const isRedeemable = matured && ptBalance > 0n;
 
-  const { underlyingToken, ptToken, inputTokenList } = usePendleTokens(market);
-  const [selectedOutputToken, setSelectedOutputToken] = useState<Token>(underlyingToken);
+  const { ptToken, withdrawTokenList } = usePendleTokens(market);
+  const [selectedOutputToken, setSelectedOutputToken] = useState<Token>(withdrawTokenList[0]);
   const outputTokenAddress = selectedOutputToken.address[mainnet.id] as `0x${string}`;
 
   const { slippage, setSlippage, defaultSlippage } = usePendleSlippage('redeem');
@@ -116,7 +116,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
       <PendleRedeem
         market={market}
         ptBalance={ptBalance}
-        outputTokenList={inputTokenList}
+        outputTokenList={withdrawTokenList}
         selectedOutputToken={selectedOutputToken}
         onOutputTokenChange={setSelectedOutputToken}
         quote={quote}
@@ -128,7 +128,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
     [
       market,
       ptBalance,
-      inputTokenList,
+      withdrawTokenList,
       selectedOutputToken,
       quote,
       isFetchingQuote,

--- a/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -25,8 +25,10 @@ import { PendleStatsCard } from './PendleStatsCard';
 type SupplyWithdrawProps = {
   market: PendleMarketConfig;
   ptToken: Token;
-  /** USDS / USDC / underlying — selectable on BUY input and SELL output. */
-  inputTokenList: Token[];
+  /** Tokens selectable on BUY input — underlying + USDS + USDC (de-duped). */
+  supplyTokenList: Token[];
+  /** Tokens selectable on SELL output — supply list minus sUSDS. */
+  withdrawTokenList: Token[];
   /** Currently-selected BUY input token. */
   selectedSupplyToken: Token;
   onSupplyTokenChange: (token: Token) => void;
@@ -57,7 +59,8 @@ type SupplyWithdrawProps = {
 export const SupplyWithdraw = ({
   market,
   ptToken,
-  inputTokenList,
+  supplyTokenList,
+  withdrawTokenList,
   selectedSupplyToken,
   onSupplyTokenChange,
   selectedWithdrawOutToken,
@@ -157,7 +160,7 @@ export const SupplyWithdraw = ({
                 label={t`How much would you like to supply?`}
                 placeholder={t`Enter amount`}
                 token={selectedSupplyToken}
-                tokenList={inputTokenList}
+                tokenList={supplyTokenList}
                 onTokenSelected={t => onSupplyTokenChange(t)}
                 balance={enabled ? inputBalance : undefined}
                 value={amount}
@@ -209,7 +212,7 @@ export const SupplyWithdraw = ({
                 className="w-full"
                 label={t`You receive`}
                 token={targetToken}
-                tokenList={inputTokenList}
+                tokenList={withdrawTokenList}
                 onTokenSelected={t => onWithdrawOutTokenChange(t)}
                 balance={enabled ? outputBalance : undefined}
                 value={quote?.amountOut ?? 0n}

--- a/apps/webapp/src/widgets/PendleWidget/hooks/usePendleTokens.ts
+++ b/apps/webapp/src/widgets/PendleWidget/hooks/usePendleTokens.ts
@@ -5,13 +5,10 @@ import { mainnet } from 'viem/chains';
 export type PendleTokens = {
   underlyingToken: Token;
   ptToken: Token;
-  /**
-   * The selectable token list for the user-picked side of the convert flow:
-   * BUY input or SELL output. Always begins with the market's underlying
-   * (default selection) and appends USDS / USDC if they aren't already the
-   * underlying. Reuses the global TOKENS registry — no inline definitions.
-   */
-  inputTokenList: Token[];
+  /** Supply (BUY) tokens: market underlying + USDS + USDC (de-duped). */
+  supplyTokenList: Token[];
+  /** Withdraw (SELL) tokens: supply list with sUSDS excluded — sUSDS is not a withdrawal option even when it is the SY underlying. */
+  withdrawTokenList: Token[];
 };
 
 // Pendle markets are dynamic (per-market PT address + arbitrary underlying),
@@ -45,7 +42,7 @@ export const usePendleTokens = (market: PendleMarketConfig): PendleTokens => {
     [market.underlyingSymbol, market.underlyingDecimals, market.ptToken]
   );
 
-  const inputTokenList = useMemo<Token[]>(() => {
+  const supplyTokenList = useMemo<Token[]>(() => {
     const seen = new Set<string>([market.underlyingToken.toLowerCase()]);
     const list: Token[] = [underlyingToken];
     for (const candidate of [TOKENS.usds, TOKENS.usdc]) {
@@ -59,5 +56,11 @@ export const usePendleTokens = (market: PendleMarketConfig): PendleTokens => {
     return list;
   }, [market.underlyingToken, underlyingToken]);
 
-  return { underlyingToken, ptToken, inputTokenList };
+  const withdrawTokenList = useMemo<Token[]>(() => {
+    const sUsdsAddr = TOKENS.susds.address[mainnet.id]?.toLowerCase();
+    if (!sUsdsAddr) return supplyTokenList;
+    return supplyTokenList.filter(t => t.address[mainnet.id]?.toLowerCase() !== sUsdsAddr);
+  }, [supplyTokenList]);
+
+  return { underlyingToken, ptToken, supplyTokenList, withdrawTokenList };
 };

--- a/apps/webapp/src/widgets/PendleWidget/index.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/index.tsx
@@ -117,10 +117,10 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
 
   const balanceChainId = isTestnetId(chainId) ? chainId : mainnet.id;
 
-  const { underlyingToken, ptToken, inputTokenList } = usePendleTokens(market);
+  const { underlyingToken, ptToken, supplyTokenList, withdrawTokenList } = usePendleTokens(market);
 
   const [selectedSupplyToken, setSelectedSupplyToken] = useState<Token>(underlyingToken);
-  const [selectedWithdrawOutToken, setSelectedWithdrawOutToken] = useState<Token>(underlyingToken);
+  const [selectedWithdrawOutToken, setSelectedWithdrawOutToken] = useState<Token>(withdrawTokenList[0]);
 
   const handleSupplyTokenChange = (next: Token) => {
     const prevDecimals = getTokenDecimals(selectedSupplyToken, mainnet.id);
@@ -507,7 +507,8 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
             <SupplyWithdraw
               market={market}
               ptToken={ptToken}
-              inputTokenList={inputTokenList}
+              supplyTokenList={supplyTokenList}
+              withdrawTokenList={withdrawTokenList}
               selectedSupplyToken={selectedSupplyToken}
               onSupplyTokenChange={handleSupplyTokenChange}
               selectedWithdrawOutToken={selectedWithdrawOutToken}


### PR DESCRIPTION
## Summary

- Split the token list returned by `usePendleTokens` into two: `supplyTokenList` (deposit side) and `withdrawTokenList` (redeem side).
- Exclude sUSDS from `withdrawTokenList` even when it is the SY underlying. sUSDS is no longer offered as an output token in the withdraw flow or in the matured-redeem modal.
- Keep sUSDS available on the supply side when it is the market underlying.
- The asymmetry only activates when a market underlying is sUSDS.
- Propagate the new prop names through `PendleWidget`, `SupplyWithdraw`, and `usePendleRedeemModal`. The default withdraw selection now reads `withdrawTokenList[0]` so initial state never points at a filtered-out token.

## Resulting behaviour

| Market underlying | Supply dropdown | Withdraw dropdown | Matured redeem dropdown |
|---|---|---|---|
| sUSDS | sUSDS, USDS, USDC | USDS, USDC | USDS, USDC |
| Anything else | underlying, USDS, USDC | underlying, USDS, USDC | underlying, USDS, USDC |

## Testing steps

- [ ] `pnpm -F webapp exec tsc --noEmit` is clean.
- [ ] `pnpm -F webapp exec vitest run src/widgets/PendleWidget src/modules/pendle` is green.
- [ ] In `pnpm dev`, open each shipping Pendle market and confirm supply/withdraw dropdowns both list `underlying + USDS + USDC`.
- [ ] Once a PT-sUSDS market entry exists, confirm supply offers sUSDS (default) + USDS + USDC, while withdraw and matured redeem only offer USDS (default) + USDC.