### PR TITLE
Add GA4 cross-domain linker config with accept_incoming (APP-277)

### DIFF
--- a/apps/webapp/src/modules/analytics/gtag.ts
+++ b/apps/webapp/src/modules/analytics/gtag.ts
@@ -36,7 +36,30 @@ function initializeGtag() {
   document.head.appendChild(script);
 
   gtag('js', new Date());
-  gtag('config', GA_MEASUREMENT_ID, { cookie_domain: 'auto' });
+  gtag('config', GA_MEASUREMENT_ID, {
+    cookie_domain: 'auto',
+    linker: {
+      // Cross-domain (_gl) link-decoration allowlist. gtag matches a destination if its
+      // hostname equals or is a subdomain-suffix of an entry, so we list specific
+      // subdomains rather than the bare `sky.money` root (which would match every
+      // subdomain, including docs).
+      //
+      // docs.sky.money is deliberately OMITTED: it's hosted on GitBook, which ignores
+      // the _gl param and mishandles it in its URL/anchor routing (e.g. the footer's
+      // /legal-terms#privacy-policy link). *.sky.money subdomains already share the
+      // `.sky.money` _ga cookie via cookie_domain:'auto', so they don't need _gl anyway.
+      //
+      // The authoritative fix is removing docs.sky.money from this GA4 property's
+      // cross-domain "Configure your domains" list; this allowlist is the in-repo
+      // backstop and may be merged with (not override) that admin config.
+      domains: ['app.sky.money', 'vote.sky.money', 'upgrademkrtosky.skyeco.com'],
+      // Accept the incoming _gl param on inbound links so a client ID minted on the
+      // marketing site (sky.money) carries into the app, stitching the visit into one
+      // GA4 session. This is the receiving half only; the sending site must decorate
+      // its outbound links to app.sky.money for there to be a _gl to accept.
+      accept_incoming: true
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a cross-domain `linker` block to the GA4 `config` call in `apps/webapp/src/modules/analytics/gtag.ts`, enabling `accept_incoming` so a GA4 client ID minted on the marketing site (`sky.money`) carries into `app.sky.money` and stitches the cross-site visit into a single session.

Implements [APP-277](https://linear.app/skybasestar/issue/APP-277/update-ga4-tag-config-for-domain-filtering).

## Scope note

`development`'s GA4 config previously had **only** `cookie_domain: 'auto'` — there was no `linker` object at all. `accept_incoming` lives inside `linker`, so this PR necessarily **introduces the whole linker block**, not just the one flag:

- `domains: ['app.sky.money', 'vote.sky.money', 'upgrademkrtosky.skyeco.com']`
  - Bare `sky.money` is deliberately omitted — gtag matches destinations by subdomain-suffix, so the root would decorate *every* subdomain including `docs.sky.money` (GitBook), which mishandles the `_gl` param in its URL/anchor routing.
- `accept_incoming: true` — reads the inbound `_gl` param so an existing client ID is adopted rather than a new one minted.

## Caveats for reviewers

- **Receiving half only.** This makes the app *accept* `_gl`. For sessions to actually stitch, the **marketing site (`sky.money`) must decorate its outbound links** to `app.sky.money` (its own linker config — not in this repo). Worth confirming that's in place.
- **Possibly partially redundant.** `sky.money` and `app.sky.money` share the registrable domain, so they already share the `.sky.money` `_ga` cookie via `cookie_domain: 'auto'`. If marketing is on the **same GA4 property** and shares that cookie, sessions may already be continuous and `accept_incoming` is a harmless no-op. The canonical place for GA4 cross-domain is the property's "Configure your domains" admin list.

## Test plan

- [ ] Confirm marketing site decorates outbound links to `app.sky.money` with `_gl`
- [ ] Verify GA4 realtime shows continuous session from `sky.money` → `app.sky.money`
- [ ] Confirm no regression to existing `app.sky.money` analytics / consent flow