### PR TITLE
refactor(vaults): make sUSDT (Spark) TVL API-first with on-chain fallback

### DIFF
--- a/apps/webapp/src/modules/morpho/components/VaultInfoDetails.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultInfoDetails.tsx
@@ -49,22 +49,26 @@ export function VaultInfoDetails({ vaultAddress, assetToken, provider = 'morpho'
     query: { enabled: !isMorpho && !!assetAddress && !!vaultAddress }
   });
 
-  // TVL: Morpho reads its market API. For Spark, on-chain ERC-4626 `totalAssets()`
-  // is authoritative and real-time — and correct on whatever chain the user is on
-  // (a fork/testnet reflects its own state, where the API would report mainnet). It
-  // also matches the in-widget card, which already reads on-chain. Fall back to the
-  // API only if the on-chain read is unavailable.
+  // TVL: API-first for both providers. Morpho reads its market API; Spark reads our
+  // sky.money Savings API (the dispatcher's normalized `totalAssets`) and falls back
+  // to the on-chain ERC-4626 `totalAssets()` only when the API is empty/down. This
+  // matches the expert stats card and the in-widget card, which are also API-first
+  // for Spark.
   const totalAssets = isMorpho
     ? marketData?.totalAssets
-    : (onChainData?.totalAssets ?? marketData?.totalAssets);
+    : (marketData?.totalAssets ?? onChainData?.totalAssets);
   // Available liquidity: API vault-level figure (summed `liquidity[]`), falling
   // back to the on-chain vault buffer for Spark.
   const liquidity = marketData?.liquidity ?? onChainLiquidity;
 
-  // Morpho tracks its API's loading/error; Spark tracks the on-chain fallback so
-  // an empty/down API degrades to the on-chain figure with no error surfaced.
-  const tvlLoading = isMorpho ? marketDataLoading : onChainLoading;
-  const tvlError = isMorpho ? marketError : onChainError;
+  // Morpho tracks its API's loading/error. For Spark, TVL is API-first with an
+  // on-chain fallback, so we are loading only while no figure has resolved yet, and
+  // we surface an error only if BOTH sources fail (a healthy fallback hides an API
+  // outage). Liquidity keeps its own on-chain buffer fallback.
+  const tvlLoading = isMorpho
+    ? marketDataLoading
+    : totalAssets === undefined && (marketDataLoading || onChainLoading);
+  const tvlError = isMorpho ? marketError : totalAssets === undefined ? (marketError ?? onChainError) : null;
   const liquidityLoading = isMorpho ? marketDataLoading : onChainLiquidityLoading;
 
   // Fees apply to Morpho vaults only. Spark surfaces a single net APY with no fee

--- a/apps/webapp/src/modules/morpho/components/vaultInfoDetails.spark.test.tsx
+++ b/apps/webapp/src/modules/morpho/components/vaultInfoDetails.spark.test.tsx
@@ -82,7 +82,9 @@ describe('VaultInfoDetails (Spark API-first, on-chain fallback)', () => {
     expect(liquidity).toContain('60,000,000');
     expect(liquidity).not.toContain('40,000,000'); // not the per-user maxWithdraw
     expect(liquidity).not.toContain('101,000,000'); // not the on-chain buffer (API wins)
-    expect(screen.getAllByText('0%').length).toBeGreaterThanOrEqual(2);
+    // Fees are a Morpho-only concept; the Spark panel omits the fee cards entirely.
+    expect(screen.queryByText('Management Fee')).toBeNull();
+    expect(screen.queryByText('Performance Fee')).toBeNull();
     expect(screen.queryByText(/Unable to fetch data/i)).toBeNull();
   });
 

