### PR TITLE
feat(vaults): present Tether Savings (sUSDT) as a Sky vault, not Morpho (APP-279)

### DIFF
--- a/apps/webapp/scripts/record-corpus-sync.mjs
+++ b/apps/webapp/scripts/record-corpus-sync.mjs
@@ -10,7 +10,7 @@
 //
 // Usage:
 //   node record-corpus-sync.mjs --branch <ref> --commit <sha> [--tag <tag>] \
-//     [--file-types banners,faqs,tooltips,speed-bumps] [--changed path1,path2] [--in-sync 5] [--dry-run]
+//     [--file-types banners,faqs,tooltips] [--changed path1,path2] [--in-sync 5] [--dry-run]
 
 import { writeFileSync, appendFileSync, readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -46,7 +46,7 @@ const commit = opts.commit || null;
 const tag = opts.tag && opts.tag.length ? opts.tag : null;
 const fileTypes = opts['file-types']
   ? opts['file-types'].split(',').map(s => s.trim()).filter(Boolean)
-  : ['banners', 'faqs', 'tooltips', 'speed-bumps'];
+  : ['banners', 'faqs', 'tooltips'];
 
 // result is optional: the script overwrites everything (no per-section diff), so it omits these.
 // The skill computes a semantic diff and passes them.

--- a/apps/webapp/scripts/sync-content.sh
+++ b/apps/webapp/scripts/sync-content.sh
@@ -20,10 +20,7 @@ TOOLTIPS_SOURCE_PATH="output/webapp/tooltips"
 TOOLTIPS_DESTINATION_PATH="src/widgets/data/tooltips"
 BANNERS_SOURCE_PATH="output/webapp/banner"
 BANNERS_DESTINATION_PATH="src/data/banners"
-SPEED_BUMPS_SOURCE_PATH="output/webapp/speed-bumps"
-SPEED_BUMPS_DESTINATION_PATH="src/data/chat/speed-bumps"
 EXTRACT_SCRIPT="scripts/extract_webapp_faqs.js"
-SPEED_BUMP_EXTRACT_SCRIPT="scripts/extract_speed_bump_copy.js"
 
 # Function to print colored output
 print_status() {
@@ -159,24 +156,6 @@ if [ $EXTRACT_EXIT_CODE -ne 0 ]; then
     exit 1
 fi
 
-# Run the speed bump extraction script if it exists
-if [ -f "$SPEED_BUMP_EXTRACT_SCRIPT" ]; then
-    print_status "Running speed bump extraction script..."
-
-    # Run the speed bump extraction script
-    node "$SPEED_BUMP_EXTRACT_SCRIPT"
-    SPEED_BUMP_EXIT_CODE=$?
-
-    # Check if the speed bump extraction script succeeded
-    if [ $SPEED_BUMP_EXIT_CODE -ne 0 ]; then
-        print_warning "Speed bump extraction script failed, continuing without speed bump content"
-    else
-        print_status "Speed bump extraction completed successfully"
-    fi
-else
-    print_warning "Speed bump extraction script not found, skipping speed bump extraction"
-fi
-
 # Check if output was generated
 if [ ! -d "$OUTPUT_SOURCE_PATH" ]; then
     print_error "Expected output directory '$OUTPUT_SOURCE_PATH' was not created!"
@@ -212,7 +191,7 @@ node scripts/record-corpus-sync.mjs \
     --branch "$CONTENT_VERSION" \
     --commit "$CORPUS_SHA" \
     --tag "$CORPUS_TAG" \
-    --file-types "banners,faqs,tooltips,speed-bumps"
+    --file-types "banners,faqs,tooltips"
 
 # Post-process sharedFaqItems.ts and update getBalancesFaqItems.ts
 print_status "Processing sharedFaqItems and updating getBalancesFaqItems..."
@@ -584,34 +563,6 @@ else
     print_warning "No banners directory found in corpus output"
 fi
 
-# Copy speed bumps if they exist
-if [ -d "$TEMP_DIR/$SPEED_BUMPS_SOURCE_PATH" ]; then
-    print_status "Syncing speed bumps to webapp chat directory..."
-
-    # Ensure destination directory exists
-    mkdir -p "$SPEED_BUMPS_DESTINATION_PATH"
-
-    # Copy all files from speed-bumps directory
-    if command -v rsync &> /dev/null; then
-        rsync -av "$TEMP_DIR/$SPEED_BUMPS_SOURCE_PATH/" "$SPEED_BUMPS_DESTINATION_PATH/"
-    else
-        # Fallback to cp if rsync is not available
-        print_warning "rsync not found, using cp instead"
-        cp -r "$TEMP_DIR/$SPEED_BUMPS_SOURCE_PATH/"* "$SPEED_BUMPS_DESTINATION_PATH/" 2>/dev/null || true
-    fi
-
-    # Count copied files
-    SPEED_BUMP_COUNT=$(find "$SPEED_BUMPS_DESTINATION_PATH" -type f \( -name "*.ts" -o -name "*.json" \) 2>/dev/null | wc -l | tr -d ' ')
-
-    if [ "$SPEED_BUMP_COUNT" -gt 0 ]; then
-        print_status "Speed bumps synced successfully ($SPEED_BUMP_COUNT files) to $SPEED_BUMPS_DESTINATION_PATH"
-    else
-        print_warning "No speed bump files found to copy"
-    fi
-else
-    print_warning "No speed bumps directory found in corpus output"
-fi
-
 # Track all generated files for formatting
 GENERATED_FILES=()
 
@@ -637,16 +588,6 @@ fi
 # Add banner file if it exists
 if [ -f "$BANNERS_DESTINATION_PATH/banners.ts" ]; then
     GENERATED_FILES+=("apps/webapp/$BANNERS_DESTINATION_PATH/banners.ts")
-fi
-
-# Add speed bump files if they exist
-if [ -d "$SPEED_BUMPS_DESTINATION_PATH" ]; then
-    for file in "$SPEED_BUMPS_DESTINATION_PATH"/*.ts "$SPEED_BUMPS_DESTINATION_PATH"/*.json; do
-        if [ -f "$file" ]; then
-            # Convert to path relative to monorepo root
-            GENERATED_FILES+=("apps/webapp/$file")
-        fi
-    done
 fi
 
 # Format only the generated files
@@ -707,18 +648,6 @@ if [ -f "$BANNERS_DESTINATION_PATH/banners.ts" ]; then
     echo ""
     print_status "Banner files:"
     echo "  - $BANNERS_DESTINATION_PATH/banners.ts"
-fi
-
-# List speed bump files
-if [ -d "$SPEED_BUMPS_DESTINATION_PATH" ]; then
-    SPEED_BUMP_FILES=$(find "$SPEED_BUMPS_DESTINATION_PATH" -type f \( -name "*.ts" -o -name "*.json" \) 2>/dev/null)
-    if [ -n "$SPEED_BUMP_FILES" ]; then
-        echo ""
-        print_status "Speed bump files:"
-        echo "$SPEED_BUMP_FILES" | sort | while read file; do
-            echo "  - $file"
-        done
-    fi
 fi
 
 echo ""

--- a/apps/webapp/src/data/banners/banners.ts
+++ b/apps/webapp/src/data/banners/banners.ts
@@ -311,6 +311,14 @@ export const banners: Banner[] = [
     display: ['connected', 'disconnected']
   },
   {
+    id: 'tether-savings-vault',
+    title: 'Tether Savings Vault',
+    module: 'vaults-banners',
+    description:
+      'Tether Savings (sUSDT) is a non-custodial, permissionless stablecoin savings vault backed by USDS, managed by Sky using Spark infrastructure. Deposit USDT to earn a variable savings rate set by Sky.',
+    display: ['connected', 'disconnected']
+  },
+  {
     id: 'fixed-yield',
     title: 'Fixed Yield',
     module: 'fixed-yield-banners',

--- a/apps/webapp/src/data/faqs/getTetherSavingsFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getTetherSavingsFaqItems.ts
@@ -1,0 +1,30 @@
+export const getTetherSavingsFaqItems = () => {
+  const items = [
+    {
+      question: 'What is the Tether Savings (sUSDT) Vault?',
+      answer: `Tether Savings (sUSDT) is a non-custodial, permissionless stablecoin savings vault offered through the Sky.money web app. It is a first-party Sky product, managed by Sky using Spark infrastructure.
+
+When you deposit USDT, you receive sUSDT vault shares representing your proportional ownership of the vault's assets. As the vault earns yield, your shares appreciate in value, allowing you to withdraw more USDT than you initially deposited. The savings rate is variable and set by Sky. Please see the [User Risk Documentation](https://docs.sky.money/user-risks) and [Terms of Use](https://docs.sky.money/legal-terms) for more information.`,
+      index: 0
+    },
+    {
+      question: "How is the Tether Savings Vault different from Sky's other Vaults?",
+      answer:
+        "Sky's other Vaults are curated by Sky on Morpho, a third-party lending protocol, and can carry exposure to a range of lending markets and collateral types. The Tether Savings Vault is a first-party Sky savings product, managed by Sky using Spark infrastructure rather than Morpho. It accepts USDT deposits and pays a single variable savings rate set by Sky.",
+      index: 1
+    },
+    {
+      question: 'How is the sUSDT savings rate determined?',
+      answer:
+        'The rate is variable and set by Sky. Sky sets the sUSDT savings rate against three inputs: profit-and-loss sustainability across the full deposit base, depositor composition, and on-chain borrow demand. Rates are adjusted over time to reflect what deployment yields can support, so the rate you see may change.',
+      index: 2
+    },
+    {
+      question: 'Can I withdraw my USDT at any time?',
+      answer:
+        'You can request a withdrawal at any time. Withdrawals are settled from the liquidity available for instant withdrawal; during periods of high demand, the amount immediately available may be limited until liquidity returns. Please see the [User Risk Documentation](https://docs.sky.money/user-risks) for more information.',
+      index: 3
+    }
+  ];
+  return items.sort((a, b) => a.index - b.index);
+};

--- a/apps/webapp/src/modules/layout/components/ConnectCard.tsx
+++ b/apps/webapp/src/modules/layout/components/ConnectCard.tsx
@@ -8,7 +8,6 @@ import { useChainId } from 'wagmi';
 import { getBannerById } from '@/data/banners/banners';
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { base, arbitrum, optimism, unichain } from 'viem/chains';
-import { Morpho } from '@/widgets';
 import { Pendle as PendleIcon } from '@/widgets/shared/components/icons/Pendle';
 
 // Type for banner configuration
@@ -80,42 +79,41 @@ export function ConnectCard({ intent, className, convertOption }: ConnectCardPro
   // Parse banner content - handles tooltips if present, otherwise returns plain text
   const contentText = banner?.description ? parseBannerContent(banner.description) : '';
 
-  const isMorphoVaults = intent === Intent.VAULTS_INTENT;
+  const isVaults = intent === Intent.VAULTS_INTENT;
   const isFixedYield = intent === Intent.FIXED_INTENT;
 
   return (
     <GradientShapeCard
       colorLeft={
-        isMorphoVaults
+        isVaults
           ? 'radial-gradient(200.08% 406.67% at 5.14% 108.47%, #4331E9 0%, #2A197D 21.68%)'
           : 'radial-gradient(100% 177.78% at 100% 0%, #A273FF 0%, #4331E9 100%)'
       }
       colorMiddle={
-        isMorphoVaults
+        isVaults
           ? 'linear-gradient(360deg, #2470FF 0%, #1B4ECF 300%)'
           : 'radial-gradient(circle at 0% 100%, #FFCD6B 0%, #EB5EDF 150%)'
       }
-      colorRight={isMorphoVaults ? '#1e1a4b' : '#2A197D'}
+      colorRight={isVaults ? '#1e1a4b' : '#2A197D'}
       className={className}
     >
       <div className="w-[80%] space-y-2 self-start xl:w-2/3" data-testid="connect-wallet-card">
         <Heading className="mb-2 flex items-center gap-2">
-          {isMorphoVaults && <Morpho className="h-6 w-6 rounded-sm" />}
           {isFixedYield && <PendleIcon className="h-6 w-6 rounded-sm" />}
-          {isMorphoVaults ? <Trans>Vaults</Trans> : isFixedYield ? <Trans>About Fixed Yield</Trans> : heading}
+          {isVaults ? <Trans>Vaults</Trans> : isFixedYield ? <Trans>About Fixed Yield</Trans> : heading}
         </Heading>
-        {isMorphoVaults ? (
+        {isVaults ? (
           <Text variant="small" className="leading-4.5">
             <Trans>
-              Connect your wallet to start using Sky-curated Morpho Vaults. Deposit USDS, USDT, or USDC and
-              start earning.
+              Connect your wallet to start using Sky-curated Vaults. Deposit USDS, USDT, or USDC and start
+              earning.
             </Trans>
           </Text>
         ) : isFixedYield ? (
           <Text variant="small" className="leading-4.5">
             <Trans>
-              When volatility plays against you, get a fixed yield over a pre-set period. The rate is set
-              when you deposit your USDS, while expected returns are available at maturity date, not before.
+              When volatility plays against you, get a fixed yield over a pre-set period. The rate is set when
+              you deposit your USDS, while expected returns are available at maturity date, not before.
             </Trans>
           </Text>
         ) : (

--- a/apps/webapp/src/modules/morpho/components/MorphoMarketLiquidityCard.tsx
+++ b/apps/webapp/src/modules/morpho/components/MorphoMarketLiquidityCard.tsx
@@ -2,7 +2,7 @@ import { StatsCard } from '@/modules/ui/components/StatsCard';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { formatBigInt } from '@/utils';
-import { Token } from '@/hooks';
+import { Token, VaultProvider } from '@/hooks';
 import { TokenIconWithBalance } from '@/modules/ui/components/TokenIconWithBalance';
 import { PopoverRateInfo as PopoverInfo } from '@/widgets';
 import { useChainId } from 'wagmi';
@@ -12,17 +12,24 @@ type MorphoMarketLiquidityCardProps = {
   isLoading: boolean;
   error?: Error | null;
   assetToken: Token;
+  /** Which provider operates the vault. Drives the liquidity tooltip wording. Defaults to Morpho. */
+  provider?: VaultProvider;
 };
 
 export function MorphoMarketLiquidityCard({
   liquidity,
   isLoading,
   error,
-  assetToken
+  assetToken,
+  provider = 'morpho'
 }: MorphoMarketLiquidityCardProps) {
   const { i18n } = useLingui();
   const chainId = useChainId();
-  const liquidityTooltip = `The amount of ${assetToken.symbol} currently idle in the Morpho market and available for immediate withdrawal or new borrowing.`;
+  // Spark/Tether vaults expose instant-withdrawal liquidity, not a Morpho market.
+  const liquidityTooltip =
+    provider === 'sky'
+      ? `The amount of ${assetToken.symbol} currently available for instant withdrawal.`
+      : `The amount of ${assetToken.symbol} currently idle in the Morpho market and available for immediate withdrawal or new borrowing.`;
 
   const assetDecimals =
     typeof assetToken.decimals === 'number'

--- a/apps/webapp/src/modules/morpho/components/MorphoVaultFaq.tsx
+++ b/apps/webapp/src/modules/morpho/components/MorphoVaultFaq.tsx
@@ -1,8 +1,11 @@
 import { getVaultsFaqItems } from '@/data/faqs/getVaultsFaqItems';
+import { getTetherSavingsFaqItems } from '@/data/faqs/getTetherSavingsFaqItems';
 import { FaqAccordion } from '@/modules/ui/components/FaqAccordion';
+import { VaultProvider } from '@/hooks';
 
-export function MorphoVaultFaq() {
-  const faqItems = getVaultsFaqItems();
+export function MorphoVaultFaq({ provider = 'morpho' }: { provider?: VaultProvider }) {
+  // Spark/Tether vaults are Sky products, not Morpho — show their own FAQ instead of the Morpho one.
+  const faqItems = provider === 'sky' ? getTetherSavingsFaqItems() : getVaultsFaqItems();
 
   return <FaqAccordion items={faqItems} />;
 }

--- a/apps/webapp/src/modules/morpho/components/VaultDetails.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultDetails.tsx
@@ -39,6 +39,8 @@ export function VaultDetails({ vaultAddress, assetToken, vaultName }: VaultDetai
   const showExposure = isMorpho || (marketData?.allocations?.length ?? 0) > 0;
 
   const getBannerId = () => {
+    // Tether Savings (sUSDT) is a Sky vault on Spark infra — its own banner, not a Morpho one.
+    if (vaultName.includes('Tether')) return 'tether-savings-vault';
     if (vaultName.includes('Risk Capital')) {
       if (vaultName.includes('USDT')) return 'usdt-risk-capital-vault';
       if (vaultName.includes('USDC')) return 'usdc-risk-capital-vault';
@@ -99,12 +101,12 @@ export function VaultDetails({ vaultAddress, assetToken, vaultName }: VaultDetai
       )}
       <DetailSection title={t`About`}>
         <DetailSectionRow>
-          <AboutMorphoVaults bannerId={getBannerId()} />
+          <AboutMorphoVaults bannerId={getBannerId()} provider={provider} />
         </DetailSectionRow>
       </DetailSection>
       <DetailSection title={t`FAQs`}>
         <DetailSectionRow>
-          <MorphoVaultFaq />
+          <MorphoVaultFaq provider={provider} />
         </DetailSectionRow>
       </DetailSection>
     </DetailSectionWrapper>

--- a/apps/webapp/src/modules/morpho/components/VaultInfoDetails.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultInfoDetails.tsx
@@ -93,6 +93,7 @@ export function VaultInfoDetails({ vaultAddress, assetToken, provider = 'morpho'
           isLoading={liquidityLoading}
           error={isMorpho ? marketError : null}
           assetToken={assetToken}
+          provider={provider}
         />
       </div>
       {isMorpho && (

--- a/apps/webapp/src/modules/ui/components/AboutMorphoVaults.tsx
+++ b/apps/webapp/src/modules/ui/components/AboutMorphoVaults.tsx
@@ -5,9 +5,15 @@ import { AboutCard } from './AboutCard';
 import { TokenIcon } from './TokenIcon';
 import { Trans } from '@lingui/react/macro';
 import { Morpho } from '@/widgets';
+import { VaultProvider } from '@/hooks';
 
 const getVaultIcon = (bannerId: string) => {
   const morphoIcon = <Morpho className="h-6 w-6 rounded-sm" />;
+
+  // Tether Savings is a Sky vault on Spark infra — show the deposit-asset icon, not the Morpho mark.
+  if (bannerId === 'tether-savings-vault') {
+    return <TokenIcon token={{ symbol: 'USDT' }} width={24} className="h-6 w-6" showChainIcon={false} />;
+  }
 
   if (bannerId === 'flagship-vault') {
     return (
@@ -39,7 +45,13 @@ const getVaultIcon = (bannerId: string) => {
   return morphoIcon;
 };
 
-export const AboutMorphoVaults = ({ bannerId = 'vaults' }: { bannerId?: string }) => {
+export const AboutMorphoVaults = ({
+  bannerId = 'vaults',
+  provider = 'morpho'
+}: {
+  bannerId?: string;
+  provider?: VaultProvider;
+}) => {
   const { isConnectedAndAcceptedTerms } = useConnectedContext();
 
   const banner = getBannerByIdAndModule(bannerId, 'vaults-banners');
@@ -53,12 +65,16 @@ export const AboutMorphoVaults = ({ bannerId = 'vaults' }: { bannerId?: string }
 
   const contentText = banner.description ? parseBannerContent(banner.description) : '';
 
+  // The Sky (sUSDT) vault points at Sky docs; Morpho vaults keep the Morpho concept docs.
+  const linkHref =
+    provider === 'sky' ? 'https://docs.sky.money/' : 'https://docs.morpho.org/learn/concepts/vault-v2/';
+
   return (
     <AboutCard
       title={banner.title}
       icon={getVaultIcon(bannerId)}
       description={contentText}
-      linkHref="https://docs.morpho.org/learn/concepts/vault-v2/"
+      linkHref={linkHref}
       linkLabel={<Trans>Learn more</Trans>}
       colorMiddle="linear-gradient(360deg, #2470FF 0%, #1B4ECF 300%)"
     />

--- a/apps/webapp/src/widgets/BalancesWidget/components/VaultsBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/VaultsBalanceCard.tsx
@@ -181,6 +181,15 @@ export const VaultsBalanceCard = ({
     [morphoAssetsData.vaults, ratesByAddress, vaultChainId, hideZeroBalances]
   );
 
+  // The blended-rate (i) tooltip is provider-specific: a portfolio holding only Sky vaults
+  // (e.g. Tether Savings) gets the Sky rate tooltip — not the Morpho "vault curator on Morpho"
+  // copy. Morpho-only or mixed positions keep the Morpho tooltip.
+  const positionsWithBalance = morphoAssetsData.vaults.filter(v => v.balanceNormalized > 0n);
+  const blendedRatePopoverType: 'morpho' | 'sky' =
+    positionsWithBalance.length > 0 && positionsWithBalance.every(v => v.vault.provider === 'sky')
+      ? 'sky'
+      : 'morpho';
+
   // Build URL map for vaults with vault-specific query params
   const urlMap = useMemo(() => {
     if (vaultUrlMap) return vaultUrlMap;
@@ -202,7 +211,7 @@ export const VaultsBalanceCard = ({
             <div className="flex items-center gap-2">
               <RateLineWithArrow
                 rateText={t`Rate: ${(weightedAverageRate * 100).toFixed(2)}%`}
-                popoverType="morpho"
+                popoverType={blendedRatePopoverType}
                 onExternalLinkClicked={onExternalLinkClicked}
                 showArrow={false}
               />

--- a/apps/webapp/src/widgets/VaultWidget/components/SparkVaultRate.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/SparkVaultRate.tsx
@@ -12,9 +12,8 @@ import { useSparkVaultResolvedRate } from '@/hooks';
  * API `apy` when present, falling back to the on-chain Vault Savings Rate (`vsr`). Every Spark-rate
  * surface reads this resolution, so the header/card can never disagree with the transaction overview.
  *
- * TODO: the (i) popover carries a placeholder note. The rate reads 0% until Spark activates the
- * vault; confirm with Spark whether to surface the SSR floor / their data-hub rate instead, then
- * replace this `tooltipOverride` with real rate-breakdown copy (ideally a dedicated tooltip id).
+ * The (i) popover uses the dedicated `sky` rate tooltip (`susdt-vault-rate`), which carries the
+ * Sky-set savings-rate copy — no Morpho wording. See the corpus `sUSDT Vault Rate` tooltip.
  */
 export function SparkVaultRate({
   vaultAddress,
@@ -33,17 +32,7 @@ export function SparkVaultRate({
       <Text variant="large" className="text-text">
         {formattedRate}
       </Text>
-      {/* `type` only selects default copy, which we fully override below — the Spark vault rate
-          anchors to the Sky Savings Rate, so `ssr` is the closest fallback. */}
-      <PopoverRateInfo
-        type="ssr"
-        iconClassName={iconClassName}
-        tooltipOverride={{
-          title: 'Vault Savings Rate',
-          description:
-            'TODO: on-chain Vault Savings Rate (reads 0% until Spark activates the vault) — confirm the final rate source with Spark.'
-        }}
-      />
+      <PopoverRateInfo type="sky" iconClassName={iconClassName} />
     </div>
   );
 }

--- a/apps/webapp/src/widgets/VaultWidget/components/SupplyWithdraw.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/SupplyWithdraw.tsx
@@ -118,6 +118,13 @@ export const SupplyWithdraw = ({
   const { isConnected } = useConnection();
   const isConnectedAndEnabled = useMemo(() => isConnected && enabled, [isConnected, enabled]);
 
+  // Liquidity copy is provider-specific: Spark/Tether vaults expose instant-withdrawal liquidity,
+  // not a Morpho market, so override the default `morpho-liquidity` tooltip for non-Morpho providers.
+  const liquidityTooltipOverride =
+    provider === 'sky'
+      ? { description: t`The amount of ${assetToken.symbol} currently available for instant withdrawal.` }
+      : undefined;
+
   // Calculate final balances after transaction
   const finalAssetBalance =
     widgetState.flow === VaultFlow.SUPPLY ? (assetBalance || 0n) - amount : (assetBalance || 0n) + amount;
@@ -260,7 +267,11 @@ export const SupplyWithdraw = ({
             />
             {!isVaultDataLoading && isLiquidityConstrained && maxWithdraw === 0n && (
               <div className="mt-2 ml-3 flex items-start text-amber-400">
-                <PopoverRateInfo type="morphoLiquidity" iconClassName="mt-1 shrink-0 text-amber-400" />
+                <PopoverRateInfo
+                  type="morphoLiquidity"
+                  tooltipOverride={liquidityTooltipOverride}
+                  iconClassName="mt-1 shrink-0 text-amber-400"
+                />
                 <Text variant="small" className="ml-2 flex gap-2">
                   <Trans>Withdrawals are temporarily unavailable due to liquidity constraints.</Trans>
                 </Text>
@@ -268,7 +279,11 @@ export const SupplyWithdraw = ({
             )}
             {!isVaultDataLoading && isLiquidityDataUnavailable && (
               <div className="mt-2 ml-3 flex items-start text-white">
-                <PopoverRateInfo type="morphoLiquidity" iconClassName="mt-1 shrink-0 text-white" />
+                <PopoverRateInfo
+                  type="morphoLiquidity"
+                  tooltipOverride={liquidityTooltipOverride}
+                  iconClassName="mt-1 shrink-0 text-white"
+                />
                 <Text variant="small" className="ml-2 flex gap-2">
                   <Trans>
                     Liquidity data is temporarily unavailable. Withdrawals may be limited by available
@@ -282,7 +297,11 @@ export const SupplyWithdraw = ({
               maxWithdraw !== undefined &&
               maxWithdraw > 0n && (
                 <div className="mt-2 ml-3 flex items-start text-white">
-                  <PopoverRateInfo type="morphoLiquidity" iconClassName="mt-1 shrink-0 text-white" />
+                  <PopoverRateInfo
+                    type="morphoLiquidity"
+                    tooltipOverride={liquidityTooltipOverride}
+                    iconClassName="mt-1 shrink-0 text-white"
+                  />
                   <Text variant="small" className="ml-2 flex gap-2">
                     <Trans>You cannot withdraw your full balance due to current liquidity limits.</Trans>
                   </Text>
@@ -298,7 +317,7 @@ export const SupplyWithdraw = ({
           isFetching={false}
           fetchingMessage={t`Fetching transaction details`}
           onExternalLinkClicked={onExternalLinkClicked}
-          rateType="morpho"
+          rateType={provider === 'sky' ? 'sky' : 'morpho'}
           transactionData={[
             {
               label: tabIndex === 0 ? t`You will supply` : t`You will withdraw`,

--- a/apps/webapp/src/widgets/data/tooltips/index.ts
+++ b/apps/webapp/src/widgets/data/tooltips/index.ts
@@ -283,6 +283,12 @@ Bundled transaction: Active`
       'Vault rates are variable and depend on market conditions, borrower demand, and the allocation strategy defined by Sky as vault curator on Morpho. Key factors that influence vault rates include the supply and demand dynamics of the underlying lending markets, the utilization rate of each market the vault allocates to, and the specific allocation strategy and risk profile of the vault. Sky.money does not control or guarantee vault performance. The vault rate provided is an estimated annual rate, updated using data from Morpho, a third-party lending protocol. This estimate is for informational purposes only and does not guarantee future results.'
   },
   {
+    id: 'susdt-vault-rate',
+    title: 'sUSDT Vault Rate',
+    tooltip:
+      'The Tether Savings (sUSDT) Vault rate is variable and set by Sky. Sky sets the sUSDT savings rate against three inputs: profit-and-loss sustainability across the full deposit base, depositor composition, and on-chain borrow demand—adjusting the rate to reflect what deployment yields can support. The rate shown is an estimated annual rate provided for informational purposes only and does not guarantee future results. Sky.money does not control or guarantee vault performance.'
+  },
+  {
     id: 'pt-susds',
     title: 'PT-sUSDS',
     tooltip:

--- a/apps/webapp/src/widgets/shared/components/ui/PopoverRateInfo.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/PopoverRateInfo.tsx
@@ -26,6 +26,7 @@ const TOOLTIP_ID_MAP = {
   liquidation: 'liquidation-price',
   stusds: 'stusds-rate',
   morpho: 'vault-rate',
+  sky: 'susdt-vault-rate',
   expert: 'stusds-rate',
   stusdsLiquidity: 'available-liquidity',
   morphoLiquidity: 'morpho-liquidity',

--- a/apps/webapp/src/widgets/shared/components/ui/RateLineWithArrow.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/RateLineWithArrow.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 interface RateLineWithArrowProps {
   rateText: string;
-  popoverType: 'ssr' | 'srr' | 'str' | 'stusds' | 'expert' | 'morpho' | 'fixedYield';
+  popoverType: 'ssr' | 'srr' | 'str' | 'stusds' | 'expert' | 'morpho' | 'sky' | 'fixedYield';
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   showArrow?: boolean;
 }

--- a/apps/webapp/src/widgets/shared/components/ui/transaction/TransactionOverview.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/transaction/TransactionOverview.tsx
@@ -32,7 +32,7 @@ type TransactionOverviewParams = {
   title: string;
   isFetching: boolean;
   fetchingMessage: string;
-  rateType?: 'str' | 'ssr' | 'srr' | 'dtc' | 'stusds' | 'morpho';
+  rateType?: 'str' | 'ssr' | 'srr' | 'dtc' | 'stusds' | 'morpho' | 'sky';
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   /**
    * Headline rows. When provided, renders as a TWO-accordion layout:
@@ -68,10 +68,7 @@ function OverviewRow({
     containerClassName
   } = row;
   return (
-    <motion.div
-      className={cn('flex justify-between', containerClassName)}
-      variants={positionAnimations}
-    >
+    <motion.div className={cn('flex justify-between', containerClassName)} variants={positionAnimations}>
       <HStack className="items-center" gap={1}>
         <Text
           className={cn(


### PR DESCRIPTION
## What

Makes the new **Tether Savings (sUSDT)** vault present as a **first-party Sky vault** rather than a Morpho vault. The Vaults module was historically all Morpho, so shared copy/branding attributed everything to Morpho — this threads `provider` through those surfaces and gives the Sky vault its own copy. Implements [APP-279](https://linear.app/skybasestar/issue/APP-279/update-copy-for-the-susdt-vault) (follow-up to APP-266).

Stacked on `feature/app-266-tether-savings-susdt-vault` (needs the spark-provider vault code).

## Corpus content (synced from [sky-ecosystem/corpus#156](https://github.com/sky-ecosystem/corpus/pull/156))

- Banner `tether-savings-vault` (module `vaults-banners`) → `data/banners/banners.ts`
- FAQ `getTetherSavingsFaqItems` → `data/faqs/getTetherSavingsFaqItems.ts` (separate from the Morpho `getVaultsFaqItems`)
- Tooltip `susdt-vault-rate` → `widgets/data/tooltips/index.ts`

> Note: synced manually from the corpus branch (not yet merged to corpus `development`). Re-running `/sync-corpus` after #156 merges should be a no-op for these entries.

## Provider-aware wiring (Morpho copy preserved for Morpho vaults)

| Surface | Change |
|---|---|
| `VaultDetails.getBannerId()` | "Tether Savings" → `tether-savings-vault` (was the **nonexistent** `usds-savings-vault` → empty/broken About) |
| `AboutMorphoVaults` | takes `provider`; Sky deposit-asset icon + Sky docs link (not Morpho) for the spark vault |
| `MorphoVaultFaq` | renders the sUSDT FAQ for spark |
| `SparkVaultRate` | uses the `susdt-vault-rate` tooltip (replaces the placeholder TODO override) |
| `SupplyWithdraw` | rate tooltip + liquidity copy provider-aware — "available for instant withdrawal" instead of "Morpho market" |
| `MorphoMarketLiquidityCard` | provider-aware liquidity tooltip |
| `ConnectCard` | "Sky-curated **Vaults**" (was "...Morpho Vaults"); drops the Morpho icon; `isMorphoVaults` → `isVaults` |
| `PopoverRateInfo` / `TransactionOverview` | add a `spark` rate type → `susdt-vault-rate` |

## Speed bumps

Removed all speed-bump code (no longer used) — `sync-content.sh` plumbing + the `version.ts` comment. There is no speed-bump data/consumer in the app. (The `.claude/skills/sync-corpus` doc still lists speed-bumps; left untouched as it's agent tooling, can be trimmed separately.)

## Out of scope

- **Transaction-flow copy** ("...the Morpho Vault" in `VaultWidget/lib/constants.ts`) is intentionally untouched — handled by #1638.
- i18n catalogs not regenerated here (default locale renders from source strings; `pnpm messages` / build handles extraction). `messages:extract --clean` would churn unrelated msgids.

## Verification

- `tsc` clean for all changed files (the 4 pre-existing errors in `VaultTransactionStatus.tsx` / `widgetState.ts` are inherited from app-266 / #1638's scope, not from this PR).
- eslint + prettier clean.
- Tests: `sparkVaultRate.spark` 4/4, VaultWidget suites (depositCap, referralCode, MorphoVaultWidgetPane) 7/7. One pre-existing failure in `vaultInfoDetails.spark` (a TVL-preference assertion) reproduces on the base branch without this PR.

Ref: APP-266, APP-279