### PR TITLE
feat(theming): token audit + semantic completion (A2 · APP-289)

### DIFF
--- a/apps/webapp/src/components/ui/THEMING.md
+++ b/apps/webapp/src/components/ui/THEMING.md
@@ -1,0 +1,102 @@
+# Theming & semantic token map
+
+> Scope: APP-289 (A2) — Webapp V2 Redesign, Phase 0 foundation.
+> Source of truth for values: [`apps/webapp/src/globals.css`](../../globals.css). This doc maps the
+> mechanism and the semantics; it deliberately does **not** re-list every hex (that would rot).
+
+The unified `components/ui` primitives (`button`, `dialog`, `sheet`, `select`, …) are styled with
+**semantic `--color-*` tokens**, never raw hex. The theme that's active decides what each semantic
+token resolves to. This is the two-mode `data-theme` mechanism adopted from PR #1653 (A0).
+
+## The three scopes in `globals.css`
+
+There is **no `.dark` block**. "Dark" is the default; "light" is an override layer. Reading the file
+top-to-bottom, the tokens live in three places:
+
+| Scope | Lines (approx) | Holds | Notes |
+|---|---|---|---|
+| `@theme { … }` | top of file | The semantic `--color-*` tokens, **dark values** | Tailwind v4 emits these as live CSS vars and treats them as the default. This is the **dark / at-parity** palette. |
+| `:root { … }` | base layer | Raw **primitives** (`--brand-*`, `--transparent-*`, gradients) | Non-semantic building blocks the `@theme` tokens reference via `var()`. Not theme-switched. |
+| `:root[data-theme='light'] { … }` | base layer | **Light overrides** of the semantic `--color-*` tokens | Only the tokens that need to change for light are redeclared here. |
+
+`<html data-theme="…">` is set before first paint by an inline script in `src/index.html` (mirrors
+`src/lib/theme.ts`: stored choice → OS pref → `dark`). `dark` (or no attribute) → `@theme` defaults.
+`light` → the override block wins via the cascade.
+
+### How resolution works (worth internalising)
+
+A utility like `bg-secondary` compiles to `background-color: var(--color-secondary)`. The `var()` is
+read **at the consumption site**, so redeclaring `--color-secondary` inside `:root[data-theme='light']`
+re-themes every `bg-secondary` on the page with zero per-component work. That's the whole trick.
+
+Two consequences that surprised us during the audit:
+
+1. **Tailwind v4 tree-shakes unused `@theme` tokens.** A `--color-*` token that no compiled utility
+   references is *not emitted* to `:root` at runtime, so it reads as undefined in DevTools even though
+   it's declared in `globals.css`. That's dead-code elimination, not a bug. (Example: `selectBackground`
+   has no consumer and is absent at runtime in dark; it still resolves in light because the light block
+   declares it as a literal, which is not tree-shaken.)
+2. **A missing `var()` or an undefined referenced primitive makes a token resolve to an invalid value**
+   (it falls back to the property's initial value — e.g. `currentColor`/black for color, transparent for
+   background). These render as silent breakage, not console errors. See the audit fixes below.
+
+## Adding or overriding a semantic token
+
+1. **New semantic token:** add `--color-<name>: <dark value>;` to the `@theme` block. Reference a
+   primitive with `var(--primitive)` rather than inlining a hex where a primitive exists.
+2. **Light value:** add `--color-<name>: <light value>;` inside `:root[data-theme='light']`. Omit it
+   only if the dark value is genuinely theme-neutral.
+3. Consume it as a Tailwind utility (`bg-<name>`, `text-<name>`, `border-<name>`). Prefer the `light:`
+   variant for one-off light tweaks that don't deserve a token.
+
+## Parity status
+
+- **Dark = at-parity.** It must stay **pixel-identical** to production. Do not "improve" dark values;
+  only fix outright invalid ones (missing `var()`, undefined referenced primitive).
+- **Light = mechanism + interim placeholder.** It must render without crashing; full visual parity is
+  deferred to **G2**. Expect rough edges (e.g. the wordmark/logo still reads light-on-light).
+
+## Audit results (A2)
+
+Fixes landed in this ticket, all keeping dark pixel-identical:
+
+| # | Token | Was | Now | Dark impact |
+|---|---|---|---|---|
+| 1 | `--color-borderActive` (dark) | `--transparent-white-25` (no `var()`, **invalid**) | `var(--transparent-white-25)` | None — only `light:` consumers (CookieConsentBanner). Now valid if dark ever consumes it. |
+| 1b | `--transparent-white-25` primitive | commented out | restored `#ffffff40` | None — required so `borderActive` (and the unused `selectBackground`) resolve. |
+| 2 | `--color-secondaryHover` (dark) | `var(--transparent-black-20)` (== `--color-secondary`, no-op hover) | **unchanged** (parity) | None. Light already differentiates the secondary states; dark parity preserved. Annotated in `globals.css`. |
+| 3 | `--color-bgHover` | **undefined everywhere** → `bg-bgHover` was an unknown class (silent no-op) | `transparent` in `@theme` (dark), `rgba(26,24,85,0.06)` in light | None in dark (`transparent` == prior no-op). Light gains the real TopNav MoreMenu row hover. |
+
+### Deferred (known issue) — bug 4
+
+`--background` / `--foreground` are declared **only** in `:root[data-theme='light']`. In dark they are
+undefined, so `--color-background` (`hsl(var(--background))`) resolves to transparent and
+`--color-foreground` resolves to **black**. Consumers in dark: `dialog`, `sheet`, `select`, `sonner`,
+and the Trade/Pendle config-menu inputs — these get transparent surfaces and invisible black text.
+
+There is **no value that both defines them and keeps dark pixels identical**, so per the A2 ACs the fix
+is **deferred** (do not silently change dark). Tracked here; should be picked up alongside the work that
+properly themes these primitives for dark. `globals.css` carries a one-line pointer back to this doc.
+
+### Drive-by observation (not in A2 scope)
+
+`button.tsx` `secondary` and `chip` variants contain a stray comma:
+`active:bg-secondaryActive, focus:bg-secondaryFocus`. The trailing `,` makes the `active:` class a
+no-match, so the active state is dropped. Component-level, out of token scope — left untouched, logged
+for whoever owns the Button cleanup.
+
+## Figma ↔ code drift register (bug 5 — tracked QA pass)
+
+Reconciled into named tracking, **not** silently applied (dark is at-parity; changing these would break
+AC #1). Each row is a candidate for a deliberate, signed-off follow-up — most likely during G2 light
+parity or a Button/chrome re-skin.
+
+| Surface | Figma | Code | Where | Disposition |
+|---|---|---|---|---|
+| Primary light purple | `#6161FF` | `#504DFF` (`--brand-light-purple: 80 77 255`) | `globals.css` primitive | Drift. Don't touch the dark primitive; reconcile when the brand ramp is re-tokenised. |
+| Same `#6161FF`, hardcoded | `#6161FF` | magic hex `bg-[#6161FF]` / `text-[#1C1655]` | `widgets/shared/components/ui/card/InteractiveStatsCardAlt.tsx` | Should become a token, not an inline hex. Folds into the brand reconciliation above. |
+| Glass surfaces | glass stroke/fill | `--primary-glass-stroke` (single stroke token) | `globals.css` | Figma models glass as stroke **+** fill + blur; code has only the stroke. Capture full glass token set when glass surfaces are themed. |
+| Pill radii | per Figma spec | `rounded-full` everywhere; `--radius-sm/md/lg = 6/8/10px` | `button.tsx`, `globals.css` | Verify Figma pill/chip radii against `rounded-full` vs the `--radius-*` scale; no code change until confirmed. |
+
+> Adding a token here is cheap and reversible; changing a **dark** value is not. When in doubt, name the
+> drift and defer the change.

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -37,6 +37,7 @@
   --color-containerDark: var(--transparent-black-85);
   --color-surface: rgba(108, 104, 255, 0.3);
   --color-surfaceHover: rgba(68, 45, 125, 0.202);
+  --color-bgHover: transparent; /* nav/menu row hover — no-op in dark (parity); tinted in the light scope */
   --color-surfaceAlt: var(--transparent-white-20);
   --color-panel: var(--transparent-black-20);
   --color-widget: transparent;
@@ -47,6 +48,7 @@
   --color-primaryActive: transparent;
   --color-primaryFocus: transparent;
   --color-primaryDisabled: transparent;
+  /* dark: secondary states intentionally share one value (parity); the light scope differentiates them */
   --color-secondary: var(--transparent-black-20);
   --color-secondaryHover: var(--transparent-black-20);
   --color-secondaryActive: var(--transparent-black-20);
@@ -57,12 +59,13 @@
   --color-card: rgba(128, 117, 255, 0.07);
   --color-cardLight: rgba(64, 60, 113, 0.207);
   --color-border: var(--transparent-white-15);
-  --color-borderActive: --transparent-white-25;
+  --color-borderActive: var(--transparent-white-25);
   --color-borderPurple: #4c4577;
   --color-brand: rgb(var(--brand-purple));
   --color-brandLight: rgb(var(--brand-light-purple));
   --color-brandDark: rgb(var(--brand-dark-purple));
   --color-brandMiddle: rgb(var(--brand-middle-purple));
+  /* --background/--foreground are defined only in the light scope; undefined (invalid) in dark — known issue, fix deferred. See components/ui/THEMING.md */
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));
   --color-chartSelect: rgba(22, 17, 53, 1);
