### PR TITLE
feat(earn): C1 — EarnProduct registry + useEarnMarketplace aggregator

### DIFF
--- a/apps/webapp/src/data/wagmi/config/chainFamily.ts
+++ b/apps/webapp/src/data/wagmi/config/chainFamily.ts
@@ -1,0 +1,16 @@
+import { mainnet, base, arbitrum, optimism, unichain } from 'wagmi/chains';
+import { isTestnetId } from '@/utils/isTestnetId';
+import { chainId } from '@/utils/chainId';
+
+/**
+ * The chain family the connected chain belongs to: all production networks, or
+ * only the Tenderly fork when connected to it. Lives in its own module (rather
+ * than config.default, which re-exports it) so the engine layer can import it
+ * without dragging the wallet connectors instantiated there at module scope.
+ */
+export const getSupportedChainIds = (connectedChainId: number) => {
+  if (isTestnetId(connectedChainId)) {
+    return [chainId.tenderly];
+  }
+  return [mainnet.id, base.id, arbitrum.id, optimism.id, unichain.id];
+};

--- a/apps/webapp/src/data/wagmi/config/config.default.ts
+++ b/apps/webapp/src/data/wagmi/config/config.default.ts
@@ -97,12 +97,9 @@ export const wagmiConfigMainnet = createConfig({
   multiInjectedProviderDiscovery: true
 });
 
