### PR TITLE
Treat 'User closed modal' as a user rejection (WEBAPP-6R)

### DIFF
--- a/apps/webapp/src/modules/utils/isUserRejectedRequestError.test.ts
+++ b/apps/webapp/src/modules/utils/isUserRejectedRequestError.test.ts
@@ -12,6 +12,11 @@ describe('isUserRejectedRequestError', () => {
     expect(isUserRejectedRequestError({ message: 'The user rejected the request.' })).toBe(true);
   });
 
+  it('matches wallet SDK modal-dismissal rejections', () => {
+    expect(isUserRejectedRequestError({ message: 'User closed modal' })).toBe(true);
+    expect(isUserRejectedRequestError({ message: '[binance-w3w] User closed modal' })).toBe(true);
+  });
+
   it('does not match unrelated wallet errors', () => {
     expect(isUserRejectedRequestError({ code: -32000, message: 'execution reverted' })).toBe(false);
   });

--- a/apps/webapp/src/modules/utils/isUserRejectedRequestError.ts
+++ b/apps/webapp/src/modules/utils/isUserRejectedRequestError.ts
@@ -18,6 +18,11 @@ export function isUserRejectedRequestError(error: unknown): boolean {
   if (errorCodes.includes('ACTION_REJECTED')) return true;
   if (combinedText.includes('UserRejectedRequestError')) return true;
   if (/user rejected|rejected the request|user denied/i.test(combinedText)) return true;
+  // Wallet SDKs that render their own connect modal (MetaMask Connect multichain,
+  // Binance Web3 Wallet) reject with "User closed modal" / "[binance-w3w] User
+  // closed modal" when the user dismisses it — the modal-based equivalent of a
+  // 4001 rejection, not an app error (WEBAPP-6R).
+  if (/user closed modal/i.test(combinedText)) return true;
 
   return false;
 }


### PR DESCRIPTION
## What

Stop reporting **"User closed modal"** wallet-connect rejections to Sentry by matching them in the existing user-rejection gate (`isUserRejectedRequestError`).

## Why

Sentry issue [WEBAPP-6R](https://jetstream-gg.sentry.io/issues/WEBAPP-6R) triggered a **PagerDuty alert**, but it's a false alarm — not a bug.

When a user opens the Connect-wallet flow and then **dismisses the wallet SDK's own modal** (MetaMask Connect multichain, Binance Web3 Wallet), the SDK rejects the connect promise with `Error("User closed modal")` (or `[binance-w3w] User closed modal`). The stacktrace confirms it originates in `@metamask/connect-multichain`:

```
connect-multichain.mjs:3768   shouldTerminate ? new Error("User closed modal") : void 0
```

`ConnectModal.tsx`'s `useConnect`/`useSwitchConnection` `onError` handlers already short-circuit user rejections via `isUserRejectedRequestError(...)`, but that gate only matched the EIP-1193 forms (code `4001`, `ACTION_REJECTED`, `UserRejectedRequestError`, "user rejected/denied"). "User closed modal" matched none of them, so it fell through to `reportError(...)` → `Sentry.captureException`.

Dismissing the SDK's modal is just the modal-based equivalent of a 4001 rejection. The signal was textbook benign:

- 48 occurrences over ~8 days, **0 users impacted**, `handled: yes`
- Spread across many countries / browsers / wallets — no common thread except "someone clicked the X"

## Change

- Add `if (/user closed modal/i.test(combinedText)) return true;` to `isUserRejectedRequestError` (the substring match also covers the Binance `[binance-w3w] User closed modal` variant). This covers both the `connect` and `switch-connection` paths in one place.
- Add a unit test case for both message variants.

## Testing

- `vitest run isUserRejectedRequestError.test.ts` — 4/4 pass (incl. 2 new cases)
- typecheck, eslint, prettier — clean on changed files

## Follow-up (not in this PR)

A `handled: yes`, zero-impact, user-cancellation error reached PagerDuty. Even with this fix, the alert rule that paged is too broad and will keep firing on wallet-SDK noise (the same issue bucket also collects `[binance-w3w] User closed modal`, `Popup window was blocked`, provider timeouts, etc.). Worth reviewing the Sentry alert rule so it pages only on unhandled / high-impact regressions — needs someone with Sentry alert-admin access.

Fixes WEBAPP-6R