### PR TITLE
fix(vaults): temporarily hide Metrics chart for Spark vault due to mi…

### DIFF
--- a/apps/webapp/src/modules/morpho/components/VaultDetails.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultDetails.tsx
@@ -86,11 +86,17 @@ export function VaultDetails({ vaultAddress, assetToken, vaultName }: VaultDetai
           </DetailSectionRow>
         </DetailSection>
       )}
-      <DetailSection title={t`Metrics`}>
-        <DetailSectionRow>
-          <MorphoVaultChart vaultAddress={vaultAddress} assetToken={assetToken} provider={provider} />
-        </DetailSectionRow>
-      </DetailSection>
+      {/* TEMPORARY: the Metrics chart is hidden for the Spark (sUSDT) vault while
+          the Savings historic endpoint returns no data. Remove this
+          `provider !== 'spark'` gate to bring the chart back once the endpoint is
+          populated. */}
+      {provider !== 'spark' && (
+        <DetailSection title={t`Metrics`}>
+          <DetailSectionRow>
+            <MorphoVaultChart vaultAddress={vaultAddress} assetToken={assetToken} provider={provider} />
+          </DetailSectionRow>
+        </DetailSection>
+      )}
       <DetailSection title={t`About`}>
         <DetailSectionRow>
           <AboutMorphoVaults bannerId={getBannerId()} />


### PR DESCRIPTION
…ssing data from Savings endpoint

### What does this PR do?

### Testing steps:
