### PR TITLE
Pendle: update PT market subheader copy

### DIFF
--- a/apps/webapp/src/widgets/PendleWidget/index.tsx
+++ b/apps/webapp/src/widgets/PendleWidget/index.tsx
@@ -476,8 +476,7 @@ const PendleWidgetWrapped = ({ market, rightHeaderComponent, onBackToPendle }: P
           </Heading>
           <Text className="text-textSecondary" variant="small">
             <Trans>
-              Lock in fixed yield by buying PT-{market.underlyingSymbol}. Each PT redeems 1:1 for{' '}
-              {market.underlyingSymbol} at maturity.
+              Know your return by a pre-set maturity date. Each PT redeems 1:1 for USDS at maturity.
             </Trans>
           </Text>
         </div>


### PR DESCRIPTION
## Summary

Copy update for the Pendle PT market card subheader

**Before:** _Lock in fixed yield by buying PT-{symbol}. Each PT redeems 1:1 for {symbol} at maturity._
**After:** _Know your return by a pre-set maturity date. Each PT redeems 1:1 for USDS at maturity._

The new copy drops the `PT-{underlyingSymbol}` / `{underlyingSymbol}` interpolation and states the redemption asset as **USDS** explicitly.

## Changes

- `apps/webapp/src/widgets/PendleWidget/index.tsx` — updated the `<Trans>` subheader string.

## Notes

- Source-only change, matching the convention for recent copy tweaks in this widget (e.g. `a2d22cbe8`, `725c74614`), which did not commit regenerated lingui catalogs — `pnpm messages` is run separately/at build. Non-English locales are currently 100% untranslated and fall back to the English source, so the new copy renders everywhere immediately.
- Lint ✅, Prettier ✅.