### PR TITLE
feat(redesign): Track A/B integration — A4 route map contract + B1 V2 TopNav

### DIFF
--- a/apps/webapp/src/lib/legacyRedirects.test.ts
+++ b/apps/webapp/src/lib/legacyRedirects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { legacySearchToLocation } from './legacyRedirects';
+import { legacyPathToLocation, legacySearchToLocation } from './legacyRedirects';
 
 const SPARK_VAULT_ADDRESS = '0x74cb54e082411cfCAEADb00a0765625B10410DAa';
 const MARKET_ADDRESS = '0x36d3ca43ae7939645c306e26603ce16e39a89192';
@@ -112,5 +112,106 @@ describe('legacySearchToLocation', () => {
 
   it('handles case-insensitive widget values', () => {
     expect(legacySearchToLocation({ widget: 'Trade' })).toEqual({ to: '/convert/trade', search: {} });
+  });
+});
+
+// Dormant until the IA flip (Track B): written and tested here, registered nowhere.
+describe('legacyPathToLocation', () => {
+  it('returns null for paths that survive the IA flip unchanged', () => {
+    expect(legacyPathToLocation('/')).toBeNull();
+    expect(legacyPathToLocation('/stake')).toBeNull();
+    expect(legacyPathToLocation('/seal-engine')).toBeNull();
+    expect(legacyPathToLocation('/batch-transactions-legal-notice')).toBeNull();
+    expect(legacyPathToLocation('/dev')).toBeNull();
+  });
+
+  it('returns null for target-IA and unknown paths', () => {
+    expect(legacyPathToLocation('/portfolio')).toBeNull();
+    expect(legacyPathToLocation('/earn')).toBeNull();
+    expect(legacyPathToLocation('/earn/savings')).toBeNull();
+    expect(legacyPathToLocation('/bogus')).toBeNull();
+  });
+
+  it('maps current module paths to their target-IA destinations', () => {
+    expect(legacyPathToLocation('/balances')).toEqual({ to: '/portfolio', search: {} });
+    expect(legacyPathToLocation('/savings')).toEqual({ to: '/earn/savings', search: {} });
+    expect(legacyPathToLocation('/rewards')).toEqual({ to: '/earn/rewards', search: {} });
+    expect(legacyPathToLocation('/vaults')).toEqual({ to: '/earn/vaults', search: {} });
+    expect(legacyPathToLocation('/fixed')).toEqual({ to: '/earn/fixed', search: {} });
+    expect(legacyPathToLocation('/expert')).toEqual({ to: '/earn/expert', search: {} });
+  });
+
+  it('tolerates trailing slashes', () => {
+    expect(legacyPathToLocation('/savings/')).toEqual({ to: '/earn/savings', search: {} });
+  });
+
+  it('moves the reward contract from path segment to query param', () => {
+    expect(legacyPathToLocation(`/rewards/${REWARD_ADDRESS}`)).toEqual({
+      to: '/earn/rewards',
+      search: { reward: REWARD_ADDRESS }
+    });
+  });
+
+  it('moves vault provider and address to query params', () => {
+    expect(legacyPathToLocation(`/vaults/sky/${SPARK_VAULT_ADDRESS}`)).toEqual({
+      to: '/earn/vaults',
+      search: { vault_module: 'sky', vault: SPARK_VAULT_ADDRESS }
+    });
+    expect(legacyPathToLocation('/vaults/sky')).toEqual({
+      to: '/earn/vaults',
+      search: { vault_module: 'sky' }
+    });
+  });
+
+  it('moves the fixed market from path segments to query params', () => {
+    expect(legacyPathToLocation(`/fixed/market/${MARKET_ADDRESS}`)).toEqual({
+      to: '/earn/fixed',
+      search: { fixed_module: 'market', market: MARKET_ADDRESS }
+    });
+  });
+
+  it('moves the expert module from path segment to query param', () => {
+    expect(legacyPathToLocation('/expert/stusds')).toEqual({
+      to: '/earn/expert',
+      search: { expert_module: 'stusds' }
+    });
+  });
+
+  it('moves convert submodules from path segments to query params', () => {
+    expect(legacyPathToLocation('/convert/psm')).toEqual({
+      to: '/convert',
+      search: { convert_module: 'psm' }
+    });
+    expect(legacyPathToLocation('/convert/trade')).toEqual({
+      to: '/convert',
+      search: { convert_module: 'trade' }
+    });
+    expect(legacyPathToLocation('/convert/upgrade')).toEqual({
+      to: '/convert',
+      search: { convert_module: 'upgrade' }
+    });
+  });
+
+  it('drops unrecognised trailing segments and lands on the destination', () => {
+    expect(legacyPathToLocation('/convert/bogus')).toEqual({ to: '/convert', search: {} });
+    expect(legacyPathToLocation('/fixed/bogus')).toEqual({ to: '/earn/fixed', search: {} });
+  });
+
+  it('preserves incoming params and drops the retired ones', () => {
+    expect(
+      legacyPathToLocation('/savings', {
+        network: 'base',
+        flow: 'withdraw',
+        input_amount: '5',
+        linked_action: 'trade'
+      })
+    ).toEqual({ to: '/earn/savings', search: { network: 'base', flow: 'withdraw' } });
+  });
+
+  it('path-derived sub-state wins over a conflicting incoming param', () => {
+    expect(legacyPathToLocation(`/rewards/${REWARD_ADDRESS}`, { reward: 'stale' })).toEqual({
+      to: '/earn/rewards',
+      search: { reward: REWARD_ADDRESS }
+    });
   });
 });

--- a/apps/webapp/src/lib/legacyRedirects.ts
+++ b/apps/webapp/src/lib/legacyRedirects.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/constants';
 import { providerForVaultModule } from '@/lib/vaults/vaultProviderMapping';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
+import { ROUTES } from '@/lib/routes';
 
 // Param names of the retired query-param navigation scheme. Kept as local
 // literals: they are intentionally absent from QueryParams.
@@ -103,4 +104,75 @@ export function legacySearchToLocation(search: Record<string, string>): LegacyRe
   }
 
   return { to, search: rest };
+}
+
+// Current-generation module paths → target-IA destinations (plan §4.1).
+// DORMANT: unit-tested but registered nowhere until the IA flips (Track B).
+// `params` lifts entity path segments back into query-param sub-state.
+type V2Redirect = { to: string; params?: (segments: string[]) => Record<string, string> };
+
+const V2_REDIRECT_BY_MODULE: Record<string, V2Redirect> = {
+  balances: { to: ROUTES.PORTFOLIO },
+  savings: { to: ROUTES.EARN_SAVINGS },
+  rewards: {
+    to: ROUTES.EARN_REWARDS,
+    params: ([reward]): Record<string, string> => (reward ? { [LegacyParams.Reward]: reward } : {})
+  },
+  vaults: {
+    to: ROUTES.EARN_VAULTS,
+    params: ([provider, vault]): Record<string, string> =>
+      provider && providerForVaultModule(provider)
+        ? {
+            [LegacyParams.VaultModule]: provider.toLowerCase(),
+            ...(vault && { [LegacyParams.Vault]: vault })
+          }
+        : {}
+  },
+  fixed: {
+    to: ROUTES.EARN_FIXED,
+    params: ([module, market]): Record<string, string> =>
+      module?.toLowerCase() === FixedIntentMapping[FixedIntent.MARKET_INTENT] && market
+        ? { [LegacyParams.FixedModule]: module.toLowerCase(), [LegacyParams.Market]: market }
+        : {}
+  },
+  expert: {
+    to: ROUTES.EARN_EXPERT,
+    params: ([module]): Record<string, string> =>
+      module?.toLowerCase() === ExpertIntentMapping[ExpertIntent.STUSDS_INTENT]
+        ? { [LegacyParams.ExpertModule]: module.toLowerCase() }
+        : {}
+  },
+  convert: {
+    to: ROUTES.CONVERT,
+    params: ([module]): Record<string, string> =>
+      module && CONVERT_MODULE_VALUES.includes(module.toLowerCase())
+        ? { [LegacyParams.ConvertModule]: module.toLowerCase() }
+        : {}
+  }
+};
+
+/**
+ * Translates current module paths into their target-IA equivalents once the
+ * IA flips. Returns null when the path needs no redirect. Composes after
+ * legacySearchToLocation: ?widget= URLs first rewrite to a current path,
+ * then this maps that path forward. Entity values pass through verbatim —
+ * the target route's own validation handles invalid ones.
+ */
+export function legacyPathToLocation(
+  pathname: string,
+  search: Record<string, string> = {}
+): LegacyRedirect | null {
+  const segments = pathname.split('/').filter(Boolean);
+  const moduleKey = segments[0]?.toLowerCase();
+  const redirect = moduleKey ? V2_REDIRECT_BY_MODULE[moduleKey] : undefined;
+  if (!redirect) return null;
+  // Already at its destination with no sub-state to lift: nothing to do.
+  if (segments.length === 1 && `/${moduleKey}` === redirect.to) return null;
+
+  // input_amount/linked_action are retired in the new IA (plan §4.1); path-derived
+  // sub-state wins over any stale incoming param.
+  const preserved = Object.fromEntries(
+    Object.entries(search).filter(([key]) => key !== 'input_amount' && key !== 'linked_action')
+  );
+  return { to: redirect.to, search: { ...preserved, ...(redirect.params?.(segments.slice(1)) ?? {}) } };
 }

--- a/apps/webapp/src/lib/routes.test.ts
+++ b/apps/webapp/src/lib/routes.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { Intent } from './enums';
+import { IntentMapping } from './constants';
+import { ROUTES, intentToPath, pathToIntent } from './routes';
+
+// TRADE/UPGRADE fold into Convert: intentToPath aliases them, so they sit
+// outside the strict inverse and pathToIntent never returns them.
+const ALIAS_INTENTS = [Intent.TRADE_INTENT, Intent.UPGRADE_INTENT];
+const ROUTED_INTENTS = (Object.keys(IntentMapping) as Intent[]).filter(
+  intent => !ALIAS_INTENTS.includes(intent)
+);
+
+describe('intentToPath', () => {
+  it('maps each routed intent to its target-IA destination', () => {
+    expect(intentToPath(Intent.BALANCES_INTENT)).toBe('/portfolio');
+    expect(intentToPath(Intent.SAVINGS_INTENT)).toBe('/earn/savings');
+    expect(intentToPath(Intent.REWARDS_INTENT)).toBe('/earn/rewards');
+    expect(intentToPath(Intent.VAULTS_INTENT)).toBe('/earn/vaults');
+    expect(intentToPath(Intent.FIXED_INTENT)).toBe('/earn/fixed');
+    expect(intentToPath(Intent.EXPERT_INTENT)).toBe('/earn/expert');
+    expect(intentToPath(Intent.STAKE_INTENT)).toBe('/stake');
+    expect(intentToPath(Intent.CONVERT_INTENT)).toBe('/convert');
+  });
+
+  it('aliases the folded-into-convert intents to the convert destination', () => {
+    expect(intentToPath(Intent.TRADE_INTENT)).toBe('/convert');
+    expect(intentToPath(Intent.UPGRADE_INTENT)).toBe('/convert');
+  });
+
+  it('appends a product-instance slug as a path segment', () => {
+    expect(intentToPath(Intent.FIXED_INTENT, 'spk-usds')).toBe('/earn/fixed/spk-usds');
+    expect(intentToPath(Intent.REWARDS_INTENT, 'usds-skyfarm')).toBe('/earn/rewards/usds-skyfarm');
+  });
+
+  it('ignores an empty slug', () => {
+    expect(intentToPath(Intent.FIXED_INTENT, '')).toBe('/earn/fixed');
+  });
+});
+
+describe('pathToIntent', () => {
+  it('classifies instance paths by their product base', () => {
+    expect(pathToIntent('/earn/fixed/spk-usds')).toBe(Intent.FIXED_INTENT);
+    expect(pathToIntent('/earn/rewards/usds-skyfarm')).toBe(Intent.REWARDS_INTENT);
+  });
+
+  it('tolerates trailing slashes', () => {
+    expect(pathToIntent('/portfolio/')).toBe(Intent.BALANCES_INTENT);
+    expect(pathToIntent('/earn/savings/')).toBe(Intent.SAVINGS_INTENT);
+  });
+
+  it('returns null for the earn marketplace (net-new IA, no legacy intent)', () => {
+    expect(pathToIntent('/earn')).toBeNull();
+  });
+
+  it('returns null for non-product and unknown paths', () => {
+    expect(pathToIntent('/')).toBeNull();
+    expect(pathToIntent('/dev')).toBeNull();
+    expect(pathToIntent('/seal-engine')).toBeNull();
+    expect(pathToIntent('/batch-transactions-legal-notice')).toBeNull();
+    expect(pathToIntent('/bogus')).toBeNull();
+  });
+});
+
+describe('intentToPath ⇄ pathToIntent inverse (exhaustive over IntentMapping)', () => {
+  it('pathToIntent(intentToPath(intent)) === intent for every routed intent', () => {
+    for (const intent of ROUTED_INTENTS) {
+      expect(pathToIntent(intentToPath(intent))).toBe(intent);
+    }
+  });
+
+  it('holds with a product-instance slug', () => {
+    for (const intent of ROUTED_INTENTS) {
+      expect(pathToIntent(intentToPath(intent, 'some-slug'))).toBe(intent);
+    }
+  });
+
+  it('alias intents resolve to CONVERT through the round trip', () => {
+    for (const intent of ALIAS_INTENTS) {
+      expect(pathToIntent(intentToPath(intent))).toBe(Intent.CONVERT_INTENT);
+    }
+  });
+
+  it('intentToPath(pathToIntent(path)) === path for every intent-bearing route', () => {
+    const intentBearing = ROUTED_INTENTS.map(intent => intentToPath(intent));
+    for (const path of intentBearing) {
+      const intent = pathToIntent(path);
+      expect(intent).not.toBeNull();
+      expect(intentToPath(intent as Intent)).toBe(path);
+    }
+  });
+
+  it('every IntentMapping entry is covered: routed or a documented alias', () => {
+    for (const intent of Object.keys(IntentMapping) as Intent[]) {
+      expect(Object.values(ROUTES)).toContain(intentToPath(intent));
+    }
+  });
+});

