### PR TITLE
development -> staging

### DIFF
--- a/apps/webapp/docs/seal-engine-withdrawal.md
+++ b/apps/webapp/docs/seal-engine-withdrawal.md
@@ -13,17 +13,23 @@ There are two SEAL Engine deployments. Check both — your position may be in ei
 | LockstakeEngine (v2) | `0xCe01C90dE7FD1bcFa39e237FE6D8D9F569e8A6a3` | SKY          |
 | LockstakeEngine (v1) | `0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12` | MKR (legacy) |
 
-## Step 1 — Find your urn index
+## Step 1 — Find your urn and read your position
 
-On the appropriate engine's Etherscan page, open **Contract → Read Contract** and connect your wallet.
+Each position is held in a per-user "urn" contract. To find yours and check what's locked, you'll read from both the engine and the underlying Vat contract.
 
-1. Call `ownerUrnsCount(<yourAddress>)`. Most users have exactly one urn at index `0`.
-2. If you have multiple urns, repeat the withdrawal steps below for each index.
-3. Call `urns(<yourAddress>, <index>)` to see your locked balance (in 18-decimal units) and any outstanding USDS debt.
+On the appropriate engine's Etherscan page, open **Contract → Read Contract**:
+
+1. Call `ownerUrnsCount(<yourAddress>)`. Most users have exactly one urn at index `0`. If you have multiple, repeat the withdrawal steps below for each index.
+2. Call `ownerUrns(<yourAddress>, <index>)` → returns your **urn address**. Save this value.
+3. Call `vat()` → returns the **Vat address**. Save this value.
+4. Call `ilk()` → returns the **ilk** (bytes32 identifier). Save this value.
+5. Open the **Vat contract** on Etherscan at the address from step 3, go to **Read Contract**, and call `urns(<ilk>, <urnAddress>)` using the values from steps 4 and 2. This returns `(ink, art)`:
+   - `ink` = your locked collateral (18-decimal units — SKY in v2, MKR in v1)
+   - `art` = your outstanding USDS debt (18-decimal units)
 
 ## Step 2 — Repay USDS debt (skip if you have no debt)
 
-If `urns(...)` shows non-zero `art` (debt), repay it before withdrawing collateral. `free` will revert otherwise.
+If `art` from Step 1.5 is non-zero, repay it before withdrawing collateral. `free` will revert otherwise.
 
 1. On the **USDS token contract**, call `approve(<engineAddress>, <amount>)` with an amount ≥ your debt. A safe choice is `2^256 - 1` (max uint256).
 2. On the engine's **Write Contract** tab, call `wipeAll(<yourAddress>, <index>)` to repay the full debt.
