### PR TITLE
Pendle: hide slippage rows when redeeming to underlying + use 'Effective APY' label

### DIFF
--- a/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
@@ -58,18 +58,26 @@ export const PendleRedeem = ({
 
   const transactionData = quote
     ? [
-        {
-          label: t`Min. received`,
-          value: `${formatBigInt(quote.apiMinOut, { unit: outDecimals, maxDecimals: 4 })} ${selectedOutputToken.symbol}`
-        },
-        {
-          label: t`Slippage tolerance`,
-          value: `${formatNumber(slippage * 100, { maxDecimals: 2 })}%`
-        },
-        {
-          label: t`Price impact`,
-          value: `${formatNumber(-quote.priceImpact * 100, { maxDecimals: 3 })}%`
-        },
+        // Min. received, slippage tolerance, and price impact only matter when
+        // an aggregator hop is in the route. The pure Pendle redeem path burns
+        // PT for the underlying at the SY's expiry-frozen rate — deterministic,
+        // no swap, so these rows would be meaningless or misleading.
+        ...(aggregatorName
+          ? [
+              {
+                label: t`Min. received`,
+                value: `${formatBigInt(quote.apiMinOut, { unit: outDecimals, maxDecimals: 4 })} ${selectedOutputToken.symbol}`
+              },
+              {
+                label: t`Slippage tolerance`,
+                value: `${formatNumber(slippage * 100, { maxDecimals: 2 })}%`
+              },
+              {
+                label: t`Price impact`,
+                value: `${formatNumber(-quote.priceImpact * 100, { maxDecimals: 3 })}%`
+              }
+            ]
+          : []),
         ...(breakdown
           ? [
               {

--- a/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -268,7 +268,7 @@ export const SupplyWithdraw = ({
                       : {})
                   },
                   {
-                    label: flow === PendleFlow.BUY ? t`Fixed APY locked` : t`Effective APY`,
+                    label: t`Effective APY`,
                     value: apyDisplay,
                     className: 'text-bullish',
                     tooltipTitle: getTooltipById('effective-apy')?.title || '',


### PR DESCRIPTION
Two small Pendle UI fixes from QA.

### Hide slippage rows when redeeming to underlying
When redeeming a matured PT to its underlying token, the route is a deterministic PT→SY→underlying burn at the SY's expiry-frozen rate — no swap, no slippage. Hide **Min. received**, **Slippage tolerance**, and **Price impact** in that case. The rows still render when an aggregator hop is in the route (e.g. redeem PT-sUSDS → USDC), where they remain meaningful. The slippage gear icon at the modal level is untouched.

### Use "Effective APY" label in supply flow
The supply flow showed "Fixed APY locked" while the withdraw flow showed "Effective APY" — both pointed at the same tooltip titled "Effective APY". Aligning the supply label to match the withdraw flow and tooltip.

<!-- screenshot: drag the redeem-PT-USDe screenshot here -->