### PR TITLE
Lowercase token symbols and sentence-case 'Transaction details'

### DIFF
--- a/apps/webapp/src/hooks/pendle/buildVerifiedArgs.ts
+++ b/apps/webapp/src/hooks/pendle/buildVerifiedArgs.ts
@@ -15,8 +15,8 @@ import type { PendleAggregatorRoute, PendleConvertQuote } from './pendle';
 /**
  * The on-chain swapData struct shape. When no aggregator is used this is
  * byte-equivalent to PENDLE_EMPTY_SWAP_DATA; when an aggregator hop is taken
- * (input/output token differs from the underlying), the fields come from the
- * API after passing the pinned-pendleSwap check.
+ * (the user-side token is not one the SY accepts directly), the fields come
+ * from the API after passing the pinned-pendleSwap check.
  */
 type VerifiedSwapData = {
   swapType: number;
@@ -288,12 +288,14 @@ function extractGuessPtOut(params: unknown[]): VerifiedBuyArgs[3] {
  *   2. Override every user-controllable field with values WE know
  *      (receiver, market, amounts, minOut)
  *   3. Resolve (pendleSwap, swapData, tokenMintSy/tokenRedeemSy) based on
- *      whether the user-picked token equals the underlying:
- *        - Equal → no-aggregator: empty pendleSwap/swapData, SY field = user
+ *      whether the user-picked token is one SY accepts directly
+ *      (`syAcceptedTokens`):
+ *        - Accepted → no-aggregator: empty pendleSwap/swapData, SY field = user
  *          token (byte-equivalent to `createTokenInputStruct + emptyLimit`).
- *        - Differs → aggregator: pendleSwap from the API after a strict
- *          equality check against PENDLE_PINNED_PENDLESWAP_ADDRESSES;
- *          swapData forwarded; SY field = underlying.
+ *        - Not accepted → aggregator: pendleSwap from the API after a strict
+ *          equality check against PENDLE_PINNED_PENDLESWAP_ADDRESSES; swapData
+ *          forwarded; SY field = the API's delivery token, checked against
+ *          syAcceptedTokens.
  *   4. `limit` is always forced to its empty form — limit-orders are out of
  *      scope.
  *
@@ -302,7 +304,8 @@ function extractGuessPtOut(params: unknown[]): VerifiedBuyArgs[3] {
  *
  * Trust anchors of the aggregator branch:
  *   (a) pendleSwap is pinned (only Pendle's audited forwarder),
- *   (b) tokenMintSy/tokenRedeemSy is pinned to the underlying,
+ *   (b) tokenMintSy/tokenRedeemSy must be in syAcceptedTokens (the SY's
+ *       allowlist of directly-accepted tokens),
  *   (c) apiMinOut is floored against `amountOut * (1 - slippage)` so a
  *       compromised or buggy quote cannot sneak a too-low minOut into the
  *       signed calldata — see verifyApiMinOut.

--- a/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleRedeem.tsx
@@ -72,7 +72,7 @@ export const PendleRedeem = ({
       ]
     : undefined;
 
-  // Section 2 "Transaction Details" (collapsed by default).
+  // Section 2 "Transaction details" (collapsed by default).
   const transactionData = quote
     ? [
         // Slippage / price impact / Min. received only matter on aggregator

--- a/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/components/SupplyWithdraw.tsx
@@ -309,7 +309,7 @@ export const SupplyWithdraw = ({
                   ]
               : undefined
           }
-          // Section 2 "Transaction Details" (collapsed by default) — the
+          // Section 2 "Transaction details" (collapsed by default) — the
           // technical breakdown: actual PT amount, min received, slippage,
           // price impact + breakdown, routing, fee, plus maturity on SELL.
           transactionData={

--- a/apps/webapp/src/widgets/shared/components/ui/token/TokenInput.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/token/TokenInput.tsx
@@ -265,7 +265,7 @@ export function TokenInput({
 
     return `${formatBigInt(balance, {
       unit: decimals
-    })} ${token.symbol.toUpperCase()}`;
+    })} ${token.symbol}`;
   }, [balance, token, enabled]);
 
   const filteredTokenList = useMemo(() => {

--- a/apps/webapp/src/widgets/shared/components/ui/transaction/TransactionOverview.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/transaction/TransactionOverview.tsx
@@ -122,7 +122,7 @@ export function TransactionOverview({
   rateType = 'ssr',
   onExternalLinkClicked,
   pinnedData,
-  detailsTitle = 'Transaction Details',
+  detailsTitle = 'Transaction details',
   transactionData
 }: TransactionOverviewParams) {
   const hasPinned = !!pinnedData && pinnedData.length > 0;


### PR DESCRIPTION
- Drop `.toUpperCase()` on the TokenInput balance line so symbols render in canonical casing (sUSDS, stUSDS, cbBTC, wstETH).
- Rename the transaction-overview details section default to "Transaction details" to match the "Transaction overview" title.
- Clarify `buildVerifiedArgs` JSDoc around `syAcceptedTokens` resolution (trust anchor (b) was inaccurate).

Before:
<img width="193" height="64" alt="Screenshot 2026-05-28 at 1 48 49 PM" src="https://github.com/user-attachments/assets/4bd96892-78a3-4b70-bf1d-26fc48b93178" />
<img width="166" height="40" alt="Screenshot 2026-05-28 at 1 50 38 PM" src="https://github.com/user-attachments/assets/a8e56c6b-b6dc-4122-9948-7d9c43e52c7a" />


After:
<img width="190" height="87" alt="Screenshot 2026-05-28 at 1 47 20 PM" src="https://github.com/user-attachments/assets/c44fcf5c-d420-42cc-8497-3d8488de2a7a" />
<img width="182" height="44" alt="Screenshot 2026-05-28 at 1 47 47 PM" src="https://github.com/user-attachments/assets/7255044f-dbbd-49a7-a139-cf671d0e83ca" />