@@ -310,7 +313,7 @@
 
     --transparent-white-70: #ffffffb3;
     --transparent-white-40: #ffffff66;
-    /* --transparent-white-25: #ffffff40; */
+    --transparent-white-25: #ffffff40;
     --transparent-white-20: #ffffff33;
     --transparent-white-15: #ffffff26;
     --transparent-white-05: linear-gradient(0deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05));
@@ -350,6 +353,7 @@
     --color-containerDark: rgba(232, 235, 250, 0.94);
     --color-surface: rgba(108, 104, 255, 0.12);
     --color-surfaceHover: rgba(108, 104, 255, 0.2);
+    --color-bgHover: rgba(26, 24, 85, 0.06); /* TopNav MoreMenu row hover */
     --color-surfaceAlt: rgba(26, 24, 85, 0.06);
     --color-panel: rgba(255, 255, 255, 0.45);
     --color-card: rgba(255, 255, 255, 0.96);


### PR DESCRIPTION
Ticket: [APP-289](https://linear.app/skybasestar/issue/APP-289) · **A2 — Phase-0 foundation** of the Webapp V2 Redesign.

Adopts the shipped `data-theme` two-mode token mechanism (from A0 / #1653) as canonical: fixes token-definition bugs, completes the light side of the mechanism, and documents the semantic token map next to the `components/ui` primitives. **Dark stays pixel-identical** (it is the at-parity mode); **light boots without crashing** (full light parity is deferred to G2).

### What does this PR do?

**`globals.css`** (surgical, dark-safe):
- **Fix invalid `--color-borderActive`** — was `--transparent-white-25` (missing `var()`, i.e. an invalid value); now `var(--transparent-white-25)`. Only `light:` consumers reference it, so zero dark impact.
- **Restore the `--transparent-white-25` primitive** — it had been commented out, which is why `borderActive` (and the unused `selectBackground`) couldn't resolve.
- **Define `--color-bgHover`** — previously undefined everywhere, so TopNav's MoreMenu hover (`bg-bgHover`) was a silent no-op (unknown class). Now `transparent` in dark (identical to the prior no-op → no pixel change) and a real value in the light scope.
- **Preserve dark secondary hover for parity** — `--color-secondaryHover` equals `--color-secondary` in dark; left untouched (light already differentiates the states) and annotated so it isn't "fixed" by mistake.

**`components/ui/THEMING.md`** (new):
- Documents the three scopes (`@theme` = dark defaults · `:root` = primitives · `[data-theme='light']` = light overrides), how `var()` resolution and Tailwind v4 token tree-shaking behave, the parity status, the audit results, and a **Figma↔code drift register** (e.g. `#6161FF` vs `#504DFF`, glass surfaces, pill radii).

### Why it matters

A2 is a **foundation** ticket: every redesign track (D/E/F) builds on these tokens, so a single invalid/undefined token silently breaks every component that consumes it (invisible borders, dead hovers). `globals.css` is also a **hot file** — by convention only Phase-0/1 PRs may restructure it, so this is the window to fix it. Small diff, high leverage.

### Intentionally out of scope (documented, not changed)
- **`--background` / `--foreground` undefined in dark** (invisible `text-foreground`, transparent `bg-background` on dialog/sheet/select + Trade/Pendle config inputs): no value defines them without changing dark pixels, so per AC #1 the fix is **deferred** and tracked in `THEMING.md`.
- **Figma↔code drift** (brand purple, glass surfaces, pill radii): captured as a tracked register rather than silently applied to dark.
- A stray-comma bug in `button.tsx` secondary/chip variants is **logged** in the doc (component-level, outside token scope).

### Testing steps
1. `pnpm -F webapp dev:mock`, open in dark (default) — should look **visually identical** to before this PR.
2. Toggle to light — should render without crashing (interim placeholder theme; full polish lands in G2).
3. Optional: in DevTools, `getComputedStyle(document.documentElement).getPropertyValue('--color-bgHover')` should be `transparent` in dark and a real `rgba(...)` under `data-theme="light"`.

### Verification done
- `pnpm -F webapp typecheck` ✅ · `pnpm lint` ✅ (0 errors) · `pnpm -F webapp test` ✅ (488 passed / 88 files)
- Browser A/B confirmed the app background image and all dark token values are unchanged vs. the base branch.
