### PR TITLE
feat: enhance vault deposit functionality with referral support

### DIFF
--- a/apps/webapp/src/hooks/morpho/useBatchMorphoVaultDeposit.ts
+++ b/apps/webapp/src/hooks/morpho/useBatchMorphoVaultDeposit.ts
@@ -1,9 +1,11 @@
 import { useConnection, useChainId } from 'wagmi';
 import { BatchWriteHook, BatchWriteHookParams } from '../hooks';
-import { usdtAbi, usdtAddress, usdsRiskCapitalVaultAbi } from '../generated';
+import { usdtAbi, usdtAddress } from '../generated';
 import { getWriteContractCall } from '../shared/getWriteContractCall';
 import { useTransactionFlow } from '../shared/useTransactionFlow';
 import { useTokenAllowance } from '../tokens/useTokenAllowance';
+import { VaultProvider } from '../vaults/types';
+import { buildVaultDepositCall } from '@/lib/vaults/buildVaultDepositCall';
 import { Call, erc20Abi } from 'viem';
 
 /**
@@ -34,11 +36,17 @@ export function useBatchMorphoVaultDeposit({
   onError = () => null,
   onStart = () => null,
   enabled: activeTabEnabled = true,
-  shouldUseBatch = true
+  shouldUseBatch = true,
+  provider = 'morpho',
+  referral = 0
 }: BatchWriteHookParams & {
   amount: bigint;
   vaultAddress: `0x${string}`;
   assetAddress: `0x${string}`;
+  /** Vault provider — only Spark attaches the on-chain referral code. Defaults to Morpho. */
+  provider?: VaultProvider;
+  /** Referral code to attribute the deposit to; ignored unless provider is Spark. */
+  referral?: number;
 }): BatchWriteHook {
   const { address: connectedAddress, isConnected } = useConnection();
   const chainId = useChainId();
@@ -56,14 +64,15 @@ export function useBatchMorphoVaultDeposit({
 
   const hasAllowance = allowance !== undefined && allowance >= amount;
 
-  // Build the deposit call
-  // ERC-4626 deposit signature: deposit(uint256 assets, address receiver)
-  // receiver is the connected address - they receive the vault shares
-  const depositCall = getWriteContractCall({
-    to: vaultAddress,
-    abi: usdsRiskCapitalVaultAbi,
-    functionName: 'deposit',
-    args: [amount, connectedAddress!]
+  // Build the deposit call. ERC-4626 deposit(assets, receiver) for Morpho; Spark
+  // additionally carries the on-chain referral code via the 3-arg overload.
+  // receiver is the connected address - they receive the vault shares.
+  const depositCall = buildVaultDepositCall({
+    provider,
+    vaultAddress,
+    amount,
+    receiver: connectedAddress!,
+    referral
   });
 
   // Conditionally include approve calls if allowance is insufficient

--- a/apps/webapp/src/lib/vaults/buildVaultDepositCall.test.ts
+++ b/apps/webapp/src/lib/vaults/buildVaultDepositCall.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { Abi, decodeFunctionData, encodeFunctionData } from 'viem';
+import { buildVaultDepositCall } from './buildVaultDepositCall';
+import { sparkVaultAbi } from '@/hooks/abis/sparkVaultAbi';
+import { usdsRiskCapitalVaultAbi } from '@/hooks/generated';
+
+const VAULT_ADDRESS = '0x74cb54e082411cfCAEADb00a0765625B10410DAa' as const;
+const RECEIVER = '0x1111111111111111111111111111111111111111' as const;
+const AMOUNT = 1_000_000n;
+
+// The Call returned by getWriteContractCall carries abi/functionName/args; encode
+// it to the bytes that would actually be broadcast, then decode to assert the
+// on-chain deposit semantics (function + args), not the builder's internal shape.
+function encodeCall(call: ReturnType<typeof buildVaultDepositCall>) {
+  const { abi, functionName, args } = call as unknown as {
+    abi: Abi;
+    functionName: string;
+    args: readonly unknown[];
+  };
+  return encodeFunctionData({ abi, functionName, args });
+}
+
+describe('buildVaultDepositCall', () => {
+  it('encodes the 3-arg deposit(assets, receiver, referral) for a Spark vault with a referral code', () => {
+    const call = buildVaultDepositCall({
+      provider: 'spark',
+      vaultAddress: VAULT_ADDRESS,
+      amount: AMOUNT,
+      receiver: RECEIVER,
+      referral: 555
+    });
+
+    const decoded = decodeFunctionData({ abi: sparkVaultAbi as Abi, data: encodeCall(call) });
+
+    expect(decoded.functionName).toBe('deposit');
+    expect(decoded.args?.length).toBe(3);
+    expect(decoded.args?.[0]).toBe(AMOUNT);
+    expect((decoded.args?.[1] as string).toLowerCase()).toBe(RECEIVER);
+    expect(decoded.args?.[2]).toBe(555);
+  });
+
+  it('keeps the 2-arg deposit(assets, receiver) for a Morpho vault even when a referral code is present', () => {
+    const call = buildVaultDepositCall({
+      provider: 'morpho',
+      vaultAddress: VAULT_ADDRESS,
+      amount: AMOUNT,
+      receiver: RECEIVER,
+      referral: 555
+    });
+
+    const decoded = decodeFunctionData({ abi: usdsRiskCapitalVaultAbi, data: encodeCall(call) });
+
+    expect(decoded.functionName).toBe('deposit');
+    expect(decoded.args?.length).toBe(2);
+    expect(decoded.args?.[0]).toBe(AMOUNT);
+    expect((decoded.args?.[1] as string).toLowerCase()).toBe(RECEIVER);
+  });
+
+  it('falls back to the 2-arg deposit for a Spark vault when no referral code is configured (0)', () => {
+    const call = buildVaultDepositCall({
+      provider: 'spark',
+      vaultAddress: VAULT_ADDRESS,
+      amount: AMOUNT,
+      receiver: RECEIVER,
+      referral: 0
+    });
+
+    const decoded = decodeFunctionData({ abi: usdsRiskCapitalVaultAbi, data: encodeCall(call) });
+
+    expect(decoded.functionName).toBe('deposit');
+    expect(decoded.args?.length).toBe(2);
+  });
+});

--- a/apps/webapp/src/lib/vaults/buildVaultDepositCall.ts
+++ b/apps/webapp/src/lib/vaults/buildVaultDepositCall.ts
@@ -1,0 +1,47 @@
+import { Abi, Call } from 'viem';
+import { VaultProvider } from '@/hooks/vaults/types';
+import { sparkVaultAbi } from '@/hooks/abis/sparkVaultAbi';
+import { usdsRiskCapitalVaultAbi } from '@/hooks/generated';
+import { getWriteContractCall } from '@/hooks/shared/getWriteContractCall';
+
+/**
+ * Build the ERC-4626 deposit call for a vault, attaching the on-chain referral
+ * code only for Spark vaults (and only when a non-zero code is configured).
+ *
+ * Spark's vault exposes an overloaded `deposit(assets, receiver, uint16 referral)`
+ * that emits a `Referral` event for attribution; the Morpho ERC-4626 vault has only
+ * the 2-arg form. Gating mirrors `useBatchStUsdsDeposit`'s `referral > 0` semantics,
+ * and the Morpho path stays byte-for-byte identical to the plain 2-arg deposit.
+ */
+export function buildVaultDepositCall({
+  provider,
+  vaultAddress,
+  amount,
+  receiver,
+  referral
+}: {
+  provider: VaultProvider;
+  vaultAddress: `0x${string}`;
+  amount: bigint;
+  receiver: `0x${string}`;
+  referral: number;
+}): Call {
+  const sendReferral = provider === 'spark' && referral > 0;
+
+  if (sendReferral) {
+    // Only sparkVaultAbi carries the 3-arg overload; the Morpho abi has just the 2-arg form.
+    return getWriteContractCall({
+      to: vaultAddress,
+      abi: sparkVaultAbi as Abi,
+      functionName: 'deposit',
+      args: [amount, receiver, referral]
+    });
+  }
+
+  return getWriteContractCall({
+    to: vaultAddress,
+    abi: usdsRiskCapitalVaultAbi,
+    functionName: 'deposit',
+    args: [amount, receiver]
+  });
+}

--- a/apps/webapp/src/widgets/MorphoVaultWidget/hooks/useMorphoVaultTransactions.tsx
+++ b/apps/webapp/src/widgets/MorphoVaultWidget/hooks/useMorphoVaultTransactions.tsx
@@ -7,6 +7,7 @@ import {
   OnNotificationCallback,
   OnAnalyticsEventCallback
 } from '@/widgets/shared/types/widgetState';
+import { VaultProvider } from '@/hooks/vaults/types';
 import { useMorphoVaultTransactionCallbacks } from './useMorphoVaultTransactionCallbacks';
 
 interface UseMorphoVaultTransactionsParameters extends Pick<WidgetProps, 'onWidgetStateChange'> {
@@ -18,6 +19,10 @@ interface UseMorphoVaultTransactionsParameters extends Pick<WidgetProps, 'onWidg
   shares: bigint;
   /** Whether to use redeem instead of withdraw (for max withdrawals) */
   max: boolean;
+  /** Which provider operates the vault — only Spark attaches the on-chain referral code */
+  provider: VaultProvider;
+  /** Referral code to attribute Spark deposits to (ignored for Morpho) */
+  referralCode: number;
   /** The Morpho vault address */
   vaultAddress: `0x${string}`;
   /** The underlying asset address (e.g., USDC) */
@@ -44,6 +49,8 @@ export const useMorphoVaultTransactions = ({
   amount,
   shares,
   max,
+  provider,
+  referralCode,
   vaultAddress,
   assetAddress,
   assetDecimals,
@@ -82,6 +89,8 @@ export const useMorphoVaultTransactions = ({
     amount,
     vaultAddress,
     assetAddress,
+    provider,
+    referral: referralCode,
     shouldUseBatch,
     enabled:
       widgetState.flow === MorphoVaultFlow.SUPPLY &&

--- a/apps/webapp/src/widgets/MorphoVaultWidget/index.tsx
+++ b/apps/webapp/src/widgets/MorphoVaultWidget/index.tsx
@@ -12,6 +12,7 @@ import {
   type VaultProvider
 } from '@/hooks';
 import { useDebounce } from '@/hooks';
+import { REFERRAL_CODE } from '@/lib/constants';
 import { resolveSparkVaultRate } from '@/lib/vaults/sparkVaultRate';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { WidgetContainer } from '@/widgets/shared/components/ui/widget/WidgetContainer';
@@ -230,6 +231,8 @@ const VaultWidgetWrapped = ({
     amount: debouncedAmount,
     shares: vaultData?.userShares ?? 0n,
     max,
+    provider,
+    referralCode: REFERRAL_CODE,
     vaultAddress,
     assetAddress,
     assetDecimals,

--- a/apps/webapp/src/widgets/MorphoVaultWidget/tests/vaultWidget.referralCode-render.test.tsx
+++ b/apps/webapp/src/widgets/MorphoVaultWidget/tests/vaultWidget.referralCode-render.test.tsx
@@ -1,0 +1,58 @@
+/// <reference types="vite/client" />
+
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { WagmiWrapper } from '../../../../test/widgets/WagmiWrapper';
+import { REFERRAL_CODE } from '@/lib/constants';
+
+const captured = vi.hoisted(() => ({ params: undefined as Record<string, unknown> | undefined }));
+
+const stubTxResult = {
+  prepared: false,
+  isLoading: false,
+  error: null,
+  prepareError: null,
+  execute: () => {},
+  currentCallIndex: 0,
+  reset: () => {}
+};
+
+vi.mock('@/widgets/MorphoVaultWidget/hooks/useMorphoVaultTransactions', () => ({
+  useMorphoVaultTransactions: (params: Record<string, unknown>) => {
+    captured.params = params;
+    return {
+      morphoVaultDeposit: stubTxResult,
+      morphoVaultWithdraw: stubTxResult,
+      morphoVaultRedeem: stubTxResult
+    };
+  }
+}));
+
+import { VaultWidget } from '..';
+import { TOKENS } from '@/hooks';
+
+describe('VaultWidget referralCode render-layer parity', () => {
+  beforeEach(() => {
+    captured.params = undefined;
+  });
+
+  it('forwards provider="spark" and the REFERRAL_CODE constant to useMorphoVaultTransactions', async () => {
+    render(
+      <VaultWidget
+        vaultAddress="0x74cb54e082411cfCAEADb00a0765625B10410DAa"
+        assetAddress="0xdAC17F958D2ee523a2206206994597C13D831ec7"
+        assetToken={TOKENS.usdt}
+        vaultName="Tether Savings"
+        provider="spark"
+      />,
+      { wrapper: WagmiWrapper }
+    );
+
+    await waitFor(() => {
+      expect(captured.params).toBeDefined();
+    });
+    expect(captured.params?.provider).toBe('spark');
+    expect(captured.params?.referralCode).toBe(REFERRAL_CODE);
+    expect(typeof captured.params?.referralCode).toBe('number');
+  });
+});


### PR DESCRIPTION
Add support for referral codes in the vault deposit process, specifically for Spark vaults. Introduce a new `buildVaultDepositCall` function to handle the construction of deposit calls, accommodating both Morpho and Spark vaults. Update the `useBatchMorphoVaultDeposit` hook to include optional parameters for provider type and referral code. Additionally, implement tests to ensure correct encoding of deposit calls for both vault types. This change improves the user experience by allowing referral tracking for Spark deposits while maintaining existing functionality for Morpho.

### What does this PR do?

### Testing steps:
