### PR TITLE
Add /susdt short path redirecting to the sUSDT vault APP-266 Add shorter susdt path to the app

### DIFF
--- a/apps/webapp/src/pages/router.test.ts
+++ b/apps/webapp/src/pages/router.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { mainnet } from 'viem/chains';
+import { susdtRedirectLoader } from './router';
+import { sparkUsdtVaultAddress } from '@/hooks';
+
+describe('susdtRedirectLoader', () => {
+  it('redirects /susdt to the canonical sUSDT vault deep-link', () => {
+    const response = susdtRedirectLoader() as Response;
+
+    expect(response.status).toBe(302);
+
+    const location = response.headers.get('Location');
+    expect(location).not.toBeNull();
+
+    const url = new URL(location as string, 'https://app.sky.money');
+    expect(url.pathname).toBe('/');
+
+    const params = url.searchParams;
+    expect(params.get('network')).toBe('ethereum');
+    expect(params.get('widget')).toBe('vaults');
+    expect(params.get('vault_module')).toBe('sky');
+    expect(params.get('vault')).toBe(sparkUsdtVaultAddress[mainnet.id]);
+  });
+});

--- a/apps/webapp/src/pages/router.tsx
+++ b/apps/webapp/src/pages/router.tsx
@@ -7,6 +7,11 @@ import Dev from './Dev';
 import { SealEngine } from './SealEngine';
 import { BatchTransactionsLegal } from './BatchTransactionsLegal';
 import { rewriteLegacyWidgetParams } from '@/modules/utils/validateSearchParams';
+import { mainnet } from 'viem/chains';
+import { IntentMapping, QueryParams } from '@/lib/constants';
+import { Intent } from '@/lib/enums';
+import { vaultModuleForProvider } from '@/lib/vaults/vaultProviderMapping';
+import { sparkUsdtVaultAddress } from '@/hooks';
 
 // TODO: Remove once all references to widget=trade|upgrade are migrated
 const legacyWidgetLoader = ({ request }: { request: Request }) => {
@@ -19,11 +24,28 @@ const legacyWidgetLoader = ({ request }: { request: Request }) => {
   return null;
 };
 
+// sUSDT is mainnet-only, so the network is pinned in the deep-link.
+export const susdtRedirectLoader = () => {
+  const params = new URLSearchParams({
+    [QueryParams.Network]: 'ethereum',
+    [QueryParams.Widget]: IntentMapping[Intent.VAULTS_INTENT],
+    [QueryParams.VaultModule]: vaultModuleForProvider('sky'),
+    [QueryParams.Vault]: sparkUsdtVaultAddress[mainnet.id]
+  });
+  return redirect('/?' + params.toString());
+};
+
 const routes: RouteObject[] = [
   {
     path: '/',
     element: <Home />,
     loader: legacyWidgetLoader,
+    errorElement: <ErrorPage />
+  },
+  {
+    path: '/susdt',
+    loader: susdtRedirectLoader,
+    element: <Home />,
     errorElement: <ErrorPage />
   },
   {


### PR DESCRIPTION
## What

Adds a short, shareable `/susdt` path that redirects directly into the Tether Savings (sUSDT) vault, per APP-320.

`/susdt` → `/?network=ethereum&widget=vaults&vault_module=sky&vault=<sparkUsdtVaultAddress>`

## How

- New `/susdt` route in `apps/webapp/src/pages/router.tsx` with a `susdtRedirectLoader`, mirroring the existing `legacyWidgetLoader` redirect pattern.
- The redirect target is built from constants (`QueryParams`, `IntentMapping[Intent.VAULTS_INTENT]`, `vaultModuleForProvider('sky')`, `sparkUsdtVaultAddress[mainnet.id]`) so it tracks the source of truth rather than hardcoding the URL.
- The `vault` address param is what selects the vault; `network=ethereum` is pinned because sUSDT is mainnet-only (without it a user on an L2 would fail the address match and fall back to another vault).

## Testing

- `apps/webapp/src/pages/router.test.ts` — asserts the loader returns a 302 to pathname `/` with `network=ethereum`, `widget=vaults`, `vault_module=sky`, and `vault=` the mainnet sUSDT address.
- `pnpm -F webapp typecheck` clean; test passes.

Closes APP-320.