### PR TITLE
Don't report geo-config fetch AbortErrors to Sentry (WEBAPP-5M, 5S, 62, 6E, 8Q)

### DIFF
--- a/apps/webapp/src/modules/geo-config/context/GeoConfigProvider.tsx
+++ b/apps/webapp/src/modules/geo-config/context/GeoConfigProvider.tsx
@@ -38,12 +38,20 @@ async function fetchGeoConfig(): Promise<GeoConfig> {
     return res.json();
   } catch (error) {
     clearTimeout(timeoutId);
-    reportError(error, {
-      module: 'geo-config',
-      flow: 'fetch-config',
-      action: 'fetch',
-      type: 'request_error'
-    });
+    // AbortError (DOMException code 20) is expected and already handled: either the
+    // 5s timeout above fired on a slow/filtered network, or the user navigated away
+    // mid-flight. We fall back to FALLBACK_CONFIG either way, so it's non-actionable
+    // noise — don't report it (WEBAPP-5M). Genuine failures still surface: non-ok
+    // responses are reported as `http_error` in the branch above.
+    const isAbortError = error instanceof Error && error.name === 'AbortError';
+    if (!isAbortError) {
+      reportError(error, {
+        module: 'geo-config',
+        flow: 'fetch-config',
+        action: 'fetch',
+        type: 'request_error'
+      });
+    }
     return FALLBACK_CONFIG;
   }
 }


### PR DESCRIPTION
## Summary

Stops the geo-config fetch from reporting **expected, already-handled** `AbortError`s to Sentry. One code change resolves the entire family of abort-noise issues, currently fragmented across five Sentry groups by browser wording:

| Issue | Message | Browser | Events |
|---|---|---|---|
| [WEBAPP-5S](https://jetstream-gg.sentry.io/issues/WEBAPP-5S) | `signal is aborted without reason` | Chromium | 442 |
| [WEBAPP-5M](https://jetstream-gg.sentry.io/issues/WEBAPP-5M) | `Fetch is aborted` | Safari | 53 |
| [WEBAPP-62](https://jetstream-gg.sentry.io/issues/WEBAPP-62) | `The operation was aborted.` | Firefox | 24 |
| [WEBAPP-6E](https://jetstream-gg.sentry.io/issues/WEBAPP-6E) | `The user aborted a request.` | older Chrome | 5 |
| [WEBAPP-8Q](https://jetstream-gg.sentry.io/issues/WEBAPP-8Q) | `The operation was aborted.` | Firefox | 1 |

WEBAPP-5M is the one that tripped the PagerDuty alert; the others are the same root cause under different browser wording.

## What was happening

`fetchGeoConfig` aborts the request after a 5s timeout:

```ts
const controller = new AbortController();
const timeoutId = setTimeout(() => controller.abort(), 5000);
```

When the abort fires — the 5s timeout on a slow/filtered network, or the user navigating away mid-flight — the `catch` block reported the `AbortError` to Sentry **and then returned `FALLBACK_CONFIG`**. The user was never affected (`handled: yes`, **0 users impacted**), but the events accumulated enough volume to page. An abort on a client-imposed 5s deadline is not a server signal and isn't actionable on our side.

## Change

Skip `reportError` when the caught error is an `AbortError`, while still falling back to `FALLBACK_CONFIG`. The check keys on `error.name === 'AbortError'` rather than message text, so a single guard covers every browser's wording (the five issues above).

## Genuine failures are deliberately left intact

A real endpoint outage still surfaces — this change only silences aborts:

- **Non-ok HTTP responses (5xx/4xx)** → still reported via the separate `http_error` branch.
- **Network-layer connection failures** (`Failed to fetch` / `Load failed` / `NetworkError`) → still reported as `request_error` (e.g. [WEBAPP-5R](https://jetstream-gg.sentry.io/issues/WEBAPP-5R), 254 events, confirmed geo-config).

The only mode this no longer catches client-side is the endpoint reliably accepting connections but always responding slower than 5s for everyone (without ever refusing or erroring) — a narrow case better covered by server-side latency/uptime monitoring of the endpoint.

This matches the team's existing noise-filtering pattern (WEBAPP-5N MetaMask `TransportTimeoutError`, WEBAPP-2F), and what the archived marketing site already drops in its `ignoreErrors`.

## Testing

- `tsc --noEmit` passes clean.
- No behavior change for users: the fallback path is unchanged; only the Sentry report for aborts is suppressed.