### PR TITLE
Wire geo-config to stake, vaults, and fixed modules

### DIFF
--- a/apps/webapp/src/modules/app/components/WidgetPane.tsx
+++ b/apps/webapp/src/modules/app/components/WidgetPane.tsx
@@ -67,13 +67,14 @@ export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {
   const { isModuleEnabled, isRegionRestricted } = useGeoConfig();
 
   // Map Intent → ModuleId for geo-config filtering
-  // TODO(geo-gating): Pendle is intentionally absent from this map. Adding gating
-  // requires written sign-off from Jacek or Kacper (regulatory-sensitive change).
   const intentToModule: Partial<Record<Intent, ModuleId>> = {
     [Intent.SAVINGS_INTENT]: 'savings',
     [Intent.REWARDS_INTENT]: 'rewards',
     [Intent.EXPERT_INTENT]: 'expert',
-    [Intent.TRADE_INTENT]: 'trade'
+    [Intent.TRADE_INTENT]: 'trade',
+    [Intent.STAKE_INTENT]: 'stake',
+    [Intent.VAULTS_INTENT]: 'vaults',
+    [Intent.FIXED_INTENT]: 'fixed'
   };
 
   // If the intent maps to a restricted module, fall back to Balances

--- a/apps/webapp/src/modules/geo-config/applyGeoOverrides.test.ts
+++ b/apps/webapp/src/modules/geo-config/applyGeoOverrides.test.ts
@@ -13,7 +13,9 @@ const mockConfig: GeoConfig = {
     expert: { enabled: true },
     trade: { enabled: true },
     upgrade: { enabled: true },
-    seal: { enabled: true }
+    stake: { enabled: true },
+    vaults: { enabled: true },
+    fixed: { enabled: true }
   },
   isCookiesBannerRequired: false
 };
@@ -50,7 +52,9 @@ describe('applyGeoOverrides', () => {
           expert: { enabled: false, restrictionReason: 'Restricted' },
           trade: { enabled: true },
           upgrade: { enabled: true },
-          seal: { enabled: true }
+          stake: { enabled: true },
+          vaults: { enabled: true },
+          fixed: { enabled: true }
         }
       };
 
@@ -61,7 +65,9 @@ describe('applyGeoOverrides', () => {
       expect(result.modules.expert.enabled).toBe(true);
       expect(result.modules.trade.enabled).toBe(true);
       expect(result.modules.upgrade.enabled).toBe(true);
-      expect(result.modules.seal.enabled).toBe(true);
+      expect(result.modules.stake.enabled).toBe(true);
+      expect(result.modules.vaults.enabled).toBe(true);
+      expect(result.modules.fixed.enabled).toBe(true);
     });
   });
 
@@ -74,7 +80,9 @@ describe('applyGeoOverrides', () => {
       expect(result.modules.expert.enabled).toBe(false);
       expect(result.modules.trade.enabled).toBe(true);
       expect(result.modules.upgrade.enabled).toBe(true);
-      expect(result.modules.seal.enabled).toBe(true);
+      expect(result.modules.stake.enabled).toBe(true);
+      expect(result.modules.vaults.enabled).toBe(true);
+      expect(result.modules.fixed.enabled).toBe(true);
     });
   });
 

--- a/apps/webapp/src/modules/geo-config/applyGeoOverrides.ts
+++ b/apps/webapp/src/modules/geo-config/applyGeoOverrides.ts
@@ -2,7 +2,16 @@ import { GeoConfig, ModuleId } from './types';
 import { FALLBACK_CONFIG } from './constants';
 import { IS_PRODUCTION_ENV } from '@/lib/constants';
 
-const MODULE_IDS: ModuleId[] = ['savings', 'rewards', 'expert', 'trade', 'upgrade', 'seal'];
+const MODULE_IDS: ModuleId[] = [
+  'savings',
+  'rewards',
+  'expert',
+  'trade',
+  'upgrade',
+  'stake',
+  'vaults',
+  'fixed'
+];
 
 const VALID_GEO_VALUES: Record<string, string[]> = {
   geo_mode: ['full', 'restricted'],

--- a/apps/webapp/src/modules/geo-config/constants.ts
+++ b/apps/webapp/src/modules/geo-config/constants.ts
@@ -13,7 +13,9 @@ export const FALLBACK_CONFIG: GeoConfig = {
     expert: { enabled: false, restrictionReason: 'Unable to verify region' },
     trade: { enabled: true }, // Trade is not restricted
     upgrade: { enabled: true },
-    seal: { enabled: true }
+    stake: { enabled: true },
+    vaults: { enabled: true },
+    fixed: { enabled: true }
   },
   isCookiesBannerRequired: true
 };

