### PR TITLE
feat(redesign): tokenize CookieConsentBanner + TermsDialog surfaces (B5 / APP-297)

### DIFF
--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -56,6 +56,14 @@
   --color-tabPrimary: var(--transparent-white-40);
   --color-card: rgba(128, 117, 255, 0.07);
   --color-cardLight: rgba(64, 60, 113, 0.207);
+  /* B5 chrome-surface tokens — dark values are production parity (don't change);
+     light values are interim (G2 owns full light parity). These replace magic hex
+     in CookieConsentBanner + TermsDialog so those surfaces render on tokens. */
+  --color-cookieSurface: #1a1a2e;
+  --color-cookieToggleOn: #5116cc;
+  --color-termsCard: #181720;
+  --color-termsBtnHover: rgb(17, 16, 31);
+  --color-termsBtnActive: rgb(34, 32, 66);
   --color-border: var(--transparent-white-15);
   --color-borderActive: --transparent-white-25;
   --color-borderPurple: #4c4577;
@@ -357,6 +365,14 @@
     --color-selectBackground: rgba(26, 24, 85, 0.05);
     --color-selectActive: rgba(26, 24, 85, 0.1);
     --color-chartSelect: rgba(235, 232, 255, 1);
+
+    /* B5 chrome-surface tokens — light values mirror the prior light: overrides.
+       cookieToggleOn has no light value: the toggle track's light:bg-surfaceAlt
+       wins by source order in light, so the accent only shows in dark (parity). */
+    --color-cookieSurface: rgba(232, 235, 250, 0.94); /* was light:bg-containerDark */
+    --color-termsCard: rgba(255, 255, 255, 0.96); /* was light:bg-card */
+    --color-termsBtnHover: rgba(108, 104, 255, 0.2); /* was light:hover:bg-surfaceHover */
+    --color-termsBtnActive: rgba(26, 24, 85, 0.06); /* was light:active:bg-surfaceAlt */
 
     /* secondary buttons */
     --color-secondary: rgba(26, 24, 85, 0.05);