@@ -41,7 +47,7 @@ free(
 )
 ```
 
-Use the `ink` value from `urns(...)` as `wad` to withdraw everything. Tokens are sent directly to the `to` address.
+Use the `ink` value from Step 1.5 as `wad` to withdraw everything. Tokens are sent directly to the `to` address.
 
 ## Notes & gotchas
 

--- a/apps/webapp/docs/seal-engine-withdrawal.md
+++ b/apps/webapp/docs/seal-engine-withdrawal.md
@@ -1,0 +1,67 @@
+# Withdrawing from the SEAL Engine via Etherscan
+
+The SEAL Engine UI has been removed from the app. The SEAL Engine was deprecated by Sky governance on **April 22, 2025** (MakerDAO Poll `Qmctp1eN`) and replaced by the SKY Staking Engine. Any remaining positions can be withdrawn directly on-chain via Etherscan.
+
+The on-chain exit fee is **0** — users withdraw 100% of their position.
+
+## Which engine are you in?
+
+There are two SEAL Engine deployments. Check both — your position may be in either.
+
+| Contract              | Address                                      | Denomination |
+| --------------------- | -------------------------------------------- | ------------ |
+| LockstakeEngine (v2)  | `0xCe01C90dE7FD1bcFa39e237FE6D8D9F569e8A6a3` | SKY          |
+| LockstakeEngine (v1)  | `0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12` | MKR (legacy) |
+| LockstakeMigrator     | `0x473d02f88B53C310dD1f1f7A689b0723F3eF90B`  | v1 → v2      |
+
+**Legacy MKR holders must migrate to v2 first** via `LockstakeMigrator` (1 MKR → 24,000 SKY), then withdraw from v2.
+
+## Step 1 — Find your urn index
+
+On the appropriate engine's Etherscan page, open **Contract → Read Contract** and connect your wallet.
+
+1. Call `ownerUrnsCount(<yourAddress>)`. Most users have exactly one urn at index `0`.
+2. If you have multiple urns, repeat the withdrawal steps below for each index.
+3. Call `urns(<yourAddress>, <index>)` to see your locked balance (in 18-decimal units) and any outstanding USDS debt.
+
+## Step 2 — Repay USDS debt (skip if you have no debt)
+
+If `urns(...)` shows non-zero `art` (debt), repay it before withdrawing collateral. `free` will revert otherwise.
+
+1. On the **USDS token contract**, call `approve(<engineAddress>, <amount>)` with an amount ≥ your debt. A safe choice is `2^256 - 1` (max uint256).
+2. On the engine's **Write Contract** tab, call `wipeAll(<yourAddress>, <index>)` to repay the full debt.
+
+## Step 3 — Withdraw your collateral
+
+On the engine's **Write Contract** tab:
+
+```
+free(
+  owner: <yourAddress>,
+  index: <urnIndex>,
+  to:    <yourAddress>,
+  wad:   <amountIn18Decimals>
+)
+```
+
+Use the `ink` value from `urns(...)` as `wad` to withdraw everything. Tokens are sent directly to the `to` address.
+
+## Legacy v1 (MKR) flow
+
+If your position is in the v1 engine:
+
+1. Call `LockstakeMigrator.migrate(<index>)` (or the appropriate migration entrypoint — check the migrator's Etherscan ABI).
+2. Your position is moved to v2 as SKY at the 1:24,000 conversion ratio.
+3. Follow the v2 withdrawal flow above against `LockstakeEngine v2`.
+
+## Notes & gotchas
+
+- `wad` values are 18-decimal **SKY** in v2, not MKR. 1 MKR-equivalent position = 24,000e18 SKY.
+- `free` reverts if any USDS debt remains — always `wipeAll` first.
+- If `urnFarms(<urnAddress>)` is non-zero, `free` auto-withdraws from the farm; no explicit `selectFarm(0x0)` is required.
+- To claim pending rewards before withdrawing, call `getReward(<owner>, <index>, <farm>, <to>)`.
+- Only the position owner can call these functions, unless `hope(<owner>, <index>, <delegate>)` has been set.
+
+## Support
+
+If you can't complete the withdrawal, contact support with your wallet address and the engine version (v1 or v2) so we can help diagnose.

--- a/apps/webapp/docs/seal-engine-withdrawal.md
+++ b/apps/webapp/docs/seal-engine-withdrawal.md
@@ -8,13 +8,10 @@ The on-chain exit fee is **0** — users withdraw 100% of their position.
 
 There are two SEAL Engine deployments. Check both — your position may be in either.
 
-| Contract              | Address                                      | Denomination |
-| --------------------- | -------------------------------------------- | ------------ |
-| LockstakeEngine (v2)  | `0xCe01C90dE7FD1bcFa39e237FE6D8D9F569e8A6a3` | SKY          |
-| LockstakeEngine (v1)  | `0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12` | MKR (legacy) |
-| LockstakeMigrator     | `0x473d02f88B53C310dD1f1f7A689b0723F3eF90B`  | v1 → v2      |
-
-**Legacy MKR holders must migrate to v2 first** via `LockstakeMigrator` (1 MKR → 24,000 SKY), then withdraw from v2.
+| Contract             | Address                                      | Denomination |
+| -------------------- | -------------------------------------------- | ------------ |
+| LockstakeEngine (v2) | `0xCe01C90dE7FD1bcFa39e237FE6D8D9F569e8A6a3` | SKY          |
+| LockstakeEngine (v1) | `0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12` | MKR (legacy) |
 
 ## Step 1 — Find your urn index
 
@@ -46,17 +43,9 @@ free(
 
 Use the `ink` value from `urns(...)` as `wad` to withdraw everything. Tokens are sent directly to the `to` address.
 
-## Legacy v1 (MKR) flow
-
-If your position is in the v1 engine:
-
-1. Call `LockstakeMigrator.migrate(<index>)` (or the appropriate migration entrypoint — check the migrator's Etherscan ABI).
-2. Your position is moved to v2 as SKY at the 1:24,000 conversion ratio.
-3. Follow the v2 withdrawal flow above against `LockstakeEngine v2`.
-
 ## Notes & gotchas
 
-- `wad` values are 18-decimal **SKY** in v2, not MKR. 1 MKR-equivalent position = 24,000e18 SKY.
+- `wad` values are 18-decimal — SKY in v2, MKR in v1.
 - `free` reverts if any USDS debt remains — always `wipeAll` first.
 - If `urnFarms(<urnAddress>)` is non-zero, `free` auto-withdraws from the farm; no explicit `selectFarm(0x0)` is required.
 - To claim pending rewards before withdrawing, call `getReward(<owner>, <index>, <farm>, <to>)`.

--- a/apps/webapp/src/modules/analytics/gtag.ts
+++ b/apps/webapp/src/modules/analytics/gtag.ts
@@ -2,9 +2,11 @@ import { getStoredConsent, saveConsent } from './consentStorage';
 
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
 
-function gtag(...args: unknown[]) {
+function gtag(..._args: unknown[]) {
   window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push(args);
+  // gtag.js requires the native Arguments object — pushing a true Array breaks its consent state machine.
+  // eslint-disable-next-line prefer-rest-params
+  window.dataLayer.push(arguments);
 }
 
 export function initializeGtag() {

--- a/apps/webapp/src/modules/analytics/gtag.ts
+++ b/apps/webapp/src/modules/analytics/gtag.ts
@@ -2,12 +2,12 @@ import { getStoredConsent, saveConsent } from './consentStorage';
 
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
 
-function gtag(..._args: unknown[]) {
+const gtag = function () {
   window.dataLayer = window.dataLayer || [];
   // gtag.js requires the native Arguments object — pushing a true Array breaks its consent state machine.
   // eslint-disable-next-line prefer-rest-params
   window.dataLayer.push(arguments);
-}
+} as (...args: unknown[]) => void;
 
 export function initializeGtag() {
   if (typeof window === 'undefined' || !GA_MEASUREMENT_ID) {

--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -54,7 +54,12 @@ export function initSentry(): void {
       // unhandled rejection. Safe to drop — WalletConnect can't reliably
       // deep-link to wallets from those WebViews anyway (WEBAPP-1Z).
       /Can't find variable: indexedDB/,
-      /indexedDB is not defined/
+      /indexedDB is not defined/,
+      // Stale-chunk after deploy: a long-lived tab has the previous build's
+      // hashed chunk URLs baked into its module graph; the next __vitePreload
+      // 404s. User just needs to refresh — not actionable.
+      /Failed to fetch dynamically imported module.*\/assets\/.+\.js/,
+      /Importing a module script failed.*\/assets\/.+\.js/
     ],
     integrations: [
       Sentry.thirdPartyErrorFilterIntegration({

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -139,7 +139,19 @@ export default ({ mode }: { mode: modeEnum }) => {
       sourcemap: shouldUploadSourcemaps,
       outDir: '../dist',
       emptyOutDir: true,
-      modulePreload: { polyfill: false }
+      modulePreload: { polyfill: false },
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            // Reown's appkit-ui dynamic-imports each Phosphor icon as its own chunk
+            // (50+ per-icon files). Consolidating them shrinks the stale-chunk
+            // surface area after deploys and trades 50 requests for 1.
+            if (id.includes('@phosphor-icons/webcomponents')) {
+              return 'phosphor-icons';
+            }
+          }
+        }
+      }
     },
     test: {
       exclude: [...configDefaults.exclude, '**/test/e2e/**'],

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -140,15 +140,18 @@ export default ({ mode }: { mode: modeEnum }) => {
       outDir: '../dist',
       emptyOutDir: true,
       modulePreload: { polyfill: false },
-      rollupOptions: {
+      rolldownOptions: {
         output: {
-          manualChunks(id) {
-            // Reown's appkit-ui dynamic-imports each Phosphor icon as its own chunk
-            // (50+ per-icon files). Consolidating them shrinks the stale-chunk
-            // surface area after deploys and trades 50 requests for 1.
-            if (id.includes('@phosphor-icons/webcomponents')) {
-              return 'phosphor-icons';
-            }
+          // Reown's appkit-ui dynamic-imports each Phosphor icon as its own chunk
+          // (50+ per-icon files). Consolidating them shrinks the stale-chunk
+          // surface area after deploys and trades 50 requests for 1.
+          codeSplitting: {
+            groups: [
+              {
+                name: 'phosphor-icons',
+                test: /@phosphor-icons[\\/]webcomponents/
+              }
+            ]
           }
         }
       }

--- a/packages/hooks/src/morpho/useMorphoVaultChartInfo.ts
+++ b/packages/hooks/src/morpho/useMorphoVaultChartInfo.ts
@@ -19,9 +19,9 @@ type MorphoVaultHistoricalApiResponse = {
   data: {
     vaultV2ByAddress: {
       historicalState: {
-        totalAssets: Array<{ x: number; y: string }>;
-        totalAssetsUsd: Array<{ x: number; y: number }>;
-        avgNetApy: Array<{ x: number; y: number }>;
+        totalAssets: Array<{ x: number; y: string | null }>;
+        totalAssetsUsd: Array<{ x: number; y: number | null }>;
+        avgNetApy: Array<{ x: number; y: number | null }>;
       };
     } | null;
   };
@@ -45,27 +45,29 @@ export type MorphoVaultChartDataPoint = {
  * Transform raw API response to parsed chart data.
  */
 function transformMorphoChartData(
-  totalAssets: Array<{ x: number; y: string }>,
-  totalAssetsUsd: Array<{ x: number; y: number }>,
-  avgNetApy: Array<{ x: number; y: number }>
+  totalAssets: Array<{ x: number; y: string | null }>,
+  totalAssetsUsd: Array<{ x: number; y: number | null }>,
+  avgNetApy: Array<{ x: number; y: number | null }>
 ): MorphoVaultChartDataPoint[] {
   // Create maps for easy lookup by timestamp
   const apyMap = new Map<number, number>();
   avgNetApy.forEach(item => {
-    apyMap.set(item.x, item.y);
+    if (item.y !== null) apyMap.set(item.x, item.y);
   });
 
   const usdMap = new Map<number, number>();
   totalAssetsUsd.forEach(item => {
-    usdMap.set(item.x, item.y);
+    if (item.y !== null) usdMap.set(item.x, item.y);
   });
 
-  return totalAssets.map(item => ({
-    blockTimestamp: item.x,
-    amount: BigInt(item.y),
-    amountUsd: usdMap.get(item.x) ?? 0,
-    apy: apyMap.get(item.x)
-  }));
+  return totalAssets
+    .filter((item): item is { x: number; y: string } => item.y !== null)
+    .map(item => ({
+      blockTimestamp: item.x,
+      amount: BigInt(item.y),
+      amountUsd: usdMap.get(item.x) ?? 0,
+      apy: apyMap.get(item.x)
+    }));
 }
 
 /**

--- a/packages/hooks/src/shared/useSendBatchTransactionFlow.ts
+++ b/packages/hooks/src/shared/useSendBatchTransactionFlow.ts
@@ -62,13 +62,13 @@ export function useSendBatchTransactionFlow<const calls extends readonly unknown
   useEffect(() => {
     if (mutationData?.id) {
       if (isSuccess && data.status === 'success') {
-        onSuccess(data.receipts?.[0].transactionHash);
+        onSuccess(data.receipts?.[0]?.transactionHash);
       } else if (isSuccess && data.status === 'failure') {
         onError(new Error('ERROR: Batch transaction failed'), undefined);
       } else if (miningError) {
-        onError(miningError, data?.receipts?.[0].transactionHash);
+        onError(miningError, data?.receipts?.[0]?.transactionHash);
       } else if (failureReason && txReverted) {
-        onError(toError(failureReason), data?.receipts?.[0].transactionHash);
+        onError(toError(failureReason), data?.receipts?.[0]?.transactionHash);
       }
     }
   }, [isSuccess, miningError, failureReason, mutationData?.id, txReverted, data]);


### PR DESCRIPTION
  - fix(webapp): correct gtag initialization (#1591)
  - fix(webapp): bundle Phosphor icons into single chunk, filter stale-chunk Sentry noise; migrated to Vite 8 rolldownOptions.codeSplitting (#1580)
  - fix(hooks): handle empty receipts on successful EIP-5792 batch tx (#1579)
  - docs: SEAL engine Etherscan withdrawal guide using ownerUrns + Vat.urns (#1570)