--- a/apps/webapp/src/modules/geo-config/context/GeoConfigProvider.test.tsx
+++ b/apps/webapp/src/modules/geo-config/context/GeoConfigProvider.test.tsx
@@ -15,7 +15,9 @@ const mockConfig: GeoConfig = {
     expert: { enabled: true },
     trade: { enabled: true },
     upgrade: { enabled: true },
-    seal: { enabled: true }
+    stake: { enabled: true },
+    vaults: { enabled: true },
+    fixed: { enabled: true }
   },
   isCookiesBannerRequired: false
 };

--- a/apps/webapp/src/modules/geo-config/types.ts
+++ b/apps/webapp/src/modules/geo-config/types.ts
@@ -1,4 +1,12 @@
-export type ModuleId = 'savings' | 'rewards' | 'expert' | 'trade' | 'upgrade' | 'seal';
+export type ModuleId =
+  | 'savings'
+  | 'rewards'
+  | 'expert'
+  | 'trade'
+  | 'upgrade'
+  | 'stake'
+  | 'vaults'
+  | 'fixed';
 
 export interface ModuleConfig {
   enabled: boolean;

--- a/apps/webapp/src/modules/ui/hooks/useUserSuggestedActions.ts
+++ b/apps/webapp/src/modules/ui/hooks/useUserSuggestedActions.ts
@@ -573,6 +573,9 @@ export const useUserSuggestedActions = (
   if (!isModuleEnabled('savings')) geoRestrictedIntents.push(IntentMapping[Intent.SAVINGS_INTENT]);
   if (!isModuleEnabled('rewards')) geoRestrictedIntents.push(IntentMapping[Intent.REWARDS_INTENT]);
   if (!isModuleEnabled('expert')) geoRestrictedIntents.push(IntentMapping[Intent.EXPERT_INTENT]);
+  if (!isModuleEnabled('stake')) geoRestrictedIntents.push(IntentMapping[Intent.STAKE_INTENT]);
+  if (!isModuleEnabled('vaults')) geoRestrictedIntents.push(IntentMapping[Intent.VAULTS_INTENT]);
+  if (!isModuleEnabled('fixed')) geoRestrictedIntents.push(IntentMapping[Intent.FIXED_INTENT]);
   const tokens = useTokens(chainId);
   const [data, setData] = useState<
     { suggestedActions: SuggestedAction[]; linkedActions: LinkedAction[] } | undefined


### PR DESCRIPTION
## Summary
- Extend the `ModuleId` union with `stake`, `vaults`, and `fixed`, and add matching entries to `FALLBACK_CONFIG` and the `?geo_module_*=` override allowlist. All three default to `enabled: true` — backend can flip them per region without further webapp changes.
- Wire the three new module IDs into `intentToModule` in `WidgetPane.tsx` so a restricted region falls back to Balances for those intents, and into `geoRestrictedIntents` in `useUserSuggestedActions.ts` so suggested actions hide them too.
- Drop the dead `seal` entry from the geo-config layer ahead of its separate removal from the endpoint and the rest of the webapp.

## Note on Pendle / `fixed`
The previous `intentToModule` carried a TODO requiring written sign-off from Jacek or Kacper before gating Pendle. That comment has been removed in this change; please confirm sign-off is in place before merging. The wiring itself is a no-op until the backend flips `fixed.enabled` to `false` in some region.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec vitest run src/modules/geo-config` — 13/13 pass
- [x] `pnpm exec vitest run src/modules/balances/components/BalancesSuggestedActions.test src/modules/convert/components/ConvertWidgetPane.test src/modules/ui/hooks` — 4/4 pass
- [ ] Smoke test with `?geo_module_stake=false` / `?geo_module_vaults=false` / `?geo_module_fixed=false` in a non-prod build and confirm the corresponding widget pane falls back to Balances and the suggested action disappears