### PR TITLE
Don't report MetaMask 'connection pending' noise to Sentry (WEBAPP-5H)

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -68,7 +68,15 @@ export function initSentry(): void {
       // it reports 0 affected users (fires pre-connection). Global match
       // because ~10% of events arrive via wagmi auto-reconnect with no `flow`
       // tag, so a flow-scoped beforeSend filter would miss them (WEBAPP-5N).
-      /Transport request timed out/
+      /Transport request timed out/,
+      // MetaMask multichain SDK guard against concurrent connect requests
+      // (@metamask/connect-multichain). On MetaMask Mobile the connect deep-links
+      // and the handshake goes "pending"; a second trigger (deep-link round-trip,
+      // modal remount, or wagmi auto-reconnect) makes the SDK throw this. Benign:
+      // handled, 0 affected users, the message is itself user guidance and the
+      // pending request still resolves. Global match because the auto-reconnect
+      // path fires with no `flow` tag, like WEBAPP-5N above (WEBAPP-5H).
+      /Existing connection is pending/
     ],
     integrations: [
       Sentry.thirdPartyErrorFilterIntegration({


### PR DESCRIPTION
## What

Adds `/Existing connection is pending/` to the Sentry `ignoreErrors` list in `apps/webapp/src/modules/sentry/init.ts`.

## Why

[WEBAPP-5H](https://jetstream-gg.sentry.io/issues/WEBAPP-5H) triggered a PagerDuty alert:

> Error: Existing connection is pending. Please check your MetaMask Mobile app to continue.

It's thrown **inside** the MetaMask multichain SDK (`@metamask/connect-multichain@0.15.0`), not our code — the SDK's guard against concurrent connect requests. On MetaMask Mobile the connect deep-links to the app and the handshake stays "pending" across the round-trip back to the browser; a second trigger (deep-link round-trip, modal remount, or wagmi auto-reconnect) makes the SDK throw.

It's noise, not a bug:
- **handled: yes** — caught by the `onError` handlers in `ConnectModal.tsx` and reported via `reportError`.
- **0 affected users**, 32 occurrences over a month — fires pre-connection; the existing pending request still resolves.
- All from mobile in-app contexts (iPad / Mobile Safari / iOS).
- The message is itself user guidance, and users also see our "Failed to connect. Please try again." prompt.

## Approach

This is a direct sibling of the existing **WEBAPP-5N** `TransportTimeoutError` filter for the *same SDK*, added right below it. It goes in the global `ignoreErrors` list (rather than `isUserRejectedRequestError` or a scoped `beforeSend`) because it isn't a user rejection and the wagmi auto-reconnect path fires with no `flow` tag — the same reasoning documented for WEBAPP-5N.

## Verification

- `prettier --check` ✅
- `eslint` ✅

`Fixes WEBAPP-5H` — auto-resolves the Sentry issue on merge.