### PR TITLE
Update Fixed Yield copy across landing page and corpus-synced content

### DIFF
--- a/apps/webapp/src/data/banners/banners.ts
+++ b/apps/webapp/src/data/banners/banners.ts
@@ -331,7 +331,7 @@ export const banners: Banner[] = [
     title: 'Fixed Yield',
     module: 'fixed-yield-banners',
     description:
-      'Powered by Pendle, allows USDS deposits to lock in a fixed APY until a set maturity date by converting the deposit into PT-sUSDS. The yield is fixed at the moment of supply and guaranteed if held to maturity; early withdrawal is available but settles at the prevailing PT-sUSDS market price.',
+      "Powered by Pendle, Fixed Yield lets you set your return by a specific maturity date. Supply USDS to fix today's rate until that date. You can sell your position early, but you exit at the market's current price, which may be higher or lower than what you initially paid.",
     display: ['connected', 'disconnected']
   }
 ];

--- a/apps/webapp/src/data/faqs/getFixedYieldFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getFixedYieldFaqItems.ts
@@ -2,27 +2,26 @@ export const getFixedYieldFaqItems = () => {
   const items = [
     {
       question: 'What is Fixed Yield, and how does it work?',
-      answer: `Fixed Yield allows you to lock in a fixed APY on USDS deposits until a set maturity date through Pendle, a third-party yield-trading protocol. When you supply USDS, it is converted into PT-sUSDS, which entitles you to redeem a known amount of USDS at the maturity date.
-
-The yield is fixed at the moment you supply, regardless of how the Sky Savings Rate or PT-sUSDS market price changes afterward. The fixed APY is guaranteed only if you hold PT-sUSDS to or past maturity. You can withdraw at any time before maturity, but early withdrawal settles at the prevailing PT-sUSDS market price, so the realized yield may differ from the advertised fixed APY. Please see the [User Risk Documentation](https://docs.sky.money/user-risks) and [Terms of Use](https://docs.sky.money/legal-terms) for more information.`,
+      answer:
+        'Fixed Yield lets you set a fixed rate on your USDS until a specific maturity date through Pendle, a third-party yield-trading protocol. When you supply USDS, it is converted into PT-sUSDS, which you can redeem for a known amount of USDS on the maturity date. Your rate is set at the moment of supply and is delivered only if you hold your PT-sUSDS to or past maturity. If you sell your position early, you exit at the prevailing PT-sUSDS market price, which may make your realized return higher or lower than the initial fixed rate. Please see the [User Risk Documentation](https://docs.sky.money/user-risks) and [Terms of Use](https://docs.sky.money/legal-terms) for more information.',
       index: 0
     },
     {
       question: 'What is PT-sUSDS?',
       answer:
-        'PT-sUSDS is a Principal Token issued by Pendle that represents the right to redeem an underlying amount of USDS via sUSDS at a specific future maturity date. When you supply USDS through Fixed Yield, it is converted into PT-sUSDS at a discount to its redemption value — that discount is what produces the fixed APY when held to maturity. At maturity, each PT-sUSDS becomes redeemable for its full underlying USDS value.',
+        'PT-sUSDS is a Principal Token from Pendle that grants the right to redeem underlying USDS on a set maturity date. When you supply USDS through Fixed Yield, it is converted into PT-sUSDS at a discounted price. This discount is the mechanism that delivers your fixed rate if you hold the token until maturity, when it becomes redeemable for its full USDS value.',
       index: 1
     },
     {
       question: 'What happens if I withdraw before maturity?',
       answer:
-        'You can withdraw at any time, but early withdrawal requires selling PT-sUSDS on the Pendle market rather than redeeming it. The price depends on prevailing market conditions, so the realized APY may be higher or lower than the fixed APY locked in at supply. The advertised fixed APY is guaranteed only if PT-sUSDS is held to or past maturity.',
+        'You can withdraw at any time, but early withdrawal requires selling PT-sUSDS on the Pendle market rather than redeeming it. The price depends on prevailing market conditions, so the realized rate may be higher or lower than the fixed rate locked in at supply. The advertised fixed rate is delivered only if PT-sUSDS is held to or past maturity.',
       index: 2
     },
     {
       question: 'What happens at and after maturity?',
       answer:
-        'At maturity, each PT-sUSDS becomes redeemable for its full underlying USDS value, locking in the fixed APY advertised at the time of supply. You can redeem on or any time after the maturity date — there is no penalty for waiting, but PT-sUSDS does not accrue any additional yield once maturity has passed.',
+        "At maturity, your PT-sUSDS becomes fully redeemable for its full underlying USDS value, delivering the fixed rate you set when you supplied. You can redeem on or after this date. While waiting longer doesn't incur a penalty, your position stops earning any return once the maturity date has passed.",
       index: 3
     }
   ];

--- a/apps/webapp/src/modules/layout/components/ConnectCard.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectCard.tsx
@@ -115,8 +115,8 @@ export function ConnectCard({ intent, className, convertOption }: ConnectCardPro
         ) : isFixedYield ? (
           <Text variant="small" className="leading-4.5">
             <Trans>
-              Powered by Pendle, deposit USDS to receive PT-sUSDS at a discount and lock in a fixed yield
-              until maturity. The rate is set at deposit and guaranteed if held to maturity.
+              When volatility plays against you, get a fixed yield over a pre-set period. The rate is set
+              when you deposit your USDS, while expected returns are available at maturity date, not before.
             </Trans>
           </Text>
         ) : (

--- a/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
@@ -101,8 +101,8 @@ export function PendleWidgetPane(sharedProps: SharedProps) {
             subHeader={
               <Text className="text-textSecondary" variant="small">
                 <Trans>
-                  Lock in fixed yield by buying Principal Tokens (PT) at a discount. Each PT redeems 1:1 for
-                  the underlying asset at maturity.
+                  Know your return by a pre-set maturity date. Supply USDS at a discount. Redeem for full
+                  USDS value at maturity.
                 </Trans>
               </Text>
             }

--- a/apps/webapp/src/widgets/data/tooltips/index.ts
+++ b/apps/webapp/src/widgets/data/tooltips/index.ts
@@ -292,13 +292,13 @@ Bundled transaction: Active`
     id: 'fixed-yield-rate',
     title: 'Fixed Yield Rate',
     tooltip:
-      'The Fixed Yield Rate is the annualized return locked in at the moment USDS is supplied, based on the discount at which PT-sUSDS is purchased on the Pendle market. The rate is guaranteed only if PT-sUSDS is held to or past maturity. Sky.money does not control or guarantee the rate, which is determined by the Pendle market and may differ from the rate displayed before transaction submission.'
+      'The Fixed Yield Rate is the annualized return set when you supply USDS, calculated based on the discount at which the resulting PT-sUSDS is purchased on the Pendle market. This rate is guaranteed only if your PT-sUSDS is held to or past maturity. The rate is determined by the Pendle market, not by Sky.money, and may differ from the displayed rate before you complete the transaction.'
   },
   {
     id: 'maturity-date',
     title: 'Maturity Date',
     tooltip:
-      'The Maturity Date is the date on which each PT-sUSDS becomes redeemable for its full underlying USDS value, locking in the advertised fixed APY. PT-sUSDS can be redeemed at any time on or after this date and does not accrue any additional yield once maturity has passed. Each Pendle market has a fixed maturity date set when the market is created.'
+      'The Maturity Date is when your PT-sUSDS becomes redeemable for its full USDS value, securing your fixed return. You can redeem on or after this date. If you hold past this date, your position stops earning yield. If you sell before maturity, your exit value is the prevailing market price. This date is fixed when the Pendle market is created.'
   },
   {
     id: 'effective-apy',


### PR DESCRIPTION
## Summary

Refreshes the Fixed Yield user-facing copy across the landing page and the corpus-synced surfaces. The corpus-synced content was pulled from the `add-fixed-yield-module` branch of `sky-ecosystem/corpus`; the two non-corpus surfaces (page sub-header and connect-card variant) were updated directly because they live with the layout/module code rather than the content pipeline.

## Surfaces touched

| Surface | File | Source |
|---|---|---|
| Fixed Yield page sub-header | `modules/pendle/components/PendleWidgetPane.tsx` | Local |
| Connect-card variant | `modules/layout/components/ConnectCard.tsx` | Local |
| About Fixed Yield banner | `data/banners/banners.ts` | Corpus |
| Fixed Yield Rate tooltip | `widgets/data/tooltips/index.ts` | Corpus |
| Maturity Date tooltip | `widgets/data/tooltips/index.ts` | Corpus |
| Fixed Yield FAQ (all four Q&As) | `data/faqs/getFixedYieldFaqItems.ts` | Corpus |

The `pt-susds`, `effective-apy`, and `early-withdrawal-impact` tooltips were already in sync with corpus and required no changes.

## Testing steps

- [ ] `pnpm -F webapp exec tsc --noEmit` is clean.
- [ ] In `pnpm dev`, open the Fixed Yield module:
  - Confirm the page sub-header reads the new copy.
  - Disconnect the wallet and confirm the connect-card variant reflects the new copy.
  - Open the "About Fixed Yield" panel and confirm the description matches the new banner copy.
  - Hover the ⓘ icons next to the APY and Maturity columns on each market row — both tooltips should show the updated wording.
  - Open the FAQ accordion and confirm all four answers reflect the new copy.