### PR TITLE
Prefer MetaMask extension over MWP deeplink on desktop

### DIFF
--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -34,7 +34,10 @@ const binanceConnector = getWagmiConnectorV2();
 
 const connectors = [
   // Core wallets
-  metaMask(),
+  // preferExtension: connect via the installed browser extension on desktop instead of the
+  // MetaMask Wallet Protocol deeplink (metamask://connect/mwp), which has no registered handler
+  // on desktop. Mobile still falls through to the deeplink, where the scheme is handled.
+  metaMask({ ui: { preferExtension: true, showInstallModal: true } }),
   baseAccount({
     appName: 'sky.money',
     appLogoUrl: 'https://app.sky.money/images/sky.svg',


### PR DESCRIPTION
## Summary

Fixes desktop MetaMask connection failing with:

```
Failed to launch 'metamask://connect/mwp?…' because the scheme does not have a registered handler.
```

## Root cause

In `@wagmi/connectors@8`, the `metaMask()` connector no longer wraps the old injected SDK — it builds a client via `@metamask/connect-evm` (`createEVMClient`), MetaMask's new **Mobile/Wallet Protocol (MWP)** client. Its default connect path is the `metamask://connect/mwp` deeplink. On **desktop** no application registers the `metamask://` scheme, so the launch fails. We were calling `metaMask()` with **no options**, so nothing told it to prefer the installed extension.

## Fix

Pass `ui.preferExtension` (and `ui.showInstallModal`) to the connector:

```ts
metaMask({ ui: { preferExtension: true, showInstallModal: true } })
```

- `preferExtension: true` — on desktop with the extension installed, connect via the extension instead of the MWP deeplink.
- `showInstallModal: true` — desktop users without the extension get an install prompt instead of a dead deeplink.
- Mobile is unaffected — with no extension present it still falls through to the MWP deeplink, where the `metamask://` scheme is handled.

Both `preferExtension` and `showInstallModal` are typed properties on the connector's `ui` options (`@metamask/connect-multichain` → forwarded by `@wagmi/connectors`), so this is type-safe.

## Testing

- `pnpm -F webapp typecheck` — passes.
- Not reliably reproducible on local dev, so please verify on the **Vercel preview deploy**: on desktop with the MetaMask extension, Connect → MetaMask should open the extension popup (no `metamask://connect/mwp` scheme error).

## Notes

- Single-line functional change (`config.default.ts`); the dev/mainnet configs share the same `connectors` array, so both are covered.
- With `multiInjectedProviderDiscovery: true` already enabled, MetaMask may appear twice (explicit connector + EIP-6963 discovered); both work. Deduping that is a separate, larger change.