### PR TITLE
fix: stop Morpho vaults reporting a false deposit cap

### DIFF
--- a/apps/webapp/src/widgets/MorphoVaultWidget/index.tsx
+++ b/apps/webapp/src/widgets/MorphoVaultWidget/index.tsx
@@ -132,10 +132,17 @@ const VaultWidgetWrapped = ({
   // Token decimals for the underlying asset
   const assetDecimals = getTokenDecimals(assetToken, chainId);
 
+  // Deposit-cap enforcement is provider-specific. Spark's vault exposes a real
+  // on-chain supply cap via maxDeposit(user); Morpho V2 vaults return 0n even when
+  // deposits are open, so consulting maxDeposit there would wrongly report every
+  // Morpho vault as "cap reached" and block deposits. Mirror the withdraw side,
+  // which already special-cases Morpho (usesMarketLiquidity below).
+  const enforcesDepositCap = provider !== 'morpho';
+
   // On-chain ERC-4626 limits → effective input caps (revert-proof, no API needed).
   const limits = computeVaultLimits({
     assetBalance: assetBalance?.value,
-    maxDeposit: vaultData?.maxDeposit,
+    maxDeposit: enforcesDepositCap ? vaultData?.maxDeposit : undefined,
     userAssets,
     userShares: vaultData?.userShares,
     maxWithdraw: vaultData?.maxWithdraw
@@ -289,6 +296,7 @@ const VaultWidgetWrapped = ({
   const isOverDepositCap =
     txStatus === TxStatus.IDLE &&
     !!address &&
+    enforcesDepositCap &&
     vaultData?.maxDeposit !== undefined &&
     debouncedAmount > vaultData.maxDeposit &&
     !isSupplyBalanceError &&

--- a/apps/webapp/src/widgets/MorphoVaultWidget/tests/vaultWidget.depositCap.test.tsx
+++ b/apps/webapp/src/widgets/MorphoVaultWidget/tests/vaultWidget.depositCap.test.tsx
@@ -61,4 +61,25 @@ describe('VaultWidget deposit cap', () => {
     });
     expect(capNotice).toBeTruthy();
   }, 30000);
+
+  // Regression: Morpho V2 vaults return maxDeposit(user) === 0n on-chain even when
+  // deposits are open, so the cap-reached gate must NOT fire for the morpho provider
+  // (only Spark exposes a real on-chain cap). Same 0n data as above, different provider.
+  it('does not show the deposit-cap-reached state for Morpho vaults reading maxDeposit === 0n', async () => {
+    render(
+      <VaultWidget
+        vaultAddress="0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11"
+        assetAddress="0xdAC17F958D2ee523a2206206994597C13D831ec7"
+        assetToken={TOKENS.usdt}
+        vaultName="USDT Savings"
+        provider="morpho"
+      />,
+      { wrapper: WagmiWrapper }
+    );
+
+    // The supply input must render (proves the widget mounted past loading)...
+    await screen.findByTestId('supply-input-morpho', undefined, { timeout: 10000 });
+    // ...without the false cap-reached notice that Morpho's 0n maxDeposit would trigger.
+    expect(screen.queryByTestId('deposit-cap-reached-morpho')).toBeNull();
+  }, 30000);
 });


### PR DESCRIPTION
## Problem

Building on #1609, the new deposit-cap feature was added to the **shared** vault widget (used by both Morpho and the new Spark/sUSDT vault). The new `useErc4626VaultData` hook reads `maxDeposit(user)` for **every** vault, and `computeVaultLimits` flags `depositCapReached = (maxDeposit === 0n)`.

That signal is valid for Spark (a real ERC-4626 supply cap), but **wrong for Morpho V2 vaults** — their `maxDeposit` semantics differ and return `0n` even when deposits are wide open. Verified on mainnet:

| Vault | `maxDeposit(user)` | `totalAssets` |
|---|---|---|
| USDT Savings | 0 | 80,091,619,079,941 |
| USDS Flagship | 0 | 37,709,266,483,765,142,539,816,143 |
| USDS Risk Capital | 0 | 1,312,227,143,353,167,501,763,200 |
| USDT Risk Capital | 0 | 616,554,608,174 |
| USDC Risk Capital | 0 | 10,820,992,084,776 |

So every Morpho vault showed a false **"This vault has reached its deposit cap"**, and `maxDepositInput` was clamped to `0`, blocking deposits entirely.

The **"No wallet connected"** symptom is the same bug: when `depositCapReached` is true, the supply `TokenInput` gets `enabled={isConnectedAndEnabled && !depositCapReached}` → `false`, and `TokenInput` renders "No wallet connected" whenever it's disabled — even with a connected wallet. One root cause, two symptoms.

## Fix

Make deposit-cap enforcement **provider-aware** in `MorphoVaultWidget/index.tsx`, mirroring the withdraw side which already special-cases Morpho (`usesMarketLiquidity = provider === 'morpho'`):

- `const enforcesDepositCap = provider !== 'morpho'`
- Only pass `maxDeposit` into `computeVaultLimits` when `enforcesDepositCap` — Morpho passes `undefined`, treated as uncapped, restoring prior behavior (clamp to wallet balance, no cap message, input stays enabled).
- Gate `isOverDepositCap` with the same flag.

`computeVaultLimits` stays pure and provider-agnostic (its unit tests are untouched); Spark's real cap enforcement is unchanged.

## Tests

- Added a regression test in `vaultWidget.depositCap.test.tsx`: same `maxDeposit: 0n` data, `provider="morpho"` → asserts the cap-reached notice is **absent** (the existing Spark test asserts it's present with identical data).
- `pnpm -F webapp typecheck` ✅
- All `MorphoVaultWidget` tests pass; `computeVaultLimits` tests pass.
- Lint: 0 errors.

## Note

`useErc4626VaultData` still reads `maxDeposit`/`maxWithdraw`/`maxRedeem` for Morpho on-chain — harmless now since the widget ignores the deposit-cap signal for Morpho. Left in place to keep the hook generic; could be skipped per-provider later to trim the RPC batch.