--- a/apps/webapp/src/lib/routes.ts
+++ b/apps/webapp/src/lib/routes.ts
@@ -1,0 +1,61 @@
+import { Intent } from '@/lib/enums';
+
+// Target-IA route map (plan §4.1). Single source of truth: downstream code
+// imports route knowledge from here — never hardcode paths.
+export const ROUTES = {
+  PORTFOLIO: '/portfolio',
+  EARN: '/earn',
+  EARN_SAVINGS: '/earn/savings',
+  EARN_REWARDS: '/earn/rewards',
+  EARN_VAULTS: '/earn/vaults',
+  EARN_FIXED: '/earn/fixed',
+  EARN_EXPERT: '/earn/expert',
+  STAKE: '/stake',
+  CONVERT: '/convert',
+  SEAL_ENGINE: '/seal-engine',
+  BATCH_TRANSACTIONS_LEGAL_NOTICE: '/batch-transactions-legal-notice',
+  DEV: '/dev'
+} as const;
+
+export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
+
+// Intents with their own destination. TRADE/UPGRADE have none: they folded
+// into Convert before this migration and alias to its path.
+const PATH_BY_INTENT: Record<Intent, RoutePath> = {
+  [Intent.BALANCES_INTENT]: ROUTES.PORTFOLIO,
+  [Intent.SAVINGS_INTENT]: ROUTES.EARN_SAVINGS,
+  [Intent.REWARDS_INTENT]: ROUTES.EARN_REWARDS,
+  [Intent.VAULTS_INTENT]: ROUTES.EARN_VAULTS,
+  [Intent.FIXED_INTENT]: ROUTES.EARN_FIXED,
+  [Intent.EXPERT_INTENT]: ROUTES.EARN_EXPERT,
+  [Intent.STAKE_INTENT]: ROUTES.STAKE,
+  [Intent.CONVERT_INTENT]: ROUTES.CONVERT,
+  [Intent.TRADE_INTENT]: ROUTES.CONVERT,
+  [Intent.UPGRADE_INTENT]: ROUTES.CONVERT
+};
+
+// `sub` is a configured product-instance slug, appended as a path segment
+// (slug-as-path, plan §4.1 / decision log).
+export function intentToPath(intent: Intent, sub?: string): string {
+  const base = PATH_BY_INTENT[intent];
+  return sub ? `${base}/${sub}` : base;
+}
+
+const ALIAS_INTENTS: ReadonlySet<Intent> = new Set([Intent.TRADE_INTENT, Intent.UPGRADE_INTENT]);
+
+// Canonical destination → intent, aliases excluded so the inverse is exact.
+// Longest base first so nested destinations win over any future parent.
+const INTENT_ROUTES = (Object.entries(PATH_BY_INTENT) as [Intent, RoutePath][])
+  .filter(([intent]) => !ALIAS_INTENTS.has(intent))
+  .sort(([, a], [, b]) => b.length - a.length);
+
+// Classifies a pathname into the Intent its screen consumes (validation,
+// analytics, network mapping). Returns null for intent-less routes; route
+// existence/404 stays the router's concern.
+export function pathToIntent(pathname: string): Intent | null {
+  const path = pathname.toLowerCase().replace(/\/+$/, '');
+  for (const [intent, base] of INTENT_ROUTES) {
+    if (path === base || path.startsWith(`${base}/`)) return intent;
+  }
+  return null;
+}

--- a/apps/webapp/src/modules/app/shell/NetworkSelector.tsx
+++ b/apps/webapp/src/modules/app/shell/NetworkSelector.tsx
@@ -1,0 +1,6 @@
+import { ChainModal } from '@/modules/ui/components/ChainModal';
+
+/** Drawer-embedded network control. Presentation wrapper only — switching logic stays in ChainModal. */
+export function NetworkSelector() {
+  return <ChainModal dataTestId="wallet-drawer-network" />;
+}

--- a/apps/webapp/src/modules/app/shell/TopNav.test.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.test.tsx
@@ -1,0 +1,270 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { base, mainnet } from 'viem/chains';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider
+} from '@tanstack/react-router';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { Intent } from '@/lib/enums';
+import { ROUTES } from '@/lib/routes';
+import { TopNav } from './TopNav';
+
+const mocks = vi.hoisted(() => ({
+  chainId: 1,
+  showBanner: vi.fn(),
+  setIsSwitchingNetwork: vi.fn(),
+  setIsAutoSwitching: vi.fn()
+}));
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useChainId: () => mocks.chainId
+  };
+});
+
+// Import-time env flag; force it on so the menu exercises the toggle slot.
+vi.mock('@/lib/constants', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/constants')>();
+  return { ...actual, BATCH_TX_ENABLED: true };
+});
+
+// Wallet-dependent components stubbed: TopNav composes them, their behavior is
+// covered by their own tests.
+vi.mock('@/components/BatchTransactionsToggle', () => ({
+  BatchTransactionsToggle: () => <div data-testid="batch-transactions-toggle-stub" />
+}));
+
+vi.mock('@/modules/layout/components/CustomConnectButton', () => ({
+  CustomConnectButton: () => <div data-testid="custom-connect-button-stub" />
+}));
+
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle-stub" />
+}));
+
+vi.mock('@/modules/analytics/PostHogProvider', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/analytics/PostHogProvider')>();
+  return { ...actual, POSTHOG_ENABLED: true };
+});
+
+vi.mock('@/modules/ui/context/NetworkSwitchContext', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/ui/context/NetworkSwitchContext')>();
+  return {
+    ...actual,
+    useNetworkSwitch: () => ({
+      isSwitchingNetwork: false,
+      setIsSwitchingNetwork: mocks.setIsSwitchingNetwork,
+      isAutoSwitching: false,
+      setIsAutoSwitching: mocks.setIsAutoSwitching
+    })
+  };
+});
+
+vi.mock('@/modules/analytics/context/CookieConsentContext', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/analytics/context/CookieConsentContext')>();
+  return { ...actual, useCookieConsent: () => ({ showBanner: mocks.showBanner }) };
+});
+
+beforeEach(() => {
+  mocks.chainId = mainnet.id;
+  mocks.showBanner.mockClear();
+  mocks.setIsSwitchingNetwork.mockClear();
+  mocks.setIsAutoSwitching.mockClear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// Memory-router harness: TopNav at the root, stub routes for every path the
+// tests navigate to (staticData mirrors the real routes' intents).
+function renderTopNav(initialPath = '/') {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <TopNav />
+        <Outlet />
+      </>
+    )
+  });
+  const stubRoute = (path: string, intent?: Intent) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      component: () => null,
+      ...(intent ? { staticData: { intent } } : {})
+    });
+  const routeTree = rootRoute.addChildren([
+    stubRoute('/', Intent.BALANCES_INTENT),
+    stubRoute(ROUTES.PORTFOLIO, Intent.BALANCES_INTENT),
+    stubRoute(ROUTES.EARN),
+    stubRoute(ROUTES.STAKE, Intent.STAKE_INTENT),
+    stubRoute(ROUTES.CONVERT, Intent.CONVERT_INTENT),
+    stubRoute('/savings', Intent.SAVINGS_INTENT),
+    stubRoute('/fixed', Intent.FIXED_INTENT)
+  ]);
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] })
+  });
+
+  render(
+    <I18nWidgetProvider locale="en">
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <RouterProvider router={router as any} />
+    </I18nWidgetProvider>
+  );
+  return router;
+}
+
+describe('TopNav destinations', () => {
+  it('renders the 4 destinations with V2 testids linking to the route map paths', async () => {
+    renderTopNav();
+
+    expect((await screen.findByTestId('nav-portfolio')).getAttribute('href')).toBe(ROUTES.PORTFOLIO);
+    expect(screen.getByTestId('nav-earn').getAttribute('href')).toBe(ROUTES.EARN);
+    expect(screen.getByTestId('nav-stake').getAttribute('href')).toBe(ROUTES.STAKE);
+    expect(screen.getByTestId('nav-convert').getAttribute('href')).toBe(ROUTES.CONVERT);
+  });
+});
+
+describe('TopNav wallet chip', () => {
+  it('wraps the existing connect button under the V2 wallet-chip testid', async () => {
+    renderTopNav();
+    const chip = await screen.findByTestId('wallet-chip');
+    expect(chip.querySelector('[data-testid="custom-connect-button-stub"]')).toBeTruthy();
+  });
+});
+
+// NEW_INTENTS currently contains the Fixed module, which lives under Earn.
+describe('TopNav new-module dot', () => {
+  it('shows the dot on the destination owning an unseen new module', async () => {
+    renderTopNav();
+    await screen.findByTestId('nav-earn');
+    expect(screen.queryByTestId('nav-earn-new-dot')).toBeTruthy();
+    expect(screen.queryByTestId('nav-portfolio-new-dot')).toBeNull();
+  });
+
+  it('hides the dot once the new module was seen in a previous session', async () => {
+    localStorage.setItem('seenNewNavIntents', JSON.stringify([Intent.FIXED_INTENT]));
+    renderTopNav();
+    await screen.findByTestId('nav-earn');
+    expect(screen.queryByTestId('nav-earn-new-dot')).toBeNull();
+  });
+
+  it('clears the dot when landing on the new module route', async () => {
+    renderTopNav('/fixed');
+    await screen.findByTestId('nav-earn');
+    expect(screen.queryByTestId('nav-earn-new-dot')).toBeNull();
+  });
+});
+
+describe('TopNav More menu', () => {
+  it('lists batch toggle, upgrade shortcut, legal links and cookie settings', async () => {
+    vi.stubEnv(
+      'VITE_FOOTER_LINKS',
+      JSON.stringify([
+        { url: 'https://docs.sky.money/', name: 'Docs' },
+        { url: 'https://sky.money/terms', name: 'Terms' },
+        { url: 'https://sky.money/privacy', name: 'Privacy' }
+      ])
+    );
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-more'));
+
+    expect((await screen.findByTestId('nav-more-upgrade')).getAttribute('href')).toBe('/convert/upgrade');
+    expect(screen.getByTestId('batch-transactions-toggle-stub')).toBeTruthy();
+    expect(screen.getByTestId('theme-toggle-stub')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Docs/ }).getAttribute('href')).toBe('https://docs.sky.money/');
+    expect(screen.getByRole('link', { name: /Terms/ })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Privacy/ })).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('nav-more-cookie-settings'));
+    expect(mocks.showBanner).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TopNav network override', () => {
+  it('carries network=ethereum on the mainnet-only Stake link when on an L2', async () => {
+    mocks.chainId = base.id;
+    renderTopNav();
+
+    expect((await screen.findByTestId('nav-stake')).getAttribute('href')).toBe(
+      `${ROUTES.STAKE}?network=ethereum`
+    );
+    expect(screen.getByTestId('nav-convert').getAttribute('href')).toBe(ROUTES.CONVERT);
+  });
+
+  it('links Stake plainly from mainnet', async () => {
+    renderTopNav();
+    expect((await screen.findByTestId('nav-stake')).getAttribute('href')).toBe(ROUTES.STAKE);
+  });
+});
+
+describe('TopNav network switch feedback', () => {
+  it('flags the auto-switch when plainly clicking a mainnet-only destination from an L2', async () => {
+    mocks.chainId = base.id;
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-stake'));
+
+    expect(mocks.setIsSwitchingNetwork).toHaveBeenCalledWith(true);
+    expect(mocks.setIsAutoSwitching).toHaveBeenCalledWith(true);
+  });
+
+  it('skips the side effect on modified clicks (new tab: this tab does not navigate)', async () => {
+    mocks.chainId = base.id;
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-stake'), { metaKey: true });
+
+    expect(mocks.setIsSwitchingNetwork).not.toHaveBeenCalled();
+  });
+
+  it('does not flag switches for multichain destinations', async () => {
+    mocks.chainId = base.id;
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-convert'));
+
+    expect(mocks.setIsSwitchingNetwork).not.toHaveBeenCalled();
+  });
+});
+
+describe('TopNav active destination', () => {
+  async function activeTestIds(): Promise<string[]> {
+    await screen.findByTestId('nav-portfolio');
+    return ['nav-portfolio', 'nav-earn', 'nav-stake', 'nav-convert'].filter(
+      testId => screen.getByTestId(testId).getAttribute('aria-current') === 'page'
+    );
+  }
+
+  it('marks the destination matching the current path', async () => {
+    renderTopNav(ROUTES.STAKE);
+    expect(await activeTestIds()).toEqual(['nav-stake']);
+  });
+
+  it('marks Earn on the intent-less /earn placeholder', async () => {
+    renderTopNav(ROUTES.EARN);
+    expect(await activeTestIds()).toEqual(['nav-earn']);
+  });
+
+  it('marks the owning destination while a legacy module path is mounted', async () => {
+    renderTopNav('/savings');
+    expect(await activeTestIds()).toEqual(['nav-earn']);
+  });
+
+  it('marks Portfolio on the legacy landing route', async () => {
+    renderTopNav('/');
+    expect(await activeTestIds()).toEqual(['nav-portfolio']);
+  });
+});

