### PR TITLE
feat(seal): re-add Seal Engine withdrawal page with position notification

### DIFF
--- a/apps/webapp/docs/seal-engine-withdrawal.md
+++ b/apps/webapp/docs/seal-engine-withdrawal.md
@@ -4,27 +4,26 @@ The SEAL Engine UI has been removed from the app. The SEAL Engine was deprecated
 
 The on-chain exit fee is **0** — users withdraw 100% of their position.
 
-## Which engine are you in?
+## The Seal Engine contract
 
-There are two SEAL Engine deployments. Check both — your position may be in either.
+Positions are held in the LockstakeEngine (v1), denominated in MKR:
 
 | Contract             | Address                                      | Denomination |
 | -------------------- | -------------------------------------------- | ------------ |
-| LockstakeEngine (v2) | `0xCe01C90dE7FD1bcFa39e237FE6D8D9F569e8A6a3` | SKY          |
-| LockstakeEngine (v1) | `0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12` | MKR (legacy) |
+| LockstakeEngine (v1) | `0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12` | MKR          |
 
 ## Step 1 — Find your urn and read your position
 
 Each position is held in a per-user "urn" contract. To find yours and check what's locked, you'll read from both the engine and the underlying Vat contract.
 
-On the appropriate engine's Etherscan page, open **Contract → Read Contract**:
+On the engine's Etherscan page, open **Contract → Read Contract**:
 
 1. Call `ownerUrnsCount(<yourAddress>)`. Most users have exactly one urn at index `0`. If you have multiple, repeat the withdrawal steps below for each index.
 2. Call `ownerUrns(<yourAddress>, <index>)` → returns your **urn address**. Save this value.
 3. Call `vat()` → returns the **Vat address**. Save this value.
 4. Call `ilk()` → returns the **ilk** (bytes32 identifier). Save this value.
 5. Open the **Vat contract** on Etherscan at the address from step 3, go to **Read Contract**, and call `urns(<ilk>, <urnAddress>)` using the values from steps 4 and 2. This returns `(ink, art)`:
-   - `ink` = your locked collateral (18-decimal units — SKY in v2, MKR in v1)
+   - `ink` = your locked MKR collateral (18-decimal units)
    - `art` = your outstanding USDS debt (18-decimal units)
 
 ## Step 2 — Repay USDS debt (skip if you have no debt)
@@ -51,7 +50,7 @@ Use the `ink` value from Step 1.5 as `wad` to withdraw everything. Tokens are se
 
 ## Notes & gotchas
 
-- `wad` values are 18-decimal — SKY in v2, MKR in v1.
+- `wad` values are 18-decimal MKR.
 - `free` reverts if any USDS debt remains — always `wipeAll` first.
 - If `urnFarms(<urnAddress>)` is non-zero, `free` auto-withdraws from the farm; no explicit `selectFarm(0x0)` is required.
 - To claim pending rewards before withdrawing, call `getReward(<owner>, <index>, <farm>, <to>)`.
@@ -59,4 +58,4 @@ Use the `ink` value from Step 1.5 as `wad` to withdraw everything. Tokens are se
 
 ## Support
 
-If you can't complete the withdrawal, contact support with your wallet address and the engine version (v1 or v2) so we can help diagnose.
+If you can't complete the withdrawal, contact support with your wallet address so we can help diagnose.

--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -182,6 +182,11 @@ export const REFERRAL_CODE: number = Number(import.meta.env.VITE_REFERRAL_CODE) 
 export const BATCH_TX_LEGAL_NOTICE_URL = '/batch-transactions-legal-notice';
 export const BATCH_TX_SUPPORTED_WALLETS_URL = 'https://swiss-knife.xyz/7702beat';
 
