### PR TITLE
D3 · Reusable savings supply flow: trigger + shared form model (Portfolio in-place supply)

### DIFF
--- a/apps/webapp/src/modules/portfolio/components/PortfolioPositionsSection.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioPositionsSection.test.tsx
@@ -1,0 +1,145 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, within, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PortfolioPositionsSection } from './PortfolioPositionsSection';
+import type { SuppliedPosition, SuppliedView } from '../helpers/suppliedView';
+import type { IdleView } from '../helpers/idleView';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const h = vi.hoisted(() => ({ navigate: vi.fn(), openSupply: vi.fn(), openWithdraw: vi.fn(), chainId: 1 }));
+
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => h.navigate }));
+
+// The resolver reads the connected chain to gate in-place supply; keep real wagmi
+// exports, override only useChainId.
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return { ...actual, useChainId: () => h.chainId };
+});
+
+// The savings trigger under test — capture its opener.
+vi.mock('@/modules/savings/hooks/useSavingsModal', () => ({
+  useSavingsModal: () => ({ openSupply: h.openSupply, openWithdraw: h.openWithdraw })
+}));
+
+// Carousel → passthroughs so the cards render flat (no embla/DOM coupling).
+vi.mock('@/components/ui/carousel', () => ({
+  Carousel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CarouselPrevious: () => <button type="button" />,
+  CarouselNext: () => <button type="button" />
+}));
+
+// Not under test — stub to keep the import graph + render light.
+vi.mock('./PortfolioTabs', () => ({ PortfolioTabs: () => <div data-testid="tabs" /> }));
+vi.mock('./IdleStablecoinsTable', () => ({ IdleStablecoinsTable: () => <div /> }));
+vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
+
+const position = (over: Partial<SuppliedPosition>): SuppliedPosition => ({
+  id: 'x',
+  name: 'X',
+  tokenSymbol: 'USDS',
+  kind: 'vault',
+  amountUsd: 100,
+  rate: 0.05,
+  color: '#000',
+  share: 0.5,
+  detailPath: '/earn/x',
+  chainIds: [1],
+  ...over
+});
+
+const SAVINGS = position({ id: 'savings', name: 'Sky Savings Rate', kind: 'savings', detailPath: '/earn/savings' });
+const VAULT = position({ id: 'vault-sky-1', name: 'A Vault', kind: 'vault', detailPath: '/earn/vault' });
+
+const view = (positions: SuppliedPosition[]): SuppliedView => ({
+  positions,
+  totalSupplied: 200,
+  projected1Y: 0,
+  avgRate: 0,
+  activePositions: positions.length,
+  suppliedTokens: [],
+  networksWithPositions: [1]
+});
+
+function renderSection(positions: SuppliedPosition[]) {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <PortfolioPositionsSection
+        suppliedView={view(positions)}
+        suppliedLoading={false}
+        idleView={{ tokens: [] } as unknown as IdleView}
+        idleSupplyInfo={new Map()}
+        idleLoading={false}
+        tab="supplied"
+        onTabChange={() => undefined}
+      />
+    </I18nProvider>
+  );
+}
+
+describe('PortfolioPositionsSection — supply routing', () => {
+  beforeEach(() => {
+    h.navigate.mockClear();
+    h.openSupply.mockClear();
+    h.openWithdraw.mockClear();
+    h.chainId = 1;
+  });
+  afterEach(() => cleanup());
+
+  it('opens the savings modal in place from the Sky Savings Rate card (no navigation)', () => {
+    renderSection([SAVINGS, VAULT]);
+    const savingsCard = screen.getAllByTestId('position-card')[0];
+
+    fireEvent.click(within(savingsCard).getByTestId('position-card-supply'));
+
+    expect(h.openSupply).toHaveBeenCalledTimes(1);
+    expect(h.navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the product page for a non-savings card Supply', () => {
+    renderSection([SAVINGS, VAULT]);
+    const vaultCard = screen.getAllByTestId('position-card')[1];
+
+    fireEvent.click(within(vaultCard).getByTestId('position-card-supply'));
+
+    expect(h.openSupply).not.toHaveBeenCalled();
+    expect(h.navigate).toHaveBeenCalledTimes(1);
+    expect(h.navigate.mock.calls[0][0].to).toBe('/earn/vault');
+  });
+
+  it('Manage always routes to the product page, even on the savings card', () => {
+    renderSection([SAVINGS, VAULT]);
+    const savingsCard = screen.getAllByTestId('position-card')[0];
+
+    fireEvent.click(within(savingsCard).getByTestId('position-card-manage'));
+
+    expect(h.openSupply).not.toHaveBeenCalled();
+    expect(h.navigate).toHaveBeenCalledTimes(1);
+    expect(h.navigate.mock.calls[0][0].to).toBe('/earn/savings');
+  });
+
+  it('navigates (does not open the modal) when the savings card is on a non-connected chain', () => {
+    h.chainId = 1; // wallet on mainnet
+    // Savings position scoped to Base — the in-place modal would supply on mainnet.
+    const savingsOnBase = position({
+      id: 'savings',
+      name: 'Sky Savings Rate',
+      kind: 'savings',
+      detailPath: '/earn/savings',
+      chainIds: [8453]
+    });
+    renderSection([savingsOnBase]);
+    const savingsCard = screen.getAllByTestId('position-card')[0];
+
+    fireEvent.click(within(savingsCard).getByTestId('position-card-supply'));
+
+    expect(h.openSupply).not.toHaveBeenCalled();
+    expect(h.navigate).toHaveBeenCalledTimes(1);
+    expect(h.navigate.mock.calls[0][0].to).toBe('/earn/savings');
+  });
+});

--- a/apps/webapp/src/modules/portfolio/components/PortfolioPositionsSection.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioPositionsSection.tsx
@@ -12,6 +12,7 @@ import {
   CarouselNext
 } from '@/components/ui/carousel';
 import { Text } from '@/modules/layout/components/Typography';
+import { usePortfolioSupplyActions } from '../hooks/usePortfolioSupplyActions';
 import type { SuppliedView } from '../helpers/suppliedView';
 import type { IdleSupplyInfo, IdleView } from '../helpers/idleView';
 import { PositionCard } from './PositionCard';
@@ -48,6 +49,9 @@ export function PortfolioPositionsSection({
   onTabChange: (tab: PortfolioTab) => void;
 }) {
   const navigate = useNavigate();
+  // Products with an in-place supply modal (savings today) open it without
+  // navigating; everything else — and all Manage buttons — route to the product page.
+  const resolveSupplyAction = usePortfolioSupplyActions();
   const goToProduct = (detailPath: string) =>
     void navigate({ to: detailPath as '/', search: retainOnNavigate });
   // Deep-link to the Earn list pre-filtered by the chosen stablecoin (keeps the
@@ -107,7 +111,11 @@ export function PortfolioPositionsSection({
         <CarouselContent>
           {suppliedView.positions.map(position => (
             <CarouselItem key={position.id} className={ITEM_BASIS}>
-              <PositionCard position={position} onSelect={() => goToProduct(position.detailPath)} />
+              <PositionCard
+                position={position}
+                onSupply={resolveSupplyAction(position) ?? (() => goToProduct(position.detailPath))}
+                onManage={() => goToProduct(position.detailPath)}
+              />
             </CarouselItem>
           ))}
         </CarouselContent>

--- a/apps/webapp/src/modules/portfolio/components/PositionCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PositionCard.tsx
@@ -26,10 +26,18 @@ const ringColor = (position: SuppliedPosition): string => {
 /**
  * One supplied position in the Portfolio carousel: ringed token icon, stacked
  * network badge, a 2×2 stats block and Supply/Manage actions. Presentational —
- * the caller owns navigation via `onSelect` (both buttons route to the product
- * page for now).
+ * the caller owns each action (e.g. the savings card opens the supply modal in
+ * place via `onSupply`; others route to the product page).
  */
-export function PositionCard({ position, onSelect }: { position: SuppliedPosition; onSelect: () => void }) {
+export function PositionCard({
+  position,
+  onSupply,
+  onManage
+}: {
+  position: SuppliedPosition;
+  onSupply: () => void;
+  onManage: () => void;
+}) {
   const projected = projectAnnualEarnings(position.amountUsd, position.rate);
 
   return (
@@ -96,10 +104,10 @@ export function PositionCard({ position, onSelect }: { position: SuppliedPositio
       </div>
 
       <div className="mt-1 flex gap-2">
-        <Button variant="primary" className="flex-1" onClick={onSelect}>
+        <Button variant="primary" className="flex-1" onClick={onSupply} data-testid="position-card-supply">
           <Trans>Supply</Trans>
         </Button>
-        <Button variant="outline" className="flex-1" onClick={onSelect}>
+        <Button variant="outline" className="flex-1" onClick={onManage} data-testid="position-card-manage">
           <Trans>Manage</Trans>
         </Button>
       </div>

--- a/apps/webapp/src/modules/portfolio/hooks/usePortfolioSupplyActions.test.tsx
+++ b/apps/webapp/src/modules/portfolio/hooks/usePortfolioSupplyActions.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePortfolioSupplyActions } from './usePortfolioSupplyActions';
+import type { SuppliedPosition } from '../helpers/suppliedView';
+
+const h = vi.hoisted(() => ({ openSupply: vi.fn(), chainId: 1 }));
+
+vi.mock('wagmi', () => ({ useChainId: () => h.chainId }));
+
+vi.mock('@/modules/savings/hooks/useSavingsModal', () => ({
+  useSavingsModal: () => ({ openSupply: h.openSupply, openWithdraw: vi.fn() })
+}));
+
+const position = (kind: SuppliedPosition['kind'], chainIds: number[] = [1]): SuppliedPosition => ({
+  id: kind,
+  name: kind,
+  tokenSymbol: 'USDS',
+  kind,
+  amountUsd: 100,
+  rate: 0.05,
+  color: '#000',
+  share: 1,
+  detailPath: `/earn/${kind}`,
+  chainIds
+});
+
+describe('usePortfolioSupplyActions', () => {
+  beforeEach(() => {
+    h.openSupply.mockClear();
+    h.chainId = 1;
+  });
+  afterEach(() => cleanup());
+
+  it('resolves a savings position on the connected chain to an opener that launches the supply modal', () => {
+    const { result } = renderHook(() => usePortfolioSupplyActions());
+    const handler = result.current(position('savings', [1]));
+
+    expect(handler).toBeTypeOf('function');
+    handler!();
+    expect(h.openSupply).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined for a savings position not on the connected chain (caller navigates)', () => {
+    h.chainId = 1; // wallet on mainnet
+    const { result } = renderHook(() => usePortfolioSupplyActions());
+
+    // Card scoped to Base — the in-place modal would supply on mainnet, so don't open it.
+    expect(result.current(position('savings', [8453]))).toBeUndefined();
+    expect(h.openSupply).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for products with no in-place supply modal (caller navigates)', () => {
+    const { result } = renderHook(() => usePortfolioSupplyActions());
+
+    for (const kind of ['rewards', 'vault', 'fixed', 'stusds'] as const) {
+      expect(result.current(position(kind))).toBeUndefined();
+    }
+    expect(h.openSupply).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/modules/portfolio/hooks/usePortfolioSupplyActions.ts
+++ b/apps/webapp/src/modules/portfolio/hooks/usePortfolioSupplyActions.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { useChainId } from 'wagmi';
+import { useSavingsModal } from '@/modules/savings/hooks/useSavingsModal';
+import type { SuppliedPosition } from '../helpers/suppliedView';
+
+/**
+ * Resolves a supplied position to its in-place "Supply" handler — the modal a
+ * product opens without leaving the Portfolio page — or `undefined` when the
+ * product has none (the caller then navigates to its product page).
+ *
+ * Product families are wired once here, so the position card stays declarative:
+ * integrating a new in-place supply is a single case in this resolver, never a
+ * branch in the carousel JSX. Hooks can't be dispatched dynamically, so each
+ * family's trigger hook is called unconditionally above and matched by `kind`.
+ *
+ * In-place modals supply on the wallet's connected chain, so a family only opens
+ * one when the card's position lives on that chain; otherwise we return undefined
+ * and the caller navigates to the product page, which owns the cross-chain case.
+ */
+export function usePortfolioSupplyActions(): (position: SuppliedPosition) => (() => void) | undefined {
+  const connectedChainId = useChainId();
+  const { openSupply: openSavingsSupply } = useSavingsModal();
+
+  return useCallback(
+    (position: SuppliedPosition) => {
+      const onConnectedChain = position.chainIds.includes(connectedChainId);
+      switch (position.kind) {
+        case 'savings':
+          return onConnectedChain ? () => openSavingsSupply() : undefined;
+        // 'rewards' | 'vault' | 'fixed' | 'stusds' have no in-place supply modal
+        // yet — add a case as each product's trigger is integrated.
+        default:
+          return undefined;
+      }
+    },
+    [connectedChainId, openSavingsSupply]
+  );
+}

--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.test.tsx
@@ -63,6 +63,9 @@ vi.mock('@/hooks', async importOriginal => {
     // Canonical Sky Savings Rate (skySavingsRatecRate) — the "Savings rate" row source.
     useOverallSkyData: () => ({ data: { skySavingsRatecRate: '0.0375' } }),
     useTokenBalance: () => ({ data: { value: h.walletBalance }, refetch: vi.fn() }),
+    // Mainnet-supply sUSDS preview — gated off in the modal (enablePreview=false), so
+    // it stays disabled here; stubbed only to keep the read out of real wagmi.
+    useReadSavingsUsds: () => ({ data: undefined }),
     // L2 PSM preview reads — stubbed (real ones need a wagmi read provider).
     usePreviewSwapExactIn: () => ({ value: h.convertedValue }),
     usePreviewSwapExactOut: () => ({ value: h.maxAmountIn })

--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
@@ -1,34 +1,23 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { useChainId, useChains, useConnection } from 'wagmi';
-import { formatUnits, parseUnits } from 'viem';
+import { useChainId, useChains } from 'wagmi';
+import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
-import {
-  getTokenDecimals,
-  useSavingsData,
-  useOverallSkyData,
-  useTokenBalance,
-  usePreviewSwapExactIn,
-  usePreviewSwapExactOut,
-  TOKENS
-} from '@/hooks';
-import { formatBigInt, formatNumber, formatDecimalPercentage, isL2ChainId } from '@/utils';
-import { REFERRAL_CODE } from '@/lib/constants';
+import { formatBigInt, formatNumber } from '@/utils';
 import { Text } from '@/modules/layout/components/Typography';
 import { useTransaction, useEntrySlot } from '@/modules/ui/context/TransactionContext';
 import { useSavingsLaunch, type SavingsLaunchFlow } from '../hooks/useSavingsLaunch';
-import { useSavingsSupplyMinAmountOut } from '../hooks/useSavingsSupplyMinAmountOut';
-import { buildSupplyModalRows, buildWithdrawModalRows, type SavingsModalRow } from './savingsModalRows';
-import { SavingsAmountSummary } from './SavingsAmountSummary';
 import {
-  ORIGIN_TOKENS,
-  MAINNET_SUPPLY_ORIGINS,
-  L2_SUPPLY_ORIGINS,
-  L2_WITHDRAW_ORIGINS,
-  SavingsOriginSelect,
-  type OriginSymbol
-} from './SavingsOriginSelect';
+  useSavingsTransactionForm,
+  type SavingsModalPreset
+} from '../hooks/useSavingsTransactionForm';
+import { buildSupplyModalRows, buildWithdrawModalRows, type SavingsModalRow } from './savingsModalRows';
+import { SavingsOriginSelect } from './SavingsOriginSelect';
+
+// `SavingsModalPreset` now lives with the shared form model; re-exported here so the
+// modal trigger (`useSavingsModal`) and tests keep importing it from this module.
+export type { SavingsModalPreset } from '../hooks/useSavingsTransactionForm';
 
 const NO_VALUE = '–';
 const USDS_DECIMALS = 18;
@@ -58,39 +47,19 @@ function ModalRow({ row }: { row: SavingsModalRow }) {
 /**
  * Editable body for the has-position "Supply to / Withdraw from Sky Savings" modals
  * (Figma 527:7591 / 527:10945), mounted as the shared modal's `entry.content`. One
- * body, two flows (`flow`) — the single component the PRD calls for (module 2).
+ * body, two flows (`flow`).
  *
- * Token choice (Figma `USDS ▾`):
- *  - mainnet supply  → USDS / DAI (DAI routes to upgrade-and-supply, calldata unchanged)
- *  - mainnet withdraw → USDS-only (static chip)
- *  - L2 supply       → USDS / USDC (USDC swaps through the PSM)
- *  - L2 withdraw     → USDS / USDC destination choice (sUSDS swaps out to the picked token)
- *
- * It owns its amount/max state and renders the input + Max + the flow's before→after
- * rows. The shared modal owns the confirm button; this body keeps that button's
- * gating + handler live via `updateModalContent`, which *merges* into the entry (so
- * this `content` is never re-pushed and the body never remounts — keeping the input
- * focused and loop-free). Confirm fires the engine `execute` from `useSavingsLaunch`
- * directly (the modal is already open, so there is no separate review screen) —
- * calldata is identical to the inline/launch path.
- *
- * Supply spends the wallet balance of the origin token; withdraw spends the position
- * (mainnet: the USDS savings balance; L2: the sUSDS balance converted to the chosen
- * destination token). A withdraw Max sets the `max` flag so the engine redeems the
- * whole position with no dust — mainnet via `maxWithdraw(owner)`, L2 via
- * `swapExactIn(whole sUSDS balance)`; the UI never computes the redeem amount. The L2
- * PSM bounds (`minAmountOut` / `sUsdsBalance` / `minAmountOutForWithdrawAll` /
- * `maxAmountInForWithdraw`) are computed here and handed straight to the orchestrator
- * (mirroring `SavingsSupplyWithdrawPanel`); they are no-ops on mainnet.
+ * The form model (amount/Max/token state, the balance + L2 PSM reads, and the spend
+ * gate) lives in `useSavingsTransactionForm`, shared with the inline no-position
+ * surface; this component is the modal *presentation* over it: the input + Max + the
+ * flow's before→after rows. The shared modal owns the confirm button; this body keeps
+ * that button's gating + handler + step labels + the wallet-screen summary +
+ * minimized-toast titles live via `updateModalContent`, which *merges* into the entry
+ * (so this `content` is never re-pushed and the body never remounts — keeping the
+ * input focused and loop-free). Confirm fires the engine `execute` from
+ * `useSavingsLaunch` directly (the modal is already open, so there is no separate
+ * review screen) — calldata is identical to the inline/launch path.
  */
-/** Seeds the body's initial amount/token (e.g. a Portfolio quick-deposit shortcut). */
-export type SavingsModalPreset = {
-  /** Raw amount string to seed the input (e.g. '100'). */
-  amount?: string;
-  /** Origin/destination token to preselect; must be valid for the flow/chain. Defaults to USDS. */
-  token?: OriginSymbol;
-};
-
 export function SavingsModalForm({
   sessionId,
   flow,
@@ -100,12 +69,8 @@ export function SavingsModalForm({
   flow: SavingsLaunchFlow;
   preset?: SavingsModalPreset;
 }) {
-  const isSupply = flow === 'supply';
   const chainId = useChainId();
   const chains = useChains();
-  const { address, isConnected } = useConnection();
-  const { data: savingsData } = useSavingsData();
-  const { data: overall } = useOverallSkyData();
   const { updateModalContent } = useTransaction();
   // Rendered as the modal's `backgroundContent` (a hidden, always-mounted host so
   // the in-flight engine hook survives minimize). The visible inputs portal into
@@ -113,69 +78,32 @@ export function SavingsModalForm({
   // they render inline in the hidden host.
   const entrySlot = useEntrySlot();
 
-  // Seeded from `preset` on each fresh launch (the host remounts per launchCount).
-  const [value, setValue] = useState(preset?.amount ?? '');
-  // Withdraw-only: set by Max so the engine redeems the whole position (no dust).
-  // Cleared the moment the user edits the amount.
-  const [max, setMax] = useState(false);
-  const [originSymbol, setOriginSymbol] = useState<OriginSymbol>(preset?.token ?? 'USDS');
-  const isL2 = isL2ChainId(chainId);
-  // Supply always offers an origin choice (USDS/DAI mainnet, USDS/USDC L2); withdraw
-  // offers a destination choice only on L2 (USDS/USDC). Mainnet withdraw → USDS-only
-  // static chip.
-  const showOriginSelect = isSupply || isL2;
-  const origins = isSupply ? (isL2 ? L2_SUPPLY_ORIGINS : MAINNET_SUPPLY_ORIGINS) : L2_WITHDRAW_ORIGINS;
-  const originOptions: OriginSymbol[] = showOriginSelect ? origins : ['USDS'];
-  const originToken = showOriginSelect ? ORIGIN_TOKENS[originSymbol] : TOKENS.usds;
-  const originDecimals = getTokenDecimals(originToken, chainId);
-
-  const amount = parseAmount(value, originDecimals);
-  const { data: walletBalance } = useTokenBalance({
-    address,
-    chainId,
-    token: originToken.address[chainId]
-  });
-  const walletBalanceValue = walletBalance?.value ?? 0n;
-  // sUSDS token balance — the whole of it is swapped out on a max L2 withdraw.
-  const { data: susdsBalance } = useTokenBalance({
-    address,
-    chainId,
-    token: TOKENS.susds.address[chainId]
-  });
-  const position = savingsData?.userSavingsBalance ?? 0n;
-
-  // L2 PSM bounds (no-ops on mainnet / where the flow doesn't use them):
-  //  - minAmountOut: chi-projected sUSDS-out floor for an L2 supply (swapExactIn)
-  //  - convertedBalance: the whole sUSDS balance valued in the destination token →
-  //    the L2 withdraw source balance + the max-withdraw floor (swapExactIn)
-  //  - maxAmountInForWithdraw: the sUSDS-in ceiling to take exactly `amount` out
-  //    (specific L2 withdraw, swapExactOut)
-  const minAmountOut = useSavingsSupplyMinAmountOut({ amount, originToken });
-  const convertedBalance = usePreviewSwapExactIn(susdsBalance?.value ?? 0n, TOKENS.susds, originToken);
-  const { value: maxAmountInForWithdraw } = usePreviewSwapExactOut(amount, TOKENS.susds, originToken);
-
-  // Supply is capped by the wallet balance of the origin token; withdraw by the
-  // position (mainnet: USDS savings balance; L2: sUSDS converted to the destination
-  // token).
-  const available = isSupply ? walletBalanceValue : isL2 ? convertedBalance.value : position;
-  const isZero = amount === 0n;
-  // A max withdraw bypasses the amount check — the redeem is driven by the flag, not
-  // the displayed (rounded) value.
-  const insufficient = isConnected && !max && amount > available;
-
-  const { execute, steps, prepared } = useSavingsLaunch({
-    flow,
-    originToken,
+  const form = useSavingsTransactionForm({ flow, preset });
+  const {
+    isConnected,
+    isSupply,
+    isL2,
+    originSymbol,
+    originOptions,
+    originDecimals,
+    value,
     amount,
-    max: !isSupply && max,
-    referralCode: REFERRAL_CODE,
-    minAmountOut,
-    sUsdsBalance: susdsBalance?.value,
-    minAmountOutForWithdrawAll: convertedBalance.value,
-    maxAmountInForWithdraw
-  });
+    available,
+    isZero,
+    insufficient,
+    amountReady,
+    position,
+    apyDisplay,
+    engineParams,
+    transactionScreenContent,
+    toast,
+    onInput,
+    setMaxAmount,
+    switchOrigin
+  } = form;
 
-  const disabled = !isConnected || !prepared || (!max && (isZero || insufficient));
+  const { execute, steps, prepared } = useSavingsLaunch(engineParams);
+  const disabled = !amountReady || !prepared;
 
   // The modal's confirm calls this. `execute` is rebuilt every render (its calls
   // array is fresh each time), so pushing it directly would loop the sync below;
@@ -187,32 +115,6 @@ export function SavingsModalForm({
   }, [execute]);
   const onConfirm = useCallback(() => executeRef.current(), []);
 
-  // Compact summary for the wallet/status screen (Figma "Confirm in the wallet").
-  // Memoised so the sync effect below only fires when the amount/token/flow change
-  // — a fresh element every render would loop the merge.
-  const transactionScreenContent = useMemo(() => {
-    const display = value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : '0';
-    return (
-      <SavingsAmountSummary
-        label={isSupply ? t`Supply amount` : t`Withdrawal amount`}
-        amount={display}
-        symbol={originToken.symbol}
-        usd={value ? display : undefined}
-        dataTestId="savings-confirm-summary"
-      />
-    );
-  }, [isSupply, value, originToken.symbol]);
-
-  // Amount-aware titles for the minimized toast (Figma "10,000.00 USDS supplied!").
-  // Memoised on the amount/token/flow so the sync effect below stays bounded.
-  const toastTitles = useMemo(() => {
-    const display = value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : '0';
-    const amount = `${display} ${originToken.symbol}`;
-    return isSupply
-      ? { loading: t`Supplying ${amount}`, success: t`${amount} supplied!`, error: t`Supply failed` }
-      : { loading: t`Withdrawing ${amount}`, success: t`${amount} withdrawn!`, error: t`Withdrawal failed` };
-  }, [isSupply, value, originToken.symbol]);
-
   // Keep the shared modal's confirm gating + handler + step labels + the
   // wallet-screen summary + minimized-toast titles in sync. Merged (not replacing
   // `content`), so the body never remounts; bounded to amount-driven changes, so it
@@ -223,32 +125,11 @@ export function SavingsModalForm({
       onConfirm,
       steps,
       transactionScreenContent,
-      toast: toastTitles
+      toast
     });
-  }, [sessionId, disabled, steps, onConfirm, transactionScreenContent, toastTitles, updateModalContent]);
-
-  const onInput = (raw: string) => {
-    setMax(false);
-    setValue(raw.replace(/[^0-9.]/g, ''));
-  };
-  const setMaxAmount = () => {
-    if (!isSupply) setMax(true);
-    setValue(formatUnits(available, originDecimals));
-  };
-  // Switching the origin token resets the amount + Max (the previous amount was
-  // denominated in the old token's balance/decimals).
-  const switchOrigin = (next: OriginSymbol) => {
-    setOriginSymbol(next);
-    setMax(false);
-    setValue('');
-  };
+  }, [sessionId, disabled, steps, onConfirm, transactionScreenContent, toast, updateModalContent]);
 
   const networkName = chains.find(c => c.id === chainId)?.name ?? 'Ethereum';
-  // Canonical Sky Savings Rate — same source as the page headline + Details grid
-  // (skySavingsRatecRate), NOT useSavingsData().savingsRate (the DSR).
-  const savingsRate = overall?.skySavingsRatecRate
-    ? formatDecimalPercentage(parseFloat(overall.skySavingsRatecRate))
-    : NO_VALUE;
   // The position is always USDS-denominated (18-dec — on L2 `userSavingsBalance` is
   // the sUSDS balance pre-converted to USDS). Express the entered amount as a USDS
   // wad for the before→after delta: USDS/DAI are already 18-dec; an L2 USDC amount
@@ -257,12 +138,14 @@ export function SavingsModalForm({
   const amountWad = originDecimals === 18 ? amount : amount * 10n ** BigInt(18 - originDecimals);
   const rows = isSupply
     ? buildSupplyModalRows({
-        savingsRate,
+        savingsRate: apyDisplay,
         supplyBefore: formatUsds(position),
         supplyAfter: formatUsds(position + amountWad),
         // L2 PSM supply: surface the sUSDS slippage floor once an amount is entered.
         minReceived:
-          isL2 && !isZero ? `${formatBigInt(minAmountOut, { unit: 18, maxDecimals: 2 })} sUSDS` : undefined,
+          isL2 && !isZero
+            ? `${formatBigInt(engineParams.minAmountOut ?? 0n, { unit: 18, maxDecimals: 2 })} sUSDS`
+            : undefined,
         // 1Y est. earnings has no projection source yet (PRD Out of Scope) — stubbed.
         earningsBefore: NO_VALUE,
         earningsAfter: NO_VALUE,
@@ -271,8 +154,8 @@ export function SavingsModalForm({
       })
     : buildWithdrawModalRows({
         // Rate is unchanged by a withdrawal, but Figma 527:10945 draws it as a delta.
-        savingsRateBefore: savingsRate,
-        savingsRateAfter: savingsRate,
+        savingsRateBefore: apyDisplay,
+        savingsRateAfter: apyDisplay,
         supplyBefore: formatUsds(position),
         supplyAfter: formatUsds(position > amountWad ? position - amountWad : 0n),
         earningsBefore: NO_VALUE,
@@ -336,14 +219,4 @@ export function SavingsModalForm({
   // Display inside the dialog when its entry slot is mounted; otherwise render
   // inline in the hidden host (keeps the body — and its engine hook — mounted).
   return entrySlot ? createPortal(body, entrySlot) : body;
-}
-
-// Parse the raw input to a bigint at the origin token's decimals; partial/invalid → 0.
-function parseAmount(raw: string, decimals: number): bigint {
-  if (!raw) return 0n;
-  try {
-    return parseUnits(raw, decimals);
-  } catch {
-    return 0n;
-  }
 }

--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
@@ -83,7 +83,23 @@ function ModalRow({ row }: { row: SavingsModalRow }) {
  * `maxAmountInForWithdraw`) are computed here and handed straight to the orchestrator
  * (mirroring `SavingsSupplyWithdrawPanel`); they are no-ops on mainnet.
  */
-export function SavingsModalForm({ sessionId, flow }: { sessionId: string; flow: SavingsLaunchFlow }) {
+/** Seeds the body's initial amount/token (e.g. a Portfolio quick-deposit shortcut). */
+export type SavingsModalPreset = {
+  /** Raw amount string to seed the input (e.g. '100'). */
+  amount?: string;
+  /** Origin/destination token to preselect; must be valid for the flow/chain. Defaults to USDS. */
+  token?: OriginSymbol;
+};
+
+export function SavingsModalForm({
+  sessionId,
+  flow,
+  preset
+}: {
+  sessionId: string;
+  flow: SavingsLaunchFlow;
+  preset?: SavingsModalPreset;
+}) {
   const isSupply = flow === 'supply';
   const chainId = useChainId();
   const chains = useChains();
@@ -97,11 +113,12 @@ export function SavingsModalForm({ sessionId, flow }: { sessionId: string; flow:
   // they render inline in the hidden host.
   const entrySlot = useEntrySlot();
 
-  const [value, setValue] = useState('');
+  // Seeded from `preset` on each fresh launch (the host remounts per launchCount).
+  const [value, setValue] = useState(preset?.amount ?? '');
   // Withdraw-only: set by Max so the engine redeems the whole position (no dust).
   // Cleared the moment the user edits the amount.
   const [max, setMax] = useState(false);
-  const [originSymbol, setOriginSymbol] = useState<OriginSymbol>('USDS');
+  const [originSymbol, setOriginSymbol] = useState<OriginSymbol>(preset?.token ?? 'USDS');
   const isL2 = isL2ChainId(chainId);
   // Supply always offers an origin choice (USDS/DAI mainnet, USDS/USDC L2); withdraw
   // offers a destination choice only on L2 (USDS/USDC). Mainnet withdraw → USDS-only

--- a/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
@@ -1,15 +1,13 @@
-import { ReactNode, useCallback, useId } from 'react';
+import { ReactNode, useCallback } from 'react';
 import { useChainId, useConnection } from 'wagmi';
 import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
-import { t } from '@lingui/core/macro';
 import { useSavingsData, useTokenBalance, TOKENS } from '@/hooks';
 import { formatNumber } from '@/utils';
 import { Button } from '@/components/ui/button';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
-import { useTransaction } from '@/modules/ui/context/TransactionContext';
+import { useSavingsModal } from '../hooks/useSavingsModal';
 import { SavingsSupplyCard } from './SavingsSupplyCard';
-import { SavingsModalForm } from './SavingsModalForm';
 
 const NO_VALUE = '–';
 
@@ -51,10 +49,6 @@ export function SavingsPositionCard() {
     chainId,
     token: TOKENS.susds.address[chainId]
   });
-  const { launch } = useTransaction();
-  const supplySessionId = useId();
-  const withdrawSessionId = useId();
-
   // Refresh position card + sUSDS balance after a successful supply/withdraw.
   // A no-position supply also flips this card to "My position" once the savings
   // balance refetches above zero.
@@ -63,57 +57,9 @@ export function SavingsPositionCard() {
     refetchSusds();
   }, [mutateSavings, refetchSusds]);
 
-  // Opens the editable "Supply to Sky Savings" modal (Figma 527:7591). The entry
-  // body owns the amount and live-syncs the confirm gating + handler; the
-  // placeholder onConfirm is replaced by the body's engine execute before it
-  // enables. No analytics here — analytics parity is a separate sign-off-gated
-  // slice (PRD Out of Scope).
-  const openSupplyModal = useCallback(() => {
-    launch({
-      title: t`Supply to Sky Savings`,
-      transactionTitle: t`Confirm in the wallet`,
-      subtitles: {
-        loading: t`Your supply is being processed on the blockchain. Please wait.`,
-        success: t`You've successfully supplied to Sky Savings.`,
-        error: t`An error occurred while supplying to Sky Savings.`
-      },
-      sessionId: supplySessionId,
-      entry: {
-        confirmLabel: t`Supply`,
-        confirmDisabled: true
-      },
-      // The editable body lives outside the dialog (hidden host) so its in-flight
-      // hook survives minimize; it portals its inputs into the modal's entry slot.
-      backgroundContent: <SavingsModalForm sessionId={supplySessionId} flow="supply" />,
-      onConfirm: () => {},
-      onSuccess: refreshPosition
-    });
-  }, [launch, supplySessionId, refreshPosition]);
-
-  // Opens the editable "Withdraw from Sky Savings" modal (Figma 527:10945). Same
-  // entry-step machinery as supply — the body just runs the withdraw flow (its Max
-  // redeems the whole position with no dust via maxWithdraw(owner)).
-  const openWithdrawModal = useCallback(() => {
-    launch({
-      title: t`Withdraw from Sky Savings`,
-      transactionTitle: t`Confirm in the wallet`,
-      subtitles: {
-        loading: t`Your withdrawal is being processed on the blockchain. Please wait.`,
-        success: t`You've successfully withdrawn from Sky Savings.`,
-        error: t`An error occurred while withdrawing from Sky Savings.`
-      },
-      sessionId: withdrawSessionId,
-      entry: {
-        confirmLabel: t`Withdraw`,
-        confirmDisabled: true
-      },
-      // The editable body lives outside the dialog (hidden host) so its in-flight
-      // hook survives minimize; it portals its inputs into the modal's entry slot.
-      backgroundContent: <SavingsModalForm sessionId={withdrawSessionId} flow="withdraw" />,
-      onConfirm: () => {},
-      onSuccess: refreshPosition
-    });
-  }, [launch, withdrawSessionId, refreshPosition]);
+  // Supply/withdraw triggers for the editable modal (Figma 527:7591 / 527:10945),
+  // shared with any other surface that opens this flow (e.g. Portfolio quick-deposit).
+  const { openSupply, openWithdraw } = useSavingsModal({ onSuccess: refreshPosition });
 
   const hasPosition = (savingsData?.userSavingsBalance ?? 0n) > 0n;
   if (!hasPosition) {
@@ -163,7 +109,7 @@ export function SavingsPositionCard() {
           <Button
             variant="primary"
             className="flex-1"
-            onClick={openSupplyModal}
+            onClick={() => openSupply()}
             disabled={!isConnected}
             data-testid="savings-position-supply"
           >
@@ -172,7 +118,7 @@ export function SavingsPositionCard() {
           <Button
             variant="secondary"
             className="flex-1"
-            onClick={openWithdrawModal}
+            onClick={() => openWithdraw()}
             disabled={!isConnected}
             data-testid="savings-position-withdraw"
           >

--- a/apps/webapp/src/modules/savings/components/SavingsSupplyWithdrawPanel.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsSupplyWithdrawPanel.tsx
@@ -1,47 +1,16 @@
 import { useState } from 'react';
-import { useChainId, useConnection } from 'wagmi';
-import { formatUnits, parseUnits } from 'viem';
+import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
-import {
-  TOKENS,
-  useTokenBalance,
-  useSavingsData,
-  useOverallSkyData,
-  useReadSavingsUsds,
-  getTokenDecimals,
-  usePreviewSwapExactIn,
-  usePreviewSwapExactOut
-} from '@/hooks';
-import { formatBigInt, formatNumber, formatDecimalPercentage, isL2ChainId } from '@/utils';
-import { REFERRAL_CODE } from '@/lib/constants';
+import { formatBigInt, formatNumber } from '@/utils';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/modules/layout/components/Typography';
 import { useSavingsLaunch, type SavingsLaunchFlow } from '../hooks/useSavingsLaunch';
-import { useSavingsSupplyMinAmountOut } from '../hooks/useSavingsSupplyMinAmountOut';
-import {
-  ORIGIN_TOKENS,
-  MAINNET_SUPPLY_ORIGINS,
-  L2_SUPPLY_ORIGINS,
-  L2_WITHDRAW_ORIGINS,
-  SavingsOriginSelect,
-  type OriginSymbol
-} from './SavingsOriginSelect';
+import { useSavingsTransactionForm } from '../hooks/useSavingsTransactionForm';
+import { SavingsOriginSelect } from './SavingsOriginSelect';
 import { SavingsSupplyReview } from './SavingsSupplyReview';
-import { SavingsAmountSummary } from './SavingsAmountSummary';
 
 const NO_VALUE = '–';
-
-// Parse the raw input to a bigint at the origin token's decimals (USDC is 6 on
-// L2); partial/invalid input → 0.
-function parseAmount(value: string, decimals: number): bigint {
-  if (!value) return 0n;
-  try {
-    return parseUnits(value, decimals);
-  } catch {
-    return 0n;
-  }
-}
 
 /**
  * Inline supply/withdraw input for the redesigned Savings detail page (D3).
@@ -49,16 +18,11 @@ function parseAmount(value: string, decimals: number): bigint {
  * amount entry and the supply/withdraw choice happen inline, and confirming hands
  * off to the shared review modal via `useSavingsLaunch().launch()`.
  *
- * Mainnet: supply draws from the wallet balance of the selected origin token
- * (USDS or DAI — DAI upgrades to USDS then deposits), withdraw from the savings
- * position. A withdraw "Max" flags the engine to redeem the whole position via
- * `maxWithdraw(owner)` (no dust), rather than passing a stale displayed balance.
- *
- * L2: supply/withdraw swap through the PSM. Supply takes USDS/USDC and surfaces the
- * sUSDS slippage floor; withdraw swaps sUSDS back to the chosen destination token —
- * a "Max" swaps the whole sUSDS balance out (swapExactIn), otherwise a specific
- * amount caps the sUSDS in (swapExactOut). The PSM min-out / max-in bounds are
- * computed here and handed to the orchestrator.
+ * The form model (amount/Max/token state, the balance + L2 PSM reads, and the spend
+ * gate) lives in `useSavingsTransactionForm`, shared with the editable modal body
+ * (`SavingsModalForm`); this component is the inline *presentation* over it: the
+ * optional Supply/Withdraw tabs, the amount input, the supply projection rows, and a
+ * full-width CTA that opens the review modal. Calldata is unchanged across surfaces.
  */
 export function SavingsSupplyWithdrawPanel({
   onSuccess,
@@ -69,8 +33,8 @@ export function SavingsSupplyWithdrawPanel({
   /**
    * Controlled flow. When provided, the in-panel Supply/Withdraw tab toggle is
    * hidden and the body renders single-flow (the redesigned no-position "Supply"
-   * card and, from slice 02, the editable modal). Omit it for the interim
-   * has-position card, which keeps its own tab state.
+   * card and the editable modal). Omit it for the interim has-position card, which
+   * keeps its own tab state.
    */
   flow?: SavingsLaunchFlow;
   /**
@@ -80,97 +44,37 @@ export function SavingsSupplyWithdrawPanel({
    */
   projection?: boolean;
 }) {
-  const chainId = useChainId();
-  const { address, isConnected } = useConnection();
-  const { data: savingsData } = useSavingsData();
-  const { data: overall } = useOverallSkyData();
-  // Canonical Sky Savings Rate APY — the same source as the page headline + the
-  // Details grid (skySavingsRatecRate), NOT useSavingsData().savingsRate (the DSR,
-  // a different number).
-  const apyDisplay = overall?.skySavingsRatecRate
-    ? formatDecimalPercentage(parseFloat(overall.skySavingsRatecRate))
-    : NO_VALUE;
-
-  const isL2 = isL2ChainId(chainId);
   const [flowState, setFlowState] = useState<SavingsLaunchFlow>('supply');
   const controlled = flowProp !== undefined;
   const flow = flowProp ?? flowState;
-  const [originSymbol, setOriginSymbol] = useState<OriginSymbol>('USDS');
-  const [value, setValue] = useState('');
-  const [max, setMax] = useState(false);
 
-  const isSupply = flow === 'supply';
-  // Supply always offers an origin choice (USDS/DAI mainnet, USDS/USDC L2).
-  // Withdraw offers a destination choice only on L2 (USDS/USDC); mainnet withdraw
-  // is USDS-only.
-  const showOriginSelect = isSupply || isL2;
-  const origins = isSupply ? (isL2 ? L2_SUPPLY_ORIGINS : MAINNET_SUPPLY_ORIGINS) : L2_WITHDRAW_ORIGINS;
-  // The token-selector options: the flow's origins when a choice exists, else a
-  // single static USDS chip (mainnet withdraw).
-  const originOptions: OriginSymbol[] = showOriginSelect ? origins : ['USDS'];
-  const originToken = showOriginSelect ? ORIGIN_TOKENS[originSymbol] : TOKENS.usds;
-  const originDecimals = getTokenDecimals(originToken, chainId);
-  const amount = parseAmount(value, originDecimals);
-
-  const { data: walletBalance } = useTokenBalance({
-    address,
-    chainId,
-    token: originToken.address[chainId]
-  });
-  // sUSDS token balance — the whole of it is swapped out on a max L2 withdraw.
-  const { data: susdsBalance } = useTokenBalance({
-    address,
-    chainId,
-    token: TOKENS.susds.address[chainId]
-  });
-
-  // L2 PSM supply slippage floor (chi-projected sUSDS out). The orchestrator hands
-  // this straight to the engine; it's ignored on the mainnet / withdraw paths.
-  const minAmountOut = useSavingsSupplyMinAmountOut({ amount, originToken });
-
-  // Inline "Supply" card preview: mainnet origin (USDS/DAI, both wad) → sUSDS
-  // shares via the vault's ERC-4626 convertToShares. Read-only; the actual
-  // supply still routes through useSavingsLaunch. L2 has its own min-out row.
-  const { data: previewSharesData } = useReadSavingsUsds({
-    functionName: 'convertToShares',
-    args: [amount],
-    // No chainId — the read uses the connected chain and is gated to mainnet
-    // supply below, where the sUSDS vault address resolves.
-    query: { enabled: projection && flow === 'supply' && !isL2 && amount > 0n }
-  });
-  const previewShares = typeof previewSharesData === 'bigint' ? previewSharesData : undefined;
-
-  // L2 PSM withdraw previews (mirror the legacy L2 widget; no-ops on mainnet):
-  //  - convert the whole sUSDS balance to the destination token → max-withdraw
-  //    floor + the withdrawable balance shown to the user
-  //  - the sUSDS in needed to take exactly `amount` destination token out → the
-  //    specific-withdraw ceiling
-  const convertedBalance = usePreviewSwapExactIn(susdsBalance?.value ?? 0n, TOKENS.susds, originToken);
-  const { value: maxAmountInForWithdraw } = usePreviewSwapExactOut(amount, TOKENS.susds, originToken);
-
-  // Supply draws from the origin token's wallet balance; withdraw from the
-  // position (mainnet: the USDS-denominated savings balance; L2: the sUSDS balance
-  // converted to the destination token).
-  const sourceBalance = isSupply
-    ? (walletBalance?.value ?? 0n)
-    : isL2
-      ? convertedBalance.value
-      : (savingsData?.userSavingsBalance ?? 0n);
-  const isZero = amount === 0n;
-  const insufficient = isConnected && !max && amount > sourceBalance;
+  const form = useSavingsTransactionForm({ flow, enablePreview: projection });
+  const {
+    isConnected,
+    isSupply,
+    isL2,
+    originSymbol,
+    originOptions,
+    originToken,
+    originDecimals,
+    value,
+    available,
+    isZero,
+    insufficient,
+    amountReady,
+    apyDisplay,
+    previewShares,
+    engineParams,
+    transactionScreenContent,
+    onInput,
+    setMaxAmount,
+    switchOrigin,
+    clearAmount,
+    resetToUsds
+  } = form;
 
   const { launch, prepared } = useSavingsLaunch({
-    flow,
-    originToken,
-    amount,
-    // `max` only applies to withdraw — it routes to maxWithdraw(owner) on mainnet
-    // or swapExactIn(whole sUSDS balance) on L2.
-    max: !isSupply && max,
-    referralCode: REFERRAL_CODE,
-    minAmountOut,
-    sUsdsBalance: susdsBalance?.value,
-    minAmountOutForWithdrawAll: convertedBalance.value,
-    maxAmountInForWithdraw,
+    ...engineParams,
     transactionContent: (
       <SavingsSupplyReview
         amount={value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : '0'}
@@ -185,50 +89,19 @@ export function SavingsSupplyWithdrawPanel({
         apy={apyDisplay}
       />
     ),
-    // Compact summary shown on the wallet/status screen in place of the full
-    // breakdown (Figma "Confirm in the wallet").
-    transactionScreenContent: (
-      <SavingsAmountSummary
-        label={isSupply ? t`Supply amount` : t`Withdrawal amount`}
-        amount={value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : '0'}
-        symbol={originToken.symbol}
-        usd={value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : undefined}
-        dataTestId="savings-confirm-summary"
-      />
-    ),
+    transactionScreenContent,
     onSuccess: () => {
-      setValue('');
-      setMax(false);
+      clearAmount();
       onSuccess?.();
     }
   });
 
-  const disabled = !isConnected || !prepared || (!max && (isZero || insufficient));
+  const disabled = !amountReady || !prepared;
 
   const switchFlow = (next: SavingsLaunchFlow) => {
     setFlowState(next);
     // Withdraw is USDS-only; reset the origin so re-entering supply starts on USDS.
-    setOriginSymbol('USDS');
-    setValue('');
-    setMax(false);
-  };
-
-  const switchOrigin = (next: OriginSymbol) => {
-    setOriginSymbol(next);
-    setValue('');
-    setMax(false);
-  };
-
-  const onInput = (raw: string) => {
-    setValue(raw.replace(/[^0-9.]/g, ''));
-    // Typing overrides a previous max selection.
-    setMax(false);
-  };
-
-  const setMaxAmount = () => {
-    setValue(formatUnits(sourceBalance, originDecimals));
-    // Flag a max only for withdraw; supply just deposits exactly the input.
-    setMax(!isSupply);
+    resetToUsds();
   };
 
   const tabClass = (active: boolean) =>
@@ -275,7 +148,7 @@ export function SavingsSupplyWithdrawPanel({
           data-testid="savings-amount-max"
         >
           {isConnected
-            ? formatNumber(parseFloat(formatUnits(sourceBalance, originDecimals)), { maxDecimals: 2 })
+            ? formatNumber(parseFloat(formatUnits(available, originDecimals)), { maxDecimals: 2 })
             : NO_VALUE}{' '}
           <span className="text-textEmphasis">
             <Trans>MAX</Trans>
@@ -314,7 +187,7 @@ export function SavingsSupplyWithdrawPanel({
             <Trans>Receive at least</Trans>
           </Text>
           <Text className="text-text text-sm font-medium">
-            {formatBigInt(minAmountOut, { unit: 18, maxDecimals: 2 })} sUSDS
+            {formatBigInt(engineParams.minAmountOut ?? 0n, { unit: 18, maxDecimals: 2 })} sUSDS
           </Text>
         </div>
       )}

--- a/apps/webapp/src/modules/savings/hooks/useSavingsModal.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsModal.test.tsx
@@ -1,0 +1,78 @@
+/// <reference types="vite/client" />
+
+import { i18n } from '@lingui/core';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactElement } from 'react';
+
+// The `t` macro resolves against the global i18n singleton (empty catalog → source strings).
+i18n.load('en', {});
+i18n.activate('en');
+
+const h = vi.hoisted(() => ({ launchMock: vi.fn() }));
+
+// Capture the config handed to launch() — the only channel the trigger speaks through.
+vi.mock('@/modules/ui/context/TransactionContext', () => ({
+  useTransaction: () => ({ launch: h.launchMock })
+}));
+
+// Stub the collaborator body: the hook's job is to wire its props (flow/sessionId/preset),
+// not to render it. The real form is covered by its own specs.
+vi.mock('../components/SavingsModalForm', () => ({
+  SavingsModalForm: () => null
+}));
+
+import { useSavingsModal } from './useSavingsModal';
+import type { SavingsModalPreset } from '../components/SavingsModalForm';
+
+type LaunchConfig = Parameters<typeof h.launchMock>[0];
+// The backgroundContent element's props — React 19 types ReactElement.props as `unknown`.
+type BodyElement = ReactElement<{ flow: string; sessionId: string; preset?: SavingsModalPreset }>;
+
+describe('useSavingsModal', () => {
+  beforeEach(() => h.launchMock.mockClear());
+  afterEach(() => cleanup());
+
+  it('openSupply launches the supply modal and hosts the supply body in its own session', () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useSavingsModal({ onSuccess }));
+    act(() => result.current.openSupply());
+
+    expect(h.launchMock).toHaveBeenCalledTimes(1);
+    const config: LaunchConfig = h.launchMock.mock.calls[0][0];
+    expect(config.title).toBe('Supply to Sky Savings');
+    expect(config.entry).toEqual({ confirmLabel: 'Supply', confirmDisabled: true });
+    expect(config.onSuccess).toBe(onSuccess);
+    expect(typeof config.sessionId).toBe('string');
+
+    const body = config.backgroundContent as BodyElement;
+    expect(body.props.flow).toBe('supply');
+    // The host shares the config's session so updateModalContent reaches this body.
+    expect(body.props.sessionId).toBe(config.sessionId);
+    // No preset → opens empty.
+    expect(body.props.preset).toBeUndefined();
+  });
+
+  it('threads a preset (amount/token) into the supply body', () => {
+    const { result } = renderHook(() => useSavingsModal());
+    act(() => result.current.openSupply({ amount: '100', token: 'USDS' }));
+
+    const config: LaunchConfig = h.launchMock.mock.calls[0][0];
+    const body = config.backgroundContent as BodyElement;
+    expect(body.props.preset).toEqual({ amount: '100', token: 'USDS' });
+  });
+
+  it('openWithdraw launches the withdraw modal in a session distinct from supply', () => {
+    const { result } = renderHook(() => useSavingsModal());
+    act(() => result.current.openSupply());
+    act(() => result.current.openWithdraw());
+
+    const supplyCfg: LaunchConfig = h.launchMock.mock.calls[0][0];
+    const withdrawCfg: LaunchConfig = h.launchMock.mock.calls[1][0];
+    expect(withdrawCfg.title).toBe('Withdraw from Sky Savings');
+    expect(withdrawCfg.entry).toEqual({ confirmLabel: 'Withdraw', confirmDisabled: true });
+    expect((withdrawCfg.backgroundContent as BodyElement).props.flow).toBe('withdraw');
+    // Sibling sessions must differ so their live updates never cross-talk.
+    expect(withdrawCfg.sessionId).not.toBe(supplyCfg.sessionId);
+  });
+});

--- a/apps/webapp/src/modules/savings/hooks/useSavingsModal.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsModal.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useId } from 'react';
+import { t } from '@lingui/core/macro';
+import { useTransaction } from '@/modules/ui/context/TransactionContext';
+import { SavingsModalForm, type SavingsModalPreset } from '../components/SavingsModalForm';
+
+type UseSavingsModalOptions = {
+  /** Fires after a successful supply/withdraw — refetch the position/balances. */
+  onSuccess?: () => void;
+};
+
+/**
+ * Reusable trigger for the editable Savings supply/withdraw modal. Any surface
+ * (the position card, Portfolio quick-deposit, …) calls this instead of
+ * re-declaring the launch config. Each opener mints its own session so sibling
+ * modals never cross-talk; pass a `preset` to seed the amount/token, or omit it
+ * to open empty.
+ */
+export function useSavingsModal({ onSuccess }: UseSavingsModalOptions = {}) {
+  const { launch } = useTransaction();
+  const supplySessionId = useId();
+  const withdrawSessionId = useId();
+
+  // Analytics-free by design — attribution for these surfaces is a separate
+  // sign-off-gated slice (PRD Out of Scope), not part of the trigger.
+  const openSupply = useCallback(
+    (preset?: SavingsModalPreset) => {
+      launch({
+        title: t`Supply to Sky Savings`,
+        transactionTitle: t`Confirm in the wallet`,
+        subtitles: {
+          loading: t`Your supply is being processed on the blockchain. Please wait.`,
+          success: t`You've successfully supplied to Sky Savings.`,
+          error: t`An error occurred while supplying to Sky Savings.`
+        },
+        sessionId: supplySessionId,
+        entry: { confirmLabel: t`Supply`, confirmDisabled: true },
+        // The editable body lives outside the dialog (hidden host) so its in-flight
+        // hook survives minimize; it portals its inputs into the modal's entry slot.
+        backgroundContent: (
+          <SavingsModalForm sessionId={supplySessionId} flow="supply" preset={preset} />
+        ),
+        onConfirm: () => {},
+        onSuccess
+      });
+    },
+    [launch, supplySessionId, onSuccess]
+  );
+
+  const openWithdraw = useCallback(
+    (preset?: SavingsModalPreset) => {
+      launch({
+        title: t`Withdraw from Sky Savings`,
+        transactionTitle: t`Confirm in the wallet`,
+        subtitles: {
+          loading: t`Your withdrawal is being processed on the blockchain. Please wait.`,
+          success: t`You've successfully withdrawn from Sky Savings.`,
+          error: t`An error occurred while withdrawing from Sky Savings.`
+        },
+        sessionId: withdrawSessionId,
+        entry: { confirmLabel: t`Withdraw`, confirmDisabled: true },
+        backgroundContent: (
+          <SavingsModalForm sessionId={withdrawSessionId} flow="withdraw" preset={preset} />
+        ),
+        onConfirm: () => {},
+        onSuccess
+      });
+    },
+    [launch, withdrawSessionId, onSuccess]
+  );
+
+  return { openSupply, openWithdraw };
+}

--- a/apps/webapp/src/modules/savings/hooks/useSavingsTransactionForm.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsTransactionForm.tsx
@@ -1,0 +1,322 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useChainId, useConnection } from 'wagmi';
+import { formatUnits, parseUnits } from 'viem';
+import { t } from '@lingui/core/macro';
+import {
+  getTokenDecimals,
+  TOKENS,
+  useOverallSkyData,
+  usePreviewSwapExactIn,
+  usePreviewSwapExactOut,
+  useReadSavingsUsds,
+  useSavingsData,
+  useTokenBalance,
+  type Token
+} from '@/hooks';
+import { formatDecimalPercentage, formatNumber, isL2ChainId } from '@/utils';
+import { REFERRAL_CODE } from '@/lib/constants';
+import { SavingsAmountSummary } from '../components/SavingsAmountSummary';
+import {
+  ORIGIN_TOKENS,
+  MAINNET_SUPPLY_ORIGINS,
+  L2_SUPPLY_ORIGINS,
+  L2_WITHDRAW_ORIGINS,
+  type OriginSymbol
+} from '../components/SavingsOriginSelect';
+import { useSavingsSupplyMinAmountOut } from './useSavingsSupplyMinAmountOut';
+import { type SavingsLaunchFlow, type UseSavingsLaunchParams } from './useSavingsLaunch';
+
+const NO_VALUE = '–';
+
+/** Seeds the form's initial amount/token (e.g. a Portfolio quick-deposit shortcut). */
+export type SavingsModalPreset = {
+  /** Raw amount string to seed the input (e.g. '100'). */
+  amount?: string;
+  /** Origin/destination token to preselect; must be valid for the flow/chain. Defaults to USDS. */
+  token?: OriginSymbol;
+};
+
+/** Minimized-toast titles, amount-aware (e.g. "10,000.00 USDS supplied!"). */
+export type SavingsToastTitles = { loading: string; success: string; error: string };
+
+/** The subset of `useSavingsLaunch` params the form derives — spread into the engine by each surface. */
+export type SavingsEngineParams = Pick<
+  UseSavingsLaunchParams,
+  | 'flow'
+  | 'originToken'
+  | 'amount'
+  | 'max'
+  | 'referralCode'
+  | 'minAmountOut'
+  | 'sUsdsBalance'
+  | 'minAmountOutForWithdrawAll'
+  | 'maxAmountInForWithdraw'
+>;
+
+export interface SavingsTransactionForm {
+  // Connection / network / flow
+  isConnected: boolean;
+  isL2: boolean;
+  isSupply: boolean;
+
+  // Token selection
+  originSymbol: OriginSymbol;
+  originOptions: OriginSymbol[];
+  originToken: Token;
+  originDecimals: number;
+
+  // Amount state + gating
+  value: string;
+  amount: bigint;
+  max: boolean;
+  /** Source balance for the active flow (wallet for supply; position / converted sUSDS for withdraw). */
+  available: bigint;
+  isZero: boolean;
+  insufficient: boolean;
+  /** True when the amount/connection gate is satisfied; combine with the engine's `prepared` for the submit gate. */
+  amountReady: boolean;
+
+  // Display
+  /** USDS-denominated savings balance (position). */
+  position: bigint;
+  /** Canonical Sky Savings Rate APY, formatted (e.g. "6.50%"). */
+  apyDisplay: string;
+  /** Mainnet supply preview: sUSDS shares for the entered amount (when `enablePreview`). */
+  previewShares?: bigint;
+
+  // Engine + shared transaction content
+  engineParams: SavingsEngineParams;
+  /** Compact wallet/status-screen summary — identical across surfaces, so the form owns it. */
+  transactionScreenContent: ReactNode;
+  /** Amount-aware minimized-toast titles for the active flow. */
+  toast: SavingsToastTitles;
+
+  // Handlers
+  onInput: (raw: string) => void;
+  setMaxAmount: () => void;
+  switchOrigin: (next: OriginSymbol) => void;
+  /** Clear the amount + Max (keeps the selected token) — for a post-success reset. */
+  clearAmount: () => void;
+  /** Reset the amount, Max, and token back to USDS — for a flow (Supply/Withdraw) switch. */
+  resetToUsds: () => void;
+}
+
+// Parse the raw input to a bigint at the origin token's decimals (USDC is 6 on
+// L2); partial/invalid input → 0.
+function parseAmount(raw: string, decimals: number): bigint {
+  if (!raw) return 0n;
+  try {
+    return parseUnits(raw, decimals);
+  } catch {
+    return 0n;
+  }
+}
+
+/**
+ * The shared supply/withdraw form model for Sky Savings — the single source of
+ * truth behind both savings supply surfaces: the inline no-position card
+ * (`SavingsSupplyWithdrawPanel`) and the editable has-position modal body
+ * (`SavingsModalForm`). It owns amount/Max/token state, resolves the origin token
+ * and its options for the flow + network, runs the wallet/sUSDS balance and L2 PSM
+ * preview reads, derives the spend gate, and maps all of it to the `useSavingsLaunch`
+ * engine params. Surfaces stay thin: they render their own chrome and call
+ * `useSavingsLaunch({ ...form.engineParams, ...surface content })`.
+ *
+ * Token choice (Figma `USDS ▾`):
+ *  - mainnet supply   → USDS / DAI (DAI routes to upgrade-and-supply, calldata unchanged)
+ *  - mainnet withdraw → USDS-only (static chip)
+ *  - L2 supply        → USDS / USDC (USDC swaps through the PSM)
+ *  - L2 withdraw      → USDS / USDC destination choice (sUSDS swaps out to the picked token)
+ *
+ * Supply spends the wallet balance of the origin token; withdraw spends the position
+ * (mainnet: the USDS savings balance; L2: the sUSDS balance converted to the chosen
+ * destination token). A withdraw Max sets the `max` flag so the engine redeems the
+ * whole position with no dust; the UI never computes the redeem amount. The L2 PSM
+ * bounds (`minAmountOut` / `sUsdsBalance` / `minAmountOutForWithdrawAll` /
+ * `maxAmountInForWithdraw`) are computed here and handed straight to the orchestrator;
+ * they are no-ops on mainnet.
+ */
+export function useSavingsTransactionForm({
+  flow,
+  preset,
+  enablePreview = false
+}: {
+  flow: SavingsLaunchFlow;
+  /** Seeds the initial amount/token (e.g. a Portfolio quick-deposit). Read once on mount. */
+  preset?: SavingsModalPreset;
+  /** Run the mainnet-supply sUSDS preview read (the inline card's "You'll receive" projection). */
+  enablePreview?: boolean;
+}): SavingsTransactionForm {
+  const isSupply = flow === 'supply';
+  const chainId = useChainId();
+  const { address, isConnected } = useConnection();
+  const { data: savingsData } = useSavingsData();
+  const { data: overall } = useOverallSkyData();
+  const isL2 = isL2ChainId(chainId);
+
+  // Seeded from `preset` on mount.
+  const [value, setValue] = useState(preset?.amount ?? '');
+  // Withdraw-only: set by Max so the engine redeems the whole position (no dust).
+  // Cleared the moment the user edits the amount.
+  const [max, setMax] = useState(false);
+  const [originSymbol, setOriginSymbol] = useState<OriginSymbol>(preset?.token ?? 'USDS');
+
+  // Supply always offers an origin choice (USDS/DAI mainnet, USDS/USDC L2); withdraw
+  // offers a destination choice only on L2 (USDS/USDC). Mainnet withdraw → USDS-only
+  // static chip.
+  const showOriginSelect = isSupply || isL2;
+  const origins = isSupply ? (isL2 ? L2_SUPPLY_ORIGINS : MAINNET_SUPPLY_ORIGINS) : L2_WITHDRAW_ORIGINS;
+  const originOptions: OriginSymbol[] = showOriginSelect ? origins : ['USDS'];
+  const originToken = showOriginSelect ? ORIGIN_TOKENS[originSymbol] : TOKENS.usds;
+  const originDecimals = getTokenDecimals(originToken, chainId);
+  const amount = parseAmount(value, originDecimals);
+
+  const { data: walletBalance } = useTokenBalance({
+    address,
+    chainId,
+    token: originToken.address[chainId]
+  });
+  // sUSDS token balance — the whole of it is swapped out on a max L2 withdraw.
+  const { data: susdsBalance } = useTokenBalance({
+    address,
+    chainId,
+    token: TOKENS.susds.address[chainId]
+  });
+  const position = savingsData?.userSavingsBalance ?? 0n;
+
+  // L2 PSM bounds (no-ops on mainnet / where the flow doesn't use them):
+  //  - minAmountOut: chi-projected sUSDS-out floor for an L2 supply (swapExactIn)
+  //  - convertedBalance: the whole sUSDS balance valued in the destination token →
+  //    the L2 withdraw source balance + the max-withdraw floor (swapExactIn)
+  //  - maxAmountInForWithdraw: the sUSDS-in ceiling to take exactly `amount` out
+  //    (specific L2 withdraw, swapExactOut)
+  const minAmountOut = useSavingsSupplyMinAmountOut({ amount, originToken });
+  const convertedBalance = usePreviewSwapExactIn(susdsBalance?.value ?? 0n, TOKENS.susds, originToken);
+  const { value: maxAmountInForWithdraw } = usePreviewSwapExactOut(amount, TOKENS.susds, originToken);
+
+  // Mainnet supply preview: origin (USDS/DAI, both wad) → sUSDS shares via the vault's
+  // ERC-4626 convertToShares. Read-only; the supply still routes through the engine.
+  // Gated off in the modal (no consumer there) and on L2 (its min-out row covers it).
+  const { data: previewSharesData } = useReadSavingsUsds({
+    functionName: 'convertToShares',
+    args: [amount],
+    query: { enabled: enablePreview && isSupply && !isL2 && amount > 0n }
+  });
+  const previewShares = typeof previewSharesData === 'bigint' ? previewSharesData : undefined;
+
+  // Supply is capped by the wallet balance of the origin token; withdraw by the
+  // position (mainnet: the USDS savings balance; L2: sUSDS converted to the
+  // destination token).
+  const available = isSupply
+    ? (walletBalance?.value ?? 0n)
+    : isL2
+      ? convertedBalance.value
+      : position;
+  const isZero = amount === 0n;
+  // A max withdraw bypasses the amount check — the redeem is driven by the flag, not
+  // the displayed (rounded) value.
+  const insufficient = isConnected && !max && amount > available;
+  const amountReady = isConnected && !(!max && (isZero || insufficient));
+
+  const engineParams: SavingsEngineParams = {
+    flow,
+    originToken,
+    amount,
+    // `max` only applies to withdraw — it routes to maxWithdraw(owner) on mainnet
+    // or swapExactIn(whole sUSDS balance) on L2.
+    max: !isSupply && max,
+    referralCode: REFERRAL_CODE,
+    minAmountOut,
+    sUsdsBalance: susdsBalance?.value,
+    minAmountOutForWithdrawAll: convertedBalance.value,
+    maxAmountInForWithdraw
+  };
+
+  // Compact summary for the wallet/status screen (Figma "Confirm in the wallet").
+  // Identical across surfaces, so the form owns it; memoised on the amount/token/flow
+  // so the modal's `updateModalContent` sync stays bounded.
+  const transactionScreenContent = useMemo(() => {
+    const display = value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : '0';
+    return (
+      <SavingsAmountSummary
+        label={isSupply ? t`Supply amount` : t`Withdrawal amount`}
+        amount={display}
+        symbol={originToken.symbol}
+        usd={value ? display : undefined}
+        dataTestId="savings-confirm-summary"
+      />
+    );
+  }, [isSupply, value, originToken.symbol]);
+
+  // Amount-aware titles for the minimized toast (Figma "10,000.00 USDS supplied!").
+  const toast = useMemo<SavingsToastTitles>(() => {
+    const display = value ? formatNumber(parseFloat(value), { maxDecimals: 2 }) : '0';
+    const label = `${display} ${originToken.symbol}`;
+    return isSupply
+      ? { loading: t`Supplying ${label}`, success: t`${label} supplied!`, error: t`Supply failed` }
+      : { loading: t`Withdrawing ${label}`, success: t`${label} withdrawn!`, error: t`Withdrawal failed` };
+  }, [isSupply, value, originToken.symbol]);
+
+  const apyDisplay = overall?.skySavingsRatecRate
+    ? formatDecimalPercentage(parseFloat(overall.skySavingsRatecRate))
+    : NO_VALUE;
+
+  const onInput = useCallback((raw: string) => {
+    // Typing overrides a previous Max selection.
+    setMax(false);
+    setValue(raw.replace(/[^0-9.]/g, ''));
+  }, []);
+
+  const setMaxAmount = useCallback(() => {
+    // Flag a max only for withdraw; supply just deposits exactly the input.
+    setMax(!isSupply);
+    setValue(formatUnits(available, originDecimals));
+  }, [isSupply, available, originDecimals]);
+
+  // Switching the origin token resets the amount + Max (the previous amount was
+  // denominated in the old token's balance/decimals).
+  const switchOrigin = useCallback((next: OriginSymbol) => {
+    setOriginSymbol(next);
+    setMax(false);
+    setValue('');
+  }, []);
+
+  const clearAmount = useCallback(() => {
+    setMax(false);
+    setValue('');
+  }, []);
+
+  const resetToUsds = useCallback(() => {
+    setOriginSymbol('USDS');
+    setMax(false);
+    setValue('');
+  }, []);
+
+  return {
+    isConnected,
+    isL2,
+    isSupply,
+    originSymbol,
+    originOptions,
+    originToken,
+    originDecimals,
+    value,
+    amount,
+    max,
+    available,
+    isZero,
+    insufficient,
+    amountReady,
+    position,
+    apyDisplay,
+    previewShares,
+    engineParams,
+    transactionScreenContent,
+    toast,
+    onInput,
+    setMaxAmount,
+    switchOrigin,
+    clearAmount,
+    resetToUsds
+  };
+}


### PR DESCRIPTION
### What does this PR do?

Makes the Savings supply/withdraw flow reusable by any surface, and uses it from the Portfolio **Supplied** carousel so a position card's **Supply** button opens the modal in place instead of navigating to the product page. Calldata and the savings engine hooks are unchanged.

**Reusable trigger**
- New `useSavingsModal()` returns `{ openSupply, openWithdraw }`, each assembling the `launch()` config (title, subtitles, `entry`, `backgroundContent`, session id) so callers no longer copy ~20 lines of config per entry point.
- Each opener takes an optional `{ amount?, token? }` preset, seeded into the form's initial state on launch (the host already remounts per launch, so no effect is needed).
- `SavingsPositionCard` consumes the hook instead of inlining the two configs; Portfolio reuses the same `openSupply`.

**Shared form model**
- New headless `useSavingsTransactionForm()` owns the supply/withdraw form: amount/Max/token state, origin-token resolution per flow + network, wallet/sUSDS balance reads, L2 PSM preview reads, the spend gate, and the `useSavingsLaunch` engine-param mapping.
- The editable modal body (`SavingsModalForm`) and the inline no-position panel (`SavingsSupplyWithdrawPanel`) each previously carried their own copy of all of that; both are now thin presentation over the one hook, keeping only their own chrome (the panel's tabs + review-modal CTA; the modal's entry-slot portal + `updateModalContent` sync + before/after rows).
- Net: the supply form logic is single-sourced across all three surfaces — the no-position inline panel, the has-position editable modal, and the Portfolio in-place modal. ~350 lines of duplication removed; behavior and calldata unchanged.

**Portfolio carousel**
- `PositionCard`'s single `onSelect` is split into `onSupply` / `onManage`, so the caller owns each button.
- A `usePortfolioSupplyActions` resolver maps a position's `kind` to its in-place supply opener (or `undefined` → navigate). Adding a future product is a single case in the resolver, never a branch in the carousel JSX.
- The savings card opens in place **only when its position is on the connected chain**. An off-chain card — e.g. a Base-badged savings position while the wallet is on mainnet — falls back to navigation, so the modal never supplies on a chain other than the one the card represents.

No analytics/telemetry changes.

### Testing steps:

Automated (Vitest): `useSavingsModal` config + preset; `usePortfolioSupplyActions` kind + connected-chain dispatch; `PortfolioPositionsSection` routing. The form-model extraction is behavior-preserving, so the existing `SavingsModalForm` and `SavingsSupplyWithdrawPanel` suites pass unchanged (the modal suite gains one mock for the now-shared, gated-off `useReadSavingsUsds` read). Full savings suite 128/128; typecheck and lint clean.

Manual (`pnpm -F webapp dev:mock` → Portfolio → **Supplied** tab):
- Sky Savings Rate card **Supply** while on the connected chain → opens the modal in place (no navigation); a supply succeeds.
- Sky Savings Rate card **Manage** → navigates to the savings product page.
- Any non-savings card **Supply** / **Manage** → navigate (unchanged).
- Set the network filter to a chain the wallet is **not** connected to → that savings card's **Supply** navigates to the product page instead of opening a mismatched modal.

Also exercise the savings product page itself (same shared form model now backs all of these):
- No-position **Supply** card → still inline amount entry → read-only review modal.
- Has-position **Supply** / **Withdraw** → still open the editable modal.

### Notes / known follow-ups

- **Post-supply refresh:** opening from Portfolio passes no `onSuccess` (the marketplace query exposes no refetch handle), so the card refreshes on the next window-focus refetch rather than instantly. Deferred.
- `usePortfolioSupplyActions` runs above the section's early returns, so the idle/empty/loading paths now transitively require a `TransactionProvider` (always present today via `App.tsx`). Latent only.
- The inline panel's uncontrolled Supply/Withdraw tab mode now has no production consumer (`SavingsSupplyCard` always passes `flow="supply"`); it's preserved for its test but is a candidate to prune.
