### PR TITLE
fix(vaults): provider-agnostic tooltip on vaults overview rate range

### DIFF
--- a/apps/webapp/src/modules/vaults/components/VaultsTvlCard.tsx
+++ b/apps/webapp/src/modules/vaults/components/VaultsTvlCard.tsx
@@ -35,7 +35,7 @@ export function VaultsRatesCard(): React.ReactElement {
               <span className="text-bullish">{formattedMaxRate}</span>
             </Trans>
           </Text>
-          <PopoverInfo type="morpho" />
+          <PopoverInfo type="vaultsAggregate" />
         </div>
       }
       isLoading={isLoading}

--- a/apps/webapp/src/widgets/data/tooltips/index.ts
+++ b/apps/webapp/src/widgets/data/tooltips/index.ts
@@ -283,6 +283,12 @@ Bundled transaction: Active`
       'Vault rates are variable and depend on market conditions, borrower demand, and the allocation strategy defined by Sky as vault curator on Morpho. Key factors that influence vault rates include the supply and demand dynamics of the underlying lending markets, the utilization rate of each market the vault allocates to, and the specific allocation strategy and risk profile of the vault. Sky.money does not control or guarantee vault performance. The vault rate provided is an estimated annual rate, updated using data from Morpho, a third-party lending protocol. This estimate is for informational purposes only and does not guarantee future results.'
   },
   {
+    id: 'vault-rates',
+    title: 'Vault Rates',
+    tooltip:
+      "The rates shown reflect the range of variable rates currently offered across the vaults available here, from lowest to highest. These vaults come from different sources: some are curated by Sky on third-party lending protocols such as Morpho, while others are first-party vaults managed by Sky. Each vault's rate is variable and depends on that specific vault—its underlying strategy, the market conditions and supply-and-demand dynamics of the lending markets or products it uses, and its risk profile. Sky.money does not control or guarantee vault performance. The rates shown are estimated annual rates, updated using data from the relevant protocols, for informational purposes only, and do not guarantee future results."
+  },
+  {
     id: 'susdt-vault-rate',
     title: 'sUSDT Vault Rate',
     tooltip:

--- a/apps/webapp/src/widgets/shared/components/ui/PopoverRateInfo.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/PopoverRateInfo.tsx
@@ -27,6 +27,7 @@ const TOOLTIP_ID_MAP = {
   stusds: 'stusds-rate',
   morpho: 'vault-rate',
   sky: 'susdt-vault-rate',
+  vaultsAggregate: 'vault-rates',
   expert: 'stusds-rate',
   stusdsLiquidity: 'available-liquidity',
   morphoLiquidity: 'morpho-liquidity',


### PR DESCRIPTION
## Problem

The Vaults overview **"Rates"** card shows an aggregate **From / To** range that spans **every** vault in the pane — including the first-party Sky **sUSDT (Tether Savings)** vault — but its info popover reused the Morpho-specific **"Vault Rate"** tooltip. So the aggregate explains the range as if every vault were a Morpho-curated vault.

This was a known residual from APP-279 (the aggregate `(i)` was left hardcoded to `morpho` because it spans all providers; product now wants it neutral).

## Fix

- `VaultsRatesCard` (`modules/vaults/components/VaultsTvlCard.tsx`) now points its `PopoverInfo` at a new provider-neutral **"Vault Rates"** tooltip (`vault-rates`) instead of `morpho`.
- Added the `vaultsAggregate → vault-rates` entry to `TOOLTIP_ID_MAP` in `PopoverRateInfo.tsx`.
- Synced the new `vault-rates` tooltip into `widgets/data/tooltips/index.ts` from corpus.

The per-vault tooltips are **unchanged**: individual Morpho vaults keep the Morpho-specific `vault-rate`, and the sUSDT vault keeps `susdt-vault-rate`. Only the cross-provider aggregate range gets neutral copy.

## Copy source

Authored in **sky-ecosystem/corpus#156** (`**Vault Rates**` tooltip in the VAULTS TOOLTIPS section) and regenerated. This PR carries the synced output so it's self-contained; no behavior depends on the corpus PR merging first.

## Checks

- `tsc --noEmit` ✓
- `eslint` (changed files) ✓
- `prettier --check` (changed files) ✓