+// Deprecated Seal Engine (LockstakeEngine v1, MKR). The UI was removed; this address backs the
+// static /seal-engine withdrawal guide. Mirrors the leftover `sealModuleAddress` in generated.ts,
+// which is no longer in contracts.ts and will be dropped on the next codegen run.
+export const SEAL_ENGINE_V1_ADDRESS = '0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12';
+
 // LocalStorage keys
 export const USER_SETTINGS_KEY = 'user-settings';
 export const GOVERNANCE_MIGRATION_NOTIFICATION_KEY = 'governance-migration-notice-shown';

--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -187,6 +187,7 @@ export const USER_SETTINGS_KEY = 'user-settings';
 export const GOVERNANCE_MIGRATION_NOTIFICATION_KEY = 'governance-migration-notice-shown';
 export const SPK_STAKING_NOTIFICATION_KEY = 'spk-staking-rewards-notice-shown';
 export const USDS_SKY_REWARDS_NOTIFICATION_KEY = 'usds-sky-rewards-notice-shown';
+export const SEAL_ENGINE_NOTIFICATION_KEY = 'seal-engine-position-notice-shown';
 
 export const WALLET_ICONS = {
   metaMaskSDK: '/wallets/metamask.svg',

--- a/apps/webapp/src/modules/app/components/MainApp.tsx
+++ b/apps/webapp/src/modules/app/components/MainApp.tsx
@@ -15,6 +15,7 @@ import { useSafeAppNotification } from '../hooks/useSafeAppNotification';
 import { useGovernanceMigrationToast } from '../hooks/useGovernanceMigrationToast';
 import { useSpkStakingRewardsToast } from '../hooks/useSpkStakingRewardsToast';
 import { useUsdsSkyRewardsToast } from '../hooks/useUsdsSkyRewardsToast';
+import { useSealEnginePositionToast } from '../hooks/useSealEnginePositionToast';
 import { useNotificationQueue } from '../hooks/useNotificationQueue';
 import { usePageLoadNotifications } from '../hooks/usePageLoadNotifications';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
@@ -116,11 +117,13 @@ export function MainApp() {
   // 1. Governance Migration (for connected wallets with MKR ≥ 0.05)
   // 2. SPK Staking Rewards (for users with staking positions using SPK rewards)
   // 3. USDS-SKY Rewards (for users with position in deprecated USDS-SKY rewards)
+  // 4. Seal Engine (for users with MKR locked in the deprecated Seal Engine)
 
   // Display notifications based on queue priority
   useGovernanceMigrationToast(isAuthorized && shouldShowNotification('governance-migration'));
   useSpkStakingRewardsToast(isAuthorized && shouldShowNotification('spk-staking-rewards'));
   useUsdsSkyRewardsToast(isAuthorized && shouldShowNotification('usds-sky-rewards'));
+  useSealEnginePositionToast(isAuthorized && shouldShowNotification('seal-engine-position'));
 
   // If the user is connected to a Safe Wallet using WalletConnect, notify they can use the Safe App
   useSafeAppNotification();

--- a/apps/webapp/src/modules/app/hooks/useHasSealEnginePosition.ts
+++ b/apps/webapp/src/modules/app/hooks/useHasSealEnginePosition.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { request, gql } from 'graphql-request';
+import { useConnection, useChainId } from 'wagmi';
+import { getSubgraphUrl } from '@/hooks/helpers/getSubgraphUrl';
+import { isMainnetId, chainId as chainIdMap } from '@/utils';
+
+/**
+ * Detection-only hook for the deprecated Seal Engine. The Seal Engine UI was removed from the app,
+ * but a small number of wallets still have MKR locked in it. This reads the Sky Ecosystem subgraph
+ * for any MKR the connected wallet still has sealed, so we can surface a withdrawal notification that
+ * links to the static /seal-engine instructions page.
+ *
+ * Seal Engine only ever existed on mainnet, so we always query the mainnet subgraph.
+ */
+async function fetchSealedMkr(urlSubgraph: string, chainId: number, address: string): Promise<bigint> {
+  const query = gql`
+    {
+      sealUrns: SealUrn(where: { owner: { _ilike: "${address}" }, chainId: { _eq: ${chainId} } }) {
+        mkrLocked
+      }
+    }
+  `;
+
+  const response = (await request(urlSubgraph, query)) as { sealUrns: { mkrLocked: string }[] };
+
+  if (!response.sealUrns || response.sealUrns.length === 0) {
+    return 0n;
+  }
+
+  return response.sealUrns.reduce((acum, urn) => acum + BigInt(urn.mkrLocked), 0n);
+}
+
+export const useHasSealEnginePosition = () => {
+  const { address, isConnected } = useConnection();
+  const currentChainId = useChainId();
+  // Seal Engine is mainnet-only; resolve to mainnet regardless of the connected chain.
+  const sealChainId = isMainnetId(currentChainId) ? currentChainId : chainIdMap.mainnet;
+  const urlSubgraph = getSubgraphUrl(sealChainId) || '';
+
+  const { data: sealedMkr, isLoading } = useQuery({
+    enabled: Boolean(urlSubgraph && address && isConnected),
+    queryKey: ['seal-engine-position', urlSubgraph, address, sealChainId],
+    queryFn: () => fetchSealedMkr(urlSubgraph, sealChainId, address!)
+  });
+
+  // The user said to simply notify on any amount deposited, so a non-zero locked balance qualifies.
+  const hasPosition = !!(isConnected && address && sealedMkr && sealedMkr > 0n);
+
+  return {
+    hasPosition,
+    sealedMkr,
+    isLoading,
+    isReady: !isLoading
+  };
+};

--- a/apps/webapp/src/modules/app/hooks/usePageLoadNotifications.tsx
+++ b/apps/webapp/src/modules/app/hooks/usePageLoadNotifications.tsx
@@ -5,11 +5,13 @@ import { parseEther } from 'viem';
 import {
   GOVERNANCE_MIGRATION_NOTIFICATION_KEY,
   SPK_STAKING_NOTIFICATION_KEY,
-  USDS_SKY_REWARDS_NOTIFICATION_KEY
+  USDS_SKY_REWARDS_NOTIFICATION_KEY,
+  SEAL_ENGINE_NOTIFICATION_KEY
 } from '@/lib/constants';
 import { NotificationConfig } from './useNotificationQueue';
 import { useHasSpkStakingPositions } from './useHasSpkStakingPositions';
 import { useHasUsdsSkyRewardsPosition } from './useHasUsdsSkyRewardsPosition';
+import { useHasSealEnginePosition } from './useHasSealEnginePosition';
 
 /**
  * Hook to manage page load notifications configuration.
@@ -19,6 +21,7 @@ import { useHasUsdsSkyRewardsPosition } from './useHasUsdsSkyRewardsPosition';
  * 1. Governance Migration (requires MKR balance)
  * 2. SPK Staking Rewards (requires staking positions with SPK reward)
  * 3. USDS-SKY Rewards (requires position in deprecated USDS-SKY rewards)
+ * 4. Seal Engine (requires MKR locked in the deprecated Seal Engine)
  */
 export const usePageLoadNotifications = (): NotificationConfig[] => {
   const { address, isConnected } = useConnection();
@@ -49,6 +52,9 @@ export const usePageLoadNotifications = (): NotificationConfig[] => {
   // Check if user has USDS-SKY rewards position
   const { hasPosition: hasUsdsSkyPosition, isReady: usdsSkyPositionReady } = useHasUsdsSkyRewardsPosition();
 
+  // Check if user has MKR locked in the deprecated Seal Engine
+  const { hasPosition: hasSealEnginePosition, isReady: sealEnginePositionReady } = useHasSealEnginePosition();
+
   // Define notification configurations with priority order
   const notificationConfigs: NotificationConfig[] = useMemo(
     () => [
@@ -72,6 +78,13 @@ export const usePageLoadNotifications = (): NotificationConfig[] => {
         isReady: () => usdsSkyPositionReady, // Wait for rewards balance to load
         checkConditions: () => isConnected && hasUsdsSkyPosition,
         hasBeenShown: () => localStorage.getItem(USDS_SKY_REWARDS_NOTIFICATION_KEY) === 'true'
+      },
+      {
+        id: 'seal-engine-position',
+        priority: 4,
+        isReady: () => sealEnginePositionReady, // Wait for the subgraph read to load
+        checkConditions: () => isConnected && hasSealEnginePosition,
+        hasBeenShown: () => localStorage.getItem(SEAL_ENGINE_NOTIFICATION_KEY) === 'true'
       }
     ],
     [
@@ -82,7 +95,9 @@ export const usePageLoadNotifications = (): NotificationConfig[] => {
       spkPositionsReady,
       hasSpkPositions,
       usdsSkyPositionReady,
-      hasUsdsSkyPosition
+      hasUsdsSkyPosition,
+      sealEnginePositionReady,
+      hasSealEnginePosition
     ]
   );
 

--- a/apps/webapp/src/modules/app/hooks/useSealEnginePositionToast.tsx
+++ b/apps/webapp/src/modules/app/hooks/useSealEnginePositionToast.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast, toastWithClose } from '@/components/ui/use-toast';
+import { Text } from '@/modules/layout/components/Typography';
+import { VStack } from '@/modules/layout/components/VStack';
+import { Button } from '@/components/ui/button';
+import { SEAL_ENGINE_NOTIFICATION_KEY } from '@/lib/constants';
+
+/**
+ * Notifies a connected wallet that still has MKR locked in the deprecated Seal Engine, linking to the
+ * static /seal-engine withdrawal instructions page. Gated by the page-load notification queue so only
+ * one notification shows per page load. Dismissal is persisted to localStorage.
+ */
+export const useSealEnginePositionToast = (isAuthorized: boolean) => {
+  const navigate = useNavigate();
+
+  const onClose = useCallback(() => {
+    localStorage.setItem(SEAL_ENGINE_NOTIFICATION_KEY, 'true');
+  }, []);
+
+  useEffect(() => {
+    // Only show if authorized by the notification queue
+    if (!isAuthorized) {
+      return;
+    }
+
+    // Add a small delay to ensure smooth UX
+    const timer = setTimeout(() => {
+      toastWithClose(
+        toastId => (
+          <div>
+            <Text variant="medium" className="text-selectActive">
+              Seal Engine deprecated
+            </Text>
+            <VStack className="mt-4 gap-4">
+              <Text variant="medium">
+                You still have MKR supplied to the Seal Engine, which has been deprecated. You can withdraw
+                your position at any time — the exit fee is now 0.
+              </Text>
+              <Button
+                className="place-self-start"
+                variant="pill"
+                size="xs"
+                onClick={() => {
+                  navigate('/seal-engine');
+                  toast.dismiss(toastId);
+                  onClose();
+                }}
+              >
+                Withdraw from Seal Engine
+              </Button>
+            </VStack>
+          </div>
+        ),
+        {
+          id: 'seal-engine-position-toast',
+          duration: Infinity,
+          dismissible: true,
+          onDismiss: onClose
+        }
+      );
+    }, 1000); // 1 second delay
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isAuthorized, navigate, onClose]);
+};

--- a/apps/webapp/src/pages/SealEngine.tsx
+++ b/apps/webapp/src/pages/SealEngine.tsx
@@ -1,0 +1,228 @@
+import { Layout } from '@/modules/layout/components/Layout';
+import { Text, Heading, List } from '@/modules/layout/components/Typography';
+import { ExternalLink } from '@/modules/layout/components/ExternalLink';
+import { HStack } from '@/modules/layout/components/HStack';
+import { Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+
+// Inline monospace token for contract addresses and function names.
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="bg-surface text-textEmphasis rounded px-1 py-0.5 font-mono text-[13px]">{children}</code>
+  );
+}
+
+const ENGINES = [
+  {
+    contract: 'LockstakeEngine (v1)',
+    address: '0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12',
+    denomination: 'MKR'
+  }
+];
+
+export function SealEngine() {
+  return (
+    <Layout>
+      <main
+        className="scrollbar-hidden md:scrollbar-thin bg-container group mx-4 mt-20 mb-10 flex h-auto max-w-[680px] min-w-[375px] flex-col gap-3 overflow-x-hidden overflow-y-auto rounded-t-3xl border bg-blend-overlay backdrop-blur-[50px] md:rounded-3xl"
+        style={{ borderRadius: '1.5rem' }}
+      >
+        <div className="flex flex-col gap-4 p-8">
+          <Link to="/" className={'text-textSecondary'}>
+            <HStack className="mb-3 space-x-2">
+              <ArrowLeft className="self-center" />
+              <Heading tag="h3" variant="small" className="text-textSecondary">
+                Back to Home Page
+              </Heading>
+            </HStack>
+          </Link>
+
+          <Heading tag="h2" className="text-text">
+            Withdrawing from the Seal Engine via Etherscan
+          </Heading>
+
+          <Text variant="large" className="text-text">
+            The Seal Engine UI has been removed from the app. The Seal Engine was deprecated by Sky governance
+            on <span className="font-semibold">April 22, 2025</span> (MakerDAO Poll <Code>Qmctp1eN</Code>) and
+            replaced by the SKY Staking Engine. Any remaining positions can be withdrawn directly on-chain via
+            Etherscan.
+          </Text>
+          <Text variant="large" className="text-text">
+            The on-chain exit fee is <span className="font-semibold">0</span> — users withdraw 100% of their
+            position.
+          </Text>
+
+          <Heading tag="h3" variant="small" className="text-text mt-2">
+            The Seal Engine contract
+          </Heading>
+          <Text variant="large" className="text-text">
+            Positions are held in the LockstakeEngine (v1), denominated in MKR:
+          </Text>
+          <table className="w-full border-collapse text-left">
+            <thead>
+              <tr className="border-textSecondary/20 border-b">
+                <th className="text-textSecondary py-2 pr-4 text-sm font-normal">Contract</th>
+                <th className="text-textSecondary py-2 pr-4 text-sm font-normal">Address</th>
+                <th className="text-textSecondary py-2 text-sm font-normal">Denomination</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ENGINES.map(engine => (
+                <tr key={engine.address} className="border-textSecondary/10 border-b align-top">
+                  <td className="text-text py-2 pr-4 text-sm">{engine.contract}</td>
+                  <td className="py-2 pr-4 text-sm">
+                    <ExternalLink
+                      href={`https://etherscan.io/address/${engine.address}`}
+                      className="text-textEmphasis font-mono text-[13px] break-all"
+                    >
+                      {engine.address}
+                    </ExternalLink>
+                  </td>
+                  <td className="text-text py-2 text-sm">{engine.denomination}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <Heading tag="h3" variant="small" className="text-text mt-2">
+            Step 1 — Find your urn and read your position
+          </Heading>
+          <Text variant="large" className="text-text">
+            Each position is held in a per-user &quot;urn&quot; contract. To find yours and check what&apos;s
+            locked, you&apos;ll read from both the engine and the underlying Vat contract.
+          </Text>
+          <Text variant="large" className="text-text">
+            On the appropriate engine&apos;s Etherscan page, open{' '}
+            <span className="font-semibold">Contract → Read Contract</span>:
+          </Text>
+          <List variant="ordered" className="text-text">
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                Call <Code>ownerUrnsCount(&lt;yourAddress&gt;)</Code>. Most users have exactly one urn at
+                index <Code>0</Code>. If you have multiple, repeat the withdrawal steps below for each index.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                Call <Code>ownerUrns(&lt;yourAddress&gt;, &lt;index&gt;)</Code> → returns your{' '}
+                <span className="font-semibold">urn address</span>. Save this value.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                Call <Code>vat()</Code> → returns the <span className="font-semibold">Vat address</span>. Save
+                this value.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                Call <Code>ilk()</Code> → returns the <span className="font-semibold">ilk</span> (bytes32
+                identifier). Save this value.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                Open the <span className="font-semibold">Vat contract</span> on Etherscan at the address from
+                step 3, go to <span className="font-semibold">Read Contract</span>, and call{' '}
+                <Code>urns(&lt;ilk&gt;, &lt;urnAddress&gt;)</Code> using the values from steps 4 and 2. This
+                returns <Code>(ink, art)</Code>:
+                <List variant="unordered" className="text-text">
+                  <li>
+                    <Code>ink</Code> = your locked MKR collateral (18-decimal units)
+                  </li>
+                  <li>
+                    <Code>art</Code> = your outstanding USDS debt (18-decimal units)
+                  </li>
+                </List>
+              </Text>
+            </li>
+          </List>
+
+          <Heading tag="h3" variant="small" className="text-text mt-2">
+            Step 2 — Repay USDS debt (skip if you have no debt)
+          </Heading>
+          <Text variant="large" className="text-text">
+            If <Code>art</Code> from Step 1.5 is non-zero, repay it before withdrawing collateral.{' '}
+            <Code>free</Code> will revert otherwise.
+          </Text>
+          <List variant="ordered" className="text-text">
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                On the <span className="font-semibold">USDS token contract</span>, call{' '}
+                <Code>approve(&lt;engineAddress&gt;, &lt;amount&gt;)</Code> with an amount ≥ your debt. A safe
+                choice is <Code>2^256 - 1</Code> (max uint256).
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                On the engine&apos;s <span className="font-semibold">Write Contract</span> tab, call{' '}
+                <Code>wipeAll(&lt;yourAddress&gt;, &lt;index&gt;)</Code> to repay the full debt.
+              </Text>
+            </li>
+          </List>
+
+          <Heading tag="h3" variant="small" className="text-text mt-2">
+            Step 3 — Withdraw your collateral
+          </Heading>
+          <Text variant="large" className="text-text">
+            On the engine&apos;s <span className="font-semibold">Write Contract</span> tab:
+          </Text>
+          <pre className="bg-surface text-text overflow-x-auto rounded-lg p-4 font-mono text-[13px]">
+            {`free(
+  owner: <yourAddress>,
+  index: <urnIndex>,
+  to:    <yourAddress>,
+  wad:   <amountIn18Decimals>
+)`}
+          </pre>
+          <Text variant="large" className="text-text">
+            Use the <Code>ink</Code> value from Step 1.5 as <Code>wad</Code> to withdraw everything. Tokens
+            are sent directly to the <Code>to</Code> address.
+          </Text>
+
+          <Heading tag="h3" variant="small" className="text-text mt-2">
+            Notes &amp; gotchas
+          </Heading>
+          <List variant="unordered" className="text-text">
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                <Code>wad</Code> values are 18-decimal MKR.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                <Code>free</Code> reverts if any USDS debt remains — always <Code>wipeAll</Code> first.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                If <Code>urnFarms(&lt;urnAddress&gt;)</Code> is non-zero, <Code>free</Code> auto-withdraws
+                from the farm; no explicit <Code>selectFarm(0x0)</Code> is required.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                To claim pending rewards before withdrawing, call{' '}
+                <Code>getReward(&lt;owner&gt;, &lt;index&gt;, &lt;farm&gt;, &lt;to&gt;)</Code>.
+              </Text>
+            </li>
+            <li>
+              <Text tag="span" variant="large" className="text-text">
+                Only the position owner can call these functions, unless{' '}
+                <Code>hope(&lt;owner&gt;, &lt;index&gt;, &lt;delegate&gt;)</Code> has been set.
+              </Text>
+            </li>
+          </List>
+
+          <Heading tag="h3" variant="small" className="text-text mt-2">
+            Support
+          </Heading>
+          <Text variant="large" className="text-text">
+            If you can&apos;t complete the withdrawal, contact support with your wallet address so we can help
+            diagnose.
+          </Text>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/apps/webapp/src/pages/SealEngine.tsx
+++ b/apps/webapp/src/pages/SealEngine.tsx
@@ -4,6 +4,7 @@ import { ExternalLink } from '@/modules/layout/components/ExternalLink';
 import { HStack } from '@/modules/layout/components/HStack';
 import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import { SEAL_ENGINE_V1_ADDRESS } from '@/lib/constants';
 
 // Inline monospace token for contract addresses and function names.
 function Code({ children }: { children: React.ReactNode }) {
@@ -15,7 +16,7 @@ function Code({ children }: { children: React.ReactNode }) {
 const ENGINES = [
   {
     contract: 'LockstakeEngine (v1)',
-    address: '0x2b16C07D5fD5cC701a0a871eae2aad6DA5fc8f12',
+    address: SEAL_ENGINE_V1_ADDRESS,
     denomination: 'MKR'
   }
 ];

--- a/apps/webapp/src/pages/router.tsx
+++ b/apps/webapp/src/pages/router.tsx
@@ -4,6 +4,7 @@ import Home from './Home';
 import ErrorPage from './ErrorPage';
 import { NotFound } from '../modules/layout/components/NotFound';
 import Dev from './Dev';
+import { SealEngine } from './SealEngine';
 import { BatchTransactionsLegal } from './BatchTransactionsLegal';
 import { rewriteLegacyWidgetParams } from '@/modules/utils/validateSearchParams';
 
@@ -23,6 +24,11 @@ const routes: RouteObject[] = [
     path: '/',
     element: <Home />,
     loader: legacyWidgetLoader,
+    errorElement: <ErrorPage />
+  },
+  {
+    path: '/seal-engine',
+    element: <SealEngine />,
     errorElement: <ErrorPage />
   },
   {


### PR DESCRIPTION
## Summary

The Seal Engine UI was removed in APP-259, but a small number of wallets still have MKR locked in the deprecated **LockstakeEngine v1**. This restores a self-serve exit path — a static instructions page plus a detection notification — without resurrecting the old migration widget.

## Changes

- **`/seal-engine` page** (`pages/SealEngine.tsx`, re-added to `router.tsx`): static page with step-by-step on-chain (Etherscan) withdrawal instructions, scoped to **v1 (MKR)** only. Mirrors the `BatchTransactionsLegal` static-page pattern. No wallet writes.
- **Detection** (`useHasSealEnginePosition`): reads the Sky Ecosystem subgraph for any MKR the connected wallet still has locked in v1 (mainnet-only). Self-contained in `modules/app/hooks/` to keep deprecated logic out of the core hooks barrel.
- **Notification** (`useSealEnginePositionToast`): page-load toast that links to `/seal-engine`; dismissal persisted via `SEAL_ENGINE_NOTIFICATION_KEY`.
- **Queue wiring**: registered in `usePageLoadNotifications` (priority 4) and `MainApp`, so it respects the existing one-notification-per-page-load priority system.
- **Docs** (`docs/seal-engine-withdrawal.md`): scoped to v1/MKR only (dropped v2/SKY references).

## Notes

- Detection relies on the subgraph still indexing the historical `SealUrn` entity (the same query the pre-removal code used). Worth a sanity check against a wallet known to hold a v1 position.
- Nothing else in the app links to `/seal-engine`; it's reachable via the notification or direct URL.

## Testing

- `pnpm typecheck` ✅
- `pnpm exec eslint` on changed files ✅ (exit 0)
- prettier ✅