### PR TITLE
Portfolio onboarding callouts + Sky Savings simulator

### DIFF
--- a/apps/webapp/src/hooks/earn/types.ts
+++ b/apps/webapp/src/hooks/earn/types.ts
@@ -80,4 +80,6 @@ export type EarnMarketplaceResult = {
   rows: EarnProductRow[];
   /** True while any row is still loading. Rows fail independently — check per-row error. */
   isLoading: boolean;
+  /** Σ of every row's user position USD — the wallet's total deposited across all earn products. */
+  totalDepositedUsd: number;
 };

--- a/apps/webapp/src/hooks/earn/useEarnMarketplace.test.tsx
+++ b/apps/webapp/src/hooks/earn/useEarnMarketplace.test.tsx
@@ -33,6 +33,9 @@ describe('useEarnMarketplace', () => {
     expect(byId['stusds'].rate.value).toBeGreaterThan(0);
     expect(byId['stusds'].tvl?.totalUsd).toBeGreaterThan(0);
 
+    // Aggregate of all user positions (>= 0; the fork test account holds none).
+    expect(result.current.totalDepositedUsd).toBeGreaterThanOrEqual(0);
+
     // Every row resolved without error and 30D rate stays unwired (TODO C1).
     for (const row of result.current.rows) {
       expect(row.error).toBeNull();

--- a/apps/webapp/src/hooks/earn/useEarnMarketplace.ts
+++ b/apps/webapp/src/hooks/earn/useEarnMarketplace.ts
@@ -343,6 +343,7 @@ export function useEarnMarketplace(): EarnMarketplaceResult {
 
   return {
     rows,
-    isLoading: rows.some(row => row.isLoading)
+    isLoading: rows.some(row => row.isLoading),
+    totalDepositedUsd: rows.reduce((acc, row) => acc + (row.position?.totalUsd ?? 0), 0)
   };
 }

--- a/apps/webapp/src/modules/portfolio/components/AllocateStablecoinsBanner.tsx
+++ b/apps/webapp/src/modules/portfolio/components/AllocateStablecoinsBanner.tsx
@@ -1,0 +1,50 @@
+import { Trans } from '@lingui/react/macro';
+import { formatDecimalPercentage, formatNumber, projectAnnualEarnings } from '@/utils';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/modules/layout/components/Typography';
+
+/**
+ * Top-of-page nudge shown when the user holds idle stablecoins but has no
+ * significant earn position: how much those idle funds could earn at the Sky
+ * Savings Rate, with a CTA into the Sky Savings product.
+ */
+export function AllocateStablecoinsBanner({
+  idleUsd,
+  savingsRate,
+  onAllocate
+}: {
+  idleUsd: number;
+  savingsRate: number;
+  onAllocate: () => void;
+}) {
+  const yearly = projectAnnualEarnings(idleUsd, savingsRate);
+
+  return (
+    <div
+      className="bg-container flex flex-col gap-4 rounded-3xl border p-6 bg-blend-overlay backdrop-blur-[50px] md:flex-row md:items-center md:justify-between md:p-8"
+      data-testid="allocate-stablecoins-banner"
+    >
+      <div className="flex flex-col gap-2">
+        <div className="flex items-baseline gap-1">
+          <span className="text-text font-circle text-3xl leading-none font-medium">{`$${formatNumber(yearly)}`}</span>
+          <Text variant="medium" tag="span" className="text-textSecondary">
+            <Trans>/year</Trans>
+          </Text>
+        </div>
+        <Text variant="medium" className="text-textSecondary max-w-xl">
+          <Trans>
+            That&apos;s what your idle stablecoins can earn at today&apos;s{' '}
+            <span className="text-text font-medium">
+              {formatDecimalPercentage(savingsRate)} Sky Savings Rate
+            </span>
+            .
+          </Trans>
+        </Text>
+      </div>
+
+      <Button variant="primary" className="shrink-0" onClick={onAllocate}>
+        <Trans>Allocate your stablecoins</Trans>
+      </Button>
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/portfolio/components/PortfolioPage.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioPage.tsx
@@ -1,32 +1,41 @@
 import { useState } from 'react';
 import { useChainId, useChains, useConnection, useEnsName } from 'wagmi';
+import { useNavigate } from '@tanstack/react-router';
 import { mainnet } from 'viem/chains';
 import { Trans } from '@lingui/react/macro';
 import { useEarnMarketplace, useOverallSkyData } from '@/hooks';
 import { formatAddress, getChainIcon } from '@/utils';
 import { getSupportedChainIds } from '@/data/wagmi/config/chainFamily';
+import { ROUTES } from '@/lib/routes';
+import { retainOnNavigate } from '@/lib/navigation';
 import { FilterSelect, type FilterOption } from '@/components/product/FilterSelect';
 import { Heading, Text } from '@/modules/layout/components/Typography';
 import { buildSuppliedView } from '../helpers/suppliedView';
 import { buildIdleSupplyInfo, buildIdleView } from '../helpers/idleView';
+import { portfolioCallout, SIGNIFICANT_BALANCE_USD } from '../helpers/portfolioCallout';
 import { useStablecoinBalances } from '../hooks/useStablecoinBalances';
 import { StablecoinEarningsCard } from './StablecoinEarningsCard';
 import { PortfolioPositionsSection } from './PortfolioPositionsSection';
+import { SavingsTvlCallout } from './SavingsTvlCallout';
+import { AllocateStablecoinsBanner } from './AllocateStablecoinsBanner';
 import { type PortfolioTab } from './PortfolioTabs';
 
 export function PortfolioPage() {
   const connectedChainId = useChainId();
-  const { rows, isLoading } = useEarnMarketplace();
+  const { rows, isLoading, totalDepositedUsd } = useEarnMarketplace();
   const { balances, isLoading: balancesLoading } = useStablecoinBalances();
   const { data: overallSkyData } = useOverallSkyData();
   const { address } = useConnection();
   const chains = useChains();
+  const navigate = useNavigate();
   const { data: ensName } = useEnsName({ address, chainId: mainnet.id });
 
   // 'all' or a chain id (as string, the FilterSelect value type).
   const [selectedNetwork, setSelectedNetwork] = useState('all');
   // Supplied/Idle is shared across sections (earnings card + positions carousel).
-  const [tab, setTab] = useState<PortfolioTab>('supplied');
+  // Until the user picks a tab, it follows a data-derived default: Idle once it's
+  // settled that there's no significant earn position. A manual choice then wins.
+  const [userTab, setUserTab] = useState<PortfolioTab | null>(null);
 
   const network = selectedNetwork === 'all' ? 'all' : Number(selectedNetwork);
   const suppliedView = buildSuppliedView(rows, network);
@@ -38,6 +47,16 @@ export function PortfolioPage() {
   const savingsRate = overallSkyData?.skySavingsRatecRate
     ? parseFloat(overallSkyData.skySavingsRatecRate)
     : 0;
+  const savingsTvlUsd = overallSkyData?.skySavingsRateTvl ? parseFloat(overallSkyData.skySavingsRateTvl) : 0;
+
+  // Onboarding callout gates on family-wide totals (ignores the network filter),
+  // and only after both data sources settle so it never flashes the wrong state.
+  const idleTotalUsd = balances.reduce((acc, balance) => acc + balance.amountUsd, 0);
+  const callout = isLoading || balancesLoading ? 'none' : portfolioCallout(totalDepositedUsd, idleTotalUsd);
+
+  const tab = userTab ?? (!isLoading && totalDepositedUsd <= SIGNIFICANT_BALANCE_USD ? 'idle' : 'supplied');
+
+  const goToSavings = () => void navigate({ to: ROUTES.EARN_SAVINGS, search: retainOnNavigate });
 
   // The filter lists every supported chain — idle balances may sit on a chain
   // where the user has no supplied position.
@@ -91,6 +110,15 @@ export function PortfolioPage() {
         />
       </div>
 
+      {callout === 'simulate' && <SavingsTvlCallout tvlUsd={savingsTvlUsd} savingsRate={savingsRate} />}
+      {callout === 'allocate' && (
+        <AllocateStablecoinsBanner
+          idleUsd={idleTotalUsd}
+          savingsRate={savingsRate}
+          onAllocate={goToSavings}
+        />
+      )}
+
       <StablecoinEarningsCard
         suppliedView={suppliedView}
         suppliedLoading={isLoading}
@@ -98,7 +126,7 @@ export function PortfolioPage() {
         idleLoading={balancesLoading}
         savingsRate={savingsRate}
         tab={tab}
-        onTabChange={setTab}
+        onTabChange={setUserTab}
       />
       <PortfolioPositionsSection
         suppliedView={suppliedView}
@@ -107,7 +135,7 @@ export function PortfolioPage() {
         idleSupplyInfo={idleSupplyInfo}
         idleLoading={balancesLoading}
         tab={tab}
-        onTabChange={setTab}
+        onTabChange={setUserTab}
       />
     </div>
   );

--- a/apps/webapp/src/modules/portfolio/components/SavingsTvlCallout.tsx
+++ b/apps/webapp/src/modules/portfolio/components/SavingsTvlCallout.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Trans } from '@lingui/react/macro';
+import { formatNumber } from '@/utils';
+import { Button } from '@/components/ui/button';
+import { Heading, Text } from '@/modules/layout/components/Typography';
+import { SimulateEarningsModal } from './SimulateEarningsModal';
+
+/**
+ * Top-of-page onboarding pitch shown when the user has no significant earn
+ * position and nothing idle to allocate: how much is already earning the Sky
+ * Savings Rate, plus a "Simulate earnings" entry point.
+ */
+export function SavingsTvlCallout({ tvlUsd, savingsRate }: { tvlUsd: number; savingsRate: number }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      className="bg-container flex flex-col gap-4 rounded-3xl border p-6 bg-blend-overlay backdrop-blur-[50px] md:flex-row md:items-center md:justify-between md:p-8"
+      data-testid="savings-tvl-callout"
+    >
+      <div className="flex flex-col gap-2">
+        <Heading tag="h2" className="text-text text-xl font-medium">
+          <Trans>
+            {`$${formatNumber(tvlUsd, { compact: true }).toLowerCase()}`} in stablecoins already earning the
+            Sky Savings Rate
+          </Trans>
+        </Heading>
+        <Text variant="medium" className="text-textSecondary max-w-xl">
+          <Trans>
+            Projections assume current rate held constant. Sky Savings Rate is variable and set by Sky
+            Ecosystem governance. Not financial advice.
+          </Trans>
+        </Text>
+      </div>
+
+      <Button variant="primary" className="shrink-0" onClick={() => setOpen(true)}>
+        <Trans>Simulate earnings</Trans>
+      </Button>
+
+      <SimulateEarningsModal open={open} onOpenChange={setOpen} savingsRate={savingsRate} />
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/portfolio/components/SimulateEarningsModal.tsx
+++ b/apps/webapp/src/modules/portfolio/components/SimulateEarningsModal.tsx
@@ -1,0 +1,118 @@
+import { ReactNode, useState } from 'react';
+import * as SliderPrimitive from '@radix-ui/react-slider';
+import { Trans } from '@lingui/react/macro';
+import { Info, X } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { formatDecimalPercentage, formatUsd, projectAnnualEarnings } from '@/utils';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { Text } from '@/modules/layout/components/Typography';
+
+// First-iteration slider bounds (per design): $50k–$10M, starting at $100k.
+const MIN_BALANCE = 50_000;
+const MAX_BALANCE = 10_000_000;
+const STEP = 10_000;
+const INITIAL_BALANCE = 100_000;
+
+/**
+ * "Simulate earnings with Sky Savings" modal: a balance slider whose Daily /
+ * Monthly / Yearly figures update live from the current Sky Savings Rate
+ * (simple, non-compounded — projections assume the rate holds).
+ */
+export function SimulateEarningsModal({
+  open,
+  onOpenChange,
+  savingsRate
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  savingsRate: number;
+}) {
+  const [balance, setBalance] = useState(INITIAL_BALANCE);
+
+  const yearly = projectAnnualEarnings(balance, savingsRate);
+  const monthly = yearly / 12;
+  const daily = yearly / 365;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[640px]">
+        <DialogClose className="text-textSecondary hover:text-text absolute top-5 right-5 transition-colors">
+          <X className="h-5 w-5" />
+          <span className="sr-only">
+            <Trans>Close</Trans>
+          </span>
+        </DialogClose>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2 pr-8">
+            <DialogTitle className="text-text text-lg font-medium">
+              <Trans>Simulate earnings with Sky Savings</Trans>
+            </DialogTitle>
+            <Pill>{formatDecimalPercentage(savingsRate)}</Pill>
+          </div>
+          <DialogDescription className="text-textSecondary text-sm">
+            <Trans>
+              Projections assume current rate held constant. Sky Savings Rate is variable and updates daily.
+              Not financial advice.
+            </Trans>
+          </DialogDescription>
+        </div>
+
+        <div className="mt-2 flex flex-col gap-3">
+          <div className="text-textSecondary flex items-center gap-1.5">
+            <Text variant="medium" tag="span">
+              <Trans>Balance deposited</Trans>
+            </Text>
+            <Info className="h-3.5 w-3.5" />
+          </div>
+          <span className="text-text font-circle text-3xl leading-none font-medium">
+            {formatUsd(balance)}
+          </span>
+
+          <SliderPrimitive.Root
+            className="relative mt-2 flex w-full touch-none items-center select-none"
+            value={[balance]}
+            min={MIN_BALANCE}
+            max={MAX_BALANCE}
+            step={STEP}
+            onValueChange={([value]) => setBalance(value)}
+            aria-label="Balance deposited"
+          >
+            <SliderPrimitive.Track className="bg-surface relative h-1.5 w-full grow cursor-pointer rounded-full">
+              <SliderPrimitive.Range className="bg-text absolute h-full rounded-full" />
+            </SliderPrimitive.Track>
+            <SliderPrimitive.Thumb className="border-text focus-visible:ring-ring block h-5 w-5 cursor-pointer rounded-full border-2 bg-white shadow transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden" />
+          </SliderPrimitive.Root>
+
+          <div className="text-textSecondary flex justify-between text-xs">
+            <span>$50k</span>
+            <span>$10M</span>
+          </div>
+        </div>
+
+        <div className="border-borderPrimary mt-4 grid grid-cols-3 border-t pt-4">
+          <Stat label={<Trans>Daily</Trans>} value={formatUsd(daily)} />
+          <Stat label={<Trans>Monthly</Trans>} value={formatUsd(monthly)} divided />
+          <Stat label={<Trans>Yearly</Trans>} value={formatUsd(yearly)} divided />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Stat({ label, value, divided }: { label: ReactNode; value: string; divided?: boolean }) {
+  return (
+    <div className={cn('flex flex-col gap-1.5 px-4', divided && 'border-borderPrimary border-l')}>
+      <Text variant="medium" tag="span" className="text-textSecondary">
+        {label}
+      </Text>
+      <span className="text-text text-lg font-medium">{value}</span>
+    </div>
+  );
+}
+
+function Pill({ children }: { children: ReactNode }) {
+  return (
+    <span className="bg-surface text-text rounded-full px-2 py-0.5 text-xs font-medium">{children}</span>
+  );
+}

--- a/apps/webapp/src/modules/portfolio/helpers/portfolioCallout.test.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/portfolioCallout.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { portfolioCallout, SIGNIFICANT_BALANCE_USD } from './portfolioCallout';
+
+describe('portfolioCallout', () => {
+  it('shows nothing once the earn position clears the floor', () => {
+    expect(portfolioCallout(SIGNIFICANT_BALANCE_USD + 0.01, 0)).toBe('none');
+    expect(portfolioCallout(1000, 1000)).toBe('none');
+  });
+
+  it('pitches allocating when there is no position but idle stablecoins to supply', () => {
+    expect(portfolioCallout(0, SIGNIFICANT_BALANCE_USD + 0.01)).toBe('allocate');
+    expect(portfolioCallout(SIGNIFICANT_BALANCE_USD, 5000)).toBe('allocate');
+  });
+
+  it('falls back to the simulate pitch with no position and nothing idle', () => {
+    expect(portfolioCallout(0, 0)).toBe('simulate');
+    expect(portfolioCallout(SIGNIFICANT_BALANCE_USD, SIGNIFICANT_BALANCE_USD)).toBe('simulate');
+  });
+});

--- a/apps/webapp/src/modules/portfolio/helpers/portfolioCallout.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/portfolioCallout.ts
@@ -1,0 +1,19 @@
+/**
+ * A position is "significant" (and the onboarding callouts are suppressed) once
+ * it clears this USD floor. Dust deposits/balances shouldn't flip the page out
+ * of its promotional state.
+ */
+export const SIGNIFICANT_BALANCE_USD = 10;
+
+/**
+ * Which top-of-page onboarding callout to show:
+ * - `none`     — the user already has a meaningful earn position; show nothing.
+ * - `allocate` — no earn position, but idle stablecoins worth supplying.
+ * - `simulate` — no earn position and nothing idle; show the Sky Savings pitch.
+ */
+export type PortfolioCallout = 'none' | 'allocate' | 'simulate';
+
+export function portfolioCallout(depositedUsd: number, idleUsd: number): PortfolioCallout {
+  if (depositedUsd > SIGNIFICANT_BALANCE_USD) return 'none';
+  return idleUsd > SIGNIFICANT_BALANCE_USD ? 'allocate' : 'simulate';
+}


### PR DESCRIPTION
## Scenarios
- Wallet has less than $10 supplied and less than $10 worth of idle stablecoins: show the "Simulate earnings banner
<img width="1527" height="404" alt="image" src="https://github.com/user-attachments/assets/f613659c-d00f-471f-9800-b61902b6531d" />
<img width="685" height="425" alt="image" src="https://github.com/user-attachments/assets/7913aa4a-2456-4449-8a83-7395e063d54d" />


- Wallet has less than $10 supplied and at least $10 worth of idle stabelcoins: show the "Allocate your stablecoins" banner
<img width="1541" height="400" alt="image" src="https://github.com/user-attachments/assets/5428aa9e-e274-4bff-91a3-b698023d9fbe" />

- Wallet has more than $10 supplied, don't show any banners
<img width="1563" height="319" alt="image" src="https://github.com/user-attachments/assets/0ab125b2-d03d-4780-877b-025fad52e542" />


## What

Adds the conditional top-of-page onboarding section to the Portfolio dashboard (D1), shown when the connected wallet has no significant earn position.

### Gating
- `useEarnMarketplace` now returns **`totalDepositedUsd`** (Σ of every row's position USD).
- New pure helper `portfolioCallout(depositedUsd, idleUsd) → 'none' | 'allocate' | 'simulate'` with a shared `SIGNIFICANT_BALANCE_USD = 10` threshold:
  - deposits > $10 → **none** (no callout; normal portfolio)
  - else idle stablecoins > $10 → **allocate** banner
  - else → **simulate** hero card

Gating uses family-wide totals (ignores the network filter) and only resolves once both data sources settle, so it never flashes the wrong state.

### Components
- **`SavingsTvlCallout`** — "$X in stablecoins already earning the Sky Savings Rate" (savings TVL) + "Simulate earnings".
- **`SimulateEarningsModal`** — balance slider ($50k–$10M, initial $100k) with live Daily / Monthly / Yearly earnings at the current Sky Savings Rate (simple, non-compounded; reuses `projectAnnualEarnings`).
- **`AllocateStablecoinsBanner`** — "$Y/year" from idle stablecoins + CTA into `/earn/savings`.

### Page
- Renders the right callout **above** the earnings card (the rest of the page still shows).
- Defaults the shared Supplied/Idle tab to **Idle** when there's no significant earn position (derived during render; a manual toggle wins).

## Notes
- Modal math is simple (non-compounded); the wireframe's modal figures were inconsistent mock values.
- Slider is linear; disconnected wallet counts as no position (shows the simulate hero).

## Testing
- typecheck, eslint (0 warnings), prettier clean.
- 22 portfolio unit tests pass (incl. 3 new `portfolioCallout` cases); `useEarnMarketplace` vnet test asserts `totalDepositedUsd >= 0`.
- Visually verified both banners + the live slider modal via a throwaway preview route (removed before commit).