### PR TITLE
feat(routes): mount earn modules under /earn + root not-found mode

### DIFF
--- a/apps/webapp/src/lib/legacyRedirects.test.ts
+++ b/apps/webapp/src/lib/legacyRedirects.test.ts
@@ -115,11 +115,14 @@ describe('legacySearchToLocation', () => {
   });
 });
 
-// Dormant until the IA flip (Track B): written and tested here, registered nowhere.
 describe('legacyPathToLocation', () => {
-  it('returns null for paths that survive the IA flip unchanged', () => {
+  it('returns null for paths that survived the IA flip unchanged', () => {
     expect(legacyPathToLocation('/')).toBeNull();
     expect(legacyPathToLocation('/stake')).toBeNull();
+    expect(legacyPathToLocation('/convert')).toBeNull();
+    expect(legacyPathToLocation('/convert/psm')).toBeNull();
+    expect(legacyPathToLocation('/convert/trade')).toBeNull();
+    expect(legacyPathToLocation('/convert/upgrade')).toBeNull();
     expect(legacyPathToLocation('/seal-engine')).toBeNull();
     expect(legacyPathToLocation('/batch-transactions-legal-notice')).toBeNull();
     expect(legacyPathToLocation('/dev')).toBeNull();
@@ -132,7 +135,7 @@ describe('legacyPathToLocation', () => {
     expect(legacyPathToLocation('/bogus')).toBeNull();
   });
 
-  it('maps current module paths to their target-IA destinations', () => {
+  it('maps pre-flip module paths to their target-IA destinations', () => {
     expect(legacyPathToLocation('/balances')).toEqual({ to: '/portfolio', search: {} });
     expect(legacyPathToLocation('/savings')).toEqual({ to: '/earn/savings', search: {} });
     expect(legacyPathToLocation('/rewards')).toEqual({ to: '/earn/rewards', search: {} });
@@ -145,56 +148,42 @@ describe('legacyPathToLocation', () => {
     expect(legacyPathToLocation('/savings/')).toEqual({ to: '/earn/savings', search: {} });
   });
 
-  it('moves the reward contract from path segment to query param', () => {
+  it('keeps the reward contract as a path segment', () => {
     expect(legacyPathToLocation(`/rewards/${REWARD_ADDRESS}`)).toEqual({
-      to: '/earn/rewards',
-      search: { reward: REWARD_ADDRESS }
+      to: `/earn/rewards/${REWARD_ADDRESS}`,
+      search: {}
     });
   });
 
-  it('moves vault provider and address to query params', () => {
+  it('keeps vault provider and address as path segments when both are present', () => {
     expect(legacyPathToLocation(`/vaults/sky/${SPARK_VAULT_ADDRESS}`)).toEqual({
-      to: '/earn/vaults',
-      search: { vault_module: 'sky', vault: SPARK_VAULT_ADDRESS }
+      to: `/earn/vaults/sky/${SPARK_VAULT_ADDRESS}`,
+      search: {}
     });
-    expect(legacyPathToLocation('/vaults/sky')).toEqual({
-      to: '/earn/vaults',
-      search: { vault_module: 'sky' }
-    });
+    // A bare provider has no detail route to land on → vaults overview.
+    expect(legacyPathToLocation('/vaults/sky')).toEqual({ to: '/earn/vaults', search: {} });
   });
 
-  it('moves the fixed market from path segments to query params', () => {
+  it('keeps the fixed market as path segments', () => {
     expect(legacyPathToLocation(`/fixed/market/${MARKET_ADDRESS}`)).toEqual({
-      to: '/earn/fixed',
-      search: { fixed_module: 'market', market: MARKET_ADDRESS }
+      to: `/earn/fixed/market/${MARKET_ADDRESS}`,
+      search: {}
     });
   });
 
-  it('moves the expert module from path segment to query param', () => {
+  it('keeps the expert module as a path segment', () => {
     expect(legacyPathToLocation('/expert/stusds')).toEqual({
-      to: '/earn/expert',
-      search: { expert_module: 'stusds' }
-    });
-  });
-
-  it('moves convert submodules from path segments to query params', () => {
-    expect(legacyPathToLocation('/convert/psm')).toEqual({
-      to: '/convert',
-      search: { convert_module: 'psm' }
-    });
-    expect(legacyPathToLocation('/convert/trade')).toEqual({
-      to: '/convert',
-      search: { convert_module: 'trade' }
-    });
-    expect(legacyPathToLocation('/convert/upgrade')).toEqual({
-      to: '/convert',
-      search: { convert_module: 'upgrade' }
+      to: '/earn/expert/stusds',
+      search: {}
     });
   });
 
   it('drops unrecognised trailing segments and lands on the destination', () => {
-    expect(legacyPathToLocation('/convert/bogus')).toEqual({ to: '/convert', search: {} });
     expect(legacyPathToLocation('/fixed/bogus')).toEqual({ to: '/earn/fixed', search: {} });
+    expect(legacyPathToLocation(`/vaults/aave/${SPARK_VAULT_ADDRESS}`)).toEqual({
+      to: '/earn/vaults',
+      search: {}
+    });
   });
 
   it('preserves incoming params and drops the retired ones', () => {
@@ -206,12 +195,5 @@ describe('legacyPathToLocation', () => {
         linked_action: 'trade'
       })
     ).toEqual({ to: '/earn/savings', search: { network: 'base', flow: 'withdraw' } });
-  });
-
-  it('path-derived sub-state wins over a conflicting incoming param', () => {
-    expect(legacyPathToLocation(`/rewards/${REWARD_ADDRESS}`, { reward: 'stale' })).toEqual({
-      to: '/earn/rewards',
-      search: { reward: REWARD_ADDRESS }
-    });
   });
 });

--- a/apps/webapp/src/lib/legacyRedirects.ts
+++ b/apps/webapp/src/lib/legacyRedirects.ts
@@ -106,57 +106,45 @@ export function legacySearchToLocation(search: Record<string, string>): LegacyRe
   return { to, search: rest };
 }
 
-// Current-generation module paths → target-IA destinations (plan §4.1).
-// DORMANT: unit-tested but registered nowhere until the IA flips (Track B).
-// `params` lifts entity path segments back into query-param sub-state.
-type V2Redirect = { to: string; params?: (segments: string[]) => Record<string, string> };
+// Pre-flip module paths → target-IA destinations (plan §4.1). The modules kept
+// their entity path params when they moved under /earn, so `subpath` carries
+// recognised entity segments across; unrecognised ones drop to the overview.
+// Convert needs no entry: its paths survived the flip unchanged.
+type V2Redirect = { to: string; subpath?: (segments: string[]) => string[] };
 
 const V2_REDIRECT_BY_MODULE: Record<string, V2Redirect> = {
   balances: { to: ROUTES.PORTFOLIO },
   savings: { to: ROUTES.EARN_SAVINGS },
   rewards: {
     to: ROUTES.EARN_REWARDS,
-    params: ([reward]): Record<string, string> => (reward ? { [LegacyParams.Reward]: reward } : {})
+    subpath: ([reward]): string[] => (reward ? [reward] : [])
   },
   vaults: {
     to: ROUTES.EARN_VAULTS,
-    params: ([provider, vault]): Record<string, string> =>
-      provider && providerForVaultModule(provider)
-        ? {
-            [LegacyParams.VaultModule]: provider.toLowerCase(),
-            ...(vault && { [LegacyParams.Vault]: vault })
-          }
-        : {}
+    subpath: ([provider, vault]): string[] =>
+      // The vault detail route needs both segments; a bare provider has no target.
+      provider && vault && providerForVaultModule(provider) ? [provider.toLowerCase(), vault] : []
   },
   fixed: {
     to: ROUTES.EARN_FIXED,
-    params: ([module, market]): Record<string, string> =>
+    subpath: ([module, market]): string[] =>
       module?.toLowerCase() === FixedIntentMapping[FixedIntent.MARKET_INTENT] && market
-        ? { [LegacyParams.FixedModule]: module.toLowerCase(), [LegacyParams.Market]: market }
-        : {}
+        ? [module.toLowerCase(), market]
+        : []
   },
   expert: {
     to: ROUTES.EARN_EXPERT,
-    params: ([module]): Record<string, string> =>
-      module?.toLowerCase() === ExpertIntentMapping[ExpertIntent.STUSDS_INTENT]
-        ? { [LegacyParams.ExpertModule]: module.toLowerCase() }
-        : {}
-  },
-  convert: {
-    to: ROUTES.CONVERT,
-    params: ([module]): Record<string, string> =>
-      module && CONVERT_MODULE_VALUES.includes(module.toLowerCase())
-        ? { [LegacyParams.ConvertModule]: module.toLowerCase() }
-        : {}
+    subpath: ([module]): string[] =>
+      module?.toLowerCase() === ExpertIntentMapping[ExpertIntent.STUSDS_INTENT] ? [module.toLowerCase()] : []
   }
 };
 
 /**
- * Translates current module paths into their target-IA equivalents once the
- * IA flips. Returns null when the path needs no redirect. Composes after
- * legacySearchToLocation: ?widget= URLs first rewrite to a current path,
- * then this maps that path forward. Entity values pass through verbatim —
- * the target route's own validation handles invalid ones.
+ * Translates pre-flip module paths into their target-IA equivalents. Returns
+ * null when the path needs no redirect. Composes after legacySearchToLocation:
+ * ?widget= URLs first rewrite to a pre-flip path, then this maps that path
+ * forward. Entity values pass through verbatim — the target route's own
+ * validation handles invalid ones.
  */
 export function legacyPathToLocation(
   pathname: string,
@@ -166,13 +154,12 @@ export function legacyPathToLocation(
   const moduleKey = segments[0]?.toLowerCase();
   const redirect = moduleKey ? V2_REDIRECT_BY_MODULE[moduleKey] : undefined;
   if (!redirect) return null;
-  // Already at its destination with no sub-state to lift: nothing to do.
-  if (segments.length === 1 && `/${moduleKey}` === redirect.to) return null;
 
-  // input_amount/linked_action are retired in the new IA (plan §4.1); path-derived
-  // sub-state wins over any stale incoming param.
+  const subpath = redirect.subpath?.(segments.slice(1)) ?? [];
+  const to = [redirect.to, ...subpath].join('/');
+  // input_amount/linked_action are retired in the new IA (plan §4.1).
   const preserved = Object.fromEntries(
     Object.entries(search).filter(([key]) => key !== 'input_amount' && key !== 'linked_action')
   );
-  return { to: redirect.to, search: { ...preserved, ...(redirect.params?.(segments.slice(1)) ?? {}) } };
+  return { to, search: preserved };
 }

--- a/apps/webapp/src/lib/navigation.tsx
+++ b/apps/webapp/src/lib/navigation.tsx
@@ -28,13 +28,13 @@ export type AppRoutePath = FileRouteTypes['to'];
 /** Path each module lives at. TRADE/UPGRADE intents render as Convert submodules. */
 export const INTENT_PATHS: Record<Intent, AppRoutePath> = {
   [Intent.BALANCES_INTENT]: '/',
-  [Intent.SAVINGS_INTENT]: '/savings',
-  [Intent.REWARDS_INTENT]: '/rewards',
+  [Intent.SAVINGS_INTENT]: '/earn/savings',
+  [Intent.REWARDS_INTENT]: '/earn/rewards',
   [Intent.STAKE_INTENT]: '/stake',
   [Intent.CONVERT_INTENT]: '/convert',
-  [Intent.EXPERT_INTENT]: '/expert',
-  [Intent.VAULTS_INTENT]: '/vaults',
-  [Intent.FIXED_INTENT]: '/fixed',
+  [Intent.EXPERT_INTENT]: '/earn/expert',
+  [Intent.VAULTS_INTENT]: '/earn/vaults',
+  [Intent.FIXED_INTENT]: '/earn/fixed',
   [Intent.TRADE_INTENT]: '/convert/trade',
   [Intent.UPGRADE_INTENT]: '/convert/upgrade'
 };

--- a/apps/webapp/src/modules/app/hooks/useAppOrchestration.ts
+++ b/apps/webapp/src/modules/app/hooks/useAppOrchestration.ts
@@ -144,7 +144,7 @@ export function useAppOrchestration(): { intent: Intent } {
 
     // Expert submodules require the risk disclaimer to have been acknowledged.
     if (expertIntent !== undefined && !expertRiskDisclaimerShown) {
-      void navigate({ to: '/expert', search: keepSearch, replace: true });
+      void navigate({ to: '/earn/expert', search: keepSearch, replace: true });
       return;
     }
 
@@ -154,7 +154,7 @@ export function useAppOrchestration(): { intent: Intent } {
       rewardContract !== undefined &&
       !rewardContracts?.some(c => c.contractAddress?.toLowerCase() === rewardContract.toLowerCase())
     ) {
-      void navigate({ to: '/rewards', search: keepSearch, replace: true });
+      void navigate({ to: '/earn/rewards', search: keepSearch, replace: true });
     }
   }, [
     intent,

--- a/apps/webapp/src/modules/app/shell/TopNav.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.tsx
@@ -59,9 +59,8 @@ const navTestId = (path: RoutePath) => `nav-${path.slice(1)}`;
 
 const isUnderDestination = (path: string, base: RoutePath) => path === base || path.startsWith(`${base}/`);
 
-// Active destination: the current path when it's already a target-IA path
-// (covers the intent-less /earn placeholder), else the destination owning the
-// legacy route's intent (e.g. /savings → /earn/savings → Earn).
+// Active destination: the current path when it sits under a destination, else
+// the destination owning the route's intent (covers Balances at / → Portfolio).
 function useActiveDestinationPath(): RoutePath | null {
   const pathname = useRouterState({ select: s => s.location.pathname });
   const routeIntent = useRouteIntent();

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.test.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.test.tsx
@@ -211,7 +211,7 @@ describe('WalletPreviewDrawer', () => {
     await openDrawer();
 
     await act(async () => {
-      await lastRouter!.navigate({ to: '/savings' });
+      await lastRouter!.navigate({ to: '/earn/savings' });
     });
 
     expect(screen.queryByTestId('wallet-drawer')).toBeNull();

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.test.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.test.tsx
@@ -130,7 +130,7 @@ describe('BalancesSuggestedActions', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Tether Savings \(sUSDT\)/i }));
 
-    expect(lastNavigation?.to).toBe(`/vaults/sky/${SPARK_USDT_VAULT_ADDRESS}`);
+    expect(lastNavigation?.to).toBe(`/earn/vaults/sky/${SPARK_USDT_VAULT_ADDRESS}`);
     expect(lastNavigation?.search).toEqual({ network: 'ethereum', lang: 'en' });
   });
 });

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
@@ -6,6 +6,7 @@ import { QueryParams, mapQueryParamToIntent, isNewIntent } from '@/lib/constants
 import { Intent } from '@/lib/enums';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
 import { vaultModuleForProvider } from '@/lib/vaults/vaultProviderMapping';
+import { ROUTES } from '@/lib/routes';
 import { isMultichain } from '@/lib/widget-network-map';
 import { useNetworkSwitch } from '@/modules/ui/context/NetworkSwitchContext';
 import { Text } from '@/modules/layout/components/Typography';
@@ -79,7 +80,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
     rateKey: 'vaults',
     subtitle: 'Rates up to {rate}',
     module: 'morpho',
-    url: '/vaults'
+    url: ROUTES.EARN_VAULTS
   },
   {
     label: 'Rewards and Points',
@@ -87,7 +88,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
     rateKey: 'rewards',
     subtitle: 'Rates up to {rate}',
     module: 'rewards',
-    url: '/rewards'
+    url: ROUTES.EARN_REWARDS
   },
   {
     label: 'Sky Savings Rate (sUSDS)',
@@ -95,7 +96,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
     rateKey: 'savings',
     subtitle: 'Rate: {rate}',
     module: 'savings',
-    url: '/savings'
+    url: ROUTES.EARN_SAVINGS
   },
   {
     label: 'Tether Savings (sUSDT)',
@@ -103,7 +104,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
     rateKey: 'sparkVault',
     subtitle: 'Rate: {rate}',
     module: 'morpho',
-    url: `/vaults/${vaultModuleForProvider('sky')}/${sparkUsdtVaultAddress[mainnet.id]}`,
+    url: `${ROUTES.EARN_VAULTS}/${vaultModuleForProvider('sky')}/${sparkUsdtVaultAddress[mainnet.id]}`,
     badge: 'New'
   },
   {
@@ -112,7 +113,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
     tokens: [],
     rateKey: 'fixedYield',
     module: 'fixedYield',
-    url: '/fixed'
+    url: ROUTES.EARN_FIXED
   },
   {
     label: 'Expert: stUSDS',
@@ -120,7 +121,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
     rateKey: 'stusds',
     subtitle: 'Rate: {rate}',
     module: 'stusds',
-    url: '/expert/stusds'
+    url: `${ROUTES.EARN_EXPERT}/stusds`
   }
 ];
 

--- a/apps/webapp/src/modules/balances/components/BalancesWidgetPane.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesWidgetPane.tsx
@@ -13,7 +13,7 @@ export function BalancesWidgetPane(widgetProps: BalancesWidgetProps) {
   const flow = (searchParams.get(QueryParams.Flow) || undefined) as SavingsFlow | undefined;
 
   const onExploreVaults = useCallback(() => {
-    void navigate({ to: '/vaults', search: retainOnNavigate });
+    void navigate({ to: '/earn/vaults', search: retainOnNavigate });
   }, [navigate]);
 
   const onBalancesWidgetStateChange = ({ widgetState }: WidgetStateChangeParams) => {

--- a/apps/webapp/src/modules/morpho/components/MorphoVaultWidgetPane.tsx
+++ b/apps/webapp/src/modules/morpho/components/MorphoVaultWidgetPane.tsx
@@ -52,7 +52,7 @@ export function MorphoVaultWidgetPane({
   };
 
   const handleBack = () => {
-    void navigate({ to: '/vaults', search: keepSearch });
+    void navigate({ to: '/earn/vaults', search: keepSearch });
   };
 
   if (!currentVaultAddress || !currentAssetAddress) {

--- a/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleWidgetPane.tsx
@@ -66,14 +66,14 @@ export function PendleWidgetPane() {
 
   const handleSelectMarket = (market: PendleMarketConfig) => {
     void navigate({
-      to: '/fixed/market/$marketAddress',
+      to: '/earn/fixed/market/$marketAddress',
       params: { marketAddress: market.marketAddress },
       search: keepSearch
     });
   };
 
   const handleBack = () => {
-    void navigate({ to: '/fixed', search: keepSearch });
+    void navigate({ to: '/earn/fixed', search: keepSearch });
   };
 
   return (

--- a/apps/webapp/src/modules/rewards/components/RewardsWidgetPane.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsWidgetPane.tsx
@@ -29,13 +29,13 @@ export function RewardsWidgetPane() {
 
     if (rewardContract?.contractAddress) {
       void navigate({
-        to: '/rewards/$rewardContract',
+        to: '/earn/rewards/$rewardContract',
         params: { rewardContract: rewardContract.contractAddress },
         search: keepSearch,
         replace: true
       });
     } else {
-      void navigate({ to: '/rewards', search: keepSearch, replace: true });
+      void navigate({ to: '/earn/rewards', search: keepSearch, replace: true });
     }
   };
 

--- a/apps/webapp/src/modules/stusds/components/StUSDSWidgetPane.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUSDSWidgetPane.tsx
@@ -60,7 +60,7 @@ export function StUSDSWidgetPane() {
   };
 
   const handleBack = () => {
-    void navigate({ to: '/expert', search: keepSearch });
+    void navigate({ to: '/earn/expert', search: keepSearch });
   };
 
   return (

--- a/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.test.tsx
+++ b/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.test.tsx
@@ -168,7 +168,7 @@ describe('VaultsWidgetPane card-select navigation', () => {
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
     const navArg = navigateMock.mock.calls[0][0];
-    expect(navArg.to).toBe('/vaults/$provider/$vaultAddress');
+    expect(navArg.to).toBe('/earn/vaults/$provider/$vaultAddress');
     expect(navArg.params.provider).toBe('sky');
     expect(navArg.params.vaultAddress.toLowerCase()).toBe(SPARK_USDT_VAULT_ADDRESS.toLowerCase());
   });
@@ -180,7 +180,7 @@ describe('VaultsWidgetPane card-select navigation', () => {
 
     expect(navigateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: '/vaults/$provider/$vaultAddress',
+        to: '/earn/vaults/$provider/$vaultAddress',
         params: expect.objectContaining({ provider: 'morpho' })
       })
     );

--- a/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.tsx
+++ b/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.tsx
@@ -61,7 +61,7 @@ export function VaultsWidgetPane() {
   // path reflects the vault the user opened.
   const handleSelectVault = (vaultAddress: `0x${string}`, provider: VaultProvider) => {
     void navigate({
-      to: '/vaults/$provider/$vaultAddress',
+      to: '/earn/vaults/$provider/$vaultAddress',
       params: { provider: vaultModuleForProvider(provider), vaultAddress },
       search: keepSearch
     });

--- a/apps/webapp/src/pages/router.tsx
+++ b/apps/webapp/src/pages/router.tsx
@@ -1,4 +1,4 @@
-import { createRouter } from '@tanstack/react-router';
+import { createRouter, type RouterHistory } from '@tanstack/react-router';
 import { routeTree } from '../routeTree.gen';
 import ErrorPage from './ErrorPage';
 import { NotFound } from '../modules/layout/components/NotFound';
@@ -23,15 +23,24 @@ const stringifySearch = (search: Record<string, unknown>): string => {
   return str ? `?${str}` : '';
 };
 
-export const router = createRouter({
-  routeTree,
-  parseSearch,
-  stringifySearch,
-  // Prefetch lazy route chunks when links are hovered/focused
-  defaultPreload: 'intent',
-  defaultErrorComponent: ErrorPage,
-  defaultNotFoundComponent: NotFound
-});
+// Factory so tests can boot the app's real router config on a memory history.
+export const createAppRouter = (history?: RouterHistory) =>
+  createRouter({
+    routeTree,
+    history,
+    parseSearch,
+    stringifySearch,
+    // Prefetch lazy route chunks when links are hovered/focused
+    defaultPreload: 'intent',
+    defaultErrorComponent: ErrorPage,
+    defaultNotFoundComponent: NotFound,
+    // NotFound renders its own full-page Layout, so unmatched paths must surface
+    // at the root; the default fuzzy mode would nest it inside the closest
+    // partially-matching layout (e.g. /earn/bogus inside the app shell).
+    notFoundMode: 'root'
+  });
+
+export const router = createAppRouter();
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/apps/webapp/src/routeTree.gen.ts
+++ b/apps/webapp/src/routeTree.gen.ts
@@ -14,22 +14,22 @@ import { Route as DevRouteImport } from './routes/dev'
 import { Route as BatchTransactionsLegalNoticeRouteImport } from './routes/batch-transactions-legal-notice'
 import { Route as ShellRouteImport } from './routes/_shell'
 import { Route as ShellIndexRouteImport } from './routes/_shell.index'
-import { Route as ShellVaultsRouteImport } from './routes/_shell.vaults'
 import { Route as ShellStakeRouteImport } from './routes/_shell.stake'
-import { Route as ShellSavingsRouteImport } from './routes/_shell.savings'
-import { Route as ShellRewardsRouteImport } from './routes/_shell.rewards'
 import { Route as ShellPortfolioRouteImport } from './routes/_shell.portfolio'
-import { Route as ShellFixedRouteImport } from './routes/_shell.fixed'
-import { Route as ShellExpertRouteImport } from './routes/_shell.expert'
-import { Route as ShellEarnRouteImport } from './routes/_shell.earn'
 import { Route as ShellConvertRouteImport } from './routes/_shell.convert'
-import { Route as ShellRewardsRewardContractRouteImport } from './routes/_shell.rewards.$rewardContract'
-import { Route as ShellExpertStusdsRouteImport } from './routes/_shell.expert.stusds'
+import { Route as ShellEarnIndexRouteImport } from './routes/_shell.earn.index'
+import { Route as ShellEarnVaultsRouteImport } from './routes/_shell.earn.vaults'
+import { Route as ShellEarnSavingsRouteImport } from './routes/_shell.earn.savings'
+import { Route as ShellEarnRewardsRouteImport } from './routes/_shell.earn.rewards'
+import { Route as ShellEarnFixedRouteImport } from './routes/_shell.earn.fixed'
+import { Route as ShellEarnExpertRouteImport } from './routes/_shell.earn.expert'
 import { Route as ShellConvertUpgradeRouteImport } from './routes/_shell.convert.upgrade'
 import { Route as ShellConvertTradeRouteImport } from './routes/_shell.convert.trade'
 import { Route as ShellConvertPsmRouteImport } from './routes/_shell.convert.psm'
-import { Route as ShellVaultsProviderVaultAddressRouteImport } from './routes/_shell.vaults.$provider.$vaultAddress'
-import { Route as ShellFixedMarketMarketAddressRouteImport } from './routes/_shell.fixed.market.$marketAddress'
+import { Route as ShellEarnRewardsRewardContractRouteImport } from './routes/_shell.earn.rewards.$rewardContract'
+import { Route as ShellEarnExpertStusdsRouteImport } from './routes/_shell.earn.expert.stusds'
+import { Route as ShellEarnVaultsProviderVaultAddressRouteImport } from './routes/_shell.earn.vaults.$provider.$vaultAddress'
+import { Route as ShellEarnFixedMarketMarketAddressRouteImport } from './routes/_shell.earn.fixed.market.$marketAddress'
 
 const SealEngineRoute = SealEngineRouteImport.update({
   id: '/seal-engine',
@@ -56,24 +56,9 @@ const ShellIndexRoute = ShellIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellVaultsRoute = ShellVaultsRouteImport.update({
-  id: '/vaults',
-  path: '/vaults',
-  getParentRoute: () => ShellRoute,
-} as any)
 const ShellStakeRoute = ShellStakeRouteImport.update({
   id: '/stake',
   path: '/stake',
-  getParentRoute: () => ShellRoute,
-} as any)
-const ShellSavingsRoute = ShellSavingsRouteImport.update({
-  id: '/savings',
-  path: '/savings',
-  getParentRoute: () => ShellRoute,
-} as any)
-const ShellRewardsRoute = ShellRewardsRouteImport.update({
-  id: '/rewards',
-  path: '/rewards',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellPortfolioRoute = ShellPortfolioRouteImport.update({
@@ -81,36 +66,40 @@ const ShellPortfolioRoute = ShellPortfolioRouteImport.update({
   path: '/portfolio',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellFixedRoute = ShellFixedRouteImport.update({
-  id: '/fixed',
-  path: '/fixed',
-  getParentRoute: () => ShellRoute,
-} as any)
-const ShellExpertRoute = ShellExpertRouteImport.update({
-  id: '/expert',
-  path: '/expert',
-  getParentRoute: () => ShellRoute,
-} as any)
-const ShellEarnRoute = ShellEarnRouteImport.update({
-  id: '/earn',
-  path: '/earn',
-  getParentRoute: () => ShellRoute,
-} as any)
 const ShellConvertRoute = ShellConvertRouteImport.update({
   id: '/convert',
   path: '/convert',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellRewardsRewardContractRoute =
-  ShellRewardsRewardContractRouteImport.update({
-    id: '/$rewardContract',
-    path: '/$rewardContract',
-    getParentRoute: () => ShellRewardsRoute,
-  } as any)
-const ShellExpertStusdsRoute = ShellExpertStusdsRouteImport.update({
-  id: '/stusds',
-  path: '/stusds',
-  getParentRoute: () => ShellExpertRoute,
+const ShellEarnIndexRoute = ShellEarnIndexRouteImport.update({
+  id: '/earn/',
+  path: '/earn/',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellEarnVaultsRoute = ShellEarnVaultsRouteImport.update({
+  id: '/earn/vaults',
+  path: '/earn/vaults',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellEarnSavingsRoute = ShellEarnSavingsRouteImport.update({
+  id: '/earn/savings',
+  path: '/earn/savings',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellEarnRewardsRoute = ShellEarnRewardsRouteImport.update({
+  id: '/earn/rewards',
+  path: '/earn/rewards',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellEarnFixedRoute = ShellEarnFixedRouteImport.update({
+  id: '/earn/fixed',
+  path: '/earn/fixed',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellEarnExpertRoute = ShellEarnExpertRouteImport.update({
+  id: '/earn/expert',
+  path: '/earn/expert',
+  getParentRoute: () => ShellRoute,
 } as any)
 const ShellConvertUpgradeRoute = ShellConvertUpgradeRouteImport.update({
   id: '/upgrade',
@@ -127,17 +116,28 @@ const ShellConvertPsmRoute = ShellConvertPsmRouteImport.update({
   path: '/psm',
   getParentRoute: () => ShellConvertRoute,
 } as any)
-const ShellVaultsProviderVaultAddressRoute =
-  ShellVaultsProviderVaultAddressRouteImport.update({
+const ShellEarnRewardsRewardContractRoute =
+  ShellEarnRewardsRewardContractRouteImport.update({
+    id: '/$rewardContract',
+    path: '/$rewardContract',
+    getParentRoute: () => ShellEarnRewardsRoute,
+  } as any)
+const ShellEarnExpertStusdsRoute = ShellEarnExpertStusdsRouteImport.update({
+  id: '/stusds',
+  path: '/stusds',
+  getParentRoute: () => ShellEarnExpertRoute,
+} as any)
+const ShellEarnVaultsProviderVaultAddressRoute =
+  ShellEarnVaultsProviderVaultAddressRouteImport.update({
     id: '/$provider/$vaultAddress',
     path: '/$provider/$vaultAddress',
-    getParentRoute: () => ShellVaultsRoute,
+    getParentRoute: () => ShellEarnVaultsRoute,
   } as any)
-const ShellFixedMarketMarketAddressRoute =
-  ShellFixedMarketMarketAddressRouteImport.update({
+const ShellEarnFixedMarketMarketAddressRoute =
+  ShellEarnFixedMarketMarketAddressRouteImport.update({
     id: '/market/$marketAddress',
     path: '/market/$marketAddress',
-    getParentRoute: () => ShellFixedRoute,
+    getParentRoute: () => ShellEarnFixedRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -146,43 +146,43 @@ export interface FileRoutesByFullPath {
   '/dev': typeof DevRoute
   '/seal-engine': typeof SealEngineRoute
   '/convert': typeof ShellConvertRouteWithChildren
-  '/earn': typeof ShellEarnRoute
-  '/expert': typeof ShellExpertRouteWithChildren
-  '/fixed': typeof ShellFixedRouteWithChildren
   '/portfolio': typeof ShellPortfolioRoute
-  '/rewards': typeof ShellRewardsRouteWithChildren
-  '/savings': typeof ShellSavingsRoute
   '/stake': typeof ShellStakeRoute
-  '/vaults': typeof ShellVaultsRouteWithChildren
   '/convert/psm': typeof ShellConvertPsmRoute
   '/convert/trade': typeof ShellConvertTradeRoute
   '/convert/upgrade': typeof ShellConvertUpgradeRoute
-  '/expert/stusds': typeof ShellExpertStusdsRoute
-  '/rewards/$rewardContract': typeof ShellRewardsRewardContractRoute
-  '/fixed/market/$marketAddress': typeof ShellFixedMarketMarketAddressRoute
-  '/vaults/$provider/$vaultAddress': typeof ShellVaultsProviderVaultAddressRoute
+  '/earn/expert': typeof ShellEarnExpertRouteWithChildren
+  '/earn/fixed': typeof ShellEarnFixedRouteWithChildren
+  '/earn/rewards': typeof ShellEarnRewardsRouteWithChildren
+  '/earn/savings': typeof ShellEarnSavingsRoute
+  '/earn/vaults': typeof ShellEarnVaultsRouteWithChildren
+  '/earn/': typeof ShellEarnIndexRoute
+  '/earn/expert/stusds': typeof ShellEarnExpertStusdsRoute
+  '/earn/rewards/$rewardContract': typeof ShellEarnRewardsRewardContractRoute
+  '/earn/fixed/market/$marketAddress': typeof ShellEarnFixedMarketMarketAddressRoute
+  '/earn/vaults/$provider/$vaultAddress': typeof ShellEarnVaultsProviderVaultAddressRoute
 }
 export interface FileRoutesByTo {
   '/batch-transactions-legal-notice': typeof BatchTransactionsLegalNoticeRoute
   '/dev': typeof DevRoute
   '/seal-engine': typeof SealEngineRoute
   '/convert': typeof ShellConvertRouteWithChildren
-  '/earn': typeof ShellEarnRoute
-  '/expert': typeof ShellExpertRouteWithChildren
-  '/fixed': typeof ShellFixedRouteWithChildren
   '/portfolio': typeof ShellPortfolioRoute
-  '/rewards': typeof ShellRewardsRouteWithChildren
-  '/savings': typeof ShellSavingsRoute
   '/stake': typeof ShellStakeRoute
-  '/vaults': typeof ShellVaultsRouteWithChildren
   '/': typeof ShellIndexRoute
   '/convert/psm': typeof ShellConvertPsmRoute
   '/convert/trade': typeof ShellConvertTradeRoute
   '/convert/upgrade': typeof ShellConvertUpgradeRoute
-  '/expert/stusds': typeof ShellExpertStusdsRoute
-  '/rewards/$rewardContract': typeof ShellRewardsRewardContractRoute
-  '/fixed/market/$marketAddress': typeof ShellFixedMarketMarketAddressRoute
-  '/vaults/$provider/$vaultAddress': typeof ShellVaultsProviderVaultAddressRoute
+  '/earn/expert': typeof ShellEarnExpertRouteWithChildren
+  '/earn/fixed': typeof ShellEarnFixedRouteWithChildren
+  '/earn/rewards': typeof ShellEarnRewardsRouteWithChildren
+  '/earn/savings': typeof ShellEarnSavingsRoute
+  '/earn/vaults': typeof ShellEarnVaultsRouteWithChildren
+  '/earn': typeof ShellEarnIndexRoute
+  '/earn/expert/stusds': typeof ShellEarnExpertStusdsRoute
+  '/earn/rewards/$rewardContract': typeof ShellEarnRewardsRewardContractRoute
+  '/earn/fixed/market/$marketAddress': typeof ShellEarnFixedMarketMarketAddressRoute
+  '/earn/vaults/$provider/$vaultAddress': typeof ShellEarnVaultsProviderVaultAddressRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -191,22 +191,22 @@ export interface FileRoutesById {
   '/dev': typeof DevRoute
   '/seal-engine': typeof SealEngineRoute
   '/_shell/convert': typeof ShellConvertRouteWithChildren
-  '/_shell/earn': typeof ShellEarnRoute
-  '/_shell/expert': typeof ShellExpertRouteWithChildren
-  '/_shell/fixed': typeof ShellFixedRouteWithChildren
   '/_shell/portfolio': typeof ShellPortfolioRoute
-  '/_shell/rewards': typeof ShellRewardsRouteWithChildren
-  '/_shell/savings': typeof ShellSavingsRoute
   '/_shell/stake': typeof ShellStakeRoute
-  '/_shell/vaults': typeof ShellVaultsRouteWithChildren
   '/_shell/': typeof ShellIndexRoute
   '/_shell/convert/psm': typeof ShellConvertPsmRoute
   '/_shell/convert/trade': typeof ShellConvertTradeRoute
   '/_shell/convert/upgrade': typeof ShellConvertUpgradeRoute
-  '/_shell/expert/stusds': typeof ShellExpertStusdsRoute
-  '/_shell/rewards/$rewardContract': typeof ShellRewardsRewardContractRoute
-  '/_shell/fixed/market/$marketAddress': typeof ShellFixedMarketMarketAddressRoute
-  '/_shell/vaults/$provider/$vaultAddress': typeof ShellVaultsProviderVaultAddressRoute
+  '/_shell/earn/expert': typeof ShellEarnExpertRouteWithChildren
+  '/_shell/earn/fixed': typeof ShellEarnFixedRouteWithChildren
+  '/_shell/earn/rewards': typeof ShellEarnRewardsRouteWithChildren
+  '/_shell/earn/savings': typeof ShellEarnSavingsRoute
+  '/_shell/earn/vaults': typeof ShellEarnVaultsRouteWithChildren
+  '/_shell/earn/': typeof ShellEarnIndexRoute
+  '/_shell/earn/expert/stusds': typeof ShellEarnExpertStusdsRoute
+  '/_shell/earn/rewards/$rewardContract': typeof ShellEarnRewardsRewardContractRoute
+  '/_shell/earn/fixed/market/$marketAddress': typeof ShellEarnFixedMarketMarketAddressRoute
+  '/_shell/earn/vaults/$provider/$vaultAddress': typeof ShellEarnVaultsProviderVaultAddressRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -216,43 +216,43 @@ export interface FileRouteTypes {
     | '/dev'
     | '/seal-engine'
     | '/convert'
-    | '/earn'
-    | '/expert'
-    | '/fixed'
     | '/portfolio'
-    | '/rewards'
-    | '/savings'
     | '/stake'
-    | '/vaults'
     | '/convert/psm'
     | '/convert/trade'
     | '/convert/upgrade'
-    | '/expert/stusds'
-    | '/rewards/$rewardContract'
-    | '/fixed/market/$marketAddress'
-    | '/vaults/$provider/$vaultAddress'
+    | '/earn/expert'
+    | '/earn/fixed'
+    | '/earn/rewards'
+    | '/earn/savings'
+    | '/earn/vaults'
+    | '/earn/'
+    | '/earn/expert/stusds'
+    | '/earn/rewards/$rewardContract'
+    | '/earn/fixed/market/$marketAddress'
+    | '/earn/vaults/$provider/$vaultAddress'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/batch-transactions-legal-notice'
     | '/dev'
     | '/seal-engine'
     | '/convert'
-    | '/earn'
-    | '/expert'
-    | '/fixed'
     | '/portfolio'
-    | '/rewards'
-    | '/savings'
     | '/stake'
-    | '/vaults'
     | '/'
     | '/convert/psm'
     | '/convert/trade'
     | '/convert/upgrade'
-    | '/expert/stusds'
-    | '/rewards/$rewardContract'
-    | '/fixed/market/$marketAddress'
-    | '/vaults/$provider/$vaultAddress'
+    | '/earn/expert'
+    | '/earn/fixed'
+    | '/earn/rewards'
+    | '/earn/savings'
+    | '/earn/vaults'
+    | '/earn'
+    | '/earn/expert/stusds'
+    | '/earn/rewards/$rewardContract'
+    | '/earn/fixed/market/$marketAddress'
+    | '/earn/vaults/$provider/$vaultAddress'
   id:
     | '__root__'
     | '/_shell'
@@ -260,22 +260,22 @@ export interface FileRouteTypes {
     | '/dev'
     | '/seal-engine'
     | '/_shell/convert'
-    | '/_shell/earn'
-    | '/_shell/expert'
-    | '/_shell/fixed'
     | '/_shell/portfolio'
-    | '/_shell/rewards'
-    | '/_shell/savings'
     | '/_shell/stake'
-    | '/_shell/vaults'
     | '/_shell/'
     | '/_shell/convert/psm'
     | '/_shell/convert/trade'
     | '/_shell/convert/upgrade'
-    | '/_shell/expert/stusds'
-    | '/_shell/rewards/$rewardContract'
-    | '/_shell/fixed/market/$marketAddress'
-    | '/_shell/vaults/$provider/$vaultAddress'
+    | '/_shell/earn/expert'
+    | '/_shell/earn/fixed'
+    | '/_shell/earn/rewards'
+    | '/_shell/earn/savings'
+    | '/_shell/earn/vaults'
+    | '/_shell/earn/'
+    | '/_shell/earn/expert/stusds'
+    | '/_shell/earn/rewards/$rewardContract'
+    | '/_shell/earn/fixed/market/$marketAddress'
+    | '/_shell/earn/vaults/$provider/$vaultAddress'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -322,32 +322,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellIndexRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/vaults': {
-      id: '/_shell/vaults'
-      path: '/vaults'
-      fullPath: '/vaults'
-      preLoaderRoute: typeof ShellVaultsRouteImport
-      parentRoute: typeof ShellRoute
-    }
     '/_shell/stake': {
       id: '/_shell/stake'
       path: '/stake'
       fullPath: '/stake'
       preLoaderRoute: typeof ShellStakeRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/savings': {
-      id: '/_shell/savings'
-      path: '/savings'
-      fullPath: '/savings'
-      preLoaderRoute: typeof ShellSavingsRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/rewards': {
-      id: '/_shell/rewards'
-      path: '/rewards'
-      fullPath: '/rewards'
-      preLoaderRoute: typeof ShellRewardsRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/portfolio': {
@@ -357,27 +336,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellPortfolioRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/fixed': {
-      id: '/_shell/fixed'
-      path: '/fixed'
-      fullPath: '/fixed'
-      preLoaderRoute: typeof ShellFixedRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/expert': {
-      id: '/_shell/expert'
-      path: '/expert'
-      fullPath: '/expert'
-      preLoaderRoute: typeof ShellExpertRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/earn': {
-      id: '/_shell/earn'
-      path: '/earn'
-      fullPath: '/earn'
-      preLoaderRoute: typeof ShellEarnRouteImport
-      parentRoute: typeof ShellRoute
-    }
     '/_shell/convert': {
       id: '/_shell/convert'
       path: '/convert'
@@ -385,19 +343,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellConvertRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/rewards/$rewardContract': {
-      id: '/_shell/rewards/$rewardContract'
-      path: '/$rewardContract'
-      fullPath: '/rewards/$rewardContract'
-      preLoaderRoute: typeof ShellRewardsRewardContractRouteImport
-      parentRoute: typeof ShellRewardsRoute
+    '/_shell/earn/': {
+      id: '/_shell/earn/'
+      path: '/earn'
+      fullPath: '/earn/'
+      preLoaderRoute: typeof ShellEarnIndexRouteImport
+      parentRoute: typeof ShellRoute
     }
-    '/_shell/expert/stusds': {
-      id: '/_shell/expert/stusds'
-      path: '/stusds'
-      fullPath: '/expert/stusds'
-      preLoaderRoute: typeof ShellExpertStusdsRouteImport
-      parentRoute: typeof ShellExpertRoute
+    '/_shell/earn/vaults': {
+      id: '/_shell/earn/vaults'
+      path: '/earn/vaults'
+      fullPath: '/earn/vaults'
+      preLoaderRoute: typeof ShellEarnVaultsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/earn/savings': {
+      id: '/_shell/earn/savings'
+      path: '/earn/savings'
+      fullPath: '/earn/savings'
+      preLoaderRoute: typeof ShellEarnSavingsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/earn/rewards': {
+      id: '/_shell/earn/rewards'
+      path: '/earn/rewards'
+      fullPath: '/earn/rewards'
+      preLoaderRoute: typeof ShellEarnRewardsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/earn/fixed': {
+      id: '/_shell/earn/fixed'
+      path: '/earn/fixed'
+      fullPath: '/earn/fixed'
+      preLoaderRoute: typeof ShellEarnFixedRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/earn/expert': {
+      id: '/_shell/earn/expert'
+      path: '/earn/expert'
+      fullPath: '/earn/expert'
+      preLoaderRoute: typeof ShellEarnExpertRouteImport
+      parentRoute: typeof ShellRoute
     }
     '/_shell/convert/upgrade': {
       id: '/_shell/convert/upgrade'
@@ -420,19 +406,33 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellConvertPsmRouteImport
       parentRoute: typeof ShellConvertRoute
     }
-    '/_shell/vaults/$provider/$vaultAddress': {
-      id: '/_shell/vaults/$provider/$vaultAddress'
-      path: '/$provider/$vaultAddress'
-      fullPath: '/vaults/$provider/$vaultAddress'
-      preLoaderRoute: typeof ShellVaultsProviderVaultAddressRouteImport
-      parentRoute: typeof ShellVaultsRoute
+    '/_shell/earn/rewards/$rewardContract': {
+      id: '/_shell/earn/rewards/$rewardContract'
+      path: '/$rewardContract'
+      fullPath: '/earn/rewards/$rewardContract'
+      preLoaderRoute: typeof ShellEarnRewardsRewardContractRouteImport
+      parentRoute: typeof ShellEarnRewardsRoute
     }
-    '/_shell/fixed/market/$marketAddress': {
-      id: '/_shell/fixed/market/$marketAddress'
+    '/_shell/earn/expert/stusds': {
+      id: '/_shell/earn/expert/stusds'
+      path: '/stusds'
+      fullPath: '/earn/expert/stusds'
+      preLoaderRoute: typeof ShellEarnExpertStusdsRouteImport
+      parentRoute: typeof ShellEarnExpertRoute
+    }
+    '/_shell/earn/vaults/$provider/$vaultAddress': {
+      id: '/_shell/earn/vaults/$provider/$vaultAddress'
+      path: '/$provider/$vaultAddress'
+      fullPath: '/earn/vaults/$provider/$vaultAddress'
+      preLoaderRoute: typeof ShellEarnVaultsProviderVaultAddressRouteImport
+      parentRoute: typeof ShellEarnVaultsRoute
+    }
+    '/_shell/earn/fixed/market/$marketAddress': {
+      id: '/_shell/earn/fixed/market/$marketAddress'
       path: '/market/$marketAddress'
-      fullPath: '/fixed/market/$marketAddress'
-      preLoaderRoute: typeof ShellFixedMarketMarketAddressRouteImport
-      parentRoute: typeof ShellFixedRoute
+      fullPath: '/earn/fixed/market/$marketAddress'
+      preLoaderRoute: typeof ShellEarnFixedMarketMarketAddressRouteImport
+      parentRoute: typeof ShellEarnFixedRoute
     }
   }
 }
@@ -453,78 +453,79 @@ const ShellConvertRouteWithChildren = ShellConvertRoute._addFileChildren(
   ShellConvertRouteChildren,
 )
 
-interface ShellExpertRouteChildren {
-  ShellExpertStusdsRoute: typeof ShellExpertStusdsRoute
+interface ShellEarnExpertRouteChildren {
+  ShellEarnExpertStusdsRoute: typeof ShellEarnExpertStusdsRoute
 }
 
-const ShellExpertRouteChildren: ShellExpertRouteChildren = {
-  ShellExpertStusdsRoute: ShellExpertStusdsRoute,
+const ShellEarnExpertRouteChildren: ShellEarnExpertRouteChildren = {
+  ShellEarnExpertStusdsRoute: ShellEarnExpertStusdsRoute,
 }
 
-const ShellExpertRouteWithChildren = ShellExpertRoute._addFileChildren(
-  ShellExpertRouteChildren,
+const ShellEarnExpertRouteWithChildren = ShellEarnExpertRoute._addFileChildren(
+  ShellEarnExpertRouteChildren,
 )
 
-interface ShellFixedRouteChildren {
-  ShellFixedMarketMarketAddressRoute: typeof ShellFixedMarketMarketAddressRoute
+interface ShellEarnFixedRouteChildren {
+  ShellEarnFixedMarketMarketAddressRoute: typeof ShellEarnFixedMarketMarketAddressRoute
 }
 
-const ShellFixedRouteChildren: ShellFixedRouteChildren = {
-  ShellFixedMarketMarketAddressRoute: ShellFixedMarketMarketAddressRoute,
+const ShellEarnFixedRouteChildren: ShellEarnFixedRouteChildren = {
+  ShellEarnFixedMarketMarketAddressRoute:
+    ShellEarnFixedMarketMarketAddressRoute,
 }
 
-const ShellFixedRouteWithChildren = ShellFixedRoute._addFileChildren(
-  ShellFixedRouteChildren,
+const ShellEarnFixedRouteWithChildren = ShellEarnFixedRoute._addFileChildren(
+  ShellEarnFixedRouteChildren,
 )
 
-interface ShellRewardsRouteChildren {
-  ShellRewardsRewardContractRoute: typeof ShellRewardsRewardContractRoute
+interface ShellEarnRewardsRouteChildren {
+  ShellEarnRewardsRewardContractRoute: typeof ShellEarnRewardsRewardContractRoute
 }
 
-const ShellRewardsRouteChildren: ShellRewardsRouteChildren = {
-  ShellRewardsRewardContractRoute: ShellRewardsRewardContractRoute,
+const ShellEarnRewardsRouteChildren: ShellEarnRewardsRouteChildren = {
+  ShellEarnRewardsRewardContractRoute: ShellEarnRewardsRewardContractRoute,
 }
 
-const ShellRewardsRouteWithChildren = ShellRewardsRoute._addFileChildren(
-  ShellRewardsRouteChildren,
-)
+const ShellEarnRewardsRouteWithChildren =
+  ShellEarnRewardsRoute._addFileChildren(ShellEarnRewardsRouteChildren)
 
-interface ShellVaultsRouteChildren {
-  ShellVaultsProviderVaultAddressRoute: typeof ShellVaultsProviderVaultAddressRoute
+interface ShellEarnVaultsRouteChildren {
+  ShellEarnVaultsProviderVaultAddressRoute: typeof ShellEarnVaultsProviderVaultAddressRoute
 }
 
-const ShellVaultsRouteChildren: ShellVaultsRouteChildren = {
-  ShellVaultsProviderVaultAddressRoute: ShellVaultsProviderVaultAddressRoute,
+const ShellEarnVaultsRouteChildren: ShellEarnVaultsRouteChildren = {
+  ShellEarnVaultsProviderVaultAddressRoute:
+    ShellEarnVaultsProviderVaultAddressRoute,
 }
 
-const ShellVaultsRouteWithChildren = ShellVaultsRoute._addFileChildren(
-  ShellVaultsRouteChildren,
+const ShellEarnVaultsRouteWithChildren = ShellEarnVaultsRoute._addFileChildren(
+  ShellEarnVaultsRouteChildren,
 )
 
 interface ShellRouteChildren {
   ShellConvertRoute: typeof ShellConvertRouteWithChildren
-  ShellEarnRoute: typeof ShellEarnRoute
-  ShellExpertRoute: typeof ShellExpertRouteWithChildren
-  ShellFixedRoute: typeof ShellFixedRouteWithChildren
   ShellPortfolioRoute: typeof ShellPortfolioRoute
-  ShellRewardsRoute: typeof ShellRewardsRouteWithChildren
-  ShellSavingsRoute: typeof ShellSavingsRoute
   ShellStakeRoute: typeof ShellStakeRoute
-  ShellVaultsRoute: typeof ShellVaultsRouteWithChildren
   ShellIndexRoute: typeof ShellIndexRoute
+  ShellEarnExpertRoute: typeof ShellEarnExpertRouteWithChildren
+  ShellEarnFixedRoute: typeof ShellEarnFixedRouteWithChildren
+  ShellEarnRewardsRoute: typeof ShellEarnRewardsRouteWithChildren
+  ShellEarnSavingsRoute: typeof ShellEarnSavingsRoute
+  ShellEarnVaultsRoute: typeof ShellEarnVaultsRouteWithChildren
+  ShellEarnIndexRoute: typeof ShellEarnIndexRoute
 }
 
 const ShellRouteChildren: ShellRouteChildren = {
   ShellConvertRoute: ShellConvertRouteWithChildren,
-  ShellEarnRoute: ShellEarnRoute,
-  ShellExpertRoute: ShellExpertRouteWithChildren,
-  ShellFixedRoute: ShellFixedRouteWithChildren,
   ShellPortfolioRoute: ShellPortfolioRoute,
-  ShellRewardsRoute: ShellRewardsRouteWithChildren,
-  ShellSavingsRoute: ShellSavingsRoute,
   ShellStakeRoute: ShellStakeRoute,
-  ShellVaultsRoute: ShellVaultsRouteWithChildren,
   ShellIndexRoute: ShellIndexRoute,
+  ShellEarnExpertRoute: ShellEarnExpertRouteWithChildren,
+  ShellEarnFixedRoute: ShellEarnFixedRouteWithChildren,
+  ShellEarnRewardsRoute: ShellEarnRewardsRouteWithChildren,
+  ShellEarnSavingsRoute: ShellEarnSavingsRoute,
+  ShellEarnVaultsRoute: ShellEarnVaultsRouteWithChildren,
+  ShellEarnIndexRoute: ShellEarnIndexRoute,
 }
 
 const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren)

--- a/apps/webapp/src/routes/__root.tsx
+++ b/apps/webapp/src/routes/__root.tsx
@@ -1,17 +1,21 @@
 import { createRootRoute, redirect } from '@tanstack/react-router';
-import { legacySearchToLocation } from '@/lib/legacyRedirects';
+import { legacyPathToLocation, legacySearchToLocation } from '@/lib/legacyRedirects';
 
 export type AppSearchParams = Record<string, string>;
 
 export const Route = createRootRoute({
   // Permissive passthrough: the router's parseSearch already guarantees string values.
   validateSearch: (search): AppSearchParams => search as AppSearchParams,
-  // Translate pre-path-navigation deep links (?widget=...) to their path
-  // equivalents so external links and bookmarks keep working.
-  beforeLoad: ({ search }) => {
+  // Translate legacy deep links so external links and bookmarks keep working:
+  // ?widget= URLs first rewrite to their pre-flip path, then pre-flip module
+  // paths (/savings, /rewards/0x…) map forward to their /earn destinations —
+  // composed here so either generation lands in a single redirect.
+  beforeLoad: ({ search, location }) => {
     const legacy = legacySearchToLocation(search);
-    if (legacy) {
-      throw redirect({ to: legacy.to, search: legacy.search, replace: true });
+    const base = legacy ?? { to: location.pathname, search };
+    const target = legacyPathToLocation(base.to, base.search) ?? legacy;
+    if (target) {
+      throw redirect({ to: target.to, search: target.search, replace: true });
     }
   }
 });

--- a/apps/webapp/src/routes/_shell.earn.expert.stusds.tsx
+++ b/apps/webapp/src/routes/_shell.earn.expert.stusds.tsx
@@ -3,6 +3,6 @@ import { ExpertIntent } from '@/lib/enums';
 
 // Gated on the expert risk disclaimer in useAppOrchestration's route-validation
 // effect (user settings live in React context).
-export const Route = createFileRoute('/_shell/expert/stusds')({
+export const Route = createFileRoute('/_shell/earn/expert/stusds')({
   staticData: { expertIntent: ExpertIntent.STUSDS_INTENT }
 });

--- a/apps/webapp/src/routes/_shell.earn.expert.tsx
+++ b/apps/webapp/src/routes/_shell.earn.expert.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { ExpertPanes } from '@/modules/expert/components/ExpertPanes';
 import { Intent } from '@/lib/enums';
 
-export const Route = createFileRoute('/_shell/expert')({
+export const Route = createFileRoute('/_shell/earn/expert')({
   component: ExpertPanes,
   staticData: { intent: Intent.EXPERT_INTENT }
 });

--- a/apps/webapp/src/routes/_shell.earn.fixed.market.$marketAddress.tsx
+++ b/apps/webapp/src/routes/_shell.earn.fixed.market.$marketAddress.tsx
@@ -5,12 +5,12 @@ import { PENDLE_MARKETS, isMarketMatured } from '@/hooks';
 
 // Matured markets have no detail view — they only render as redeem rows on
 // the overview — and unknown addresses fall back to the overview too.
-export const Route = createFileRoute('/_shell/fixed/market/$marketAddress')({
+export const Route = createFileRoute('/_shell/earn/fixed/market/$marketAddress')({
   beforeLoad: ({ params }) => {
     const lower = params.marketAddress.toLowerCase();
     const market = PENDLE_MARKETS.find(m => m.marketAddress.toLowerCase() === lower);
     if (!market || isMarketMatured(market.expiry)) {
-      throw redirect({ to: '/fixed', search: keepSearch, replace: true });
+      throw redirect({ to: '/earn/fixed', search: keepSearch, replace: true });
     }
   },
   staticData: { fixedIntent: FixedIntent.MARKET_INTENT }

--- a/apps/webapp/src/routes/_shell.earn.fixed.tsx
+++ b/apps/webapp/src/routes/_shell.earn.fixed.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { PendlePanes } from '@/modules/pendle/components/PendlePanes';
 import { Intent } from '@/lib/enums';
 
-export const Route = createFileRoute('/_shell/fixed')({
+export const Route = createFileRoute('/_shell/earn/fixed')({
   component: PendlePanes,
   staticData: { intent: Intent.FIXED_INTENT }
 });

--- a/apps/webapp/src/routes/_shell.earn.index.tsx
+++ b/apps/webapp/src/routes/_shell.earn.index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { EarnPage } from '@/modules/earn/components/EarnPage';
 
 // No staticData.intent: Earn is a destination, not a module (no Intent maps to it).
-export const Route = createFileRoute('/_shell/earn')({
+export const Route = createFileRoute('/_shell/earn/')({
   component: EarnPage,
   staticData: { fullWidth: true }
 });

--- a/apps/webapp/src/routes/_shell.earn.rewards.$rewardContract.tsx
+++ b/apps/webapp/src/routes/_shell.earn.rewards.$rewardContract.tsx
@@ -3,6 +3,6 @@ import { Intent } from '@/lib/enums';
 
 // Reward contract validity is chain-dependent (wagmi state), so it is enforced
 // in useAppOrchestration's route-validation effect rather than here.
-export const Route = createFileRoute('/_shell/rewards/$rewardContract')({
+export const Route = createFileRoute('/_shell/earn/rewards/$rewardContract')({
   staticData: { intent: Intent.REWARDS_INTENT }
 });

--- a/apps/webapp/src/routes/_shell.earn.rewards.tsx
+++ b/apps/webapp/src/routes/_shell.earn.rewards.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { RewardsPanes } from '@/modules/rewards/components/RewardsPanes';
 import { Intent } from '@/lib/enums';
 
-export const Route = createFileRoute('/_shell/rewards')({
+export const Route = createFileRoute('/_shell/earn/rewards')({
   component: RewardsPanes,
   staticData: { intent: Intent.REWARDS_INTENT }
 });

--- a/apps/webapp/src/routes/_shell.earn.savings.tsx
+++ b/apps/webapp/src/routes/_shell.earn.savings.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { SavingsPanes } from '@/modules/savings/components/SavingsPanes';
 import { Intent } from '@/lib/enums';
 
-export const Route = createFileRoute('/_shell/savings')({
+export const Route = createFileRoute('/_shell/earn/savings')({
   component: SavingsPanes,
   staticData: { intent: Intent.SAVINGS_INTENT }
 });

--- a/apps/webapp/src/routes/_shell.earn.vaults.$provider.$vaultAddress.tsx
+++ b/apps/webapp/src/routes/_shell.earn.vaults.$provider.$vaultAddress.tsx
@@ -7,7 +7,7 @@ import { VAULTS } from '@/hooks';
 // An unrecognised provider segment or an address that belongs to no known
 // vault of that provider falls back to the vaults overview. Which chain the
 // vault lives on is resolved by the panes (chain-dependent).
-export const Route = createFileRoute('/_shell/vaults/$provider/$vaultAddress')({
+export const Route = createFileRoute('/_shell/earn/vaults/$provider/$vaultAddress')({
   beforeLoad: ({ params }) => {
     const provider = providerForVaultModule(params.provider);
     const address = params.vaultAddress.toLowerCase();
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/_shell/vaults/$provider/$vaultAddress')({
         v => v.provider === provider && Object.values(v.vaultAddress).some(a => a?.toLowerCase() === address)
       );
     if (!isKnownVault) {
-      throw redirect({ to: '/vaults', search: keepSearch, replace: true });
+      throw redirect({ to: '/earn/vaults', search: keepSearch, replace: true });
     }
   },
   staticData: { intent: Intent.VAULTS_INTENT }

--- a/apps/webapp/src/routes/_shell.earn.vaults.tsx
+++ b/apps/webapp/src/routes/_shell.earn.vaults.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { VaultsPanes } from '@/modules/vaults/components/VaultsPanes';
 import { Intent } from '@/lib/enums';
 
-export const Route = createFileRoute('/_shell/vaults')({
+export const Route = createFileRoute('/_shell/earn/vaults')({
   component: VaultsPanes,
   staticData: { intent: Intent.VAULTS_INTENT }
 });

--- a/apps/webapp/src/routes/destinations.test.ts
+++ b/apps/webapp/src/routes/destinations.test.ts
@@ -1,49 +1,93 @@
 import { describe, expect, it } from 'vitest';
-import { createMemoryHistory, createRouter } from '@tanstack/react-router';
-import { routeTree } from '@/routeTree.gen';
+import { createMemoryHistory, type AnyRouter } from '@tanstack/react-router';
+import { createAppRouter } from '@/pages/router';
 import { Intent } from '@/lib/enums';
 import { ROUTES } from '@/lib/routes';
 
-// Resolves a path against the real route tree without rendering, so a missing
-// destination route fails here instead of 404ing on a preview deploy.
-async function matchedRouteIds(path: string): Promise<string[]> {
-  const router = createRouter({
-    routeTree,
-    history: createMemoryHistory({ initialEntries: [path] })
-  });
+// Boots the app's real router (route tree + redirects + not-found config)
+// against a path without rendering, so a missing destination route or broken
+// redirect fails here instead of 404ing on a preview deploy.
+async function routerAt(path: string): Promise<AnyRouter> {
+  const router = createAppRouter(createMemoryHistory({ initialEntries: [path] }));
   await router.load();
-  return router.state.matches.map(match => match.routeId as string);
+  return router;
 }
+
+const matchedRouteIds = (router: AnyRouter): string[] =>
+  router.state.matches.map(match => match.routeId as string);
 
 describe('target-IA destination routes', () => {
   it('boots /portfolio as a shell route', async () => {
-    expect(await matchedRouteIds(ROUTES.PORTFOLIO)).toContain('/_shell/portfolio');
+    expect(matchedRouteIds(await routerAt(ROUTES.PORTFOLIO))).toContain('/_shell/portfolio');
   });
 
   it('boots /earn as a shell route', async () => {
-    expect(await matchedRouteIds(ROUTES.EARN)).toContain('/_shell/earn');
+    expect(matchedRouteIds(await routerAt(ROUTES.EARN))).toContain('/_shell/earn/');
+  });
+
+  it.each([
+    [ROUTES.EARN_SAVINGS, '/_shell/earn/savings'],
+    [ROUTES.EARN_REWARDS, '/_shell/earn/rewards'],
+    [ROUTES.EARN_VAULTS, '/_shell/earn/vaults'],
+    [ROUTES.EARN_FIXED, '/_shell/earn/fixed'],
+    [ROUTES.EARN_EXPERT, '/_shell/earn/expert']
+  ])('boots the %s module under the Earn destination', async (path, routeId) => {
+    expect(matchedRouteIds(await routerAt(path))).toContain(routeId);
   });
 
   it('declares the Balances intent on /portfolio for shell orchestration', async () => {
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory({ initialEntries: [ROUTES.PORTFOLIO] })
-    });
-    await router.load();
+    const router = await routerAt(ROUTES.PORTFOLIO);
     const match = router.state.matches.find(m => (m.routeId as string) === '/_shell/portfolio');
     expect(match?.staticData?.intent).toBe(Intent.BALANCES_INTENT);
   });
 
   it.each([
     [ROUTES.PORTFOLIO, '/_shell/portfolio'],
-    [ROUTES.EARN, '/_shell/earn']
+    [ROUTES.EARN, '/_shell/earn/']
   ])('declares %s full-width so it escapes the widget-pane column', async (path, routeId) => {
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory({ initialEntries: [path] })
-    });
-    await router.load();
+    const router = await routerAt(path);
     const match = router.state.matches.find(m => (m.routeId as string) === routeId);
     expect(match?.staticData?.fullWidth).toBe(true);
+  });
+});
+
+describe('pre-flip module path redirects', () => {
+  it.each([
+    ['/savings', ROUTES.EARN_SAVINGS],
+    ['/rewards', ROUTES.EARN_REWARDS],
+    ['/vaults', ROUTES.EARN_VAULTS],
+    ['/fixed', ROUTES.EARN_FIXED],
+    ['/expert', ROUTES.EARN_EXPERT],
+    ['/expert/stusds', `${ROUTES.EARN_EXPERT}/stusds`]
+  ])('redirects %s to %s', async (from, to) => {
+    const router = await routerAt(from);
+    expect(router.state.location.pathname).toBe(to);
+  });
+
+  it('keeps entity segments in the path and preserves search params', async () => {
+    const reward = '0x0650CAF159C5A49f711e8169D4336ECB9b950275';
+    const router = await routerAt(`/rewards/${reward}?network=ethereum`);
+    expect(router.state.location.pathname).toBe(`${ROUTES.EARN_REWARDS}/${reward}`);
+    expect(router.state.location.search).toEqual({ network: 'ethereum' });
+  });
+
+  it('translates legacy ?widget= deep links through to the /earn destination', async () => {
+    const router = await routerAt('/?widget=savings&network=base');
+    expect(router.state.location.pathname).toBe(ROUTES.EARN_SAVINGS);
+    expect(router.state.location.search).toEqual({ network: 'base' });
+  });
+});
+
+describe('unmatched paths', () => {
+  // Regression: with the default fuzzy not-found mode, /earn/bogus rendered the
+  // full-page NotFound (own chrome included) nested inside the app shell.
+  it('resolves an unknown child of an existing route at the root, outside the shell', async () => {
+    const router = await routerAt('/earn/bogus');
+    expect(matchedRouteIds(router).some(id => id.startsWith('/_shell'))).toBe(false);
+  });
+
+  it('resolves an unknown top-level path at the root', async () => {
+    const router = await routerAt('/bogus');
+    expect(matchedRouteIds(router).some(id => id.startsWith('/_shell'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two routing issues on `app-redesign`, and in doing so executes the IA flip the a4 route-map contract (#1660) prepared for:

### 1. Not-found pages rendered nested inside the app shell

The router used TanStack's default `notFoundMode: 'fuzzy'`, which renders the not-found component inside the closest partially-matching route's outlet. For a URL like `/earn/hello`, `/earn` partially matches, so `NotFound` — which renders its own full-page `Layout` — got nested inside the shell, duplicating the header/chrome. Fully unknown paths (`/hello`) rendered correctly at the root, which is why the bug only showed on unknown children of existing routes.

Fixed with `notFoundMode: 'root'`: unmatched paths now always render the full-page 404 outside the shell.

### 2. `/earn/*` module routes didn't exist (the IA flip)

`lib/routes.ts` declares `/earn/savings|rewards|vaults|fixed|expert` as the target IA, but the route files still mounted the modules at top level (`/savings`, `/rewards`, …), so every `/earn/*` URL 404'd. This PR flips the IA:

- Route files renamed to `_shell.earn.*.tsx`. `_shell.earn.tsx` became `_shell.earn.index.tsx` so the EarnPage placeholder renders only at exactly `/earn` and the module routes are siblings under the shell, not children of EarnPage.
- `INTENT_PATHS`, typed `navigate`/`Link` targets in the widget panes, in-route entity-validation redirects, and `BalancesSuggestedActions` URLs (now built from `ROUTES` constants) updated accordingly.
- The dormant `legacyPathToLocation` is now registered in `__root.tsx`, composed after the `?widget=` translator so either generation of legacy URL lands at its `/earn` destination in a single redirect.

### Deviation from the dormant redirect spec (plan §4.1)

As written, `legacyPathToLocation` lifted entity segments into query params (`/rewards/0xabc` → `/earn/rewards?reward=0xabc`) and flattened convert subpaths (`/convert/psm` → `/convert?convert_module=psm`). Registering it as-is would have broken the live `/convert/*` routes and silently dropped reward/vault deep-link state (nothing consumes those retired query params anymore). It is now path-preserving (`/rewards/0xabc` → `/earn/rewards/0xabc`) and the convert entry is gone since those paths survived the flip unchanged. Flag if the decision log intended otherwise (e.g. ahead of Track C slug routes).

## Testing

- `pages/router.tsx` now exports `createAppRouter(history?)` so `destinations.test.ts` boots the real router config: boot tests for all `/earn/*` destinations, pre-flip path redirects (params preserved, entities kept in path), legacy `?widget=` composition, and root-level not-found placement for `/earn/bogus`.
- `legacyRedirects.test.ts` updated to the path-preserving semantics.
- Full unit suite passes (488/488); typecheck/lint clean.
- Manually verified in the running app (Playwright): single-chrome full-page 404 on `/earn/hello`, Savings renders at `/earn/savings`, `/savings?network=base` redirects preserving params, `/convert/trade` untouched, 404 auto-redirect to homepage still works.

Note: `pendle.spec.ts` (e2e) still navigates to old `/fixed/market/…` paths — the redirect keeps it working and it now implicitly covers the redirect path; no e2e asserts pathnames.