### PR TITLE
B6: full-width destinations scroll on the page + sticky blurred nav

### DIFF
--- a/apps/webapp/src/modules/app/components/AppContainer.tsx
+++ b/apps/webapp/src/modules/app/components/AppContainer.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { cn } from '@/lib/cn';
 
 /**
- * The shell's content box. `card` draws the classic rounded container card;
- * `bare` keeps the exact same sizing/scroll box but no chrome, so full-width
- * destination pages sit directly on the page background (V2 Figma) while
- * scrolling stays inside the box and the header keeps its place.
+ * The shell's content box. `card` draws the classic rounded container card — a
+ * viewport-capped box that scrolls internally. `bare` drops the box entirely
+ * (no height cap, no inner scroll), so full-width destination pages sit directly
+ * on the page background (V2 Figma) and scroll on the document (B6).
  */
 export function AppContainer({
   variant = 'card',
@@ -17,9 +17,12 @@ export function AppContainer({
   return (
     <main
       className={cn(
-        'scrollbar-hidden group flex h-dvh w-full max-w-[480px] min-w-[375px] flex-col gap-1.5 overflow-x-hidden overflow-y-auto md:my-auto md:h-[calc(100dvh-70px)] md:max-w-[1150px] md:flex-row xl:max-h-[1080px] xl:max-w-[calc(100vw-128px)] 2xl:max-w-[1570px]',
+        // Shared: the centered max-width column.
+        'scrollbar-hidden group flex w-full max-w-[480px] min-w-[375px] flex-col gap-1.5 overflow-x-hidden md:max-w-[1150px] md:flex-row xl:max-w-[calc(100vw-128px)] 2xl:max-w-[1570px]',
         variant === 'card' &&
-          'bg-container rounded-t-3xl border bg-blend-overlay backdrop-blur-[50px] md:overflow-hidden md:rounded-3xl md:p-3 md:pl-[10px] lg:pl-3'
+          // Card: the viewport-capped inner-scroll box + chrome. `bare` omits all
+          // of this so the page flows at content height and the document scrolls.
+          'bg-container h-dvh overflow-y-auto rounded-t-3xl border bg-blend-overlay backdrop-blur-[50px] md:my-auto md:h-[calc(100dvh-70px)] md:overflow-hidden md:rounded-3xl md:p-3 md:pl-[10px] lg:pl-3 xl:max-h-[1080px]'
       )}
     >
       {children}

--- a/apps/webapp/src/modules/app/components/AppShell.tsx
+++ b/apps/webapp/src/modules/app/components/AppShell.tsx
@@ -40,9 +40,10 @@ export function AppShell() {
   const paneStyle = bpi < BP.md ? { height: `calc(100dvh - ${MOBILE_HEADER_HEIGHT}px)` } : undefined;
 
   return (
-    <Layout>
+    <Layout fullWidth={isFullWidth}>
       {/* Destination pages render bare — directly on the page background, no
-          container card (V2 Figma). Module routes keep the card. */}
+          container card (V2 Figma), and scroll on the document. Module routes
+          keep the card + its inner-scroll box. */}
       <AppContainer variant={isFullWidth ? 'bare' : 'card'}>
         {isFullWidth ? (
           // Destination pages own the whole container; no module content, so

--- a/apps/webapp/src/modules/layout/components/Layout.tsx
+++ b/apps/webapp/src/modules/layout/components/Layout.tsx
@@ -12,14 +12,23 @@ import { Banner } from '@/components/extensible';
 import { useWalletAnalytics } from '@/modules/analytics/hooks/useWalletAnalytics';
 import { TopNav } from '@/modules/app/shell/TopNav';
 import { AppLink } from '@/lib/navigation';
+import { shellHeaderClasses, shellSurfaceClasses } from './shellLayoutClasses';
 import { defaultConfig } from '../../config/default-config';
 
 export function Layout({
   children,
-  metaDescription
+  metaDescription,
+  fullWidth = false
 }: {
   children: React.ReactNode;
   metaDescription?: string;
+  /**
+   * Full-width destination routes scroll on the document instead of inside the
+   * viewport-capped box: the VStack drops its height cap + `overflow-auto` so it
+   * grows with content, and the header pins as a sticky frosted bar (B6). Legacy
+   * two-pane routes keep the boxed scroll (the default).
+   */
+  fullWidth?: boolean;
 }): React.ReactElement {
   const { siteConfig } = useContext(ConfigContext);
   const { chain } = useConnection();
@@ -38,15 +47,9 @@ export function Layout({
       <meta name="description" content={descriptionContent} />
       <link rel="icon" href={siteConfig.favicon} />
 
-      <VStack
-        className={
-          // Dark: the sky image blended (luminosity) with the app container's
-          // #040434 backdrop so it takes that hue; light keeps the lilac gradient.
-          'bg-app-background light:bg-blend-normal flex max-h-svh min-h-svh max-w-full items-center overflow-auto [background-color:#040434] bg-cover bg-center bg-no-repeat bg-blend-luminosity md:max-h-screen md:min-h-screen md:p-4 md:pb-2'
-        }
-      >
+      <VStack className={shellSurfaceClasses(fullWidth)}>
         <ErrorBoundary>
-          <div className="flex w-full items-center gap-4 px-3 py-2 sm:px-10 md:mb-1">
+          <div className={shellHeaderClasses(fullWidth)}>
             <AppLink to="/" title="Home page" className="min-w-[96px]">
               {/* Theme-specific logo: dark is the default; light swaps in under
                   [data-theme='light'] (the `light:` variant). */}

--- a/apps/webapp/src/modules/layout/components/shellLayoutClasses.test.ts
+++ b/apps/webapp/src/modules/layout/components/shellLayoutClasses.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { shellHeaderClasses, shellSurfaceClasses } from './shellLayoutClasses';
+
+// B6: full-width destination routes scroll on the document instead of inside the
+// legacy viewport-capped box, and the header pins as a sticky, see-through
+// frosted bar (Figma: transparent + backdrop blur, content shows through).
+describe('shellHeaderClasses', () => {
+  it('pins the header as a see-through, blurred bar on full-width routes', () => {
+    const cls = shellHeaderClasses(true);
+    expect(cls).toContain('sticky');
+    expect(cls).toContain('backdrop-blur');
+    // Transparent, not an opaque slab — scrolling content shows through it.
+    expect(cls).not.toContain('bg-container');
+    // Feathered edge: the blur fades out via a gradient mask instead of cutting
+    // off at a hard line where blurred meets sharp content.
+    expect(cls).toContain('mask-image');
+  });
+
+  it('leaves the header static (no sticky, no blur) on boxed routes', () => {
+    const cls = shellHeaderClasses(false);
+    expect(cls).not.toContain('sticky');
+    expect(cls).not.toContain('backdrop-blur');
+    expect(cls).not.toContain('mask-image');
+  });
+});
+
+describe('shellSurfaceClasses', () => {
+  it('caps the surface to the viewport so it scrolls inside the box on boxed routes', () => {
+    const cls = shellSurfaceClasses(false);
+    expect(cls).toContain('overflow-auto');
+    expect(cls).toContain('max-h-svh');
+  });
+
+  it('drops the viewport cap so the document scrolls on full-width routes', () => {
+    const cls = shellSurfaceClasses(true);
+    expect(cls).not.toContain('overflow-auto');
+    expect(cls).not.toContain('max-h-svh');
+  });
+});

--- a/apps/webapp/src/modules/layout/components/shellLayoutClasses.ts
+++ b/apps/webapp/src/modules/layout/components/shellLayoutClasses.ts
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * Class logic for the shell's two scroll modes (B6), extracted so the
+ * mode-switch is testable without standing up Layout's provider tree.
+ *
+ * - Boxed (`fullWidth: false`): the legacy two-pane routes cap the surface to
+ *   the viewport and scroll inside it.
+ * - Full-width (`fullWidth: true`): destination routes scroll on the document;
+ *   the surface drops its height cap and the header pins as a sticky frosted bar.
+ */
+
+/** The shell surface (the VStack wrapping the header + content). */
+export const shellSurfaceClasses = (fullWidth: boolean) =>
+  cn(
+    // Dark: the sky image blended (luminosity) with the app container's #040434
+    // backdrop so it takes that hue; light keeps the lilac gradient.
+    'bg-app-background light:bg-blend-normal flex min-h-svh max-w-full items-center [background-color:#040434] bg-cover bg-center bg-no-repeat bg-blend-luminosity md:min-h-screen',
+    // Boxed routes cap to the viewport and scroll inside the VStack; full-width
+    // routes omit the cap so the document scrolls instead.
+    !fullWidth && 'max-h-svh overflow-auto md:max-h-screen md:p-4 md:pb-2'
+  );
+
+/** The shell header row (logo + TopNav). */
+export const shellHeaderClasses = (fullWidth: boolean) =>
+  cn(
+    'flex w-full items-center gap-4 px-3 py-2 sm:px-10 md:mb-1',
+    // Full-width routes scroll on the document, so the header pins as a sticky,
+    // see-through frosted bar (Figma: transparent + blur(7px), no opaque fill).
+    fullWidth && 'sticky top-0 z-30',
+    // Progressive blur: the blur lives on a `::before` overlay behind the nav
+    // content (so logo + pills stay sharp), and a gradient mask feathers it out
+    // toward the bottom — the blurred backdrop dissolves into the sharp content
+    // instead of cutting at a hard line. The sticky header is the containing
+    // block for the absolute pseudo, so no `relative` is needed.
+    fullWidth &&
+      "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:-z-10 before:h-[150%] before:backdrop-blur-[7px] before:content-[''] before:[mask-image:linear-gradient(to_bottom,#000_35%,transparent)] before:[-webkit-mask-image:linear-gradient(to_bottom,#000_35%,transparent)]"
+  );

--- a/apps/webapp/src/pages/router.tsx
+++ b/apps/webapp/src/pages/router.tsx
@@ -32,6 +32,10 @@ export const createAppRouter = (history?: RouterHistory) =>
     stringifySearch,
     // Prefetch lazy route chunks when links are hovered/focused
     defaultPreload: 'intent',
+    // Full-width routes scroll on the document (no inner-scroll box), so the
+    // router owns scroll position: reset to top on new navigations, restore on
+    // back/forward. A no-op for boxed routes whose scroll lives in an element.
+    scrollRestoration: true,
     defaultErrorComponent: ErrorPage,
     defaultNotFoundComponent: NotFound,
     // NotFound renders its own full-page Layout, so unmatched paths must surface


### PR DESCRIPTION
## B6 · Full-width destinations scroll on the page + sticky blurred nav

### What does this PR do?

Full-width destination routes now scroll on the **document** instead of inside the legacy viewport-capped box. Two nested caps used to own the scroll — `Layout`'s VStack (`max-h-svh` + `overflow-auto`) and `AppContainer`'s `<main>` (`h-dvh` / `md:h-[calc(100dvh-70px)]` + `overflow-y-auto`). Both are relaxed **only** when the route opts into full-width (`staticData.fullWidth`, via `useRouteFullWidth()`), so the page flows at content height and the window scrolls.

- **Sticky, see-through nav.** The header (logo + `TopNav`) pins with `sticky top-0` and a transparent **progressive blur** — the blur lives on a gradient-masked `::before` overlay behind the nav content, so the backdrop dissolves smoothly into the page (no hard line) while the logo and pills stay sharp.
- **Back button** is unchanged: it's already the first in-flow row of `ProductDetailTemplate`, so it scrolls up and away under the nav (the "one opaque sticky layer" rule) — no code needed.
- **Scroll restoration** wired via the router (`scrollRestoration: true`): resets to top on new navigations, restores on back/forward. No-op for boxed routes.
- **Mode-switch class logic** extracted into `shellLayoutClasses` (`shellSurfaceClasses` / `shellHeaderClasses`) and unit-tested (RED→GREEN).

Legacy two-pane card routes are untouched — they keep the inner-scroll box and mobile pane height.

### Routes affected (opt-in via `staticData.fullWidth`)

| Route | Component |
|---|---|
| `/portfolio` | `PortfolioPage` |
| `/earn` | `EarnPage` |
| `/earn/savings` | `SavingsProductDetail` |

All other routes (`/stake`, `/convert/*`, `/earn/rewards|vaults|fixed|expert`) stay on the boxed two-pane layout.

### Screenshots

**Layout — full-width page scroll (`/earn/savings`)**

<img width="2956" height="1538" alt="image" src="https://github.com/user-attachments/assets/176f15f1-4969-4e64-816f-580ad09a231f" />


**Header — progressive blur over scrolling content**

<img width="2956" height="488" alt="image" src="https://github.com/user-attachments/assets/4b9363cc-2aec-47b4-bfaf-04d8f7a1a3cc" />


### Testing steps

1. Visit `/portfolio`, `/earn`, `/earn/savings`: content scrolls as a normal page (document scroll); no inner scrollbar; long content reaches the bottom.
2. While scrolling, the nav stays pinned and the backdrop blur **fades** into the content (no hard edge); logo + pills stay crisp.
3. On `/earn/savings`, the "Back to products" link scrolls away with content — nothing overlaps it.
4. Legacy routes (`/convert`, `/stake`, `/earn/vaults`, …) are visually + behaviorally unchanged (inner-pane scroll + mobile pane height).
5. Open a transaction modal and minimize/restore — unaffected (portals to `document.body`).

### Notes

- The redesign source is silent on header / scroll / back behavior, so this PR **defines** it (flag for async, non-blocking design ack).
- Global removal of the box once every route is full-width is a separate Track G endgame, blocked on the remaining route flips.