--- a/apps/webapp/src/widgets/VaultWidget/components/VaultTransactionStatus.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/VaultTransactionStatus.tsx
@@ -62,9 +62,9 @@ export const VaultTransactionStatus = ({
     txStatus,
     widgetState
   } = useContext(WidgetContext);
-  const flow = widgetState.flow as MorphoVaultFlow;
-  const action = widgetState.action as MorphoVaultAction;
-  const screen = widgetState.screen as MorphoVaultScreen;
+  const flow = widgetState.flow as VaultFlow;
+  const action = widgetState.action as VaultAction;
+  const screen = widgetState.screen as VaultScreen;
 
   useEffect(() => {
     setOriginToken(assetToken);

--- a/apps/webapp/src/widgets/VaultWidget/index.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/index.tsx
@@ -118,6 +118,11 @@ const VaultWidgetWrapped = ({
 
   const userAssets = vaultData?.userAssets ?? 0n;
   const availableLiquidity = marketData?.liquidity;
+
+  // sUSDT (Spark) TVL is API-first, with the on-chain ERC-4626 `totalAssets()` as the
+  // fallback when the API is empty/down. Morpho keeps reading TVL on-chain (unchanged).
+  const vaultTvl =
+    provider === 'morpho' ? vaultData?.totalAssets : (marketData?.totalAssets ?? vaultData?.totalAssets);
   const hasLiquidityData = !isMarketDataLoading && availableLiquidity !== undefined;
 
   // User's underlying asset balance (e.g., USDC balance)
@@ -641,7 +646,7 @@ const VaultWidgetWrapped = ({
               vaultAddress={vaultAddress}
               vaultName={vaultName}
               provider={provider}
-              vaultTvl={vaultData?.totalAssets}
+              vaultTvl={vaultTvl}
               vaultRate={resolveSparkVaultRate({
                 apiFormattedRate: marketData?.rate?.formattedNetRate,
                 onChainFormattedRate: sparkRate

--- a/apps/webapp/src/widgets/shared/types/widgetState.ts
+++ b/apps/webapp/src/widgets/shared/types/widgetState.ts
@@ -15,11 +15,7 @@ import {
 import { PendleAction, PendleFlow, PendleScreen } from '@/widgets/PendleWidget/lib/constants';
 import { StakeAction, StakeFlow, StakeScreen } from '@/widgets/StakeModuleWidget/lib/constants';
 import { StUSDSAction, StUSDSFlow, StUSDSScreen } from '@/widgets/StUSDSWidget/lib/constants';
-import {
-  MorphoVaultAction,
-  MorphoVaultFlow,
-  MorphoVaultScreen
-} from '@/widgets/MorphoVaultWidget/lib/constants';
+import { VaultAction, VaultFlow, VaultScreen } from '@/widgets/VaultWidget/lib/constants';
 import { BalancesFlow } from '@/widgets/BalancesWidget/constants';
 import { RewardContract, Token } from '@/hooks';
 import { TxStatus, NotificationType, InitialAction, InitialFlow, InitialScreen } from '../constants';
@@ -35,7 +31,7 @@ export type WidgetFlow =
   | PsmConversionFlow
   | StakeFlow
   | StUSDSFlow
-  | MorphoVaultFlow
+  | VaultFlow
   | PendleFlow;
 
 export type WidgetAction =
@@ -47,7 +43,7 @@ export type WidgetAction =
   | PsmConversionAction
   | StakeAction
   | StUSDSAction
-  | MorphoVaultAction
+  | VaultAction
   | PendleAction;
 
 export type WidgetScreen =
@@ -59,7 +55,7 @@ export type WidgetScreen =
   | PsmConversionScreen
   | StakeScreen
   | StUSDSScreen
-  | MorphoVaultScreen
+  | VaultScreen
   | PendleScreen;
 
 export type WidgetState = {


### PR DESCRIPTION
### What does this PR do?

Makes the sUSDT (Spark) vault's TVL **API-first with an on-chain fallback**, and makes every surface that shows it agree. Morpho behavior is unchanged.

Before this, the four places that render vault TVL disagreed on the source for Spark:

| Surface | Spark TVL source (before) |
|---|---|
| In-widget TVL (`VaultWidget`) | on-chain only |
| "Vault info" detail panel (`VaultInfoDetails`) | on-chain first, API fallback |
| Expert stats card (`VaultStatsCard`) | API first, on-chain fallback |
| Metrics chart (`MorphoVaultChart`) | API |

So the widget and detail panel could show a different TVL number than the expert card and chart for the same vault (on-chain real-time vs the API figure). This PR aligns the first two onto API-first, matching the expert card and chart.

Changes:
- **`VaultWidget/index.tsx`**: TVL was on-chain only. Now derives `vaultTvl` as API-first for Spark (`marketData?.totalAssets ?? vaultData?.totalAssets`); Morpho keeps reading on-chain `vaultData?.totalAssets` unchanged.
- **`VaultInfoDetails.tsx`**: flipped the Spark branch from on-chain-first to API-first. Loading/error were updated to match: for Spark we are loading only until a figure resolves from either source, and we surface a TVL error only when both the API and the on-chain read fail (a healthy fallback hides an API outage).
- **`vaultInfoDetails.spark.test.tsx`**: the panel test was already written for API-first (its TVL assertion expected the API value), so flipping the component makes it pass. Also corrected one stray assertion copied from the Morpho test that expected fee cards, fees are Morpho-only, so the Spark panel asserts the fee cards are absent.

Scope: sUSDT / Spark only. The expert stats card and the metrics chart were already API-first/API, so they are untouched.

### Testing steps:

- `vaultInfoDetails.spark.test.tsx` and the `VaultWidget` suites pass (11 tests).
- `modules/morpho` and `modules/expert` suites pass (13 tests).
- Prettier clean on all changed files.
- No new typecheck errors introduced by this change.
- After deploy, confirm the in-widget TVL, the "Vault info" panel, the expert card, and the metrics chart all show the same TVL for sUSDT, sourced from the API, and that on a fork/empty-API state they fall back to the on-chain figure.