-export const getSupportedChainIds = (chainId: number) => {
-  if (isTestnetId(chainId)) {
-    return [tenderly.id];
-  }
-  return [mainnet.id, base.id, arbitrum.id, optimism.id, unichain.id];
-};
+// Re-exported from its own module so the engine layer can import the family
+// helper without this file's module-scope wallet connectors.
+export { getSupportedChainIds } from './chainFamily';
 
 export const getMainnetChainName = (chainId: number) => {
   if (isTestnetId(chainId)) {

--- a/apps/webapp/src/hooks/earn/earnProducts.test.ts
+++ b/apps/webapp/src/hooks/earn/earnProducts.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { mainnet, base, arbitrum, optimism, unichain } from 'wagmi/chains';
+import { Intent } from '@/lib/enums';
+import { ROUTES } from '@/lib/routes';
+import { TOKENS } from '../tokens/tokens.constants';
+import { VAULTS } from '../vaults/constants';
+import { PENDLE_MARKETS } from '../pendle/constants';
+import type { RewardContract } from '../rewards/rewards';
+import { buildEarnProducts, productNetworks } from './earnProducts';
+
+const TENDERLY_CHAIN_ID = 314310;
+const PRODUCTION_FAMILY = [mainnet.id, base.id, arbitrum.id, optimism.id, unichain.id];
+
+const REWARD_FIXTURES = [
+  {
+    supplyToken: TOKENS.usds,
+    rewardToken: TOKENS.spk,
+    contractAddress: '0x0000000000000000000000000000000000000001' as `0x${string}`,
+    chainId: mainnet.id,
+    name: 'With: USDS Get: SPK'
+  },
+  {
+    supplyToken: TOKENS.usds,
+    rewardToken: TOKENS.cle,
+    contractAddress: '0x0000000000000000000000000000000000000002' as `0x${string}`,
+    chainId: mainnet.id,
+    name: 'Chronicle Points'
+  }
+] as RewardContract[];
+
+describe('productNetworks', () => {
+  it('keeps savings multichain — every production chain with an sUSDS deployment', () => {
+    expect(productNetworks(Intent.SAVINGS_INTENT, PRODUCTION_FAMILY, TOKENS.susds.address)).toEqual(
+      PRODUCTION_FAMILY
+    );
+  });
+
+  it('restricts mainnet-only modules to mainnet within the production family', () => {
+    expect(productNetworks(Intent.REWARDS_INTENT, PRODUCTION_FAMILY)).toEqual([mainnet.id]);
+    expect(productNetworks(Intent.VAULTS_INTENT, PRODUCTION_FAMILY)).toEqual([mainnet.id]);
+    expect(productNetworks(Intent.FIXED_INTENT, PRODUCTION_FAMILY)).toEqual([mainnet.id]);
+    expect(productNetworks(Intent.EXPERT_INTENT, PRODUCTION_FAMILY)).toEqual([mainnet.id]);
+  });
+
+  it('maps the whole tenderly family onto the fork', () => {
+    expect(productNetworks(Intent.SAVINGS_INTENT, [TENDERLY_CHAIN_ID], TOKENS.susds.address)).toEqual([
+      TENDERLY_CHAIN_ID
+    ]);
+    expect(productNetworks(Intent.VAULTS_INTENT, [TENDERLY_CHAIN_ID])).toEqual([TENDERLY_CHAIN_ID]);
+  });
+
+  it('drops chains where the address map has no deployment', () => {
+    expect(productNetworks(Intent.SAVINGS_INTENT, PRODUCTION_FAMILY, { [mainnet.id]: '0x1' })).toEqual([
+      mainnet.id
+    ]);
+  });
+});
+
+describe('buildEarnProducts', () => {
+  const products = buildEarnProducts(PRODUCTION_FAMILY, mainnet.id, REWARD_FIXTURES);
+
+  it('emits one row per product instance: savings + rewards + vaults + markets + stUSDS', () => {
+    expect(products).toHaveLength(1 + REWARD_FIXTURES.length + VAULTS.length + PENDLE_MARKETS.length + 1);
+  });
+
+  it('assigns stable unique ids', () => {
+    const ids = products.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain('savings');
+    expect(ids).toContain('rewards-spk');
+    expect(ids).toContain('stusds');
+  });
+
+  // TODO(BL-07): update when risk ratings get a real source.
+  it('hardcodes risk tiers: advanced for stUSDS, moderate elsewhere', () => {
+    for (const product of products) {
+      expect(product.risk).toBe(product.kind === 'stusds' ? 'advanced' : 'moderate');
+    }
+  });
+
+  it('builds detail paths from the route contract', () => {
+    const byId = Object.fromEntries(products.map(p => [p.id, p]));
+    expect(byId['savings'].detailPath).toBe(ROUTES.EARN_SAVINGS);
+    expect(byId['rewards-spk'].detailPath).toBe(
+      `${ROUTES.EARN_REWARDS}/${REWARD_FIXTURES[0].contractAddress}`
+    );
+    expect(byId['stusds'].detailPath).toBe(`${ROUTES.EARN_EXPERT}/stusds`);
+    for (const product of products.filter(p => p.kind === 'vault')) {
+      expect(product.detailPath.startsWith(`${ROUTES.EARN_VAULTS}/`)).toBe(true);
+    }
+    for (const product of products.filter(p => p.kind === 'fixed')) {
+      expect(product.detailPath).toBe(`${ROUTES.EARN_FIXED}/market/${product.address}`);
+      expect(product.maturity).toBeGreaterThan(0);
+    }
+  });
+
+  it('derives network badges from static config within the family', () => {
+    const byId = Object.fromEntries(products.map(p => [p.id, p]));
+    expect(byId['savings'].networks).toEqual(PRODUCTION_FAMILY);
+    expect(byId['stusds'].networks).toEqual([mainnet.id]);
+    for (const product of products.filter(p => p.kind === 'vault')) {
+      expect(product.networks).toEqual([mainnet.id]);
+    }
+  });
+
+  it('keeps the registry static-length for the tenderly family too', () => {
+    const tenderlyProducts = buildEarnProducts([TENDERLY_CHAIN_ID], TENDERLY_CHAIN_ID, REWARD_FIXTURES);
+    expect(tenderlyProducts).toHaveLength(products.length);
+  });
+});

--- a/apps/webapp/src/hooks/earn/earnProducts.ts
+++ b/apps/webapp/src/hooks/earn/earnProducts.ts
@@ -1,0 +1,114 @@
+import { Intent } from '@/lib/enums';
+import { CHAIN_WIDGET_MAP, COMING_SOON_MAP } from '@/lib/chainAvailability';
+import { intentToPath } from '@/lib/routes';
+import { vaultModuleForProvider } from '@/lib/vaults/vaultProviderMapping';
+import { TOKENS } from '../tokens/tokens.constants';
+import { VAULTS } from '../vaults/constants';
+import { PENDLE_MARKETS } from '../pendle/constants';
+import type { RewardContract } from '../rewards/rewards';
+import type { EarnProductDescriptor, EarnRiskTier } from './types';
+
+// TODO(BL-07): hardcoded risk tiers — see EarnRiskTier in ./types.ts.
+const DEFAULT_RISK_TIER: EarnRiskTier = 'moderate';
+const STUSDS_RISK_TIER: EarnRiskTier = 'advanced';
+
+/**
+ * Chains within `familyChainIds` where a product is live: its owning module
+ * must be enabled for the chain (the existing availability config, reused
+ * unchanged) and, when the product is address-bound, the address map must
+ * have an entry for the chain.
+ */
+export function productNetworks(
+  intent: Intent,
+  familyChainIds: number[],
+  addressMap?: Record<number, unknown>
+): number[] {
+  return familyChainIds.filter(
+    id =>
+      (CHAIN_WIDGET_MAP[id] ?? []).includes(intent) &&
+      !(COMING_SOON_MAP[id] ?? []).includes(intent) &&
+      (addressMap === undefined || addressMap[id] !== undefined)
+  );
+}
+
+/**
+ * The static-length EarnProduct registry: one descriptor per product instance
+ * (savings, each active rewards contract, each vault, each PT market, stUSDS).
+ * Pure — callers pass the active chain family and the chain-resolved rewards
+ * list (from useAvailableTokenRewardContracts, deprecated already filtered).
+ * Matured Pendle markets keep their registry slot (static length) but are
+ * expected to be skipped by consumers via `maturity`.
+ */
+export function buildEarnProducts(
+  familyChainIds: number[],
+  familyMainnetId: number,
+  rewardContracts: RewardContract[]
+): EarnProductDescriptor[] {
+  const savings: EarnProductDescriptor = {
+    id: 'savings',
+    kind: 'savings',
+    intent: Intent.SAVINGS_INTENT,
+    name: 'Sky Savings Rate',
+    tokenSymbol: TOKENS.susds.symbol,
+    risk: DEFAULT_RISK_TIER,
+    networks: productNetworks(Intent.SAVINGS_INTENT, familyChainIds, TOKENS.susds.address),
+    detailPath: intentToPath(Intent.SAVINGS_INTENT)
+  };
+
+  const rewards: EarnProductDescriptor[] = rewardContracts.map(contract => ({
+    id: `rewards-${contract.rewardToken.symbol.toLowerCase()}`,
+    kind: 'rewards',
+    intent: Intent.REWARDS_INTENT,
+    name: contract.name,
+    tokenSymbol: contract.supplyToken.symbol,
+    risk: DEFAULT_RISK_TIER,
+    networks: productNetworks(Intent.REWARDS_INTENT, familyChainIds),
+    detailPath: intentToPath(Intent.REWARDS_INTENT, contract.contractAddress),
+    // RewardContract types its address as plain string; the values come from
+    // the generated per-chain address maps.
+    address: contract.contractAddress as `0x${string}`
+  }));
+
+  const vaults: EarnProductDescriptor[] = VAULTS.map(vault => {
+    const address = vault.vaultAddress[familyMainnetId];
+    return {
+      id: `vault-${vault.provider}-${(address ?? vault.name).toLowerCase()}`,
+      kind: 'vault',
+      intent: Intent.VAULTS_INTENT,
+      name: vault.name,
+      tokenSymbol: vault.assetToken.symbol,
+      risk: DEFAULT_RISK_TIER,
+      networks: productNetworks(Intent.VAULTS_INTENT, familyChainIds, vault.vaultAddress),
+      detailPath: intentToPath(Intent.VAULTS_INTENT, `${vaultModuleForProvider(vault.provider)}/${address}`),
+      address
+    };
+  });
+
+  const fixed: EarnProductDescriptor[] = PENDLE_MARKETS.map(market => ({
+    id: `fixed-${market.marketAddress.toLowerCase()}`,
+    kind: 'fixed',
+    intent: Intent.FIXED_INTENT,
+    name: market.name,
+    tokenSymbol: market.underlyingSymbol,
+    risk: DEFAULT_RISK_TIER,
+    networks: productNetworks(Intent.FIXED_INTENT, familyChainIds),
+    detailPath: intentToPath(Intent.FIXED_INTENT, `market/${market.marketAddress}`),
+    maturity: market.expiry,
+    address: market.marketAddress
+  }));
+
+  const stusds: EarnProductDescriptor = {
+    id: 'stusds',
+    kind: 'stusds',
+    intent: Intent.EXPERT_INTENT,
+    name: 'stUSDS',
+    tokenSymbol: TOKENS.stusds.symbol,
+    risk: STUSDS_RISK_TIER,
+    networks: productNetworks(Intent.EXPERT_INTENT, familyChainIds),
+    // Slug = ExpertIntentMapping[ExpertIntent.STUSDS_INTENT]; inlined because
+    // lib/constants pulls Lingui macros the hooks test runner can't transform.
+    detailPath: intentToPath(Intent.EXPERT_INTENT, 'stusds')
+  };
+
+  return [savings, ...rewards, ...vaults, ...fixed, stusds];
+}

--- a/apps/webapp/src/hooks/earn/types.ts
+++ b/apps/webapp/src/hooks/earn/types.ts
@@ -1,0 +1,81 @@
+import type { Intent } from '@/lib/enums';
+
+/**
+ * Risk tier vocabulary from the V2 Figma ("Earn Opportunities" filter pills).
+ * TODO(BL-07): tiers are HARDCODED pending the risk-rating source decision
+ * (editorial config vs endpoint). Per product decision 2026-06-12: 'moderate'
+ * for every product, 'advanced' for stUSDS. 'low' is currently unassigned —
+ * Sky Savings is the natural candidate once ratings get a real source.
+ */
+export type EarnRiskTier = 'low' | 'moderate' | 'advanced';
+
+export type EarnProductKind = 'savings' | 'rewards' | 'vault' | 'fixed' | 'stusds';
+
+/**
+ * USD-denominated amount aggregated across the active chain family, with a
+ * per-chain split where the underlying source provides one (positions always
+ * do; some TVL sources only report a global figure).
+ */
+export type EarnUsdAmount = {
+  totalUsd: number;
+  byChain?: Record<number, number>;
+};
+
+export type EarnRate = {
+  /**
+   * Decimal fraction (0.045 = 4.50%). Undefined while loading or when the
+   * product has no APY (e.g. Chronicle points).
+   */
+  value?: number;
+  /** Display string ('4.50%'), '—' when value is undefined. */
+  formatted: string;
+};
+
+/**
+ * Static, fetch-free identity of an earn product instance — one entry per
+ * contract/market. The registry (buildEarnProducts) emits these; the
+ * marketplace aggregator decorates them with live data.
+ */
+export type EarnProductDescriptor = {
+  /** Stable identifier, e.g. 'savings', 'rewards-spk', 'vault-sky-0x…', 'fixed-0x…'. */
+  id: string;
+  kind: EarnProductKind;
+  /** Module that owns the product (availability, network override, analytics). */
+  intent: Intent;
+  name: string;
+  /** Supply-asset symbol shown in the Token column. */
+  tokenSymbol: string;
+  risk: EarnRiskTier;
+  /**
+   * Chains within the active family the product is live on. Derived from
+   * static config (CHAIN_WIDGET_MAP ∩ per-product address maps) — never from
+   * fetches, so network badges render before any data arrives.
+   */
+  networks: number[];
+  /** In-app destination, built via the route contract (lib/routes) — never hardcoded. */
+  detailPath: string;
+  /** Pendle PT maturity (unix seconds); only set for kind 'fixed'. */
+  maturity?: number;
+  /** Chain-resolved contract identity for data lookups (reward contract, vault, market). */
+  address?: `0x${string}`;
+};
+
+/** A descriptor decorated with live data — one table row. */
+export type EarnProductRow = EarnProductDescriptor & {
+  rate: EarnRate;
+  /**
+   * TODO(C1 follow-up): no 30-day-rate source is wired yet (needs the
+   * historical-rate endpoints) — always undefined; consumers render '–'.
+   */
+  rate30d?: EarnRate;
+  tvl?: EarnUsdAmount;
+  position?: EarnUsdAmount;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+export type EarnMarketplaceResult = {
+  rows: EarnProductRow[];
+  /** True while any row is still loading. Rows fail independently — check per-row error. */
+  isLoading: boolean;
+};

--- a/apps/webapp/src/hooks/earn/useEarnMarketplace.test.tsx
+++ b/apps/webapp/src/hooks/earn/useEarnMarketplace.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, afterAll } from 'vitest';
+import { cleanup, waitFor, renderHook } from '@testing-library/react';
+import { WagmiWrapper } from '../../../test/hooks';
+
+import { useEarnMarketplace } from './useEarnMarketplace';
+
+describe('useEarnMarketplace', () => {
+  it('returns one row per product instance with live data', async () => {
+    const { result } = renderHook(() => useEarnMarketplace(), { wrapper: WagmiWrapper });
+
+    // Static registry shape is available immediately, before any data lands.
+    const ids = result.current.rows.map(row => row.id);
+    expect(ids).toContain('savings');
+    expect(ids).toContain('rewards-spk');
+    expect(ids).toContain('stusds');
+    expect(result.current.rows.filter(row => row.kind === 'vault').length).toBeGreaterThan(0);
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+      },
+      { timeout: 60000 }
+    );
+
+    const byId = Object.fromEntries(result.current.rows.map(row => [row.id, row]));
+
+    // Savings: SSR rate and a global TVL from BA Labs.
+    expect(byId['savings'].rate.value).toBeGreaterThan(0);
+    expect(byId['savings'].tvl?.totalUsd).toBeGreaterThan(0);
+
+    // stUSDS: onchain str-derived rate, advanced risk tier.
+    expect(byId['stusds'].risk).toBe('advanced');
+    expect(byId['stusds'].rate.value).toBeGreaterThan(0);
+    expect(byId['stusds'].tvl?.totalUsd).toBeGreaterThan(0);
+
+    // Every row resolved without error and 30D rate stays unwired (TODO C1).
+    for (const row of result.current.rows) {
+      expect(row.error).toBeNull();
+      expect(row.rate30d).toBeUndefined();
+      expect(row.detailPath.startsWith('/')).toBe(true);
+      expect(row.networks.length).toBeGreaterThan(0);
+    }
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+});

--- a/apps/webapp/src/hooks/earn/useEarnMarketplace.ts
+++ b/apps/webapp/src/hooks/earn/useEarnMarketplace.ts
@@ -1,0 +1,336 @@
+import { useMemo } from 'react';
+import { useChainId, useConnection, useReadContracts } from 'wagmi';
+import { useQueries } from '@tanstack/react-query';
+import { mainnet } from 'viem/chains';
+import {
+  chainId as chainIdConstants,
+  isTestnetId,
+  calculateApyFromStr,
+  formatDecimalPercentage,
+  math
+} from '@/utils';
+import { getSupportedChainIds } from '@/data/wagmi/config/chainFamily';
+import { ZERO_ADDRESS } from '../constants';
+import { usdsSkyRewardAbi, sparkUsdtVaultAddress } from '../generated';
+import { usePrices } from '../prices/usePrices';
+import { useOverallSkyData } from '../shared/useOverallSkyData';
+import { useMultiChainSavingsBalances } from '../savings/useMultiChainSavingsBalances';
+import { useAvailableTokenRewardContracts } from '../rewards/useAvailableTokenRewardContracts';
+import { filterDeprecatedRewardContracts } from '../rewards/deprecatedRewards';
+import { useMultipleRewardsChartInfo } from '../rewards/useMultipleRewardsChartInfo';
+import type { RewardsChartInfoParsed } from '../rewards/useRewardsChartInfo';
+import { MORPHO_VAULTS } from '../morpho/constants';
+import { useMorphoVaultMultipleRateApiData } from '../morpho/useMorphoVaultRateApiData';
+import { fetchMorphoVaultMarketData } from '../morpho/useMorphoVaultMarketApiData';
+import { useAllMorphoVaultsUserAssets } from '../morpho/useAllMorphoVaultsUserAssets';
+import { VAULTS } from '../vaults/constants';
+import { useSparkVaultResolvedRate } from '../vaults/spark/useSparkVaultResolvedRate';
+import { useSparkVaultApiData } from '../vaults/spark/useSparkVaultApiData';
+import { isMarketMatured } from '../pendle/helpers';
+import { usePendleMarketsApiData } from '../pendle/usePendleMarketsApiData';
+import { useAllPendleUserAssets } from '../pendle/useAllPendleUserAssets';
+import { useStUsdsData } from '../stusds/useStUsdsData';
+import { buildEarnProducts } from './earnProducts';
+import type { EarnMarketplaceResult, EarnProductRow, EarnRate, EarnUsdAmount } from './types';
+
+const NO_RATE = '—';
+
+// Same valuation math as useSuppliedBalancesTotalUsd (which this supersedes):
+// WAD amount × BA Labs price. Portfolio must consume these rows, not refork it.
+const bigintToUsd = (balance: bigint, priceStr: string | undefined) =>
+  (Number(balance) / 1e18) * parseFloat(priceStr || '0');
+
+const toRate = (value: number | undefined): EarnRate =>
+  value !== undefined && !isNaN(value) && value > 0
+    ? { value, formatted: formatDecimalPercentage(value) }
+    : { formatted: NO_RATE };
+
+const latestChartEntry = (data?: RewardsChartInfoParsed[]): RewardsChartInfoParsed | undefined =>
+  data && data.length > 0 ? [...data].sort((a, b) => b.blockTimestamp - a.blockTimestamp)[0] : undefined;
+
+const singleChainAmount = (chainId: number, totalUsd: number): EarnUsdAmount => ({
+  totalUsd,
+  byChain: { [chainId]: totalUsd }
+});
+
+/**
+ * The C1 marketplace aggregator: every registry product decorated with live
+ * rate / TVL / user-position data, normalized to one row shape (plan §4.1,
+ * Earn Opportunities table). Fetches the whole active chain family at once
+ * (all production networks, or only Tenderly when forked); single-chain
+ * products resolve against the family's mainnet. Every underlying hook is
+ * called unconditionally over const registries, so hook order is stable.
+ * Rows carry their own isLoading/error — one product's source failing does
+ * not sink the table.
+ */
+export function useEarnMarketplace(): EarnMarketplaceResult {
+  const connectedChainId = useChainId();
+  const { address } = useConnection();
+  const familyChainIds = getSupportedChainIds(connectedChainId);
+  // Single-chain products (rewards, vaults, fixed, stUSDS) live on mainnet;
+  // the Tenderly fork mirrors it under its own chain id.
+  const familyMainnetId = isTestnetId(connectedChainId)
+    ? chainIdConstants.tenderly
+    : chainIdConstants.mainnet;
+
+  const { data: pricesData, isLoading: pricesLoading } = usePrices();
+
+  // --- Savings (the one genuinely multichain product)
+  const { data: overallSkyData, isLoading: overallLoading, error: overallError } = useOverallSkyData();
+  const {
+    data: savingsBalances,
+    isLoading: savingsBalancesLoading,
+    error: savingsBalancesError
+  } = useMultiChainSavingsBalances({ chainIds: familyChainIds, address });
+
+  // --- Rewards: array-taking hooks keep the call count fixed regardless of
+  // how many contracts the chain resolves.
+  const allRewardContracts = useAvailableTokenRewardContracts(familyMainnetId);
+  const rewardContracts = useMemo(
+    () => filterDeprecatedRewardContracts(allRewardContracts, familyMainnetId),
+    [allRewardContracts, familyMainnetId]
+  );
+  const {
+    data: rewardsCharts,
+    isLoading: rewardsChartsLoading,
+    error: rewardsChartsError
+  } = useMultipleRewardsChartInfo({
+    rewardContractAddresses: rewardContracts.map(c => c.contractAddress)
+  });
+  const {
+    data: rewardsBalances,
+    isLoading: rewardsBalancesLoading,
+    error: rewardsBalancesError
+  } = useReadContracts({
+    contracts: rewardContracts.map(c => ({
+      address: c.contractAddress as `0x${string}`,
+      abi: usdsSkyRewardAbi,
+      chainId: familyMainnetId,
+      functionName: 'balanceOf' as const,
+      args: [address ?? ZERO_ADDRESS]
+    })),
+    query: { enabled: !!address }
+  });
+
+  // --- Vaults (Morpho + Spark via the unified VAULTS registry)
+  const morphoVaultAddresses = useMemo(
+    () => MORPHO_VAULTS.map(v => v.vaultAddress[familyMainnetId]),
+    [familyMainnetId]
+  );
+  const {
+    data: morphoRates,
+    isLoading: morphoRatesLoading,
+    error: morphoRatesError
+  } = useMorphoVaultMultipleRateApiData({ vaultAddresses: morphoVaultAddresses });
+  // Same query keys as useMorphoVaultsCombinedTvl, so the cache is shared with
+  // the existing widgets and mounting both costs no extra requests.
+  const morphoMarketResults = useQueries({
+    queries: MORPHO_VAULTS.map(vault => ({
+      queryKey: ['morpho-vault-market-data', vault.vaultAddress[mainnet.id], mainnet.id],
+      queryFn: () => fetchMorphoVaultMarketData(vault.vaultAddress[mainnet.id], mainnet.id),
+      staleTime: 30_000,
+      gcTime: 60_000
+    }))
+  });
+  const sparkRate = useSparkVaultResolvedRate({ vaultAddress: sparkUsdtVaultAddress[mainnet.id] });
+  const sparkMarket = useSparkVaultApiData({ vaultAddress: sparkUsdtVaultAddress[mainnet.id] });
+  // Despite the name, iterates the unified VAULTS registry (Morpho + Spark).
+  const {
+    data: vaultUserAssets,
+    isLoading: vaultUserAssetsLoading,
+    error: vaultUserAssetsError
+  } = useAllMorphoVaultsUserAssets();
+
+  // --- Pendle
+  const {
+    data: pendleMarketsApi,
+    isLoading: pendleMarketsLoading,
+    error: pendleMarketsError
+  } = usePendleMarketsApiData();
+  const {
+    data: pendleUserAssets,
+    isLoading: pendleUserAssetsLoading,
+    error: pendleUserAssetsError
+  } = useAllPendleUserAssets();
+
+  // --- stUSDS
+  const { data: stUsdsData, isLoading: stUsdsLoading, error: stUsdsError } = useStUsdsData();
+
+  const products = useMemo(
+    () => buildEarnProducts(familyChainIds, familyMainnetId, rewardContracts),
+    [familyChainIds, familyMainnetId, rewardContracts]
+  );
+
+  const rows = useMemo<EarnProductRow[]>(() => {
+    const usdsPrice = pricesData?.USDS?.price;
+    const priceFor = (symbol: string) => pricesData?.[symbol]?.price ?? usdsPrice;
+
+    return products
+      .filter(product => product.maturity === undefined || !isMarketMatured(product.maturity))
+      .map(product => {
+        switch (product.kind) {
+          case 'savings': {
+            const rawRate = overallSkyData?.skySavingsRatecRate;
+            const rawTvl = overallSkyData?.skySavingsRateTvl;
+            const byChain = Object.fromEntries(
+              Object.entries(savingsBalances ?? {}).map(([id, balance]) => [
+                id,
+                bigintToUsd(balance, usdsPrice)
+              ])
+            );
+            return {
+              ...product,
+              rate: toRate(rawRate ? parseFloat(rawRate) : undefined),
+              // BA Labs reports savings TVL as a global USD figure — no per-chain split.
+              tvl: rawTvl ? { totalUsd: parseFloat(rawTvl) } : undefined,
+              position: savingsBalances
+                ? {
+                    totalUsd: Object.values(byChain).reduce((acc, usd) => acc + usd, 0),
+                    byChain
+                  }
+                : undefined,
+              isLoading: overallLoading || savingsBalancesLoading || pricesLoading,
+              error: overallError || savingsBalancesError || null
+            };
+          }
+          case 'rewards': {
+            const index = rewardContracts.findIndex(c => c.contractAddress === product.address);
+            const latest = latestChartEntry(rewardsCharts?.[index]);
+            const supplied = rewardsBalances?.[index]?.result as bigint | undefined;
+            const suppliedUsd = supplied !== undefined ? bigintToUsd(supplied, usdsPrice) : undefined;
+            const tvlUsd = latest
+              ? parseFloat(latest.totalSupplied) * parseFloat(usdsPrice || '0')
+              : undefined;
+            return {
+              ...product,
+              rate: toRate(latest ? parseFloat(latest.rate) : undefined),
+              tvl: tvlUsd !== undefined ? singleChainAmount(familyMainnetId, tvlUsd) : undefined,
+              position:
+                suppliedUsd !== undefined ? singleChainAmount(familyMainnetId, suppliedUsd) : undefined,
+              isLoading: rewardsChartsLoading || rewardsBalancesLoading || pricesLoading,
+              error: rewardsChartsError || rewardsBalancesError || null
+            };
+          }
+          case 'vault': {
+            const vault = VAULTS.find(v => v.vaultAddress[familyMainnetId] === product.address);
+            const isSpark = vault?.provider === 'sky';
+            let rate: EarnRate;
+            let tvlUsd: number | undefined;
+            if (isSpark) {
+              rate = toRate(
+                sparkRate.formattedRate !== undefined ? parseFloat(sparkRate.formattedRate) / 100 : undefined
+              );
+              tvlUsd = sparkMarket.data?.totalAssetsUsd;
+              if (tvlUsd === undefined && sparkMarket.data?.totalAssets !== undefined && vault) {
+                const decimals = math.resolveDecimals(vault.assetToken.decimals, mainnet.id);
+                tvlUsd = bigintToUsd(
+                  math.scaleToBaseDecimals(sparkMarket.data.totalAssets, decimals),
+                  priceFor(vault.assetToken.symbol)
+                );
+              }
+            } else {
+              const morphoRate = morphoRates?.find(
+                r => r.address.toLowerCase() === product.address?.toLowerCase()
+              );
+              rate = toRate(morphoRate?.netRate);
+              const morphoIndex = MORPHO_VAULTS.findIndex(
+                v => v.vaultAddress[familyMainnetId] === product.address
+              );
+              tvlUsd = morphoMarketResults[morphoIndex]?.data?.totalAssetsUsd;
+            }
+            const userVault = vaultUserAssets.vaults.find(v => v.vaultAddress === product.address);
+            const positionUsd = userVault
+              ? bigintToUsd(userVault.balanceNormalized, priceFor(userVault.assetToken.symbol))
+              : undefined;
+            return {
+              ...product,
+              rate,
+              tvl: tvlUsd !== undefined ? singleChainAmount(familyMainnetId, tvlUsd) : undefined,
+              position:
+                positionUsd !== undefined ? singleChainAmount(familyMainnetId, positionUsd) : undefined,
+              isLoading:
+                (isSpark
+                  ? sparkRate.isLoading || sparkMarket.isLoading
+                  : morphoRatesLoading || morphoMarketResults.some(r => r.isLoading)) ||
+                vaultUserAssetsLoading ||
+                pricesLoading,
+              error: (isSpark ? sparkMarket.error : morphoRatesError) || vaultUserAssetsError || null
+            };
+          }
+          case 'fixed': {
+            const stats = product.address ? pendleMarketsApi?.[product.address] : undefined;
+            const userMarket = pendleUserAssets.markets.find(m => m.marketAddress === product.address);
+            return {
+              ...product,
+              rate: toRate(stats?.impliedApy),
+              tvl: stats?.tvl !== undefined ? singleChainAmount(familyMainnetId, stats.tvl) : undefined,
+              position: userMarket ? singleChainAmount(familyMainnetId, userMarket.valuationUsd) : undefined,
+              isLoading: pendleMarketsLoading || pendleUserAssetsLoading,
+              error: pendleMarketsError || pendleUserAssetsError || null
+            };
+          }
+          case 'stusds': {
+            return {
+              ...product,
+              rate: toRate(
+                stUsdsData?.moduleRate !== undefined
+                  ? calculateApyFromStr(stUsdsData.moduleRate) / 100
+                  : undefined
+              ),
+              tvl:
+                stUsdsData?.totalAssets !== undefined
+                  ? singleChainAmount(familyMainnetId, bigintToUsd(stUsdsData.totalAssets, usdsPrice))
+                  : undefined,
+              position:
+                stUsdsData?.userSuppliedUsds !== undefined
+                  ? singleChainAmount(familyMainnetId, bigintToUsd(stUsdsData.userSuppliedUsds, usdsPrice))
+                  : undefined,
+              isLoading: stUsdsLoading || pricesLoading,
+              error: stUsdsError || null
+            };
+          }
+        }
+      });
+  }, [
+    products,
+    pricesData,
+    pricesLoading,
+    overallSkyData,
+    overallLoading,
+    overallError,
+    savingsBalances,
+    savingsBalancesLoading,
+    savingsBalancesError,
+    rewardContracts,
+    rewardsCharts,
+    rewardsChartsLoading,
+    rewardsChartsError,
+    rewardsBalances,
+    rewardsBalancesLoading,
+    rewardsBalancesError,
+    morphoRates,
+    morphoRatesLoading,
+    morphoRatesError,
+    morphoMarketResults,
+    sparkRate,
+    sparkMarket,
+    vaultUserAssets,
+    vaultUserAssetsLoading,
+    vaultUserAssetsError,
+    pendleMarketsApi,
+    pendleMarketsLoading,
+    pendleMarketsError,
+    pendleUserAssets,
+    pendleUserAssetsLoading,
+    pendleUserAssetsError,
+    stUsdsData,
+    stUsdsLoading,
+    stUsdsError,
+    familyMainnetId
+  ]);
+
+  return {
+    rows,
+    isLoading: rows.some(row => row.isLoading)
+  };
+}

--- a/apps/webapp/src/hooks/earn/useEarnMarketplace.ts
+++ b/apps/webapp/src/hooks/earn/useEarnMarketplace.ts
@@ -164,6 +164,10 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
   const rows = useMemo<EarnProductRow[]>(() => {
     const usdsPrice = pricesData?.USDS?.price;
     const priceFor = (symbol: string) => pricesData?.[symbol]?.price ?? usdsPrice;
+    // Disconnected → position undefined on EVERY row (some sources report 0n
+    // without an account, which would render as a misleading $0). Connected →
+    // a number on every row, 0 included.
+    const connected = !!address;
 
     return products
       .filter(product => product.maturity === undefined || !isMarketMatured(product.maturity))
@@ -183,12 +187,13 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
               rate: toRate(rawRate ? parseFloat(rawRate) : undefined),
               // BA Labs reports savings TVL as a global USD figure — no per-chain split.
               tvl: rawTvl ? { totalUsd: parseFloat(rawTvl) } : undefined,
-              position: savingsBalances
-                ? {
-                    totalUsd: Object.values(byChain).reduce((acc, usd) => acc + usd, 0),
-                    byChain
-                  }
-                : undefined,
+              position:
+                connected && savingsBalances
+                  ? {
+                      totalUsd: Object.values(byChain).reduce((acc, usd) => acc + usd, 0),
+                      byChain
+                    }
+                  : undefined,
               isLoading: overallLoading || savingsBalancesLoading || pricesLoading,
               error: overallError || savingsBalancesError || null
             };
@@ -197,7 +202,8 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
             const index = rewardContracts.findIndex(c => c.contractAddress === product.address);
             const latest = latestChartEntry(rewardsCharts?.[index]);
             const supplied = rewardsBalances?.[index]?.result as bigint | undefined;
-            const suppliedUsd = supplied !== undefined ? bigintToUsd(supplied, usdsPrice) : undefined;
+            const suppliedUsd =
+              connected && supplied !== undefined ? bigintToUsd(supplied, usdsPrice) : undefined;
             const tvlUsd = latest
               ? parseFloat(latest.totalSupplied) * parseFloat(usdsPrice || '0')
               : undefined;
@@ -239,9 +245,10 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
               tvlUsd = morphoMarketResults[morphoIndex]?.data?.totalAssetsUsd;
             }
             const userVault = vaultUserAssets.vaults.find(v => v.vaultAddress === product.address);
-            const positionUsd = userVault
-              ? bigintToUsd(userVault.balanceNormalized, priceFor(userVault.assetToken.symbol))
-              : undefined;
+            const positionUsd =
+              connected && userVault
+                ? bigintToUsd(userVault.balanceNormalized, priceFor(userVault.assetToken.symbol))
+                : undefined;
             return {
               ...product,
               rate,
@@ -264,7 +271,11 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
               ...product,
               rate: toRate(stats?.impliedApy),
               tvl: stats?.tvl !== undefined ? singleChainAmount(familyMainnetId, stats.tvl) : undefined,
-              position: userMarket ? singleChainAmount(familyMainnetId, userMarket.valuationUsd) : undefined,
+              // The pendle breakdown only lists markets with a non-zero PT
+              // balance — connected users with none still get an explicit 0.
+              position: connected
+                ? singleChainAmount(familyMainnetId, userMarket?.valuationUsd ?? 0)
+                : undefined,
               isLoading: pendleMarketsLoading || pendleUserAssetsLoading,
               error: pendleMarketsError || pendleUserAssetsError || null
             };
@@ -282,7 +293,7 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
                   ? singleChainAmount(familyMainnetId, bigintToUsd(stUsdsData.totalAssets, usdsPrice))
                   : undefined,
               position:
-                stUsdsData?.userSuppliedUsds !== undefined
+                connected && stUsdsData?.userSuppliedUsds !== undefined
                   ? singleChainAmount(familyMainnetId, bigintToUsd(stUsdsData.userSuppliedUsds, usdsPrice))
                   : undefined,
               isLoading: stUsdsLoading || pricesLoading,
@@ -293,6 +304,7 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
       });
   }, [
     products,
+    address,
     pricesData,
     pricesLoading,
     overallSkyData,

--- a/apps/webapp/src/hooks/index.ts
+++ b/apps/webapp/src/hooks/index.ts
@@ -287,6 +287,19 @@ export { useEthereumCombinedHistory } from './shared/useEthereumCombinedHistory'
 export { useUsdsDaiData } from './shared/useUsdsDaiData';
 export { useOverallSkyData } from './shared/useOverallSkyData';
 
+// Earn marketplace (C1 registry + aggregator)
+export { useEarnMarketplace } from './earn/useEarnMarketplace';
+export { buildEarnProducts, productNetworks } from './earn/earnProducts';
+export type {
+  EarnMarketplaceResult,
+  EarnProductDescriptor,
+  EarnProductKind,
+  EarnProductRow,
+  EarnRate,
+  EarnRiskTier,
+  EarnUsdAmount
+} from './earn/types';
+
 // Decentralized Storage
 export { useIpfsStorage } from './decentralizedStorage/useIpfsStorage';
 export { useEnsContent } from './decentralizedStorage/useEnsContent';

--- a/apps/webapp/src/lib/chainAvailability.ts
+++ b/apps/webapp/src/lib/chainAvailability.ts
@@ -1,0 +1,44 @@
+import { Intent } from './enums';
+import { base, mainnet, arbitrum, unichain, optimism } from 'viem/chains';
+import { chainId } from '@/utils/chainId';
+
+// Per-chain module availability. Lives in its own Lingui-free module (extracted
+// verbatim from lib/constants) so the engine layer (src/hooks) can consume it —
+// lib/constants pulls @lingui/core/macro, which the vnet hooks test runner
+// cannot transform. lib/constants re-exports both maps, so existing import
+// sites are unaffected.
+export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
+  [mainnet.id]: [
+    Intent.BALANCES_INTENT,
+    Intent.REWARDS_INTENT,
+    Intent.SAVINGS_INTENT,
+    Intent.UPGRADE_INTENT,
+    Intent.TRADE_INTENT,
+    Intent.STAKE_INTENT,
+    Intent.EXPERT_INTENT,
+    Intent.VAULTS_INTENT,
+    Intent.CONVERT_INTENT,
+    Intent.FIXED_INTENT
+  ],
+  [chainId.tenderly]: [
+    Intent.BALANCES_INTENT,
+    Intent.REWARDS_INTENT,
+    Intent.SAVINGS_INTENT,
+    Intent.UPGRADE_INTENT,
+    Intent.TRADE_INTENT,
+    Intent.STAKE_INTENT,
+    Intent.EXPERT_INTENT,
+    Intent.VAULTS_INTENT,
+    Intent.CONVERT_INTENT,
+    Intent.FIXED_INTENT
+  ],
+  [base.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
+  [arbitrum.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
+  [unichain.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
+  [optimism.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT]
+};
+
+export const COMING_SOON_MAP: Record<number, Intent[]> = {
+  // Rewards is now treated as a mainnet-only module with auto-switching
+  // [base.id]: [Intent.YOUR_INTENT] // Example of how to add a coming soon intent
+};

--- a/apps/webapp/src/lib/constants.ts
+++ b/apps/webapp/src/lib/constants.ts
@@ -2,8 +2,6 @@ import { ConvertIntent, ExpertIntent, Intent, FixedIntent, VaultsIntent } from '
 import { vaultModuleForVaultsIntent } from './vaults/vaultProviderMapping';
 import { msg } from '@lingui/core/macro';
 import { MessageDescriptor } from '@lingui/core';
-import { base, mainnet, arbitrum, unichain, optimism } from 'viem/chains';
-import { tenderly } from '@/data/wagmi/config/config.default';
 
 // Navigation state (module, submodule, entity selection) lives in the path;
 // these are the params that remain query-driven.
@@ -59,41 +57,9 @@ export const FixedIntentMapping: Record<FixedIntent, string> = {
   [FixedIntent.MARKET_INTENT]: 'market'
 };
 
-export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
-  [mainnet.id]: [
-    Intent.BALANCES_INTENT,
-    Intent.REWARDS_INTENT,
-    Intent.SAVINGS_INTENT,
-    Intent.UPGRADE_INTENT,
-    Intent.TRADE_INTENT,
-    Intent.STAKE_INTENT,
-    Intent.EXPERT_INTENT,
-    Intent.VAULTS_INTENT,
-    Intent.CONVERT_INTENT,
-    Intent.FIXED_INTENT
-  ],
-  [tenderly.id]: [
-    Intent.BALANCES_INTENT,
-    Intent.REWARDS_INTENT,
-    Intent.SAVINGS_INTENT,
-    Intent.UPGRADE_INTENT,
-    Intent.TRADE_INTENT,
-    Intent.STAKE_INTENT,
-    Intent.EXPERT_INTENT,
-    Intent.VAULTS_INTENT,
-    Intent.CONVERT_INTENT,
-    Intent.FIXED_INTENT
-  ],
-  [base.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
-  [arbitrum.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
-  [unichain.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT],
-  [optimism.id]: [Intent.BALANCES_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT, Intent.CONVERT_INTENT]
-};
-
-export const COMING_SOON_MAP: Record<number, Intent[]> = {
-  // Rewards is now treated as a mainnet-only module with auto-switching
-  // [base.id]: [Intent.YOUR_INTENT] // Example of how to add a coming soon intent
-};
+// Moved to a Lingui-free module so the engine layer can import them; re-exported
+// here so existing import sites keep working.
+export { CHAIN_WIDGET_MAP, COMING_SOON_MAP } from './chainAvailability';
 
 export const intentTxt: Record<string, MessageDescriptor> = {
   psm: msg`1:1 conversion`,

--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -1,16 +1,80 @@
 import { Trans } from '@lingui/react/macro';
+import { useChains } from 'wagmi';
+import { useEarnMarketplace } from '@/hooks';
+import { formatNumber } from '@/utils';
 import { Heading, Text } from '@/modules/layout/components/Typography';
+import { AppLink } from '@/lib/navigation';
 
-// Placeholder destination screen; the real Earn marketplace lands with Track C.
+const NO_VALUE = '–';
+
+const formatUsd = (totalUsd?: number) => (totalUsd !== undefined ? `$${formatNumber(totalUsd)}` : NO_VALUE);
+
+// Placeholder destination screen; the real Earn marketplace lands with Track C
+// (C2). The table below is a deliberately bare rendering of the C1
+// useEarnMarketplace aggregator so the data layer can be exercised in-app.
 export function EarnPage() {
+  const { rows, isLoading } = useEarnMarketplace();
+  const chains = useChains();
+  const chainName = (id: number) => chains.find(c => c.id === id)?.name ?? id;
+
   return (
-    <div className="flex flex-col gap-2 p-4">
+    <div className="flex flex-col gap-4 p-4">
       <Heading>
         <Trans>Earn</Trans>
       </Heading>
       <Text variant="medium" className="text-textSecondary">
         <Trans>The Earn experience is coming soon.</Trans>
       </Text>
+      <table className="text-text w-full text-left text-sm" data-testid="earn-opportunities-table">
+        <thead>
+          <tr className="text-textSecondary border-b">
+            <th className="p-2 font-medium">
+              <Trans>Token</Trans>
+            </th>
+            <th className="p-2 font-medium">
+              <Trans>Network</Trans>
+            </th>
+            <th className="p-2 font-medium">
+              <Trans>Risk profile</Trans>
+            </th>
+            <th className="p-2 font-medium">
+              <Trans>Rate</Trans>
+            </th>
+            <th className="p-2 font-medium">
+              <Trans>30D Rate</Trans>
+            </th>
+            <th className="p-2 font-medium">
+              <Trans>TVL</Trans>
+            </th>
+            <th className="p-2 font-medium">
+              <Trans>My position</Trans>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(row => (
+            <tr key={row.id} className="border-b" data-testid={`earn-row-${row.id}`}>
+              <td className="p-2">
+                <AppLink to={row.detailPath} className="underline">
+                  {row.name}
+                </AppLink>
+                <span className="text-textSecondary ml-2">{row.tokenSymbol}</span>
+              </td>
+              <td className="p-2">{row.networks.map(chainName).join(', ') || NO_VALUE}</td>
+              <td className="p-2 capitalize">{row.risk}</td>
+              <td className="p-2">{row.isLoading ? '…' : row.rate.formatted}</td>
+              <td className="p-2">{row.rate30d?.formatted ?? NO_VALUE}</td>
+              <td className="p-2">{row.isLoading ? '…' : formatUsd(row.tvl?.totalUsd)}</td>
+              <td className="p-2">{row.isLoading ? '…' : formatUsd(row.position?.totalUsd)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {isLoading && (
+        <Text variant="small" className="text-textSecondary">
+          <Trans>Loading…</Trans>
+        </Text>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements ticket **C1** (Track C, Earn keystone): the data layer behind the V2 "Earn Opportunities" table — a static-length product registry plus an aggregator hook that returns one normalized row per product instance. No real UI in this PR (that's C2); the Earn placeholder page gains a deliberately barebones table so the hook can be exercised in-app.

> Stacked on `redesign/earn-ia-flip` (#1662) — retarget to `app-redesign` once that merges.

### What's here

**`src/hooks/earn/`** (new — engine layer, no existing hook signatures touched):
- `types.ts` — the normalized row model shared with Portfolio later (D1): id, owning `Intent`, supply token, static `networks` badges, risk tier, `rate` (fraction + formatted), `rate30d`, `tvl`/`position` as `{ totalUsd, byChain? }`, `detailPath`, Pendle `maturity`.
- `earnProducts.ts` — `buildEarnProducts(...)`: one descriptor per instance — Sky Savings, each active rewards contract (deprecated filtered), every vault in the unified `VAULTS` registry (Morpho + Spark sUSDT), each Pendle PT market, stUSDS. Availability/network badges derive from `CHAIN_WIDGET_MAP`/`COMING_SOON_MAP` ∩ per-product address maps (the existing config, reused unchanged); detail paths come from `intentToPath` (route contract, nothing hardcoded).
- `useEarnMarketplace.ts` — decorates descriptors with live data, reusing the existing engine hooks (`useOverallSkyData`, `useMultiChainSavingsBalances`, `useMultipleRewardsChartInfo`, `useMorphoVaultMultipleRateApiData` + market-data queries (cache-shared with `useMorphoVaultsCombinedTvl`), Spark rate/API hooks, `useAllMorphoVaultsUserAssets`, `usePendleMarketsApiData`/`useAllPendleUserAssets`, `useStUsdsData`, `usePrices`). Valuation math mirrors `useSuppliedBalancesTotalUsd` (whose docstring marks it superseded by this hook).

### Locked product decisions encoded (with TODOs)
- **Risk tiers hardcoded** — `moderate` everywhere, `advanced` for stUSDS (`TODO(BL-07)`; `low` unassigned, Savings is the natural candidate).
- **Multi-network = family fetch** — `getSupportedChainIds(activeChainId)`: all production networks at once, only Tenderly when forked. Rows expose per-chain + aggregated USD; savings is the genuinely multichain product, single-chain products resolve against the family's mainnet.
- **30D Rate unwired** — `rate30d` always undefined (`TODO`), renders '–' (sanctioned by the Figma — Chronicle row shows dashes).
- **stUSDS ships as a row** (advanced tier).

### Design notes
- **Static hook order**: every loop maps over const registries; rewards use array-taking hooks (`useMultipleRewardsChartInfo`, one `useReadContracts`) so the call count can't vary with chain.
- **Per-row failure isolation**: each row carries its own `isLoading`/`error`.
- **Disconnected state**: `position` is `undefined` on every row until a wallet connects, then an explicit number (0 included) on every row.
- **Two side-effect-free extractions** (old import paths preserved via re-exports): `CHAIN_WIDGET_MAP`/`COMING_SOON_MAP` → `lib/chainAvailability.ts` (out of Lingui-macro-bearing `lib/constants`, which the vnet test runner can't transform) and `getSupportedChainIds` → `data/wagmi/config/chainFamily.ts` (away from module-scope wallet connectors).

### Testing
- `earnProducts.test.ts` — 10 pure registry tests: row count static across families, unique stable ids, risk tiers, route-contract detail paths, config-derived network badges.
- `useEarnMarketplace.test.tsx` — vnet-backed integration test (registry shape immediately, live savings/stUSDS data, per-row error null, 30D unwired). **Not run locally**: `pnpm vnet:fork` currently returns *Forbidden* with the local Tenderly key — needs CI / a valid key.
- Fast unit suite 488/488; typecheck/lint/prettier clean.
- In-app: barebones table on `/earn` renders all 11 rows with live data (Savings 3.60% / $6.18B across 5 network badges; all vault rates; PT-sUSDS 5.07%; stUSDS 6.62% advanced).

### Known caveats
- "Tether Savings" shows '—' rate and ~$101 TVL in local dev because `VITE_AUTH_URL` defaults to the **staging** Spark API — same hook the Balances suggested-actions card uses; production hits `api.sky.money`.
- Rewards row names come from config ("With: USDS Get: SPK"); the Figma's "Earn SPK" copy is a C2/design concern.