### PR TITLE
Suppress non-actionable MetaMask transport-timeout Sentry noise (WEBAPP-5N)

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -59,7 +59,16 @@ export function initSentry(): void {
       // hashed chunk URLs baked into its module graph; the next __vitePreload
       // 404s. User just needs to refresh — not actionable.
       /Failed to fetch dynamically imported module.*\/assets\/.+\.js/,
-      /Importing a module script failed.*\/assets\/.+\.js/
+      /Importing a module script failed.*\/assets\/.+\.js/,
+      // MetaMask multichain SDK transport handshake timeout during wallet
+      // connect (@metamask/connect-multichain throws TransportTimeoutError).
+      // A client-side network timeout — common on high-latency / filtered
+      // networks (e.g. CN) — not actionable on our side. The user already sees
+      // a "Failed to connect. Please try again." prompt in ConnectModal, and
+      // it reports 0 affected users (fires pre-connection). Global match
+      // because ~10% of events arrive via wagmi auto-reconnect with no `flow`
+      // tag, so a flow-scoped beforeSend filter would miss them (WEBAPP-5N).
+      /Transport request timed out/
     ],
     integrations: [
       Sentry.thirdPartyErrorFilterIntegration({


### PR DESCRIPTION
## What

Adds a `/Transport request timed out/` entry to the Sentry `ignoreErrors` list in `apps/webapp/src/modules/sentry/init.ts`.

## Why

Sentry issue [**WEBAPP-5N**](https://jetstream-gg.sentry.io/issues/7493604023/) ("Ms: Transport request timed out") has logged 96 events since May 20 and **paged on-call via PagerDuty**. Root cause:

- The error is a `TransportTimeoutError` thrown by `@metamask/connect-multichain@0.12.1` when its transport handshake doesn't respond in time during wallet connect.
- It's a **client-side network timeout** — strongly correlated with high-latency / filtered networks (the sample event is from Shenzhen, CN). Not actionable in our code; the SDK timeout isn't cleanly configurable and a longer one wouldn't reliably help those users.
- **0 users impacted** (it fires pre-connection, before any user context is set), and the user already gets a friendly *"Failed to connect. Please try again."* prompt in `ConnectModal`.

This matches the existing convention in `init.ts` of suppressing non-actionable wallet/extension/network noise, each annotated with its issue ID (WEBAPP-2F, WEBAPP-1Z, WEBAPP-B, …).

## Why a global match (not a flow-scoped `beforeSend` filter)

~10% of the events (10/96) arrive with an empty `flow` tag — these come through wagmi's auto-reconnect at app boot, which doesn't pass through `ConnectModal.onError`. A `flow === 'wallet-connect'` scope would miss them, so a global message match is the more robust lever. The phrase is specific enough to the MetaMask SDK to be safe globally.

## Notes

- `thirdPartyErrorFilterIntegration` does not catch this today because the top stack frame is in our own bundle (the wagmi mutation wrapper / `reportError`), so the event isn't *exclusively* third-party.
- `Fixes WEBAPP-5N` auto-resolves the Sentry issue on merge. The issue is also being marked ignored now to stop the active paging.

## Testing

- `prettier --check` passes on the changed file.
- No tests reference `ignoreErrors` / `initSentry`, so no test changes needed.