--- a/apps/webapp/src/modules/app/shell/TopNav.test.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.test.tsx
@@ -41,8 +41,8 @@ vi.mock('@/components/BatchTransactionsToggle', () => ({
   BatchTransactionsToggle: () => <div data-testid="batch-transactions-toggle-stub" />
 }));
 
-vi.mock('@/modules/layout/components/CustomConnectButton', () => ({
-  CustomConnectButton: () => <div data-testid="custom-connect-button-stub" />
+vi.mock('./WalletChip', () => ({
+  WalletChip: () => <div data-testid="wallet-chip" data-stub="wallet-chip-stub" />
 }));
 
 vi.mock('@/components/ThemeToggle', () => ({
@@ -137,10 +137,10 @@ describe('TopNav destinations', () => {
 });
 
 describe('TopNav wallet chip', () => {
-  it('wraps the existing connect button under the V2 wallet-chip testid', async () => {
+  it('mounts the WalletChip (which owns the V2 wallet-chip testid)', async () => {
     renderTopNav();
     const chip = await screen.findByTestId('wallet-chip');
-    expect(chip.querySelector('[data-testid="custom-connect-button-stub"]')).toBeTruthy();
+    expect(chip.getAttribute('data-stub')).toBe('wallet-chip-stub');
   });
 });
 

--- a/apps/webapp/src/modules/app/shell/TopNav.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.tsx
@@ -1,0 +1,208 @@
+import { MouseEvent, ReactNode, useCallback, useState } from 'react';
+import { Link, useRouterState } from '@tanstack/react-router';
+import { useChainId } from 'wagmi';
+import { Menu } from 'lucide-react';
+import { Trans } from '@lingui/react/macro';
+import { cn, getFooterLinks, sanitizeUrl } from '@/lib/utils';
+import { Intent } from '@/lib/enums';
+import { BATCH_TX_ENABLED, QueryParams } from '@/lib/constants';
+import { intentToPath, ROUTES, RoutePath } from '@/lib/routes';
+import { AppRoutePath, INTENT_PATHS, retainOnNavigate, useRouteIntent } from '@/lib/navigation';
+import { getNetworkOverrideForIntent } from '@/lib/widget-network-map';
+import { useNewIntentDots } from '@/modules/app/hooks/useNewIntentDots';
+import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { BatchTransactionsToggle } from '@/components/BatchTransactionsToggle';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { CustomConnectButton } from '@/modules/layout/components/CustomConnectButton';
+import { ExternalLink } from '@/modules/layout/components/ExternalLink';
+import { useCookieConsent } from '@/modules/analytics/context/CookieConsentContext';
+import { POSTHOG_ENABLED } from '@/modules/analytics/PostHogProvider';
+
+// Destination paths must be in the route map AND mounted as routes (B1 placeholders guarantee it).
+type DestinationPath = Extract<AppRoutePath, RoutePath>;
+
+type Destination = {
+  path: DestinationPath;
+  label: ReactNode;
+  // Modules the destination covers; the first is its landing module and
+  // decides the network override for the link.
+  intents: Intent[];
+};
+
+// The 4 target-IA destinations (plan §4.2). Paths come from ROUTES, never hardcoded.
+const DESTINATIONS: Destination[] = [
+  { path: ROUTES.PORTFOLIO, label: <Trans>Portfolio</Trans>, intents: [Intent.BALANCES_INTENT] },
+  {
+    path: ROUTES.EARN,
+    label: <Trans>Earn</Trans>,
+    intents: [
+      Intent.SAVINGS_INTENT,
+      Intent.REWARDS_INTENT,
+      Intent.VAULTS_INTENT,
+      Intent.FIXED_INTENT,
+      Intent.EXPERT_INTENT
+    ]
+  },
+  { path: ROUTES.STAKE, label: <Trans>Stake SKY</Trans>, intents: [Intent.STAKE_INTENT] },
+  {
+    path: ROUTES.CONVERT,
+    label: <Trans>Convert</Trans>,
+    intents: [Intent.CONVERT_INTENT, Intent.TRADE_INTENT, Intent.UPGRADE_INTENT]
+  }
+];
+
+const navTestId = (path: RoutePath) => `nav-${path.slice(1)}`;
+
+const isUnderDestination = (path: string, base: RoutePath) => path === base || path.startsWith(`${base}/`);
+
+// Active destination: the current path when it's already a target-IA path
+// (covers the intent-less /earn placeholder), else the destination owning the
+// legacy route's intent (e.g. /savings → /earn/savings → Earn).
+function useActiveDestinationPath(): RoutePath | null {
+  const pathname = useRouterState({ select: s => s.location.pathname });
+  const routeIntent = useRouteIntent();
+  const byPath = DESTINATIONS.find(d => isUnderDestination(pathname, d.path));
+  if (byPath) return byPath.path;
+  const intentPath = intentToPath(routeIntent);
+  return DESTINATIONS.find(d => isUnderDestination(intentPath, d.path))?.path ?? null;
+}
+
+const navItemClasses =
+  'text-textSecondary hover:text-text relative rounded-lg px-3 py-1.5 text-sm font-medium transition-colors';
+
+const moreItemClasses =
+  'text-textSecondary hover:text-text hover:bg-bgHover rounded-md px-3 py-2 text-left text-sm transition-colors';
+
+/** Secondary actions that don't earn a destination: batch toggle, upgrade shortcut, legal links. */
+function MoreMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+  const { showBanner } = useCookieConsent();
+  const footerLinks = getFooterLinks();
+  const closeMenu = () => setIsOpen(false);
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger
+        data-testid="nav-more"
+        aria-label="More"
+        className="text-textSecondary hover:text-text border-borderPrimary flex h-10 w-10 items-center justify-center rounded-full border transition-colors"
+      >
+        <Menu size={16} />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex w-60 flex-col gap-1 p-2">
+        <div className="flex items-center gap-1 px-1">
+          <ThemeToggle />
+          {BATCH_TX_ENABLED && <BatchTransactionsToggle />}
+        </div>
+        <Link
+          to={INTENT_PATHS[Intent.UPGRADE_INTENT]}
+          search={retainOnNavigate}
+          onClick={closeMenu}
+          data-testid="nav-more-upgrade"
+          className={moreItemClasses}
+        >
+          <Trans>Upgrade DAI/MKR</Trans>
+        </Link>
+        {footerLinks.map(link => {
+          const url = sanitizeUrl(link.url);
+          if (!url) return null;
+          return (
+            <ExternalLink key={url} href={url} showIcon={false} className={moreItemClasses}>
+              {link.name}
+            </ExternalLink>
+          );
+        })}
+        {POSTHOG_ENABLED && (
+          <button
+            data-testid="nav-more-cookie-settings"
+            onClick={() => {
+              closeMenu();
+              showBanner();
+            }}
+            className={moreItemClasses}
+          >
+            <Trans>Cookie settings</Trans>
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/** Final 4-destination top navigation. Mounted alongside the legacy HeaderNav until B4. */
+export function TopNav() {
+  const activePath = useActiveDestinationPath();
+  const chainId = useChainId();
+  const { showNewDot } = useNewIntentDots();
+  const { setIsSwitchingNetwork, setIsAutoSwitching } = useNetworkSwitch();
+
+  // Same semantics as the legacy nav: mainnet-only destinations carry the
+  // network switch in the href itself (cmd-click and copy-link included).
+  const searchForIntent = useCallback(
+    (targetIntent: Intent) => (prev: Record<string, string | undefined>) => {
+      const retained = retainOnNavigate(prev);
+      const override = getNetworkOverrideForIntent(targetIntent, chainId);
+      if (override) retained[QueryParams.Network] = override;
+      return retained;
+    },
+    [chainId]
+  );
+
+  // Modified clicks open a new tab; this tab doesn't navigate, so skip the
+  // switching feedback. No analytics here: nav events are pending sign-off (B1 ships none).
+  const handleNavClick = useCallback(
+    (targetIntent: Intent) => (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      if (getNetworkOverrideForIntent(targetIntent, chainId)) {
+        setIsSwitchingNetwork(true);
+        setIsAutoSwitching(true);
+      }
+    },
+    [chainId, setIsSwitchingNetwork, setIsAutoSwitching]
+  );
+
+  return (
+    <nav className="flex w-full items-center gap-3" data-testid="top-nav">
+      {/* mx-auto centers the pill group between the logo (left, in Layout) and the chip cluster. */}
+      <div className="mx-auto flex items-center gap-1">
+        {DESTINATIONS.map(destination => {
+          const isActive = activePath === destination.path;
+          return (
+            <Link
+              key={destination.path}
+              to={destination.path}
+              search={searchForIntent(destination.intents[0])}
+              onClick={handleNavClick(destination.intents[0])}
+              data-testid={navTestId(destination.path)}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(navItemClasses, isActive && 'bg-surface text-text')}
+            >
+              {destination.label}
+              {destination.intents.some(showNewDot) && (
+                <span
+                  data-testid={`${navTestId(destination.path)}-new-dot`}
+                  className="bg-textEmphasis absolute top-1 right-1 h-1.5 w-1.5 rounded-full"
+                />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+      {/* B1 chip = re-tagged connect button; the WalletChip/WalletDrawer re-skin is B2. */}
+      <div data-testid="wallet-chip">
+        <CustomConnectButton />
+      </div>
+      <MoreMenu />
+    </nav>
+  );
+}

--- a/apps/webapp/src/modules/app/shell/TopNav.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.tsx
@@ -14,7 +14,7 @@ import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { BatchTransactionsToggle } from '@/components/BatchTransactionsToggle';
 import { ThemeToggle } from '@/components/ThemeToggle';
-import { CustomConnectButton } from '@/modules/layout/components/CustomConnectButton';
+import { WalletChip } from './WalletChip';
 import { ExternalLink } from '@/modules/layout/components/ExternalLink';
 import { useCookieConsent } from '@/modules/analytics/context/CookieConsentContext';
 import { POSTHOG_ENABLED } from '@/modules/analytics/PostHogProvider';
@@ -198,10 +198,7 @@ export function TopNav() {
           );
         })}
       </div>
-      {/* B1 chip = re-tagged connect button; the WalletChip/WalletDrawer re-skin is B2. */}
-      <div data-testid="wallet-chip">
-        <CustomConnectButton />
-      </div>
+      <WalletChip />
       <MoreMenu />
     </nav>
   );

--- a/apps/webapp/src/modules/app/shell/WalletChip.test.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletChip.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  Outlet,
+  RouterProvider
+} from '@tanstack/react-router';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { WalletChip } from './WalletChip';
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+const mocks = vi.hoisted(() => ({
+  connection: { isConnected: false, address: undefined as string | undefined, connector: undefined },
+  connectedContext: {
+    isConnectedAndAcceptedTerms: false,
+    isAuthorized: true,
+    authData: undefined,
+    vpnData: undefined
+  },
+  ensName: undefined as string | undefined,
+  isSafeWallet: false,
+  openConnectModal: vi.fn(),
+  disconnect: vi.fn()
+}));
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useConnection: () => mocks.connection,
+    useDisconnect: () => ({ disconnect: mocks.disconnect }),
+    useEnsName: () => ({ data: mocks.ensName }),
+    useEnsAvatar: () => ({ data: undefined })
+  };
+});
+
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return { ...actual, useIsSafeWallet: () => mocks.isSafeWallet };
+});
+
+vi.mock('@/modules/ui/context/ConnectedContext', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/ui/context/ConnectedContext')>();
+  return { ...actual, useConnectedContext: () => mocks.connectedContext };
+});
+
+vi.mock('@/modules/ui/context/ConnectModalContext', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/ui/context/ConnectModalContext')>();
+  return { ...actual, useConnectModal: () => ({ openConnectModal: mocks.openConnectModal }) };
+});
+
+// Gate components are opaque to the chip: their behavior has its own coverage.
+vi.mock('@/modules/ui/components/TermsModal', () => ({
+  TermsModal: () => <div data-testid="terms-modal-stub" />
+}));
+
+vi.mock('@/modules/auth/components/UnauthorizedPage', () => ({
+  UnauthorizedPage: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="unauthorized-page-stub">{children}</div>
+  )
+}));
+
+vi.mock('@/modules/ui/components/Avatar', () => ({
+  CustomAvatar: () => <div data-testid="avatar-stub" />
+}));
+
+vi.mock('./WalletPreviewDrawer', () => ({
+  WalletPreviewDrawer: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="wallet-drawer-stub" data-open={String(isOpen)} />
+  )
+}));
+
+beforeEach(() => {
+  mocks.connection = { isConnected: false, address: undefined, connector: undefined };
+  mocks.connectedContext = {
+    isConnectedAndAcceptedTerms: false,
+    isAuthorized: true,
+    authData: undefined,
+    vpnData: undefined
+  };
+  mocks.ensName = undefined;
+  mocks.isSafeWallet = false;
+  mocks.openConnectModal.mockClear();
+  mocks.disconnect.mockClear();
+});
+
+function renderWalletChip() {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <WalletChip />
+        <Outlet />
+      </>
+    )
+  });
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ['/'] })
+  });
+
+  render(
+    <I18nWidgetProvider locale="en">
+      <RouterProvider router={router as never} />
+    </I18nWidgetProvider>
+  );
+  return router;
+}
+
+describe('WalletChip render ladder', () => {
+  it('renders the terms gate while terms are not accepted (the gate owns its connect trigger)', async () => {
+    renderWalletChip();
+
+    const chip = await screen.findByTestId('wallet-chip');
+    expect(chip.querySelector('[data-testid="terms-modal-stub"]')).toBeTruthy();
+  });
+
+  it('offers Connect Wallet once terms are accepted but the wallet is disconnected', async () => {
+    mocks.connectedContext.isConnectedAndAcceptedTerms = true;
+    renderWalletChip();
+
+    const chip = await screen.findByTestId('wallet-chip');
+    const connectButton = chip.querySelector('button');
+    expect(connectButton?.textContent).toMatch(/Connect Wallet/);
+
+    fireEvent.click(connectButton!);
+    expect(mocks.openConnectModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the truncated address when connected', async () => {
+    mocks.connectedContext.isConnectedAndAcceptedTerms = true;
+    mocks.connection = { isConnected: true, address: ADDRESS, connector: undefined };
+    renderWalletChip();
+
+    const chip = await screen.findByTestId('wallet-chip');
+    expect(chip.textContent).toContain('0x1234...5678');
+    expect(chip.querySelector('[data-testid="avatar-stub"]')).toBeTruthy();
+  });
+
+  it('prefers the ENS name and prefixes safe: for Safe wallets', async () => {
+    mocks.connectedContext.isConnectedAndAcceptedTerms = true;
+    mocks.connection = { isConnected: true, address: ADDRESS, connector: undefined };
+    mocks.ensName = 'bartoo.eth';
+    mocks.isSafeWallet = true;
+    renderWalletChip();
+
+    const chip = await screen.findByTestId('wallet-chip');
+    expect(chip.textContent).toContain('safe:bartoo.eth');
+  });
+
+  it('opens the wallet preview drawer when the connected chip is clicked', async () => {
+    mocks.connectedContext.isConnectedAndAcceptedTerms = true;
+    mocks.connection = { isConnected: true, address: ADDRESS, connector: undefined };
+    renderWalletChip();
+
+    const chip = await screen.findByTestId('wallet-chip');
+    expect(screen.getByTestId('wallet-drawer-stub').getAttribute('data-open')).toBe('false');
+
+    fireEvent.click(chip.querySelector('button')!);
+    expect(screen.getByTestId('wallet-drawer-stub').getAttribute('data-open')).toBe('true');
+  });
+
+  it('defers to the UnauthorizedPage gate when not authorized', async () => {
+    mocks.connectedContext.isAuthorized = false;
+    renderWalletChip();
+
+    const gate = await screen.findByTestId('unauthorized-page-stub');
+    expect(gate.querySelector('button')?.textContent).toMatch(/Connect Wallet/);
+  });
+});

--- a/apps/webapp/src/modules/app/shell/WalletChip.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletChip.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { t } from '@lingui/core/macro';
+import { ChevronDown } from 'lucide-react';
+import { useConnection, useDisconnect, useEnsAvatar, useEnsName } from 'wagmi';
+import { mainnet } from 'viem/chains';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/modules/layout/components/Typography';
+import { TermsModal } from '@/modules/ui/components/TermsModal';
+import { CustomAvatar } from '@/modules/ui/components/Avatar';
+import { useConnectModal } from '@/modules/ui/context/ConnectModalContext';
+import { useConnectedContext } from '@/modules/ui/context/ConnectedContext';
+import { UnauthorizedPage } from '@/modules/auth/components/UnauthorizedPage';
+import { useIsSafeWallet } from '@/hooks';
+import { WalletPreviewDrawer } from './WalletPreviewDrawer';
+
+const formatAddress = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+
+/** V2 wallet chip. Same 4-way ladder as CustomConnectButton (kept until B4), drawer instead of ConnectedModal. */
+export function WalletChip() {
+  const { openConnectModal } = useConnectModal();
+  const { isConnected, address } = useConnection();
+  const { disconnect } = useDisconnect();
+  const { data: ensName } = useEnsName({ address, chainId: mainnet.id });
+  const { data: ensAvatar } = useEnsAvatar({ name: ensName!, chainId: mainnet.id });
+  const isSafeWallet = useIsSafeWallet();
+  const [showDrawer, setShowDrawer] = useState(false);
+  const { isConnectedAndAcceptedTerms, isAuthorized, authData, vpnData } = useConnectedContext();
+
+  const connectButton = (
+    <Button variant="connect" onClick={openConnectModal}>
+      {t`Connect Wallet`}
+    </Button>
+  );
+
+  return (
+    <div data-testid="wallet-chip">
+      {!isAuthorized ? (
+        <UnauthorizedPage authData={authData} vpnData={vpnData}>
+          {connectButton}
+        </UnauthorizedPage>
+      ) : !isConnectedAndAcceptedTerms ? (
+        <TermsModal />
+      ) : !isConnected ? (
+        connectButton
+      ) : isConnected && !!address ? (
+        <>
+          <Button
+            variant="connect"
+            onClick={() => setShowDrawer(true)}
+            className="border-borderPrimary flex h-10 items-center gap-2 rounded-full border px-3"
+          >
+            <CustomAvatar address={address} size={24} />
+            <Text className="hidden sm:inline">{`${isSafeWallet ? 'safe:' : ''}${ensName || formatAddress(address)}`}</Text>
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+          <WalletPreviewDrawer
+            isOpen={showDrawer}
+            onOpenChange={setShowDrawer}
+            ensName={ensName}
+            ensAvatar={ensAvatar}
+            onDisconnect={() => {
+              disconnect();
+              setShowDrawer(false);
+            }}
+          />
+        </>
+      ) : (
+        connectButton
+      )}
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/app/shell/WalletDrawerTabs.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletDrawerTabs.tsx
@@ -1,0 +1,68 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Trans } from '@lingui/react/macro';
+import { BalancesHistory, ModuleCardVariant, ModulesBalances } from '@/widgets';
+import { getSupportedChainIds } from '@/data/wagmi/config/config.default';
+import { useChainId } from 'wagmi';
+import { useModuleUrls } from '@/modules/app/hooks/useModuleUrls';
+import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
+import { useGeoConfig } from '@/modules/geo-config';
+
+enum WalletDrawerTab {
+  ASSETS = 'assets',
+  ACTIVITY = 'activity'
+}
+
+/** Assets/Activity tabs. Same shared-widget wiring as ConnectedModalTabs (legacy, removed in B4). */
+export function WalletDrawerTabs() {
+  const chainId = useChainId();
+  const { onExternalLinkClicked } = useConfigContext();
+  const { isRegionRestricted } = useGeoConfig();
+
+  const { rewardsUrl, savingsUrlMap, stakeUrl, expertOverviewUrl, vaultsUrl, fixedYieldUrl } =
+    useModuleUrls();
+
+  return (
+    <Tabs defaultValue={WalletDrawerTab.ASSETS} className="flex min-h-0 flex-1 flex-col">
+      <TabsList className="mb-6 grid w-full grid-cols-2">
+        <TabsTrigger position="left" value={WalletDrawerTab.ASSETS} data-testid="wallet-drawer-tab-assets">
+          <Trans>Assets</Trans>
+        </TabsTrigger>
+        <TabsTrigger
+          position="right"
+          value={WalletDrawerTab.ACTIVITY}
+          data-testid="wallet-drawer-tab-activity"
+        >
+          <Trans>Activity</Trans>
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent
+        value={WalletDrawerTab.ASSETS}
+        className="scrollbar-thin-always min-h-0 flex-1 overflow-auto [scrollbar-gutter:auto]"
+      >
+        <ModulesBalances
+          variant={ModuleCardVariant.alt}
+          chainIds={getSupportedChainIds(chainId)}
+          rewardsCardUrl={rewardsUrl}
+          savingsCardUrlMap={savingsUrlMap}
+          stakeCardUrl={stakeUrl}
+          stusdsCardUrl={expertOverviewUrl}
+          vaultsCardUrl={vaultsUrl}
+          fixedYieldCardUrl={fixedYieldUrl}
+          hideRestrictedModules={isRegionRestricted}
+          onExternalLinkClicked={onExternalLinkClicked}
+        />
+      </TabsContent>
+      <TabsContent
+        value={WalletDrawerTab.ACTIVITY}
+        className="scrollbar-thin-always min-h-0 flex-1 overflow-auto [scrollbar-gutter:auto]"
+      >
+        <BalancesHistory
+          onExternalLinkClicked={onExternalLinkClicked}
+          showAllNetworks={true}
+          className="mt-0"
+          useInfiniteScroll={true}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.test.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.test.tsx
@@ -1,0 +1,219 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import {
+  AnyRouter,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider
+} from '@tanstack/react-router';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { getEtherscanLink } from '@/utils';
+import { WalletPreviewDrawer } from './WalletPreviewDrawer';
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+const mocks = vi.hoisted(() => ({
+  connection: {
+    isConnected: true,
+    address: '0x1234567890abcdef1234567890abcdef12345678' as string | undefined,
+    connector: undefined
+  },
+  chainId: 1,
+  isSafeWallet: false,
+  disconnect: vi.fn(),
+  openConnectModal: vi.fn()
+}));
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useConnection: () => mocks.connection,
+    useChainId: () => mocks.chainId
+  };
+});
+
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return { ...actual, useIsSafeWallet: () => mocks.isSafeWallet };
+});
+
+vi.mock('@/modules/ui/context/ConnectModalContext', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/ui/context/ConnectModalContext')>();
+  return { ...actual, useConnectModal: () => ({ openConnectModal: mocks.openConnectModal }) };
+});
+
+vi.mock('./NetworkSelector', () => ({
+  NetworkSelector: () => <div data-testid="wallet-drawer-network" />
+}));
+
+vi.mock('@/modules/config/hooks/useConfigContext', () => ({
+  useConfigContext: () => ({ onExternalLinkClicked: undefined })
+}));
+
+vi.mock('@/widgets/BalancesWidget/hooks/useSuppliedBalancesTotalUsd', () => ({
+  useSuppliedBalancesTotalUsd: () => ({ totalUsd: 4605.2, isLoading: false })
+}));
+
+// Tab contents are the shared balance widgets; their behavior has its own coverage.
+vi.mock('@/widgets', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/widgets')>();
+  return {
+    ...actual,
+    ModulesBalances: () => <div data-testid="modules-balances-stub" />,
+    BalancesHistory: () => <div data-testid="balances-history-stub" />
+  };
+});
+
+vi.mock('@/modules/app/hooks/useModuleUrls', () => ({
+  useModuleUrls: () => ({
+    rewardsUrl: '/rewards',
+    savingsUrlMap: { 1: '/savings' },
+    stakeUrl: '/stake',
+    expertOverviewUrl: '/stake-expert',
+    stusdsUrl: '/stake-expert/stusds',
+    vaultsUrl: '/vaults',
+    convertUrl: '/convert',
+    fixedYieldUrl: '/fixed'
+  })
+}));
+
+vi.mock('@/modules/geo-config', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/geo-config')>();
+  return { ...actual, useGeoConfig: () => ({ isRegionRestricted: false }) };
+});
+
+beforeEach(() => {
+  mocks.connection = { isConnected: true, address: ADDRESS, connector: undefined };
+  mocks.chainId = 1;
+  mocks.isSafeWallet = false;
+  mocks.disconnect.mockClear();
+});
+
+let lastRouter: AnyRouter | undefined;
+
+// Stateful host mirroring WalletChip's wiring: mounts closed, opened via the trigger.
+function DrawerHost({ ensName }: { ensName?: string | null }) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <button data-testid="open-drawer" onClick={() => setIsOpen(true)} />
+      <WalletPreviewDrawer
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        ensName={ensName}
+        onDisconnect={mocks.disconnect}
+      />
+    </>
+  );
+}
+
+function renderDrawer({ ensName }: { ensName?: string | null } = {}) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <DrawerHost ensName={ensName} />
+        <Outlet />
+      </>
+    )
+  });
+  const stubRoute = (path: string) =>
+    createRoute({ getParentRoute: () => rootRoute, path, component: () => null });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([stubRoute('/'), stubRoute('/savings')]),
+    history: createMemoryHistory({ initialEntries: ['/'] })
+  });
+  lastRouter = router;
+
+  render(
+    <I18nWidgetProvider locale="en">
+      <TooltipProvider>
+        <RouterProvider router={router as never} />
+      </TooltipProvider>
+    </I18nWidgetProvider>
+  );
+  return router;
+}
+
+async function openDrawer() {
+  fireEvent.click(await screen.findByTestId('open-drawer'));
+  return await screen.findByTestId('wallet-drawer');
+}
+
+describe('WalletPreviewDrawer', () => {
+  it('renders the V2 wallet-drawer surface when open', async () => {
+    renderDrawer();
+    expect(await openDrawer()).toBeTruthy();
+  });
+
+  it('shows ENS name, truncated address, copy control, explorer link and network selector', async () => {
+    renderDrawer({ ensName: 'bartoo.eth' });
+    const drawer = await openDrawer();
+
+    expect(drawer.textContent).toContain('bartoo.eth');
+    expect(drawer.textContent).toContain('0x12345...45678');
+    expect(drawer.querySelector('[data-testid="copy-to-clipboard"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="wallet-card-explorer"]')?.getAttribute('href')).toBe(
+      getEtherscanLink(1, ADDRESS, 'address')
+    );
+    expect(drawer.querySelector('[data-testid="wallet-drawer-network"]')).toBeTruthy();
+  });
+
+  it('shows the total supplied USD value', async () => {
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    expect(drawer.querySelector('[data-testid="wallet-drawer-total"]')?.textContent).toContain('4,605.2');
+  });
+
+  it('disconnects via the drawer action', async () => {
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    fireEvent.click(drawer.querySelector('[data-testid="wallet-drawer-disconnect"]')!);
+    expect(mocks.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the disconnect action for Safe wallets', async () => {
+    mocks.isSafeWallet = true;
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    expect(drawer.querySelector('[data-testid="wallet-drawer-disconnect"]')).toBeNull();
+  });
+
+  it('shows the Assets tab (shared balances component) by default and switches to Activity', async () => {
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    expect(drawer.querySelector('[data-testid="modules-balances-stub"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="balances-history-stub"]')).toBeNull();
+
+    // Radix tabs activate on mousedown, not click.
+    fireEvent.mouseDown(drawer.querySelector('[data-testid="wallet-drawer-tab-activity"]')!, {
+      button: 0
+    });
+
+    expect(drawer.querySelector('[data-testid="balances-history-stub"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="modules-balances-stub"]')).toBeNull();
+
+    fireEvent.mouseDown(drawer.querySelector('[data-testid="wallet-drawer-tab-assets"]')!, { button: 0 });
+    expect(drawer.querySelector('[data-testid="modules-balances-stub"]')).toBeTruthy();
+  });
+
+  it('closes when a navigation happens', async () => {
+    renderDrawer();
+    await openDrawer();
+
+    await act(async () => {
+      await lastRouter!.navigate({ to: '/savings' });
+    });
+
+    expect(screen.queryByTestId('wallet-drawer')).toBeNull();
+  });
+});

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { useRouterState } from '@tanstack/react-router';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { t } from '@lingui/core/macro';
+import { Button } from '@/components/ui/button';
+import { useIsSafeWallet } from '@/hooks';
+import { useConnectModal } from '@/modules/ui/context/ConnectModalContext';
+import { WalletPreviewHeader } from './WalletPreviewHeader';
+import { WalletDrawerTabs } from './WalletDrawerTabs';
+
+interface WalletPreviewDrawerProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  ensName?: string | null;
+  ensAvatar?: string | null;
+  onDisconnect: () => void;
+}
+
+/** V2 right slide-out wallet preview. Replaces ConnectedModal's Dialog for the V2 chip (legacy keeps its own until B4). */
+export function WalletPreviewDrawer({
+  isOpen,
+  onOpenChange,
+  ensName,
+  ensAvatar,
+  onDisconnect
+}: WalletPreviewDrawerProps) {
+  const locationHref = useRouterState({ select: s => s.location.href });
+  const { openConnectModal } = useConnectModal();
+  const isSafeWallet = useIsSafeWallet();
+
+  useEffect(() => {
+    // Same contract as ConnectedModal: any navigation closes the preview.
+    onOpenChange(false);
+  }, [locationHref, onOpenChange]);
+
+  const onSwitchAccountClick = () => {
+    onOpenChange(false);
+    openConnectModal();
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        data-testid="wallet-drawer"
+        aria-describedby={undefined}
+        className="bg-containerDark border-borderPrimary flex w-full flex-col gap-6 overflow-hidden border-l p-4 sm:max-w-[440px]"
+        onOpenAutoFocus={e => e.preventDefault()}
+        onCloseAutoFocus={e => e.preventDefault()}
+      >
+        <SheetTitle className="sr-only">{t`Account`}</SheetTitle>
+        <WalletPreviewHeader
+          ensName={ensName}
+          ensAvatar={ensAvatar}
+          onSwitchAccountClick={onSwitchAccountClick}
+        />
+        {!isSafeWallet && (
+          <Button
+            variant="primary"
+            size="large"
+            onClick={onDisconnect}
+            data-testid="wallet-drawer-disconnect"
+            className="text-md w-full px-6 leading-6"
+          >
+            {t`Disconnect wallet`}
+          </Button>
+        )}
+        <WalletDrawerTabs />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
@@ -1,0 +1,67 @@
+import { useChainId, useConnection } from 'wagmi';
+import { Trans } from '@lingui/react/macro';
+import { WalletCard } from '@/widgets';
+import { useSuppliedBalancesTotalUsd } from '@/widgets/BalancesWidget/hooks/useSuppliedBalancesTotalUsd';
+import { getSupportedChainIds } from '@/data/wagmi/config/config.default';
+import { WALLET_ICONS } from '@/lib/constants';
+import { formatNumber } from '@/utils';
+import { Text } from '@/modules/layout/components/Typography';
+import { WalletIcon } from '@/modules/ui/components/WalletIcon';
+import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
+import { Skeleton } from '@/components/ui/skeleton';
+import { NetworkSelector } from './NetworkSelector';
+
+interface WalletPreviewHeaderProps {
+  ensName?: string | null;
+  ensAvatar?: string | null;
+  onSwitchAccountClick: () => void;
+}
+
+/** Drawer header: identity row (avatar/ENS/addr + copy/explorer/switch) and the network control. */
+export function WalletPreviewHeader({ ensName, ensAvatar, onSwitchAccountClick }: WalletPreviewHeaderProps) {
+  const { onExternalLinkClicked } = useConfigContext();
+  const { connector } = useConnection();
+  const chainId = useChainId();
+  const { totalUsd, isLoading: totalLoading } = useSuppliedBalancesTotalUsd({
+    chainIds: getSupportedChainIds(chainId)
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <WalletCard
+        className="mb-0"
+        iconSize={40}
+        showEns={true}
+        ensName={ensName}
+        ensAvatar={ensAvatar}
+        showExplorerLink={true}
+        onSwitchAccountClick={onSwitchAccountClick}
+        onExternalLinkClicked={onExternalLinkClicked}
+        walletIcon={
+          connector && (
+            <WalletIcon
+              connector={connector}
+              iconUrl={connector.icon || WALLET_ICONS[connector.id as keyof typeof WALLET_ICONS]}
+              className="h-3.5 w-3.5"
+            />
+          )
+        }
+      />
+      <div className="flex items-end justify-between">
+        <div className="flex flex-col gap-1">
+          <Text variant="medium" className="text-textSecondary">
+            <Trans>Total supplied</Trans>
+          </Text>
+          {totalLoading || totalUsd === undefined ? (
+            <Skeleton className="h-8 w-28" />
+          ) : (
+            <Text data-testid="wallet-drawer-total" className="text-text text-2xl">
+              ${formatNumber(totalUsd, { maxDecimals: 2 })}
+            </Text>
+          )}
+        </div>
+        <NetworkSelector />
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -1,0 +1,16 @@
+import { Trans } from '@lingui/react/macro';
+import { Heading, Text } from '@/modules/layout/components/Typography';
+
+// Placeholder destination screen; the real Earn marketplace lands with Track C.
+export function EarnPage() {
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <Heading>
+        <Trans>Earn</Trans>
+      </Heading>
+      <Text variant="medium" className="text-textSecondary">
+        <Trans>The Earn experience is coming soon.</Trans>
+      </Text>
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/layout/components/Header.tsx
+++ b/apps/webapp/src/modules/layout/components/Header.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { AppLink } from '@/lib/navigation';
 import { HeaderNav, HeaderNavDrawer } from './HeaderNav';
 import { HEADER_HEIGHT } from './constants';
-import { defaultConfig } from '../../config/default-config';
 import { CustomConnectButton } from './CustomConnectButton';
 import { MockConnectButton } from './MockConnectButton';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
@@ -77,11 +75,8 @@ export function Header(): React.ReactElement {
       className={`flex w-full items-center justify-center px-3 py-2 min-h-[${HEADER_HEIGHT}px] max-h-[${HEADER_HEIGHT}px] md:mb-2`}
     >
       <div className="grid w-full grid-cols-[1fr_auto_1fr] items-center gap-4 pr-0 pl-3 sm:px-5">
-        <AppLink to="/" title="Home page" className="justify-self-start">
-          <div className="min-w-[96px]">
-            <img src={defaultConfig.logo} alt="logo" width={96} />
-          </div>
-        </AppLink>
+        {/* Logo moved to the V2 main header (Layout); spacer keeps the legacy nav centered until B4. */}
+        <div aria-hidden className="min-w-[96px] justify-self-start" />
 
         {/* Center module navigation (desktop) */}
         <HeaderNav />

--- a/apps/webapp/src/modules/layout/components/Layout.tsx
+++ b/apps/webapp/src/modules/layout/components/Layout.tsx
@@ -13,6 +13,9 @@ import { useBreakpointIndex, BP } from '@/modules/ui/hooks/useBreakpointIndex';
 import { IS_DEVELOPMENT_ENV, IS_STAGING_ENV } from '@/lib/constants';
 import { Banner } from '@/components/extensible';
 import { useWalletAnalytics } from '@/modules/analytics/hooks/useWalletAnalytics';
+import { TopNav } from '@/modules/app/shell/TopNav';
+import { AppLink } from '@/lib/navigation';
+import { defaultConfig } from '../../config/default-config';
 
 export function Layout({
   children,
@@ -44,6 +47,16 @@ export function Layout({
           'bg-app-background flex max-h-svh min-h-svh max-w-full items-center overflow-auto bg-cover bg-center bg-no-repeat md:max-h-screen md:min-h-screen md:p-4 md:pb-2'
         }
       >
+        {/* V2 main header. The legacy header coexists below until B4 retires it. */}
+        <ErrorBoundary>
+          <div className="flex w-full items-center gap-4 px-3 py-2 sm:px-10 md:mb-1">
+            <AppLink to="/" title="Home page" className="min-w-[96px]">
+              <img src={defaultConfig.logo} alt="logo" width={96} />
+            </AppLink>
+            <TopNav />
+          </div>
+        </ErrorBoundary>
+
         <ErrorBoundary>
           <Header />
         </ErrorBoundary>

--- a/apps/webapp/src/modules/portfolio/components/PortfolioPage.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioPage.tsx
@@ -1,0 +1,16 @@
+import { Trans } from '@lingui/react/macro';
+import { Heading, Text } from '@/modules/layout/components/Typography';
+
+// Placeholder destination screen; the real Portfolio page lands with Track C.
+export function PortfolioPage() {
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <Heading>
+        <Trans>Portfolio</Trans>
+      </Heading>
+      <Text variant="medium" className="text-textSecondary">
+        <Trans>The Portfolio experience is coming soon.</Trans>
+      </Text>
+    </div>
+  );
+}

--- a/apps/webapp/src/routeTree.gen.ts
+++ b/apps/webapp/src/routeTree.gen.ts
@@ -18,8 +18,10 @@ import { Route as ShellVaultsRouteImport } from './routes/_shell.vaults'
 import { Route as ShellStakeRouteImport } from './routes/_shell.stake'
 import { Route as ShellSavingsRouteImport } from './routes/_shell.savings'
 import { Route as ShellRewardsRouteImport } from './routes/_shell.rewards'
+import { Route as ShellPortfolioRouteImport } from './routes/_shell.portfolio'
 import { Route as ShellFixedRouteImport } from './routes/_shell.fixed'
 import { Route as ShellExpertRouteImport } from './routes/_shell.expert'
+import { Route as ShellEarnRouteImport } from './routes/_shell.earn'
 import { Route as ShellConvertRouteImport } from './routes/_shell.convert'
 import { Route as ShellRewardsRewardContractRouteImport } from './routes/_shell.rewards.$rewardContract'
 import { Route as ShellExpertStusdsRouteImport } from './routes/_shell.expert.stusds'
@@ -74,6 +76,11 @@ const ShellRewardsRoute = ShellRewardsRouteImport.update({
   path: '/rewards',
   getParentRoute: () => ShellRoute,
 } as any)
+const ShellPortfolioRoute = ShellPortfolioRouteImport.update({
+  id: '/portfolio',
+  path: '/portfolio',
+  getParentRoute: () => ShellRoute,
+} as any)
 const ShellFixedRoute = ShellFixedRouteImport.update({
   id: '/fixed',
   path: '/fixed',
@@ -82,6 +89,11 @@ const ShellFixedRoute = ShellFixedRouteImport.update({
 const ShellExpertRoute = ShellExpertRouteImport.update({
   id: '/expert',
   path: '/expert',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellEarnRoute = ShellEarnRouteImport.update({
+  id: '/earn',
+  path: '/earn',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellConvertRoute = ShellConvertRouteImport.update({
@@ -134,8 +146,10 @@ export interface FileRoutesByFullPath {
   '/dev': typeof DevRoute
   '/seal-engine': typeof SealEngineRoute
   '/convert': typeof ShellConvertRouteWithChildren
+  '/earn': typeof ShellEarnRoute
   '/expert': typeof ShellExpertRouteWithChildren
   '/fixed': typeof ShellFixedRouteWithChildren
+  '/portfolio': typeof ShellPortfolioRoute
   '/rewards': typeof ShellRewardsRouteWithChildren
   '/savings': typeof ShellSavingsRoute
   '/stake': typeof ShellStakeRoute
@@ -153,8 +167,10 @@ export interface FileRoutesByTo {
   '/dev': typeof DevRoute
   '/seal-engine': typeof SealEngineRoute
   '/convert': typeof ShellConvertRouteWithChildren
+  '/earn': typeof ShellEarnRoute
   '/expert': typeof ShellExpertRouteWithChildren
   '/fixed': typeof ShellFixedRouteWithChildren
+  '/portfolio': typeof ShellPortfolioRoute
   '/rewards': typeof ShellRewardsRouteWithChildren
   '/savings': typeof ShellSavingsRoute
   '/stake': typeof ShellStakeRoute
@@ -175,8 +191,10 @@ export interface FileRoutesById {
   '/dev': typeof DevRoute
   '/seal-engine': typeof SealEngineRoute
   '/_shell/convert': typeof ShellConvertRouteWithChildren
+  '/_shell/earn': typeof ShellEarnRoute
   '/_shell/expert': typeof ShellExpertRouteWithChildren
   '/_shell/fixed': typeof ShellFixedRouteWithChildren
+  '/_shell/portfolio': typeof ShellPortfolioRoute
   '/_shell/rewards': typeof ShellRewardsRouteWithChildren
   '/_shell/savings': typeof ShellSavingsRoute
   '/_shell/stake': typeof ShellStakeRoute
@@ -198,8 +216,10 @@ export interface FileRouteTypes {
     | '/dev'
     | '/seal-engine'
     | '/convert'
+    | '/earn'
     | '/expert'
     | '/fixed'
+    | '/portfolio'
     | '/rewards'
     | '/savings'
     | '/stake'
@@ -217,8 +237,10 @@ export interface FileRouteTypes {
     | '/dev'
     | '/seal-engine'
     | '/convert'
+    | '/earn'
     | '/expert'
     | '/fixed'
+    | '/portfolio'
     | '/rewards'
     | '/savings'
     | '/stake'
@@ -238,8 +260,10 @@ export interface FileRouteTypes {
     | '/dev'
     | '/seal-engine'
     | '/_shell/convert'
+    | '/_shell/earn'
     | '/_shell/expert'
     | '/_shell/fixed'
+    | '/_shell/portfolio'
     | '/_shell/rewards'
     | '/_shell/savings'
     | '/_shell/stake'
@@ -326,6 +350,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellRewardsRouteImport
       parentRoute: typeof ShellRoute
     }
+    '/_shell/portfolio': {
+      id: '/_shell/portfolio'
+      path: '/portfolio'
+      fullPath: '/portfolio'
+      preLoaderRoute: typeof ShellPortfolioRouteImport
+      parentRoute: typeof ShellRoute
+    }
     '/_shell/fixed': {
       id: '/_shell/fixed'
       path: '/fixed'
@@ -338,6 +369,13 @@ declare module '@tanstack/react-router' {
       path: '/expert'
       fullPath: '/expert'
       preLoaderRoute: typeof ShellExpertRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/earn': {
+      id: '/_shell/earn'
+      path: '/earn'
+      fullPath: '/earn'
+      preLoaderRoute: typeof ShellEarnRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/convert': {
@@ -465,8 +503,10 @@ const ShellVaultsRouteWithChildren = ShellVaultsRoute._addFileChildren(
 
 interface ShellRouteChildren {
   ShellConvertRoute: typeof ShellConvertRouteWithChildren
+  ShellEarnRoute: typeof ShellEarnRoute
   ShellExpertRoute: typeof ShellExpertRouteWithChildren
   ShellFixedRoute: typeof ShellFixedRouteWithChildren
+  ShellPortfolioRoute: typeof ShellPortfolioRoute
   ShellRewardsRoute: typeof ShellRewardsRouteWithChildren
   ShellSavingsRoute: typeof ShellSavingsRoute
   ShellStakeRoute: typeof ShellStakeRoute
@@ -476,8 +516,10 @@ interface ShellRouteChildren {
 
 const ShellRouteChildren: ShellRouteChildren = {
   ShellConvertRoute: ShellConvertRouteWithChildren,
+  ShellEarnRoute: ShellEarnRoute,
   ShellExpertRoute: ShellExpertRouteWithChildren,
   ShellFixedRoute: ShellFixedRouteWithChildren,
+  ShellPortfolioRoute: ShellPortfolioRoute,
   ShellRewardsRoute: ShellRewardsRouteWithChildren,
   ShellSavingsRoute: ShellSavingsRoute,
   ShellStakeRoute: ShellStakeRoute,

--- a/apps/webapp/src/routes/_shell.earn.tsx
+++ b/apps/webapp/src/routes/_shell.earn.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { EarnPage } from '@/modules/earn/components/EarnPage';
+
+// No staticData.intent: Earn is a destination, not a module (no Intent maps to it).
+export const Route = createFileRoute('/_shell/earn')({
+  component: EarnPage
+});

--- a/apps/webapp/src/routes/_shell.portfolio.tsx
+++ b/apps/webapp/src/routes/_shell.portfolio.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { PortfolioPage } from '@/modules/portfolio/components/PortfolioPage';
+import { Intent } from '@/lib/enums';
+
+export const Route = createFileRoute('/_shell/portfolio')({
+  component: PortfolioPage,
+  staticData: { intent: Intent.BALANCES_INTENT }
+});

--- a/apps/webapp/src/routes/destinations.test.ts
+++ b/apps/webapp/src/routes/destinations.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryHistory, createRouter } from '@tanstack/react-router';
+import { routeTree } from '@/routeTree.gen';
+import { Intent } from '@/lib/enums';
+import { ROUTES } from '@/lib/routes';
+
+// Resolves a path against the real route tree without rendering, so a missing
+// destination route fails here instead of 404ing on a preview deploy.
+async function matchedRouteIds(path: string): Promise<string[]> {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] })
+  });
+  await router.load();
+  return router.state.matches.map(match => match.routeId as string);
+}
+
+describe('target-IA destination routes', () => {
+  it('boots /portfolio as a shell route', async () => {
+    expect(await matchedRouteIds(ROUTES.PORTFOLIO)).toContain('/_shell/portfolio');
+  });
+
+  it('boots /earn as a shell route', async () => {
+    expect(await matchedRouteIds(ROUTES.EARN)).toContain('/_shell/earn');
+  });
+
+  it('declares the Balances intent on /portfolio for shell orchestration', async () => {
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: [ROUTES.PORTFOLIO] })
+    });
+    await router.load();
+    const match = router.state.matches.find(m => (m.routeId as string) === '/_shell/portfolio');
+    expect(match?.staticData?.intent).toBe(Intent.BALANCES_INTENT);
+  });
+});

--- a/apps/webapp/src/test/setup.ts
+++ b/apps/webapp/src/test/setup.ts
@@ -19,6 +19,21 @@ vi.mock('wagmi/connectors', async importOriginal => {
   };
 });
 
+// posthog-js self-initializes at module import (PostHogProvider.tsx module scope)
+// whenever the local .env enables it, so any test that transitively imports the
+// analytics module fires real telemetry fetches that happy-dom aborts at window
+// teardown — the same unhandled-rejection failure mode as walletConnect above.
+vi.mock('posthog-js', () => ({
+  default: {
+    init: vi.fn(),
+    capture: vi.fn(),
+    register: vi.fn(),
+    reset: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    set_config: vi.fn()
+  }
+}));
+
 vi.mock('@sentry/react', async () => {
   const React = await import('react');
   const withScope = vi.fn(

--- a/apps/webapp/src/widgets/BalancesWidget/components/ExpertBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/ExpertBalanceCard.tsx
@@ -71,6 +71,7 @@ export const ExpertBalanceCard = ({
       icon={expertIcon}
       url={url}
       logoName="expert"
+      apyBadge={stUsdsRate > 0 ? t`Rate: ${stUsdsRate.toFixed(2)}%` : undefined}
       content={
         loading || isBalanceLoading ? (
           <Skeleton className="w-32" />

--- a/apps/webapp/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/FixedYieldBalanceCard.tsx
@@ -143,6 +143,13 @@ export const FixedYieldBalanceCard = ({
       icon={fixedYieldIcon}
       url={url}
       logoName="fixedYield"
+      apyBadge={
+        maxRate > 0
+          ? activeMarketsCount === 1
+            ? t`Rate: ${formatDecimalPercentage(maxRate)}`
+            : t`Rates up to: ${formatDecimalPercentage(maxRate)}`
+          : undefined
+      }
       content={isBalanceLoading ? <Skeleton className="w-32" /> : <Text>{formatBigInt(total)}</Text>}
     />
   );

--- a/apps/webapp/src/widgets/BalancesWidget/components/RewardsBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/RewardsBalanceCard.tsx
@@ -6,13 +6,7 @@ import {
   useHighestRateFromChartData,
   useRewardContractsToClaim
 } from '@/hooks';
-import {
-  formatBigInt,
-  formatDecimalPercentage,
-  formatNumber,
-  isMainnetId,
-  chainId
-} from '@/utils';
+import { formatBigInt, formatDecimalPercentage, formatNumber, isMainnetId, chainId } from '@/utils';
 import { Text } from '@/widgets/shared/components/ui/Typography';
 import { t } from '@lingui/core/macro';
 import { InteractiveStatsCard } from '@/widgets/shared/components/ui/card/InteractiveStatsCard';
@@ -143,6 +137,11 @@ export const RewardsBalanceCard = ({
       icon={<img src="/images/rewards_icon_large.svg" alt="Rewards" className="h-full w-full" />}
       url={url}
       logoName="rewards"
+      apyBadge={
+        mostRecentRateNumber && mostRecentRateNumber > 0
+          ? t`Rates up to: ${formatDecimalPercentage(mostRecentRateNumber)}`
+          : undefined
+      }
       content={
         loading ? (
           <Skeleton className="w-32" />

--- a/apps/webapp/src/widgets/BalancesWidget/components/SavingsBalanceCard.test.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/SavingsBalanceCard.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider
+} from '@tanstack/react-router';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { ModuleCardVariant } from './ModulesBalances';
+import { SavingsBalanceCard } from './SavingsBalanceCard';
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return { ...actual, useChainId: () => 1 };
+});
+
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    useOverallSkyData: () => ({
+      data: { skySavingsRatecRate: '0.045' },
+      isLoading: false
+    }),
+    usePrices: () => ({ data: { USDS: { price: '1' } }, isLoading: false })
+  };
+});
+
+function renderCard() {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <SavingsBalanceCard
+        urlMap={{ 1: '/savings' }}
+        savingsBalances={[{ chainId: 1, balance: 100n * 10n ** 18n }]}
+        loading={false}
+        variant={ModuleCardVariant.alt}
+      />
+    )
+  });
+  const stubRoute = (path: string) =>
+    createRoute({ getParentRoute: () => rootRoute, path, component: () => null });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([stubRoute('/'), stubRoute('/savings')]),
+    history: createMemoryHistory({ initialEntries: ['/'] })
+  });
+
+  render(
+    <I18nWidgetProvider locale="en">
+      <RouterProvider router={router as never} />
+    </I18nWidgetProvider>
+  );
+}
+
+describe('SavingsBalanceCard (alt variant)', () => {
+  it('surfaces the savings rate as an APY badge and links Start earning to the module', async () => {
+    renderCard();
+
+    const badge = await screen.findByTestId('asset-apy-badge');
+    expect(badge.textContent).toContain('4.50%');
+    expect(screen.getByTestId('start-earning-cta').getAttribute('href')).toBe('/savings');
+  });
+});

--- a/apps/webapp/src/widgets/BalancesWidget/components/SavingsBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/SavingsBalanceCard.tsx
@@ -51,7 +51,7 @@ export const SavingsBalanceCard = ({
             {urlMap[chainId] && (
               <ArrowRight
                 size={16}
-                className="opacity-0 transition-opacity group-hover/interactive-card:opacity-100 group-hover/header-link:opacity-100"
+                className="opacity-0 transition-opacity group-hover/header-link:opacity-100 group-hover/interactive-card:opacity-100"
               />
             )}
           </div>
@@ -86,6 +86,7 @@ export const SavingsBalanceCard = ({
       url={urlMap[chainId]}
       logoName="savings"
       noChain={true}
+      apyBadge={skySavingsRate > 0 ? t`Rate: ${formatDecimalPercentage(skySavingsRate)}` : undefined}
       content={
         loading ? (
           <Skeleton className="w-32" />

--- a/apps/webapp/src/widgets/BalancesWidget/components/StakeBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/StakeBalanceCard.tsx
@@ -6,13 +6,7 @@ import {
   useAllStakeUrnAddresses,
   useRewardContractsToClaim
 } from '@/hooks';
-import {
-  formatBigInt,
-  formatDecimalPercentage,
-  formatNumber,
-  isMainnetId,
-  chainId
-} from '@/utils';
+import { formatBigInt, formatDecimalPercentage, formatNumber, isMainnetId, chainId } from '@/utils';
 import { Text } from '@/widgets/shared/components/ui/Typography';
 import { t } from '@lingui/core/macro';
 import { InteractiveStatsCard } from '@/widgets/shared/components/ui/card/InteractiveStatsCard';
@@ -136,6 +130,13 @@ export const StakeBalanceCard = ({
       }
       url={url}
       logoName="staking"
+      apyBadge={
+        parseFloat(highestRateData?.rate || '0') > 0
+          ? hasMultipleRates
+            ? t`Rates up to: ${formatDecimalPercentage(parseFloat(highestRateData?.rate || '0'))}`
+            : t`Rate: ${formatDecimalPercentage(parseFloat(highestRateData?.rate || '0'))}`
+          : undefined
+      }
       content={
         loading ? (
           <Skeleton className="w-32" />

--- a/apps/webapp/src/widgets/BalancesWidget/components/VaultsBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/VaultsBalanceCard.tsx
@@ -278,6 +278,13 @@ export const VaultsBalanceCard = ({
       icon={vaultsIcon}
       url={url}
       logoName="vaults"
+      apyBadge={
+        weightedAverageRate > 0
+          ? t`Rate: ${(weightedAverageRate * 100).toFixed(2)}%`
+          : maxRate > 0
+            ? t`Rates up to: ${(maxRate * 100).toFixed(2)}%`
+            : undefined
+      }
       content={isBalanceLoading ? <Skeleton className="w-32" /> : <Text>{formatBigInt(morphoSupplied)}</Text>}
     />
   );

--- a/apps/webapp/src/widgets/BalancesWidget/components/WalletCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/WalletCard.tsx
@@ -12,7 +12,13 @@ const Jazzicon =
 import { CopyToClipboard } from '@/widgets/shared/components/ui/CopyToClipboard';
 import { ExternalLink } from '@/widgets/shared/components/ExternalLink';
 import { useChainId } from 'wagmi';
-import { isBaseChainId, isArbitrumChainId, isOptimismChainId, isUnichainChainId } from '@/utils';
+import {
+  getEtherscanLink,
+  isBaseChainId,
+  isArbitrumChainId,
+  isOptimismChainId,
+  isUnichainChainId
+} from '@/utils';
 import { useIsSafeWallet } from '@/hooks';
 import { cn } from '@/widgets/lib/utils';
 import { SwitchAccountButton } from './SwitchAccountButton';
@@ -25,7 +31,8 @@ export const WalletCard = ({
   walletIcon,
   className,
   onExternalLinkClicked,
-  onSwitchAccountClick
+  onSwitchAccountClick,
+  showExplorerLink = false
 }: {
   iconSize?: number;
   showEns?: boolean;
@@ -35,6 +42,7 @@ export const WalletCard = ({
   className?: string;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   onSwitchAccountClick?: () => void;
+  showExplorerLink?: boolean;
 }): React.ReactElement => {
   const chainId = useChainId();
   const { address } = useConnection();
@@ -85,6 +93,15 @@ export const WalletCard = ({
             <SwitchAccountButton onSwitchAccountClick={onSwitchAccountClick} />
           )}
           <CopyToClipboard text={address || ''} />
+          {showExplorerLink && address && (
+            <ExternalLink
+              href={getEtherscanLink(chainId, address, 'address')}
+              iconSize={16}
+              className="text-textSecondary hover:text-text"
+              onExternalLinkClicked={onExternalLinkClicked}
+              dataTestId="wallet-card-explorer"
+            />
+          )}
         </div>
       </div>
       {isBaseChain && (

--- a/apps/webapp/src/widgets/BalancesWidget/hooks/useSuppliedBalancesTotalUsd.test.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/hooks/useSuppliedBalancesTotalUsd.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSuppliedBalancesTotalUsd } from './useSuppliedBalancesTotalUsd';
+
+const mocks = vi.hoisted(() => {
+  const ether = (n: number) => BigInt(n) * 10n ** 18n;
+  return {
+    ether,
+    rewardsBalance: { data: ether(100), isLoading: false, error: null },
+    staked: { data: ether(50), isLoading: false, error: null },
+    stUsds: { data: { userSuppliedUsds: ether(10) }, isLoading: false, error: null },
+    morpho: { data: { total: ether(20) }, isLoading: false, error: null },
+    pendle: { data: { total: ether(5), totalUsd: 5 }, isLoading: false, error: null },
+    savings: { data: { 1: ether(200), 8453: ether(100) }, isLoading: false, error: null },
+    prices: {
+      data: { USDS: { price: '1' }, SKY: { price: '0.1' } },
+      isLoading: false
+    }
+  };
+});
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useChainId: () => 1,
+    useConnection: () => ({ address: '0x1234567890abcdef1234567890abcdef12345678' })
+  };
+});
+
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    useAvailableTokenRewardContracts: () => [
+      {
+        supplyToken: actual.TOKENS.usds,
+        rewardToken: actual.TOKENS.sky,
+        contractAddress: '0x0000000000000000000000000000000000000001'
+      },
+      {
+        supplyToken: actual.TOKENS.usds,
+        rewardToken: actual.TOKENS.cle,
+        contractAddress: '0x0000000000000000000000000000000000000002'
+      },
+      {
+        supplyToken: actual.TOKENS.usds,
+        rewardToken: actual.TOKENS.spk,
+        contractAddress: '0x0000000000000000000000000000000000000003'
+      }
+    ],
+    useRewardsSuppliedBalance: () => mocks.rewardsBalance,
+    useTotalUserStaked: () => mocks.staked,
+    useStUsdsData: () => mocks.stUsds,
+    useAllMorphoVaultsUserAssets: () => mocks.morpho,
+    useAllPendleUserAssets: () => mocks.pendle,
+    useMultiChainSavingsBalances: () => mocks.savings,
+    usePrices: () => mocks.prices
+  };
+});
+
+beforeEach(() => {
+  mocks.prices = { data: { USDS: { price: '1' }, SKY: { price: '0.1' } }, isLoading: false };
+  mocks.staked = { data: mocks.ether(50), isLoading: false, error: null };
+});
+
+describe('useSuppliedBalancesTotalUsd', () => {
+  it('sums every supplied module to a USD total', () => {
+    const { result } = renderHook(() => useSuppliedBalancesTotalUsd({ chainIds: [1, 8453] }));
+
+    // rewards 3x100 USDS + savings 300 USDS + staked 50 SKY@0.1 + morpho 20 USDS + pendle $5 + stUSDS 10 USDS
+    expect(result.current.totalUsd).toBe(300 + 300 + 5 + 20 + 5 + 10);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports loading (no total yet) while any balance is still loading', () => {
+    mocks.staked = { data: undefined as unknown as bigint, isLoading: true, error: null };
+    const { result } = renderHook(() => useSuppliedBalancesTotalUsd({ chainIds: [1, 8453] }));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.totalUsd).toBeUndefined();
+  });
+});

--- a/apps/webapp/src/widgets/BalancesWidget/hooks/useSuppliedBalancesTotalUsd.ts
+++ b/apps/webapp/src/widgets/BalancesWidget/hooks/useSuppliedBalancesTotalUsd.ts
@@ -1,0 +1,86 @@
+import { useChainId, useConnection } from 'wagmi';
+import {
+  TOKENS,
+  useAvailableTokenRewardContracts,
+  useRewardsSuppliedBalance,
+  useTotalUserStaked,
+  useStUsdsData,
+  useAllMorphoVaultsUserAssets,
+  useAllPendleUserAssets,
+  useMultiChainSavingsBalances,
+  usePrices
+} from '@/hooks';
+import { chainId as chainIdConstants, isTestnetId } from '@/utils';
+
+const bigintToUsd = (balance: bigint, priceStr: string) => (Number(balance) / 1e18) * parseFloat(priceStr);
+
+/**
+ * All-networks USD total of the user's supplied funds. Mirrors ModulesBalances'
+ * per-module valuation (errored reads count as 0, like its hide logic); the
+ * underlying queries are shared, so mounting both costs no extra requests.
+ * Superseded by the Earn marketplace aggregator when C1 lands.
+ */
+export function useSuppliedBalancesTotalUsd({ chainIds }: { chainIds?: number[] } = {}) {
+  const { address } = useConnection();
+  const currentChainId = useChainId();
+  const mainnetChainId = isTestnetId(currentChainId) ? chainIdConstants.tenderly : chainIdConstants.mainnet;
+  const rewardContracts = useAvailableTokenRewardContracts(mainnetChainId);
+
+  const findContract = (rewardSymbol: string) =>
+    rewardContracts.find(
+      f => f.supplyToken.symbol === TOKENS.usds.symbol && f.rewardToken.symbol === rewardSymbol
+    );
+
+  const { data: usdsSkySupplied, isLoading: usdsSkyLoading } = useRewardsSuppliedBalance({
+    chainId: mainnetChainId,
+    address,
+    contractAddress: findContract(TOKENS.sky.symbol)?.contractAddress as `0x${string}`
+  });
+  const { data: usdsCleSupplied, isLoading: usdsCleLoading } = useRewardsSuppliedBalance({
+    chainId: mainnetChainId,
+    address,
+    contractAddress: findContract(TOKENS.cle.symbol)?.contractAddress as `0x${string}`
+  });
+  const { data: usdsSpkSupplied, isLoading: usdsSpkLoading } = useRewardsSuppliedBalance({
+    chainId: mainnetChainId,
+    address,
+    contractAddress: findContract(TOKENS.spk.symbol)?.contractAddress as `0x${string}`
+  });
+  const { data: totalUserStaked, isLoading: stakeLoading } = useTotalUserStaked();
+  const { data: stUsdsData, isLoading: stUsdsLoading } = useStUsdsData();
+  const { data: morphoAssets, isLoading: morphoLoading } = useAllMorphoVaultsUserAssets();
+  const { data: pendleAssets, isLoading: pendleLoading } = useAllPendleUserAssets();
+  const { data: savingsBalances, isLoading: savingsLoading } = useMultiChainSavingsBalances({ chainIds });
+  const { data: pricesData, isLoading: pricesLoading } = usePrices();
+
+  const isLoading =
+    usdsSkyLoading ||
+    usdsCleLoading ||
+    usdsSpkLoading ||
+    stakeLoading ||
+    stUsdsLoading ||
+    morphoLoading ||
+    pendleLoading ||
+    savingsLoading ||
+    pricesLoading;
+
+  if (isLoading || !pricesData) {
+    return { totalUsd: undefined, isLoading: true };
+  }
+
+  const totalRewardsSupplied = (usdsSkySupplied ?? 0n) + (usdsCleSupplied ?? 0n) + (usdsSpkSupplied ?? 0n);
+  const totalSavings = Object.values(savingsBalances ?? {}).reduce((acc, balance) => acc + balance, 0n);
+
+  const usdsPrice = pricesData.USDS?.price ?? '0';
+  const skyPrice = pricesData.SKY?.price ?? '0';
+
+  const totalUsd =
+    bigintToUsd(totalRewardsSupplied, usdsPrice) +
+    bigintToUsd(totalSavings, usdsPrice) +
+    bigintToUsd(totalUserStaked ?? 0n, skyPrice) +
+    bigintToUsd(morphoAssets.total, usdsPrice) +
+    pendleAssets.totalUsd +
+    bigintToUsd(stUsdsData?.userSuppliedUsds ?? 0n, usdsPrice);
+
+  return { totalUsd, isLoading: false };
+}

--- a/apps/webapp/src/widgets/shared/components/ExternalLink.tsx
+++ b/apps/webapp/src/widgets/shared/components/ExternalLink.tsx
@@ -10,7 +10,8 @@ export function ExternalLink({
   className,
   wrapperClassName,
   inline,
-  onExternalLinkClicked
+  onExternalLinkClicked,
+  dataTestId
 }: {
   href: string;
   children?: React.ReactNode;
@@ -20,6 +21,7 @@ export function ExternalLink({
   wrapperClassName?: string;
   inline?: boolean;
   onExternalLinkClicked?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+  dataTestId?: string;
 }): React.ReactElement {
   const content = inline ? (
     <span className={cn(wrapperClassName)}>
@@ -46,6 +48,7 @@ export function ExternalLink({
       rel="noreferrer"
       className={cn('text-text inline-flex items-center', className)}
       onClick={handleClick}
+      data-testid={dataTestId}
     >
       {content}
     </a>

--- a/apps/webapp/src/widgets/shared/components/ui/CopyToClipboard.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/CopyToClipboard.tsx
@@ -19,6 +19,7 @@ export function CopyToClipboard({ text }: { text: string }) {
     <Tooltip open={hasCopied}>
       <TooltipTrigger asChild>
         <motion.div
+          data-testid="copy-to-clipboard"
           whileTap={{ scale: 0.8 }}
           initial={AnimationLabels.initial}
           animate={AnimationLabels.animate}

--- a/apps/webapp/src/widgets/shared/components/ui/card/InteractiveStatsCardAlt.test.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/card/InteractiveStatsCardAlt.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider
+} from '@tanstack/react-router';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { Text } from '@/widgets/shared/components/ui/Typography';
+import { InteractiveStatsCardAlt } from './InteractiveStatsCardAlt';
+
+function renderCard(props: Partial<React.ComponentProps<typeof InteractiveStatsCardAlt>> = {}) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <InteractiveStatsCardAlt
+        title="Supplied to Savings"
+        logoName="savings"
+        icon={<span />}
+        content={<Text>100 USDS</Text>}
+        {...props}
+      />
+    )
+  });
+  const stubRoute = (path: string) =>
+    createRoute({ getParentRoute: () => rootRoute, path, component: () => null });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([stubRoute('/'), stubRoute('/savings')]),
+    history: createMemoryHistory({ initialEntries: ['/'] })
+  });
+
+  render(
+    <I18nWidgetProvider locale="en">
+      <RouterProvider router={router as never} />
+    </I18nWidgetProvider>
+  );
+}
+
+describe('InteractiveStatsCardAlt', () => {
+  it('renders the APY badge when a rate is provided', async () => {
+    renderCard({ apyBadge: 'Rate: 4.5%' });
+
+    const badge = await screen.findByTestId('asset-apy-badge');
+    expect(badge.textContent).toContain('Rate: 4.5%');
+  });
+
+  it('omits the APY badge without a rate', async () => {
+    renderCard();
+    await screen.findByText('100 USDS');
+    expect(screen.queryByTestId('asset-apy-badge')).toBeNull();
+  });
+
+  it('reveals a Start earning link into the module when a url is provided', async () => {
+    renderCard({ url: '/savings' });
+
+    const cta = await screen.findByTestId('start-earning-cta');
+    expect(cta.getAttribute('href')).toBe('/savings');
+  });
+
+  it('omits the Start earning link without a url', async () => {
+    renderCard();
+    await screen.findByText('100 USDS');
+    expect(screen.queryByTestId('start-earning-cta')).toBeNull();
+  });
+});

--- a/apps/webapp/src/widgets/shared/components/ui/card/InteractiveStatsCardAlt.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/card/InteractiveStatsCardAlt.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@lingui/react/macro';
 import { Card } from '@/widgets/components/ui/card';
 import { Text } from '../Typography';
 import { TokenIcon } from '../token/TokenIcon';
@@ -12,7 +13,8 @@ export const InteractiveStatsCardAlt = ({
   chainId,
   noChain,
   content,
-  icon
+  icon,
+  apyBadge
 }: {
   title: React.ReactElement | string;
   tokenSymbol?: string;
@@ -22,12 +24,23 @@ export const InteractiveStatsCardAlt = ({
   noChain?: boolean;
   content: React.ReactElement;
   icon?: React.ReactNode;
+  apyBadge?: string;
 }): React.ReactElement => {
   return (
-    <Card variant={url ? 'statsInteractive' : 'stats'} className="relative p-4 lg:p-5">
+    <Card variant={url ? 'statsInteractive' : 'stats'} className="group/asset-row relative p-4 lg:p-5">
       <div className="flex items-center justify-between gap-2">
         <div className="flex flex-col gap-2">
-          <Text className="text-textSecondary text-sm leading-4">{title}</Text>
+          <div className="flex items-center gap-2">
+            <Text className="text-textSecondary text-sm leading-4">{title}</Text>
+            {apyBadge && (
+              <span
+                data-testid="asset-apy-badge"
+                className="rounded-full border border-[#1DD9BA]/40 px-2 py-0.5 text-xs leading-4 text-[#1DD9BA]"
+              >
+                {apyBadge}
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-2">
             {icon ? (
               <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center">{icon}</div>
@@ -45,11 +58,20 @@ export const InteractiveStatsCardAlt = ({
         <Logo logoName={logoName} />
       </div>
       {url && (
-        <AppLink
-          to={url}
-          aria-label={typeof title === 'string' ? title : 'Open details'}
-          className="absolute inset-0 z-0 h-full w-full rounded-[20px]"
-        />
+        <>
+          <AppLink
+            to={url}
+            aria-label={typeof title === 'string' ? title : 'Open details'}
+            className="absolute inset-0 z-0 h-full w-full rounded-[20px]"
+          />
+          <AppLink
+            to={url}
+            data-testid="start-earning-cta"
+            className="absolute right-4 bottom-4 z-10 rounded-full bg-[#6161FF] px-3 py-1 text-xs leading-4 text-[#1C1655] opacity-0 transition-opacity group-hover/asset-row:opacity-100 focus-visible:opacity-100"
+          >
+            <Trans>Start earning</Trans>
+          </AppLink>
+        </>
       )}
     </Card>
   );


### PR DESCRIPTION
> **Note:** this PR is the integration branch for the current redesign work session. It accumulates tickets one commit per ticket instead of opening a PR per ticket — see the per-ticket sections below. Originally opened as A4 only.

| Ticket | Commit | Scope |
|---|---|---|
| A4 | `fb7977b7c` | Route map contract (`routes.ts` + dormant redirect table) |
| B1 | `fe686c2bd` | V2 `TopNav` + thin B3 slice (placeholder `/portfolio`, `/earn`) |
| B2 | `691e9e103` | `WalletChip` + `WalletPreviewDrawer` + shared balance components re-skin |

---

## A4 — 4-destination route map + `routes.ts` source of truth

Implements **ticket A4** (redesign plan §4.1, Migration Mechanics "Step 1 — Route contract, nothing mounted"). Pure contract; the deliverable is route knowledge, unit-tested, so Tracks B/C build against one agreed map.

- **New `src/lib/routes.ts`** — single source of truth for the target IA:
  - `ROUTES`: `/portfolio`, `/earn`, `/earn/{savings,rewards,vaults,fixed,expert}`, `/stake`, `/convert`, plus kept routes (`/seal-engine`, `/batch-transactions-legal-notice`, `/dev`).
  - `intentToPath(intent, sub?)` ⇄ `pathToIntent(pathname)` — provably exact inverses, tested by exhaustive enumeration over `IntentMapping`.
  - `pathToIntent` is a prefix classifier ("which `Intent` does this screen consume"); route existence/404 stays the router's concern.
- **Extended `src/lib/legacyRedirects.ts`** with `legacyPathToLocation` — second-generation redirect table (current module paths → target IA), entity segments lifted into query sub-state, `input_amount`/`linked_action` dropped. **Dormant by design** — unit-tested, registered nowhere; wired into the loader when the IA flips (Track B).

**Decisions settled in-code:** slug-as-path for product instances; `TRADE`/`UPGRADE` are aliases canonicalizing to `CONVERT`; `/` root redirect excluded (conditional on connection state, belongs to the Track B loader); path-derived sub-state wins over conflicting query params.

## B1 — Final `TopNav` (4 destinations + More menu) + thin B3 slice

Implements **ticket B1** with the agreed scope extension: mount placeholder routes first so no nav link 404s (Migration Mechanics "Step 2 — grow the new tree beside the old").

**Placeholder destinations (thin B3 slice):**
- `_shell.portfolio.tsx` (`staticData.intent: BALANCES`) and `_shell.earn.tsx` (no intent — Earn is a destination, not a module) with placeholder pages in `modules/portfolio/` and `modules/earn/`. C-track replaces the page contents; route files stay.
- Route-boot tests resolve both paths against the real generated route tree (`router.load()`, no render). Landing redirect + chunk budgets stay in B3.

**`TopNav` (`src/modules/app/shell/TopNav.tsx`, plan §4.2):**
- Portfolio · Earn · Stake SKY · Convert with **V2 selector-contract testids** (`nav-<destination>`, `wallet-chip`; Testing Transition Plan §2.3).
- Active destination: path-prefix on the target IA first (covers intent-less `/earn`), falling back to `intentToPath(routeIntent)` so legacy paths highlight their owning destination (`/savings` → Earn).
- `NEW_INTENTS` dot carried over via destination→intents mapping (Fixed's dot renders on Earn; clears on visiting the module, persists in localStorage).
- Network override semantics preserved: mainnet-only destinations carry `?network=ethereum` in the href from an L2; modified-click guard skips switch feedback side effects.
- **"More" hamburger menu** (matches the hi-fi `top-navigation` frame): theme toggle + batch-transactions toggle, Upgrade DAI/MKR → `/convert/upgrade` (currently mounted path), legal/docs footer links, cookie settings.
- **No analytics events.** Old nav's `trackWidgetSelected` doesn't map 1:1 to destinations (Earn has no Intent); a new nav event needs written sign-off (flagged alongside APP-236). Old nav keeps firing its events untouched.

**Coexistence layout (until B4):** the V2 row (logo · pills · wallet chip · ☰) is the main header; the legacy header renders below with all its controls. `HeaderNav` untouched; `Header.tsx` only swaps its logo for a spacer (file dies in B4).

**Known coexistence quirks (resolved by B4):**
- Two `CustomConnectButton` instances mount; a connected-but-terms-pending user would see stacked `TermsModal`s.
- `ThemeToggle` keeps its `hidden md:flex` styling (same visibility as in the old header).

**Test infra:** global `posthog-js` stub in `src/test/setup.ts` — `PostHogProvider` calls `posthog.init` at module import, and with a real key in `.env` any test importing the analytics module fires telemetry that happy-dom aborts at teardown (intermittent exit-1 with all tests passing; same failure mode as the existing walletConnect stub). Not an analytics behavior change.

**Locale catalogs deliberately not regenerated** — the checked-in catalogs are stale relative to this branch and `pnpm messages` churns ~4k unrelated lines; `pnpm build` regenerates them and Lingui falls back to default English for new ids. (Heads-up: `pnpm dev` dirties `src/locales/` on this branch.)

### Testing steps

- `pnpm -F webapp exec vitest run src/modules/app/shell/TopNav.test.tsx src/routes/destinations.test.ts` — 18 tests (testids/hrefs, active states, network override, More menu, new-dot, wallet chip, click guard, route boot).
- `pnpm -F webapp exec vitest run src/lib/routes.test.ts src/lib/legacyRedirects.test.ts` — 39 tests (A4 contract).
- `pnpm typecheck`, `pnpm lint` (0 errors), full webapp unit suite **82 files / 447 tests** green.
- Manual: all 4 destinations clickable with correct active pill; old nav fully functional below; More menu opens with all items; theme toggles from the menu; deep link to `/portfolio` boots; legacy paths still render unchanged.

## B2 — `WalletChip` + `WalletPreviewDrawer` + shared balance components re-skin

Implements **ticket B2** (blueprint `BP_domain_navigation-wallet.md`, plan §4.2). Connect plumbing is engine-KEEP per blueprint — re-skin JSX only, no logic rewrites. 🎨 Dark hi-fi for the drawer is pending; built functional-first against the UX wireframe + blueprint DS placeholder values (`#6161FF` CTA, `#1DD9BA` APY accent, hairline borders).

**`WalletChip` (`src/modules/app/shell/WalletChip.tsx`):**
- Replaces B1's `<div data-testid="wallet-chip"><CustomConnectButton/></div>` in `TopNav`; keeps the `wallet-chip` testid and the 4-way render ladder verbatim (unauthorized → `UnauthorizedPage`; terms pending → `TermsModal`; disconnected → connect button; connected → avatar + `safe:`-prefixed ENS/truncated address pill).
- Connected chip opens `WalletPreviewDrawer` instead of `ConnectedModal`. `CustomConnectButton`/`ConnectedModal` stay untouched serving the legacy header until B4 — parallel ladders by design, so B4 deletion is a `rm`, not a refactor.

**`WalletPreviewDrawer` (Radix Sheet, `side="right"`, V2 selector-contract testid `wallet-drawer`):**
- `WalletPreviewHeader`: re-skinned `WalletCard` (new opt-in `showExplorerLink` → `getEtherscanLink` address link, testid `wallet-card-explorer`) + total supplied USD (`wallet-drawer-total`) + `NetworkSelector`.
- `NetworkSelector` is a 6-line presentation wrapper around `ChainModal` (testid `wallet-drawer-network`) — `handleSwitchChain` + `network` query-param sync untouched.
- Disconnect action (`wallet-drawer-disconnect`), hidden for Safe wallets; switch-account closes drawer + opens connect modal — both behaviors carried over from `ConnectedModal`.
- Closes on any navigation (same `locationHref` effect as `ConnectedModal`). **Open state is pure local state** — decided with Hector against the blueprint's optional `?wallet=open` param (drawer is chrome, not a route; param can layer on later without breaking the testid contract).
- `WalletDrawerTabs`: **Assets / Activity** tabs (`wallet-drawer-tab-<name>`) composing the existing `ModulesBalances` (variant=alt) / `BalancesHistory` with the exact `ConnectedModalTabs` wiring (`useModuleUrls`, geo-restriction filter, infinite scroll).

**Shared balance components re-skinned once, in place (never forked — C1 Portfolio composes the same components):**
- `InteractiveStatsCardAlt`: new optional `apyBadge` (accent-colored pill, testid `asset-apy-badge`) and a hover-revealed **"Start earning"** `AppLink` into the module (testid `start-earning-cta`). All six balance cards pass the rate they already fetch for their default variant; no new data fetching.
- **CTA targets use the `get*Url` helpers as-is** (decided with Hector): they already emit the mounted legacy paths (`/savings`, …); when C-track re-points `INTENT_PATHS` at `/earn/<product>`, the drawer follows for free. No placeholder subroutes mounted.
- New `useSuppliedBalancesTotalUsd` hook (BalancesWidget) mirrors `ModulesBalances`' USD valuation for the header total — TanStack Query dedupes the underlying reads, so mounting both costs no extra requests. Commented as superseded by C1's `useEarnMarketplace` aggregator.
- `ExternalLink`/`CopyToClipboard` gained testid passthroughs (additive only).

**Decisions settled with Hector:** pure local drawer state (no `?wallet=open`); `get*Url` CTA targets as-is; **no chain trigger in the V2 header row pre-B4** — the drawer's `NetworkSelector` plus the legacy header's `ChainModal` cover coexistence.

**Known quirks / follow-ons:**
- Double `TermsModal` coexistence quirk from B1 **persists** (verified in-browser: two stacked dialogs when terms pending) — both ladders render one; resolved by B4.
- "Total supplied" semantics chosen for the header `$total` (consistent with the Assets tab content); wireframe is ambiguous on supplied-vs-net-worth — revisit with dark hi-fi.
- **No new analytics events** (pending sign-off, per standing rule); no events existed on `ConnectedModal` to carry over.
- Pre-existing flakes observed on the *clean baseline* during verification (not B2): `routes/destinations.test.ts` `/portfolio` boot occasionally times out (5s) under full-suite load; `lib/constants.test.ts` REFERRAL_CODE is env-sensitive.

### Testing steps

- `pnpm -F webapp exec vitest run src/modules/app/shell/ src/widgets/BalancesWidget/ src/widgets/shared/components/ui/card/` — 44 tests (chip ladder ×6, drawer open/header/total/disconnect/tabs/close-on-nav ×7, total-USD hook ×2, card primitive ×4, Savings card badge wiring, plus existing TopNav/Vaults suites).
- `pnpm typecheck`, `pnpm lint` (0 errors), full webapp unit suite green bar the pre-existing flakes above.
- Manual (mock wallet): connect → terms → chip shows address; chip click slides the drawer in from the right; identity row with copy + explorer (resolves per network — Tenderly dashboard on vnets); total + network selector render; Assets/Activity tabs switch; drawer closes on nav-pill navigation; zero console errors; legacy header/modal untouched below.