--- a/apps/webapp/src/modules/analytics/components/CookieConsentBanner.tsx
+++ b/apps/webapp/src/modules/analytics/components/CookieConsentBanner.tsx
@@ -119,7 +119,7 @@ export function CookieConsentBanner() {
           animate={{ y: 0, opacity: 1 }}
           exit={{ y: 20, opacity: 0 }}
           transition={{ type: 'spring', damping: 25, stiffness: 300 }}
-          className="light:border-border light:bg-containerDark fixed right-4 bottom-4 left-4 z-40 mx-auto max-w-[420px] rounded-xl border border-white/10 bg-[#1a1a2e] p-5 md:right-6 md:left-auto md:z-[999] md:mx-0 md:min-w-[420px]"
+          className="light:border-border fixed right-4 bottom-4 left-4 z-40 mx-auto max-w-[420px] rounded-xl border border-text/10 bg-cookieSurface p-5 md:right-6 md:left-auto md:z-[999] md:mx-0 md:min-w-[420px]"
         >
           <AnimatePresence mode="wait" initial={false}>
             {bannerView === 'default' ? (
@@ -130,7 +130,7 @@ export function CookieConsentBanner() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
               >
-                <Text variant="captionSm" className="light:text-textSecondary text-white/60">
+                <Text variant="captionSm" className="light:text-textSecondary text-text/60">
                   We collect anonymous usage analytics to understand how this app is used and to improve it.
                   No personal data is collected. Accepting enables persistent cookies for better insights.
                   {privacyLink && (
@@ -149,19 +149,19 @@ export function CookieConsentBanner() {
                     </>
                   )}
                 </Text>
-                <Text variant="captionSm" className="light:text-textSecondary mt-3 text-white/60">
+                <Text variant="captionSm" className="light:text-textSecondary mt-3 text-text/60">
                   You can change your preference at any time via Cookie Settings in the footer.
                 </Text>
                 <div className="mt-4 flex gap-3">
                   <button
                     onClick={() => setBannerView('manage')}
-                    className="light:border-border light:text-textSecondary light:hover:border-borderActive light:hover:text-text rounded-lg border border-white/20 px-4 py-2 text-[13px] font-medium text-white/60 transition-colors hover:border-white/40 hover:text-white"
+                    className="light:border-border light:text-textSecondary light:hover:border-borderActive light:hover:text-text rounded-lg border border-text/20 px-4 py-2 text-[13px] font-medium text-text/60 transition-colors hover:border-text/40 hover:text-text"
                   >
                     Manage
                   </button>
                   <button
                     onClick={handleAcceptAll}
-                    className="light:bg-surfaceAlt light:text-text light:hover:bg-surfaceHover rounded-lg bg-white/10 px-4 py-2 text-[13px] font-medium text-white transition-colors hover:bg-white/20"
+                    className="light:bg-surfaceAlt light:text-text light:hover:bg-surfaceHover rounded-lg bg-text/10 px-4 py-2 text-[13px] font-medium text-text transition-colors hover:bg-text/20"
                   >
                     Accept All
                   </button>
@@ -175,19 +175,19 @@ export function CookieConsentBanner() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
               >
-                <Text variant="captionSm" className="light:text-text font-medium text-white">
+                <Text variant="captionSm" className="font-medium text-text">
                   Manage cookie preferences
                 </Text>
-                <Text variant="captionSm" className="light:text-textDimmed mt-2 text-white/40">
+                <Text variant="captionSm" className="light:text-textDimmed mt-2 text-text/40">
                   Choose which analytics services you allow. You can update these at any time.
                 </Text>
                 <div className="mt-4 space-y-3">
                   <label className="flex items-center justify-between">
                     <div>
-                      <Text variant="captionSm" className="light:text-text font-medium text-white/80">
+                      <Text variant="captionSm" className="light:text-text font-medium text-text/80">
                         PostHog
                       </Text>
-                      <Text variant="captionSm" className="light:text-textDimmed text-white/40">
+                      <Text variant="captionSm" className="light:text-textDimmed text-text/40">
                         Usage analytics
                       </Text>
                     </div>
@@ -197,14 +197,14 @@ export function CookieConsentBanner() {
                       checked={posthogEnabled}
                       onChange={() => setPosthogEnabled(prev => !prev)}
                     />
-                    <div className="light:bg-surfaceAlt light:after:bg-textDimmed relative h-6 w-11 shrink-0 cursor-pointer rounded-full bg-white/10 transition-colors peer-checked:bg-[#5116CC] peer-focus-visible:ring-2 peer-focus-visible:ring-white/50 after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white/40 after:transition-transform peer-checked:after:translate-x-5 peer-checked:after:bg-white" />
+                    <div className="light:bg-surfaceAlt light:after:bg-textDimmed relative h-6 w-11 shrink-0 cursor-pointer rounded-full bg-text/10 transition-colors peer-checked:bg-cookieToggleOn peer-focus-visible:ring-2 peer-focus-visible:ring-text/50 after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-text/40 after:transition-transform peer-checked:after:translate-x-5 peer-checked:after:bg-text" />
                   </label>
                   <label className="flex items-center justify-between">
                     <div>
-                      <Text variant="captionSm" className="light:text-text font-medium text-white/80">
+                      <Text variant="captionSm" className="light:text-text font-medium text-text/80">
                         Google Analytics
                       </Text>
-                      <Text variant="captionSm" className="light:text-textDimmed text-white/40">
+                      <Text variant="captionSm" className="light:text-textDimmed text-text/40">
                         Traffic analytics
                       </Text>
                     </div>
@@ -214,19 +214,19 @@ export function CookieConsentBanner() {
                       checked={gaEnabled}
                       onChange={() => setGaEnabled(prev => !prev)}
                     />
-                    <div className="light:bg-surfaceAlt light:after:bg-textDimmed relative h-6 w-11 shrink-0 cursor-pointer rounded-full bg-white/10 transition-colors peer-checked:bg-[#5116CC] peer-focus-visible:ring-2 peer-focus-visible:ring-white/50 after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white/40 after:transition-transform peer-checked:after:translate-x-5 peer-checked:after:bg-white" />
+                    <div className="light:bg-surfaceAlt light:after:bg-textDimmed relative h-6 w-11 shrink-0 cursor-pointer rounded-full bg-text/10 transition-colors peer-checked:bg-cookieToggleOn peer-focus-visible:ring-2 peer-focus-visible:ring-text/50 after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-text/40 after:transition-transform peer-checked:after:translate-x-5 peer-checked:after:bg-text" />
                   </label>
                 </div>
                 <div className="mt-4 flex gap-3">
                   <button
                     onClick={() => setBannerView('default')}
-                    className="light:border-border light:text-textSecondary light:hover:border-borderActive light:hover:text-text rounded-lg border border-white/20 px-4 py-2 text-[13px] font-medium text-white/60 transition-colors hover:border-white/40 hover:text-white"
+                    className="light:border-border light:text-textSecondary light:hover:border-borderActive light:hover:text-text rounded-lg border border-text/20 px-4 py-2 text-[13px] font-medium text-text/60 transition-colors hover:border-text/40 hover:text-text"
                   >
                     Back
                   </button>
                   <button
                     onClick={handleSave}
-                    className="light:bg-surfaceAlt light:text-text light:hover:bg-surfaceHover rounded-lg bg-white/10 px-4 py-2 text-[13px] font-medium text-white transition-colors hover:bg-white/20"
+                    className="light:bg-surfaceAlt light:text-text light:hover:bg-surfaceHover rounded-lg bg-text/10 px-4 py-2 text-[13px] font-medium text-text transition-colors hover:bg-text/20"
                   >
                     Save
                   </button>

--- a/apps/webapp/src/modules/ui/components/TermsDialog.tsx
+++ b/apps/webapp/src/modules/ui/components/TermsDialog.tsx
@@ -79,18 +79,18 @@ export const TermsDialog: React.FC<TermsDialogProps> = ({
     <DialogContent aria-describedby={undefined} className="bg-containerDark max-h-[95dvh] overflow-y-auto">
       <DialogTitle className="sr-only">{title}</DialogTitle>
       {termsVersion && (
-        <Text className="text-center text-xs text-white/50 light:text-textDimmed">
+        <Text className="text-center text-xs text-text/50 light:text-textDimmed">
           <Trans>Terms version: {termsVersion}</Trans>
         </Text>
       )}
 
-      <Card className="scrollbar-thin-always mx-auto max-h-[256px] w-full overflow-y-auto bg-[#181720] light:bg-card p-3 sm:max-h-[432px] sm:p-4">
+      <Card className="scrollbar-thin-always mx-auto max-h-[256px] w-full overflow-y-auto bg-termsCard p-3 sm:max-h-[432px] sm:p-4">
         {content}
         <div ref={endOfTermsRef} data-testid="end-of-terms" />
       </Card>
 
       {showScrollInstruction && (
-        <Text className="text-center text-sm leading-none text-white/50 light:text-textDimmed md:leading-tight">
+        <Text className="text-center text-sm leading-none text-text/50 light:text-textDimmed md:leading-tight">
           {scrollInstructionText || (
             <Trans>
               Please scroll to the bottom and read the entire terms; the accept button will become enabled
@@ -110,7 +110,7 @@ export const TermsDialog: React.FC<TermsDialogProps> = ({
       <div className="flex w-full justify-between gap-4 sm:mt-0 sm:w-auto">
         <Button
           variant="secondary"
-          className="flex-1 border bg-transparent hover:bg-[rgb(17,16,31)] active:bg-[rgb(34,32,66)] light:hover:bg-surfaceHover light:active:bg-surfaceAlt"
+          className="flex-1 border bg-transparent hover:bg-termsBtnHover active:bg-termsBtnActive"
           onClick={onDecline}
           disabled={isLoading}
         >


### PR DESCRIPTION
Part of the **Webapp V2 Redesign · Track B** — B5 "shell odds-and-ends re-skin" ([APP-297](https://linear.app/skybasestar/issue/APP-297)).

Re-skins the two chrome surfaces that still carried raw hex / `white/X` values onto V2 design-system tokens, so the shell "odds-and-ends" render on tokens like the rest of the app.

### What does this PR do?

- Adds 5 semantic tokens to `globals.css` for surfaces that had no token equivalent: `cookieSurface`, `cookieToggleOn`, `termsCard`, `termsBtnHover`, `termsBtnActive`. Each token's **dark value = the current hex** (so dark stays pixel-identical) and **light value = the prior `light:` override** (so light is unchanged).
- `CookieConsentBanner`: `bg-[#1a1a2e]` / `#5116CC` → tokens; every `white/X` → `text-text/X`. `--color-text` resolves to `#ffffff` in dark, so `text-text/60` compiles byte-identically to `text-white/60` — the text/border/bg hierarchy is tokenized with no new tokens.
- `TermsDialog`: `bg-[#181720]`, the decline-button `rgb()` hover/active, and `text-white/50` → tokens.

**Token/className swaps only — no behavior change.** Logic, gating, and instrumentation are untouched (the diff is className/token-only).

Dark ships at production parity; light is interim (full light parity is deferred to G2).

### Testing steps:

- **Dark (parity):** open the cookie banner (default + Manage view), the terms modal, and a toast — all identical to before. Confirmed byte-identical via computed-style fingerprints before/after (`text-text/60` ≡ `text-white/60`; container `#1a1a2e`; toggle `#5116CC`; terms card `#181720`).
- **Light:** the same surfaces boot unchanged (the `light:` overrides are kept, and the new tokens' light values mirror them).
- `pnpm -F webapp typecheck` → 0 errors
- `pnpm lint` → 0 errors (366 baseline warnings)
- `pnpm -F webapp test` → 488 passed / 88 files

### Notes

- `sonner` toast left untouched: its only non-token class (`text-foreground` on the close button) is A2's deferred `--foreground`/`--background` fix; the toast body is already on `bg-container`/`text-text` and was verified rendering in both themes.
- Other B5 surfaces (Connect modal, footer, error/404, env badge, the connected-wallet drawer) already render on tokens — no change required.
- Not in this PR: `ChainModal` still has hardcoded `white/10`–`white/15` (not in B5's surface list); NotFound does not surface for unmatched paths in the dev build (routing — coordinate with B3).
