### PR TITLE
fix(vaults): make transaction-flow copy provider-aware

### DIFF
--- a/apps/webapp/src/widgets/VaultWidget/components/VaultTransactionReview.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/VaultTransactionReview.tsx
@@ -26,7 +26,8 @@ export const VaultTransactionReview = ({
   assetToken,
   amount,
   needsAllowance,
-  needsAllowanceReset
+  needsAllowanceReset,
+  vaultLabel
 }: {
   batchEnabled?: boolean;
   setBatchEnabled?: (enabled: boolean) => void;
@@ -35,6 +36,8 @@ export const VaultTransactionReview = ({
   amount: bigint;
   needsAllowance: boolean;
   needsAllowanceReset: boolean;
+  /** How the vault is named in copy (e.g. "the Morpho Vault" or "Tether Savings") */
+  vaultLabel: string;
 }) => {
   const { i18n } = useLingui();
   const { data: batchSupported } = useIsBatchSupported();
@@ -68,7 +71,8 @@ export const VaultTransactionReview = ({
           getMorphoVaultSupplyReviewSubtitle({
             batchStatus: !!batchSupported && batchEnabled ? BatchStatus.ENABLED : BatchStatus.DISABLED,
             symbol: assetToken.symbol,
-            needsAllowance
+            needsAllowance,
+            vaultLabel
           })
         )
       );
@@ -78,12 +82,15 @@ export const VaultTransactionReview = ({
       setTxSubtitle(
         i18n._(
           getMorphoVaultWithdrawReviewSubtitle({
-            symbol: assetToken.symbol
+            symbol: assetToken.symbol,
+            vaultLabel
           })
         )
       );
     }
-    setTxDescription(i18n._(morphoVaultActionDescription({ flow, action, txStatus, needsAllowance })));
+    setTxDescription(
+      i18n._(morphoVaultActionDescription({ flow, action, txStatus, needsAllowance, vaultLabel }))
+    );
   }, [
     flow,
     action,
@@ -94,6 +101,7 @@ export const VaultTransactionReview = ({
     batchEnabled,
     assetToken.symbol,
     needsAllowance,
+    vaultLabel,
     txStatus,
     setTxTitle,
     setTxSubtitle,

--- a/apps/webapp/src/widgets/VaultWidget/components/VaultTransactionStatus.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/VaultTransactionStatus.tsx
@@ -31,7 +31,8 @@ export const VaultTransactionStatus = ({
   isBatchTransaction,
   needsAllowance,
   needsAllowanceReset,
-  currentCallIndex
+  currentCallIndex,
+  vaultLabel
 }: {
   amount: bigint;
   assetToken: Token;
@@ -40,6 +41,8 @@ export const VaultTransactionStatus = ({
   needsAllowance: boolean;
   needsAllowanceReset: boolean;
   currentCallIndex: number;
+  /** How the vault is named in copy (e.g. "the Morpho Vault" or "Tether Savings") */
+  vaultLabel: string;
 }) => {
   // Capture at mount to avoid state changes during transaction
   const [flowNeedsAllowance] = useState(needsAllowance);
@@ -93,7 +96,8 @@ export const VaultTransactionStatus = ({
               txStatus: flowTxStatus,
               amount: formattedAmount,
               symbol: assetToken.symbol,
-              needsAllowance: flowNeedsAllowance
+              needsAllowance: flowNeedsAllowance,
+              vaultLabel
             })
           )
         );
@@ -103,7 +107,8 @@ export const VaultTransactionStatus = ({
               flow,
               action,
               txStatus: flowTxStatus,
-              needsAllowance: flowNeedsAllowance
+              needsAllowance: flowNeedsAllowance,
+              vaultLabel
             })
           )
         );
@@ -143,7 +148,8 @@ export const VaultTransactionStatus = ({
             withdrawSubtitle({
               txStatus: flowTxStatus,
               amount: formattedAmount,
-              symbol: assetToken.symbol
+              symbol: assetToken.symbol,
+              vaultLabel
             })
           )
         );
@@ -153,7 +159,8 @@ export const VaultTransactionStatus = ({
               flow,
               action,
               txStatus: flowTxStatus,
-              needsAllowance: flowNeedsAllowance
+              needsAllowance: flowNeedsAllowance,
+              vaultLabel
             })
           )
         );
@@ -181,6 +188,7 @@ export const VaultTransactionStatus = ({
     amount,
     assetToken,
     chainId,
+    vaultLabel,
     i18n,
     setTxTitle,
     setTxSubtitle,

--- a/apps/webapp/src/widgets/VaultWidget/index.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/index.tsx
@@ -256,6 +256,11 @@ const VaultWidgetWrapped = ({
   // Derive current call index based on active flow (for multi-step tracking)
   const currentCallIndex = widgetState.flow === VaultFlow.SUPPLY ? morphoVaultDeposit.currentCallIndex : 0;
 
+  // How the vault is referred to in the transaction-flow copy. Morpho keeps its
+  // legacy "the Morpho Vault" phrasing; other providers use their vault name
+  // directly (e.g. "Tether Savings") so the copy isn't mis-branded as Morpho.
+  const vaultLabel = provider === 'morpho' ? 'the Morpho Vault' : vaultName;
+
   // Initialize widget state based on connection and tab
   useEffect(() => {
     if (isConnectedAndEnabled) {
@@ -591,6 +596,7 @@ const VaultWidgetWrapped = ({
               needsAllowance={needsAllowance}
               needsAllowanceReset={needsAllowanceReset}
               currentCallIndex={currentCallIndex}
+              vaultLabel={vaultLabel}
             />
           </CardAnimationWrapper>
         ) : widgetState.screen === VaultScreen.REVIEW ? (
@@ -603,6 +609,7 @@ const VaultWidgetWrapped = ({
               amount={debouncedAmount}
               needsAllowance={needsAllowance}
               needsAllowanceReset={needsAllowanceReset}
+              vaultLabel={vaultLabel}
             />
           </CardAnimationWrapper>
         ) : (

--- a/apps/webapp/src/widgets/VaultWidget/lib/constants.ts
+++ b/apps/webapp/src/widgets/VaultWidget/lib/constants.ts
@@ -45,28 +45,36 @@ export const morphoVaultWithdrawReviewTitle = msg`Begin the withdraw process`;
 export function getMorphoVaultSupplyReviewSubtitle({
   batchStatus,
   symbol,
-  needsAllowance
+  needsAllowance,
+  vaultLabel
 }: {
   batchStatus: BatchStatus;
   symbol: string;
   needsAllowance: boolean;
+  vaultLabel: string;
 }): MessageDescriptor {
   if (!needsAllowance) {
-    return msg`You will supply your ${symbol} to the Morpho Vault.`;
+    return msg`You will supply your ${symbol} to ${vaultLabel}.`;
   }
 
   switch (batchStatus) {
     case BatchStatus.ENABLED:
-      return msg`You're allowing this app to access your ${symbol} and supply it to the Morpho Vault in one bundled transaction.`;
+      return msg`You're allowing this app to access your ${symbol} and supply it to ${vaultLabel} in one bundled transaction.`;
     case BatchStatus.DISABLED:
-      return msg`You're allowing this app to access your ${symbol} and supply it to the Morpho Vault in multiple transactions.`;
+      return msg`You're allowing this app to access your ${symbol} and supply it to ${vaultLabel} in multiple transactions.`;
     default:
       return msg``;
   }
 }
 
-export function getMorphoVaultWithdrawReviewSubtitle({ symbol }: { symbol: string }): MessageDescriptor {
-  return msg`You will withdraw your ${symbol} from the Morpho Vault.`;
+export function getMorphoVaultWithdrawReviewSubtitle({
+  symbol,
+  vaultLabel
+}: {
+  symbol: string;
+  vaultLabel: string;
+}): MessageDescriptor {
+  return msg`You will withdraw your ${symbol} from ${vaultLabel}.`;
 }
 
 // Action descriptions
@@ -74,19 +82,21 @@ export function morphoVaultActionDescription({
   flow,
   action,
   txStatus,
-  needsAllowance
+  needsAllowance,
+  vaultLabel
 }: {
   flow: VaultFlow;
   action: VaultAction;
   txStatus: TxStatus;
   needsAllowance: boolean;
+  vaultLabel: string;
 }): MessageDescriptor {
   if ((action === VaultAction.SUPPLY || action === VaultAction.WITHDRAW) && txStatus === TxStatus.SUCCESS) {
-    return msg`${flow === VaultFlow.SUPPLY ? 'Approved and supplied to' : 'Withdrawn from'} the Morpho Vault`;
+    return msg`${flow === VaultFlow.SUPPLY ? 'Approved and supplied to' : 'Withdrawn from'} ${vaultLabel}`;
   }
   return needsAllowance
-    ? msg`${flow === VaultFlow.SUPPLY ? 'Approving and supplying to' : 'Withdrawing from'} the Morpho Vault`
-    : msg`${flow === VaultFlow.SUPPLY ? 'Supplying to' : 'Withdrawing from'} the Morpho Vault`;
+    ? msg`${flow === VaultFlow.SUPPLY ? 'Approving and supplying to' : 'Withdrawing from'} ${vaultLabel}`
+    : msg`${flow === VaultFlow.SUPPLY ? 'Supplying to' : 'Withdrawing from'} ${vaultLabel}`;
 }
 
 // Transaction status subtitles
@@ -94,24 +104,26 @@ export function supplySubtitle({
   txStatus,
   amount,
   symbol,
-  needsAllowance
+  needsAllowance,
+  vaultLabel
 }: {
   txStatus: TxStatus;
   amount: string;
   symbol: string;
   needsAllowance: boolean;
+  vaultLabel: string;
 }): MessageDescriptor {
   switch (txStatus) {
     case TxStatus.INITIALIZED:
       return needsAllowance
-        ? msg`Please allow this app to access your ${symbol} and supply it to the Morpho Vault.`
+        ? msg`Please allow this app to access your ${symbol} and supply it to ${vaultLabel}.`
         : msg`Almost done!`;
     case TxStatus.LOADING:
       return needsAllowance
         ? msg`Your token approval and supply are being processed on the blockchain. Please wait.`
         : msg`Your supply is being processed on the blockchain. Please wait.`;
     case TxStatus.SUCCESS:
-      return msg`You've supplied ${amount} ${symbol} to the Morpho Vault`;
+      return msg`You've supplied ${amount} ${symbol} to ${vaultLabel}`;
     case TxStatus.ERROR:
       return msg`An error occurred during the supply flow.`;
     default:
@@ -122,11 +134,13 @@ export function supplySubtitle({
 export function withdrawSubtitle({
   txStatus,
   amount,
-  symbol
+  symbol,
+  vaultLabel
 }: {
   txStatus: TxStatus;
   amount: string;
   symbol: string;
+  vaultLabel: string;
 }): MessageDescriptor {
   switch (txStatus) {
     case TxStatus.INITIALIZED:
@@ -134,7 +148,7 @@ export function withdrawSubtitle({
     case TxStatus.LOADING:
       return msg`Your withdrawal is being processed on the blockchain. Please wait.`;
     case TxStatus.SUCCESS:
-      return msg`You've withdrawn ${amount} ${symbol} from the Morpho Vault.`;
+      return msg`You've withdrawn ${amount} ${symbol} from ${vaultLabel}.`;
     case TxStatus.ERROR:
       return msg`An error occurred during the withdraw flow.`;
     default:
@@ -184,4 +198,3 @@ export function withdrawLoadingButtonText({
       return msg``;
   }
 }
-


### PR DESCRIPTION
## What

The supply/withdraw **transaction flow** copy was hardcoded to "the Morpho Vault" in `widgets/VaultWidget/lib/constants.ts`, and `VaultTransactionReview`/`VaultTransactionStatus` always rendered that copy regardless of provider. For the sUSDT (Spark) vault, users read "...supply it to the Morpho Vault", "You've supplied X sUSDT to the Morpho Vault", etc. — mis-branding a non-Morpho vault as Morpho across the entire transact flow.

This is item **#1** from the sUSDT savings sub-module audit (the highest-impact user-facing leak, spanning the whole transact flow).

## How

The `provider` (`'morpho' | 'spark'`) was already threaded through `VaultWidget` but never reached these two leaf components. This wires a `vaultLabel` down to them:

- `index.tsx`: `const vaultLabel = provider === 'morpho' ? 'the Morpho Vault' : vaultName;`
- The 5 copy functions (`getMorphoVaultSupplyReviewSubtitle`, `getMorphoVaultWithdrawReviewSubtitle`, `morphoVaultActionDescription`, `supplySubtitle`, `withdrawSubtitle`) take a `vaultLabel` param and interpolate it instead of the literal "the Morpho Vault".
- Both transaction components accept and forward `vaultLabel`.

**Result:**
- Morpho vaults render byte-identical to before ("the Morpho Vault").
- The sUSDT vault now reads e.g. *"...supply it to Tether Savings in multiple transactions."* / *"You've supplied X sUSDT to Tether Savings."*

## Notes

- i18n catalogs (`locales/*.po`/`*.ts`) are intentionally not included; they regenerate from source via `pnpm messages` on build. Lingui falls back to the inline default message at runtime, so English copy renders correctly regardless.
- Other audit items (Vaults landing card, rate/liquidity tooltips, About/FAQ sections, internal naming) are out of scope for this PR.

## Testing

- `pnpm typecheck` — passes
- VaultWidget unit tests — 8/8 pass
- ESLint — 0 errors (pre-existing warnings only); Prettier clean