### PR TITLE
Fixed Yield (Pendle) analytics: emit `amount` as USD value of the non-PT leg

### DIFF
--- a/apps/webapp/src/modules/pendle/hooks/__tests__/usePendleRedeemModal.test.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/__tests__/usePendleRedeemModal.test.tsx
@@ -45,7 +45,12 @@ const hoisted = vi.hoisted(() => ({
   launchMock: vi.fn(),
   matured: true,
   // Swappable execute fn so tests can prove the latest one fires through onConfirm.
-  currentExecute: (() => undefined) as () => void
+  currentExecute: (() => undefined) as () => void,
+  // Swappable USD value fn (default ≈$1/token) so a test can force "no value".
+  valueUsd: ((_symbol: string, amount: number) => amount) as (
+    symbol: string,
+    amount: number
+  ) => number | undefined
 }));
 
 vi.mock('@/hooks', async importOriginal => {
@@ -94,7 +99,10 @@ vi.mock('@/widgets', async importOriginal => {
       slippage: 0.01,
       setSlippage: () => undefined,
       defaultSlippage: 0.01
-    })
+    }),
+    // Stub the USD value fn so the test doesn't pull in usePrices()/wagmi reads.
+    // Reads the swappable hoisted fn (default ≈$1/token).
+    usePendleUsdValue: () => hoisted.valueUsd
   };
 });
 
@@ -154,6 +162,7 @@ describe('usePendleRedeemModal analytics', () => {
   beforeEach(() => {
     hoisted.launchMock.mockClear();
     hoisted.matured = true;
+    hoisted.valueUsd = (_symbol: string, amount: number) => amount;
   });
 
   afterEach(() => {
@@ -211,11 +220,24 @@ describe('usePendleRedeemModal analytics', () => {
     unmount();
   });
 
-  it('emits a strictly negative amount in analytics.data with PT-balance magnitude', () => {
+  it('emits a strictly negative amount = USD value of the redeemed output leg', () => {
+    // `amount` now values the non-PT output leg (USDS/USDC/underlying the user
+    // receives), not the PT count. Output = QUOTE.amountOut (1_499_500n at 6dp)
+    // = 1.4995; valued ~$1/token by the stubbed value fn; emitted negative as a
+    // withdrawal. (Previously this asserted the PT-balance magnitude of 1.5.)
     const { unmount } = renderComponent(<TestConsumer />);
     const config = hoisted.launchMock.mock.calls[0][0];
     expect(config.analytics.data.amount).toBeLessThan(0);
-    expect(Math.abs(config.analytics.data.amount)).toBeCloseTo(1.5, 6);
+    expect(Math.abs(config.analytics.data.amount)).toBeCloseTo(1.4995, 6);
+    unmount();
+  });
+
+  it('omits amount when the output leg cannot be valued (valueUsd → undefined)', () => {
+    hoisted.valueUsd = () => undefined;
+    const { unmount } = renderComponent(<TestConsumer />);
+    const config = hoisted.launchMock.mock.calls[0][0];
+    expect(config.analytics.widgetName).toBe('fixed');
+    expect('amount' in config.analytics.data).toBe(false);
     unmount();
   });
 

--- a/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
+++ b/apps/webapp/src/modules/pendle/hooks/usePendleRedeemModal.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { t } from '@lingui/core/macro';
 import { mainnet } from 'viem/chains';
-import { formatUnits } from 'viem';
 import {
   getTokenDecimals,
   isMarketMatured,
@@ -15,8 +14,10 @@ import {
 import {
   PendleConfigMenu,
   pendleAnalyticsData,
+  pendleNonPtLeg,
   usePendleSlippage,
-  usePendleTokens
+  usePendleTokens,
+  usePendleUsdValue
 } from '@/widgets';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { PendleRedeem } from '../components/PendleRedeem';
@@ -47,6 +48,8 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
   const outputTokenAddress = selectedOutputToken.address[mainnet.id] as `0x${string}`;
 
   const { slippage, setSlippage, defaultSlippage } = usePendleSlippage('redeem');
+  // Values the redeemed output leg in USD for the analytics `amount` property.
+  const valueUsd = usePendleUsdValue();
 
   // Quote: PT → user-selected output via /convert. The `maturedExit` flag
   // adds the YT-with-zero-amount entry the API requires for matured exits.
@@ -168,9 +171,24 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
       quote,
       isBatchTx: true
     });
-    // `useAppAnalytics` has no sign-flip helper — emit the withdrawal sign
-    // explicitly so dashboard tiles filtering `properties.amount < 0` pick
-    // up redeem as a withdrawal alongside SELL.
+    // `amount` = USD value of the redeemed output leg (the non-PT side), so
+    // sUSDS/PT redeems don't mis-sum the inflow/outflow tiles. amountFrom /
+    // amountTo in `data` keep the raw token counts. useAppAnalytics has no
+    // sign-flip helper, so emit the withdrawal sign explicitly — dashboard
+    // tiles filtering `properties.amount < 0` pick up redeem as a withdrawal
+    // alongside SELL. Omit `amount` when no price is available rather than
+    // emit a wrong-unit number. (pendleNonPtLeg/valueUsd are total — they never
+    // throw — and the eventual capture is guarded by safeCapture, matching the
+    // amount-math-unguarded / capture-guarded pattern in the other widgets.)
+    const leg = pendleNonPtLeg('redeem', {
+      originSymbol: ptToken.symbol,
+      targetSymbol: selectedOutputToken.symbol,
+      amountInBigint: ptBalance,
+      amountOutBigint: quote?.amountOut ?? 0n,
+      fromDecimals: market.underlyingDecimals,
+      toDecimals
+    });
+    const usd = valueUsd(leg.symbol, leg.amount);
     launch({
       title: t`Redeem PT-${market.underlyingSymbol}`,
       transactionContent,
@@ -185,7 +203,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
         action: 'redeem',
         data: {
           ...data,
-          amount: -Number(formatUnits(ptBalance, market.underlyingDecimals))
+          ...(usd !== undefined ? { amount: -Math.abs(usd) } : {})
         }
       }
     });
@@ -197,6 +215,7 @@ export function usePendleRedeemModal(market: PendleMarketConfig, opts: Options =
     selectedOutputToken,
     quote,
     slippage,
+    valueUsd,
     transactionContent,
     rightHeaderComponent,
     confirmDisabled,

--- a/apps/webapp/src/widgets/PendleWidget/hooks/usePendleTransactionCallbacks.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/hooks/usePendleTransactionCallbacks.tsx
@@ -1,5 +1,4 @@
 import { useRef } from 'react';
-import { formatUnits } from 'viem';
 import { t } from '@lingui/core/macro';
 import { getTransactionLink } from '@/utils';
 import {
@@ -18,10 +17,13 @@ import {
 import { WidgetAnalyticsEvent, WidgetAnalyticsEventType } from '@/widgets/shared/types/analyticsEvents';
 import { PENDLE_HISTORY_REFRESH_MS, PendleFlow, PendleScreen } from '../lib/constants';
 import { pendleAnalyticsData, type PendleAnalyticsSide } from '../lib/pendleAnalyticsData';
+import { pendleNonPtLeg } from '../lib/pendleUsdValue';
 
 type UsePendleTransactionCallbacksParameters = {
   onAnalyticsEvent?: OnAnalyticsEventCallback;
   onNotification?: OnNotificationCallback;
+  /** Values a token leg in USD for the analytics `amount` property. */
+  valueUsd: (symbol: string, amount: number) => number | undefined;
   flow: PendleFlow;
   side: PendleConvertSide;
   market: PendleMarketConfig;
@@ -68,7 +70,8 @@ export function usePendleTransactionCallbacks({
   refetchOutputBalance,
   refetchPtBalance,
   onNotification,
-  onAnalyticsEvent
+  onAnalyticsEvent,
+  valueUsd
 }: UsePendleTransactionCallbacksParameters) {
   // Tracks which step of a non-batch sequence we're on (approve → main).
   const supplyStepRef = useRef(0);
@@ -77,7 +80,20 @@ export function usePendleTransactionCallbacks({
 
   const mainAction: 'supply' | 'withdraw' = side === PendleConvertSide.BUY ? 'supply' : 'withdraw';
   const analyticsSide: PendleAnalyticsSide = side === PendleConvertSide.BUY ? 'buy' : 'sell';
-  const formattedAmount = Number(formatUnits(amount, fromDecimals));
+  // `amount` = USD value of the non-PT leg (input on buy, output on sell), so
+  // sUSDS supplies don't mis-sum the inflow/outflow tiles. useWidgetAnalytics
+  // applies the withdraw sign — pass positive magnitude. Raw token counts stay
+  // on amountFrom/amountTo in buildData(). undefined when price unavailable →
+  // the event omits `amount` rather than emit a wrong-unit number.
+  const leg = pendleNonPtLeg(analyticsSide, {
+    originSymbol: originToken.symbol,
+    targetSymbol: targetToken.symbol,
+    amountInBigint: amount,
+    amountOutBigint: quote?.amountOut ?? 0n,
+    fromDecimals,
+    toDecimals
+  });
+  const formattedAmount = valueUsd(leg.symbol, leg.amount);
 
   const buildData = () =>
     pendleAnalyticsData({

--- a/apps/webapp/src/widgets/PendleWidget/hooks/usePendleUsdValue.ts
+++ b/apps/webapp/src/widgets/PendleWidget/hooks/usePendleUsdValue.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { mainnet } from 'viem/chains';
+import { usePrices, useReadSavingsUsds, sUsdsAddress } from '@/hooks';
+import { pendleUsdValue } from '../lib/pendleUsdValue';
+
+const WAD = 10n ** 18n;
+
+/**
+ * Returns a `valueUsd(symbol, amount)` function that converts a token amount
+ * (decimal) into its USD value for the Fixed Yield analytics `amount` property.
+ *
+ * Primary source: BaLabs spot via `usePrices()` (covers sUSDS/USDS/USDC).
+ * Fallback when the feed hasn't loaded: the on-chain sUSDS→USDS rate
+ * (`convertToAssets(1e18)`, USDS assets per 1 sUSDS share) for sUSDS, and $1
+ * for the dollar-pegged stablecoins. Returns `undefined` when no value can be
+ * computed so callers omit `amount` rather than emit a wrong-unit number.
+ *
+ * See pendleUsdValue.ts for the analytics-standard rationale.
+ */
+export function usePendleUsdValue(): (symbol: string, amount: number) => number | undefined {
+  const { data: pricesData } = usePrices();
+
+  // sUSDS→USDS rate (chi) as a WAD: USDS assets returned for 1 sUSDS share.
+  // Only consumed as the fallback when BaLabs has no sUSDS spot; cheap enough
+  // to always read.
+  const { data: sUsdsPerShareWad } = useReadSavingsUsds({
+    functionName: 'convertToAssets',
+    args: [WAD],
+    chainId: mainnet.id as keyof typeof sUsdsAddress
+  });
+
+  return useCallback(
+    (symbol: string, amount: number) =>
+      pendleUsdValue(symbol, amount, pricesData, sUsdsPerShareWad as bigint | undefined),
+    [pricesData, sUsdsPerShareWad]
+  );
+}

--- a/apps/webapp/src/widgets/PendleWidget/index.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/index.tsx
@@ -37,7 +37,9 @@ import { PendleAction, PendleFlow, PendleScreen } from './lib/constants';
 import { usePendleSlippage } from './hooks/usePendleSlippage';
 import { usePendleTokens } from './hooks/usePendleTokens';
 import { usePendleTransactionCallbacks } from './hooks/usePendleTransactionCallbacks';
+import { usePendleUsdValue } from './hooks/usePendleUsdValue';
 import { pendleAnalyticsData } from './lib/pendleAnalyticsData';
+import { pendleNonPtLeg } from './lib/pendleUsdValue';
 import { SupplyWithdraw } from './components/SupplyWithdraw';
 import { PendleConfigMenu } from './components/PendleConfigMenu';
 import { PendlePoweredBy } from './components/PendlePoweredBy';
@@ -64,6 +66,9 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
   const onNotification = useNotification();
   const chainId = useChainId();
   const onAnalyticsEvent = useWidgetAnalytics('fixed', chainId);
+  // Values the user's non-PT leg in USD for the analytics `amount` property —
+  // sUSDS isn't $1, so a token count would mis-sum the inflow/outflow tiles.
+  const valueUsd = usePendleUsdValue();
   const { address, isConnected, isConnecting } = useConnection();
   const { isConnectedAndAcceptedTerms: enabled } = useConnectedContext();
   const { onExternalLinkClicked } = useConfigContext();
@@ -259,7 +264,8 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
     refetchOutputBalance,
     refetchPtBalance,
     onNotification,
-    onAnalyticsEvent
+    onAnalyticsEvent,
+    valueUsd
   });
 
   const batchConvert = useBatchPendleConvert({
@@ -316,11 +322,22 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
 
     try {
       const analyticsFlow = side === PendleConvertSide.BUY ? 'supply' : 'withdraw';
+      const analyticsSide = side === PendleConvertSide.BUY ? 'buy' : 'sell';
+      // `amount` = USD value of the non-PT leg (input on buy, output on sell).
+      // useWidgetAnalytics applies the withdraw sign; pass positive magnitude.
+      const leg = pendleNonPtLeg(analyticsSide, {
+        originSymbol: originToken.symbol,
+        targetSymbol: targetToken.symbol,
+        amountInBigint: debouncedAmount,
+        amountOutBigint: quote?.amountOut ?? 0n,
+        fromDecimals,
+        toDecimals
+      });
       onAnalyticsEvent?.({
         event: WidgetAnalyticsEventType.REVIEW_VIEWED,
         action: analyticsFlow,
         flow: analyticsFlow,
-        amount: Number(formatUnits(debouncedAmount, fromDecimals)),
+        amount: valueUsd(leg.symbol, leg.amount),
         data: pendleAnalyticsData({
           market,
           side: side === PendleConvertSide.BUY ? 'buy' : 'sell',

--- a/apps/webapp/src/widgets/PendleWidget/lib/pendleUsdValue.test.ts
+++ b/apps/webapp/src/widgets/PendleWidget/lib/pendleUsdValue.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import { formatUnits } from 'viem';
+import type { PriceData } from '@/hooks/prices/usePrices';
+import { pendleUsdValue, pendleNonPtLeg } from './pendleUsdValue';
+
+// Minimal PriceData factory — only `price` matters to the value fn.
+function price(p: string): PriceData {
+  return {
+    underlying_address: '0x0',
+    underlying_symbol: 'X',
+    price: p,
+    datetime: '',
+    source: 'test'
+  };
+}
+
+const PRICES: Record<string, PriceData> = {
+  // sUSDS is yield-bearing, > $1 — the case that breaks token-count math.
+  sUSDS: price('1.05'),
+  USDS: price('1.0'),
+  USDC: price('0.9998')
+};
+
+const WAD = 10n ** 18n;
+
+describe('pendleUsdValue', () => {
+  describe('dollar-pegged → face value ($1), never spot', () => {
+    it('values USDS at face — amount equals the token count, NOT the BaLabs spot', () => {
+      // PRICES.USDS is 1.0 here, but the point is the helper short-circuits
+      // pegged tokens to face regardless of the feed — see the next test.
+      expect(pendleUsdValue('USDS', 1000, PRICES, undefined)).toBe(1000);
+    });
+
+    it('values USDC at face even when BaLabs quotes it off-peg (0.9998)', () => {
+      // The real-world bug: a stablecoin deposit must report amount == amountFrom,
+      // not get nudged by market microprice. PRICES.USDC = 0.9998 is ignored.
+      expect(pendleUsdValue('USDC', 1000, PRICES, undefined)).toBe(1000);
+    });
+
+    it('values DAI at face', () => {
+      expect(pendleUsdValue('DAI', 1000, PRICES, undefined)).toBe(1000);
+    });
+  });
+
+  describe('BaLabs spot (non-pegged underlyings, e.g. sUSDS)', () => {
+    it('prices sUSDS at spot — 1000 sUSDS × 1.05 = 1050 (NOT the 1000 token count)', () => {
+      expect(pendleUsdValue('sUSDS', 1000, PRICES, undefined)).toBeCloseTo(1050, 6);
+    });
+
+    it('returns 0 for a zero amount', () => {
+      expect(pendleUsdValue('sUSDS', 0, PRICES, undefined)).toBe(0);
+    });
+  });
+
+  describe('chi fallback (feed unavailable)', () => {
+    it('uses the on-chain sUSDS→USDS rate for sUSDS when no spot price', () => {
+      // 1.05 USDS per sUSDS share, in WAD.
+      const rateWad = (105n * WAD) / 100n;
+      expect(pendleUsdValue('sUSDS', 1000, undefined, rateWad)).toBeCloseTo(1050, 6);
+    });
+
+    it('handles a realistic (non-round) chi rate at full 18-decimal precision', () => {
+      // Real chi accrues continuously — a messy WAD, not 1.05 exactly. This
+      // exercises the formatUnits(wad, 18) decimal conversion, not just the
+      // branch. Derive the expected rate the same way the helper does (rather
+      // than a lossy float literal) so the assertion tracks the real math.
+      const rateWad = 1_051_234_567_890_123_456n; // ~1.051234567890123456
+      const expectedRate = parseFloat(formatUnits(rateWad, 18));
+      expect(pendleUsdValue('sUSDS', 1234.5, undefined, rateWad)).toBeCloseTo(1234.5 * expectedRate, 6);
+    });
+
+    it('handles a sub-$1 chi rate (rate < 1 WAD)', () => {
+      // Defensive: a share worth less than 1 USDS must scale down, not up.
+      const rateWad = 998_000_000_000_000_000n; // 0.998
+      expect(pendleUsdValue('sUSDS', 1000, undefined, rateWad)).toBeCloseTo(998, 6);
+    });
+
+    it('returns undefined for sUSDS when neither spot nor chi is available', () => {
+      expect(pendleUsdValue('sUSDS', 1000, undefined, undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for sUSDS when chi is 0n (uninitialized read)', () => {
+      // A failed/empty convertToAssets read can surface as 0n — that must not
+      // value the leg at $0 and pollute flow totals; omit instead.
+      expect(pendleUsdValue('sUSDS', 1000, undefined, 0n)).toBeUndefined();
+    });
+
+    it('returns undefined for an unknown non-pegged token with no spot', () => {
+      expect(pendleUsdValue('WETH', 1, undefined, undefined)).toBeUndefined();
+    });
+
+    it('prefers spot over chi when both are present', () => {
+      const rateWad = (200n * WAD) / 100n; // 2.0 — deliberately wrong vs spot 1.05
+      expect(pendleUsdValue('sUSDS', 1000, PRICES, rateWad)).toBeCloseTo(1050, 6);
+    });
+  });
+
+  describe('defensive', () => {
+    it('returns undefined for a non-finite amount', () => {
+      expect(pendleUsdValue('USDS', NaN, PRICES, undefined)).toBeUndefined();
+    });
+
+    it('ignores a non-numeric spot string and falls through to fallback', () => {
+      const bad: Record<string, PriceData> = { sUSDS: price('not-a-number') };
+      const rateWad = (105n * WAD) / 100n;
+      expect(pendleUsdValue('sUSDS', 1000, bad, rateWad)).toBeCloseTo(1050, 6);
+    });
+
+    // The `typeof === 'bigint'` guard prevents a BigInt-mixing TypeError if a
+    // non-bigint ever reaches the chi path (e.g. a wagmi shape change). It must
+    // degrade to undefined, not throw.
+    it('returns undefined (no throw) when chi is not a bigint', () => {
+      const notABigint = '123' as unknown as bigint;
+      expect(pendleUsdValue('sUSDS', 1000, undefined, notABigint)).toBeUndefined();
+    });
+  });
+});
+
+describe('pendleNonPtLeg', () => {
+  it('BUY → values the input (origin) token', () => {
+    const leg = pendleNonPtLeg('buy', {
+      originSymbol: 'sUSDS',
+      targetSymbol: 'PT-sUSDS',
+      amountInBigint: 1000n * WAD,
+      amountOutBigint: 1020n * WAD,
+      fromDecimals: 18,
+      toDecimals: 18
+    });
+    expect(leg).toEqual({ symbol: 'sUSDS', amount: 1000 });
+  });
+
+  it('SELL → values the output (target) token, not PT', () => {
+    const leg = pendleNonPtLeg('sell', {
+      originSymbol: 'PT-sUSDS',
+      targetSymbol: 'USDS',
+      amountInBigint: 1000n * WAD, // PT in
+      amountOutBigint: 1040n * WAD, // USDS out
+      fromDecimals: 18,
+      toDecimals: 18
+    });
+    expect(leg).toEqual({ symbol: 'USDS', amount: 1040 });
+  });
+
+  it('REDEEM → values the output (target) token', () => {
+    const leg = pendleNonPtLeg('redeem', {
+      originSymbol: 'PT-sUSDS',
+      targetSymbol: 'USDC',
+      amountInBigint: 1000n * WAD, // PT in (18dp)
+      amountOutBigint: 1050_000_000n, // 1050 USDC out (6dp)
+      fromDecimals: 18,
+      toDecimals: 6
+    });
+    expect(leg).toEqual({ symbol: 'USDC', amount: 1050 });
+  });
+
+  it('returns a positive magnitude — sign is applied by the caller', () => {
+    const leg = pendleNonPtLeg('sell', {
+      originSymbol: 'PT-sUSDS',
+      targetSymbol: 'USDS',
+      amountInBigint: 1n,
+      amountOutBigint: 5n * WAD,
+      fromDecimals: 18,
+      toDecimals: 18
+    });
+    expect(leg.amount).toBeGreaterThan(0);
+  });
+});

--- a/apps/webapp/src/widgets/PendleWidget/lib/pendleUsdValue.ts
+++ b/apps/webapp/src/widgets/PendleWidget/lib/pendleUsdValue.ts
@@ -1,0 +1,105 @@
+import { formatUnits } from 'viem';
+// Import the type from its source module rather than the '@/hooks' barrel: a
+// type-only barrel import can still pull the barrel's runtime side effects
+// (posthog-js / react-query global listeners) into unit-test transforms.
+import type { PriceData } from '@/hooks/prices/usePrices';
+import type { PendleAnalyticsSide } from './pendleAnalyticsData';
+
+// Dollar-pegged tokens valued at face ($1) for flow accounting. These are the
+// protocol's unit of account; pricing them via a market feed would make a
+// stablecoin deposit look like it isn't $1 (e.g. BaLabs quotes USDS at
+// 0.9987), break `amount === amountFrom`, and diverge from how savings /
+// rewards / trade emit `amount` as the plain token count. Only genuinely
+// non-$1 underlyings (sUSDS) are priced.
+const DOLLAR_PEGGED = new Set(['USDS', 'USDC', 'DAI', 'USDT']);
+
+/**
+ * Converts a token amount (a decimal number, already `formatUnits`'d) into its
+ * USD value for use as the analytics `amount` property on Fixed Yield (Pendle)
+ * events.
+ *
+ * Analytics standard: `amount` is the USD value of the user's non-PT leg
+ * (input on BUY, output on SELL/REDEEM). `amountFrom`/`amountTo` in the data
+ * blob stay as raw token counts.
+ *
+ * Pricing precedence:
+ *   1. Dollar-pegged stablecoins (USDS/USDC/DAI/USDT) → face value ($1), so
+ *      `amount === amountFrom` and stablecoin flows match savings/rewards.
+ *   2. Otherwise (sUSDS and any future non-$1 underlying) → BaLabs spot.
+ *   3. sUSDS with no spot → on-chain sUSDS→USDS rate (chi, `sUsdsPerShareWad`
+ *      = USDS assets per 1 sUSDS share in WAD).
+ * Returns `undefined` when none apply, so callers omit `amount` rather than
+ * emit a wrong-unit number. sUSDS (yield-bearing, ≠ $1) is the case the
+ * inflow/outflow dashboards previously mis-summed as a token count.
+ *
+ * Total by construction (no throw on valid inputs): `formatUnits` on a bigint,
+ * `parseFloat`, and arithmetic don't throw; the `typeof === 'bigint'` guard
+ * avoids a BigInt-mixing TypeError. App-level safety still applies — capture
+ * goes through `safeCapture` — so a miss degrades to "no amount", never a crash.
+ */
+export function pendleUsdValue(
+  symbol: string,
+  amount: number,
+  pricesData: Record<string, PriceData> | undefined,
+  sUsdsPerShareWad: bigint | undefined
+): number | undefined {
+  if (!Number.isFinite(amount)) return undefined;
+
+  // 1. Dollar-pegged → face value. The protocol's unit of account is $1; do
+  // not apply a market price (avoids microprice noise and keeps amount == the
+  // token count, matching the other widgets).
+  if (DOLLAR_PEGGED.has(symbol)) return amount;
+
+  // 2. Non-pegged (sUSDS, future underlyings) → BaLabs spot.
+  const spot = pricesData?.[symbol]?.price;
+  if (spot !== undefined) {
+    const price = parseFloat(spot);
+    if (Number.isFinite(price)) return amount * price;
+  }
+
+  // 3. sUSDS with no spot → on-chain chi rate. Treat a non-bigint or
+  // non-positive rate as unavailable (0n surfaces from a failed/empty
+  // convertToAssets read; the typeof check also blocks a BigInt-mixing
+  // TypeError) so we omit `amount` rather than value the leg at $0.
+  if (symbol === 'sUSDS') {
+    if (typeof sUsdsPerShareWad !== 'bigint' || sUsdsPerShareWad <= 0n) return undefined;
+    const rate = parseFloat(formatUnits(sUsdsPerShareWad, 18));
+    return Number.isFinite(rate) && rate > 0 ? amount * rate : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Picks the user's non-PT leg for analytics `amount` valuation: the input on
+ * BUY, the output on SELL/REDEEM. The PT side is never the unit of account —
+ * we measure the real-money (stablecoin / sUSDS) side, matching how the
+ * inflow/outflow dashboards sum `amount` across products.
+ *
+ * Returns the leg's token symbol and its decimal amount (positive). Callers
+ * pass the result to `pendleUsdValue` and apply the in/out sign separately
+ * (BUY positive, SELL/REDEEM negative).
+ */
+export function pendleNonPtLeg(
+  side: PendleAnalyticsSide,
+  opts: {
+    originSymbol: string;
+    targetSymbol: string;
+    amountInBigint: bigint;
+    amountOutBigint: bigint;
+    fromDecimals: number;
+    toDecimals: number;
+  }
+): { symbol: string; amount: number } {
+  if (side === 'buy') {
+    return {
+      symbol: opts.originSymbol,
+      amount: Number(formatUnits(opts.amountInBigint, opts.fromDecimals))
+    };
+  }
+  // sell / redeem → value the output token the user receives.
+  return {
+    symbol: opts.targetSymbol,
+    amount: Number(formatUnits(opts.amountOutBigint, opts.toDecimals))
+  };
+}

--- a/apps/webapp/src/widgets/PendleWidget/tests/usePendleTransactionCallbacks.test.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/tests/usePendleTransactionCallbacks.test.tsx
@@ -88,6 +88,11 @@ const baseParams = (overrides: Partial<BuildParams>): BuildParams => ({
   refetchPtBalance: vi.fn(),
   onNotification: vi.fn(),
   onAnalyticsEvent: vi.fn(),
+  // `amount` is now the USD value of the non-PT leg; the hook delegates the
+  // valuation to this injected fn. The default treats every token as ~$1 so
+  // the existing action/shape assertions are unaffected; the USD-specific
+  // behaviour is covered in its own test below and in pendleUsdValue.test.ts.
+  valueUsd: (_symbol: string, amount: number) => amount,
   ...overrides
 });
 
@@ -239,6 +244,39 @@ describe('usePendleTransactionCallbacks', () => {
       expect(completed[0][0].action).toBe('supply');
       expect(completed[0][0].flow).toBe('supply');
       expect(completed[0][0].txHash).toBe('0xabc');
+    });
+  });
+
+  describe('USD amount', () => {
+    it('emits amount = USD value of the non-PT leg (valueUsd applied), not the token count', () => {
+      const onAnalyticsEvent = vi.fn();
+      // BUY of 1 USDG; value it at 1.05 USD/token to prove `amount` tracks the
+      // value-fn output, not the 1.0 token count.
+      const params = baseParams({
+        onAnalyticsEvent,
+        valueUsd: (_symbol: string, amount: number) => amount * 1.05
+      });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+      act(() => {
+        result.current.onMutate();
+      });
+
+      expect(onAnalyticsEvent.mock.calls[0][0].amount).toBeCloseTo(1.05, 6);
+    });
+
+    it('omits amount when the leg cannot be valued (valueUsd → undefined)', () => {
+      const onAnalyticsEvent = vi.fn();
+      const params = baseParams({ onAnalyticsEvent, valueUsd: () => undefined });
+
+      const { result } = renderHook(() => usePendleTransactionCallbacks(params));
+      act(() => {
+        result.current.onMutate();
+      });
+
+      // Event still fires; amount is simply absent.
+      expect(onAnalyticsEvent).toHaveBeenCalledTimes(1);
+      expect(onAnalyticsEvent.mock.calls[0][0].amount).toBeUndefined();
     });
   });
 

--- a/apps/webapp/src/widgets/index.ts
+++ b/apps/webapp/src/widgets/index.ts
@@ -52,6 +52,8 @@ export { usePendleTokens } from './PendleWidget/hooks/usePendleTokens';
 export type { PendleTokens } from './PendleWidget/hooks/usePendleTokens';
 export { usePendleSlippage } from './PendleWidget/hooks/usePendleSlippage';
 export type { PendleSlippageMode } from './PendleWidget/hooks/usePendleSlippage';
+export { usePendleUsdValue } from './PendleWidget/hooks/usePendleUsdValue';
+export { pendleUsdValue, pendleNonPtLeg } from './PendleWidget/lib/pendleUsdValue';
 export { PendleConfigMenu } from './PendleWidget/components/PendleConfigMenu';
 export { pendleAnalyticsData } from './PendleWidget/lib/pendleAnalyticsData';
 export type { PendleAnalyticsDataInput, PendleAnalyticsSide } from './PendleWidget/lib/pendleAnalyticsData';


### PR DESCRIPTION
Fixed Yield (Pendle) is the first widget whose input isn't a $1 stablecoin — sUSDS sits at ≈ $1.098 and drifts up over time. Emitting the analytics `amount` as a raw token count therefore silently skewed the protocol inflow/outflow dashboards, which sum `properties.amount` across every product. This PR makes Fixed Yield emit `amount` on the same basis as every other widget: the **USD value of the user's non-PT leg**.

### What does this PR do?

**Standard adopted.** `amount` = USD value of the non-PT leg — the **input** token on BUY, the **output** token on SELL/REDEEM — signed by direction (+ inflow, − outflow). `amountFrom` / `amountTo` keep raw token counts. This matches savings/rewards/trade, where token-count already equalled USD only because those tokens are $1 stablecoins; Fixed Yield is the first that has to actually price the leg.

**Pricing precedence** (`pendleUsdValue`, pure & total):
1. Dollar-pegged stablecoins (USDS/USDC/DAI/USDT) → **face value $1**. Avoids BaLabs micro-price noise (e.g. USDS quotes at 0.9987) and keeps `amount === amountFrom` for stablecoins, consistent with the other widgets.
2. Non-pegged (sUSDS, any future underlying) → **BaLabs spot** via `usePrices()`.
3. sUSDS with no spot → **on-chain chi rate** (`convertToAssets(1e18)`).
4. Otherwise → `amount` is **omitted** (never emit a wrong-unit number).

**Emission sites updated** (all flows): `app_widget_review_viewed`, `app_widget_flow_started/completed/error`, and matured `redeem`.

**Safety.** The pricing helpers never throw, and capture stays wrapped in `safeCapture`. A missing/unavailable price degrades to "no `amount`" — never a crash, and never a wrong-unit number.

**Files**
- New: `widgets/PendleWidget/lib/pendleUsdValue.ts` (+ unit tests), `widgets/PendleWidget/hooks/usePendleUsdValue.ts`
- Edited: `widgets/PendleWidget/index.tsx`, `widgets/PendleWidget/hooks/usePendleTransactionCallbacks.tsx`, `modules/pendle/hooks/usePendleRedeemModal.tsx`, `widgets/index.ts` (barrel)

**No dashboard change needed** — the prod flow/volume insights already sum `properties.amount` (deduped by `tx_hash`, signed by direction) and already include `widget_name = 'fixed'`.

### Testing steps

- `pnpm -F webapp typecheck` → 0 errors
- `pnpm -F webapp exec vitest run` on the 4 Pendle suites → **53/53 pass**
- **Pricing verified live** against the production BaLabs feed: sUSDS spot `1.098057` matches the on-chain chi rate `1.098225` to within 0.015%; reproducing `pendleUsdValue` in the running app, a 100-token supply emits `amount` ≈ **109.8 for sUSDS** (≈ +9.8% divergence from the token count) and exactly **100 for USDS/USDC** (face peg, not 99.87).
- Manual: open a market (`?widget=fixed&fixed_module=market&market=0x9c560ebaf78e596cbcc27411d633a74d628dd7dc`), supply with **sUSDS** vs **USDS**, and confirm the emitted `amount` is the USD value of the input — sUSDS diverges from the token count, USDS equals it.

> Note: the full UI transaction events (`flow_started/completed`, `redeem`) couldn't be driven end-to-end on the dev Tenderly fork (the PT-sUSDS market contracts aren't deployed there), so those paths are covered by the unit tests rather than a live click-through.
