### PR TITLE
C4 · Paginate the product-detail transactions table + Figma C3 restyle

### DIFF
--- a/apps/webapp/src/components/product/ProductTransactionsTable.test.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.test.tsx
@@ -1,0 +1,53 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ProductTransactionsTable,
+  ProductTransactionColumn
+} from './ProductTransactionsTable';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+type Row = { id: string };
+
+const COLUMNS: ProductTransactionColumn<Row>[] = [
+  { id: 'label', header: 'Label', width: '1fr', cell: row => <span>{`row-${row.id}`}</span> }
+];
+
+const makeRows = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ id: String(i) }));
+
+const renderTable = (rows: Row[], pageSize?: number) =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <ProductTransactionsTable columns={COLUMNS} rows={rows} rowKey={row => row.id} pageSize={pageSize} />
+    </I18nProvider>
+  );
+
+const visibleRows = () => screen.queryAllByText(/^row-/).map(el => el.textContent);
+
+describe('ProductTransactionsTable — pagination', () => {
+  afterEach(cleanup);
+
+  it('renders at most one page of rows (default page size 7)', () => {
+    renderTable(makeRows(15));
+    expect(visibleRows()).toHaveLength(7);
+    expect(visibleRows()).toContain('row-0');
+    expect(visibleRows()).not.toContain('row-7');
+  });
+
+  it('reveals the next page of rows when the next control is clicked', () => {
+    renderTable(makeRows(15));
+    fireEvent.click(screen.getByLabelText('Go to next page'));
+
+    expect(visibleRows()).toEqual(['row-7', 'row-8', 'row-9', 'row-10', 'row-11', 'row-12', 'row-13']);
+    expect(visibleRows()).not.toContain('row-0');
+  });
+
+  it('shows no pagination control when the rows fit on one page', () => {
+    renderTable(makeRows(7));
+    expect(visibleRows()).toHaveLength(7);
+    expect(screen.queryByRole('navigation', { name: 'pagination' })).toBeNull();
+  });
+});

--- a/apps/webapp/src/components/product/ProductTransactionsTable.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.tsx
@@ -1,8 +1,10 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { ArrowUpRight } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
 import { Skeleton } from '@/components/ui/skeleton';
+import { CustomPagination } from '@/modules/ui/components/CustomPagination';
+import { paginate } from './paginate';
 
 /**
  * Reusable transactions table for product-detail pages (Figma C3). Column-driven
@@ -34,6 +36,8 @@ export interface ProductTransactionsTableProps<T> {
   /** Min table width before horizontal scroll kicks in (px). */
   minWidth?: number;
   dataTestId?: string;
+  /** Rows per page; the control appears once the set exceeds it (C4). */
+  pageSize?: number;
 }
 
 // --- Reusable cells (compose these in a column's `cell`, or build your own) ---
@@ -64,15 +68,19 @@ function CheckIcon() {
 
 export function TxStatusBadge({ status }: { status: ProductTransactionStatus }) {
   if (status === 'pending') {
+    // Figma: purple-tinted pill, accent dots, primary-text label (white in dark,
+    // ink in light via the `text-text` token). Border + tint carry across themes.
     return (
-      <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[#A299F7]/10 px-2.5 py-1 text-xs font-medium text-[#A299F7]">
-        <DotsIcon />
+      <span className="text-text inline-flex w-fit items-center gap-1.5 rounded-full border border-[#9583ff]/20 bg-[#9583ff]/10 px-2.5 py-1 text-xs font-medium">
+        <span className="text-[#9583ff]">
+          <DotsIcon />
+        </span>
         <Trans>Pending</Trans>
       </span>
     );
   }
   return (
-    <span className="text-text inline-flex w-fit items-center gap-1.5 rounded-full bg-[#5AD293]/10 px-2.5 py-1 text-xs font-medium">
+    <span className="text-text inline-flex w-fit items-center gap-1.5 rounded-full border border-[#5AD293]/40 bg-[#008f44]/15 px-2.5 py-1 text-xs font-medium">
       <span className="text-[#5AD293]">
         <CheckIcon />
       </span>
@@ -97,7 +105,7 @@ export function TxActionCell({
         {icon}
       </span>
       <div className="flex flex-col">
-        <span className="text-text text-sm font-medium">{label}</span>
+        <span className="text-text text-base font-medium tracking-[-0.16px]">{label}</span>
         {timeAgo && <span className="text-textSecondary text-xs">{timeAgo}</span>}
       </div>
     </div>
@@ -142,7 +150,7 @@ export function TxHashLink({ label, href }: { label: ReactNode; href: string }) 
 
 function StateRow({ children }: { children: ReactNode }) {
   return (
-    <div className="bg-container text-textSecondary rounded-2xl px-4 py-8 text-center text-sm">
+    <div className="bg-container text-textSecondary rounded-[20px] px-4 py-8 text-center text-sm">
       {children}
     </div>
   );
@@ -156,47 +164,64 @@ export function ProductTransactionsTable<T>({
   error,
   emptyLabel,
   minWidth = 560,
-  dataTestId = 'product-transactions'
+  dataTestId = 'product-transactions',
+  pageSize = 7
 }: ProductTransactionsTableProps<T>) {
   const gridStyle = { gridTemplateColumns: columns.map(column => column.width).join(' ') };
 
-  return (
-    <div className="overflow-x-auto">
-      <div className="flex flex-col gap-2" style={{ minWidth }} data-testid={dataTestId}>
-        <div className="text-textSecondary grid items-center gap-4 px-4 text-sm" style={gridStyle}>
-          {columns.map(column => (
-            <span key={column.id} className={cn(column.alignEnd && 'text-right')}>
-              {column.header}
-            </span>
-          ))}
-        </div>
+  const allRows = rows ?? [];
+  const [page, setPage] = useState(1);
+  const { rows: pageRows, totalPages } = paginate(allRows, pageSize, page);
+  const showPagination = !isLoading && !error && totalPages > 1;
 
-        {isLoading ? (
-          Array.from({ length: 4 }).map((_, index) => (
-            <Skeleton key={index} className="h-[60px] rounded-2xl" />
-          ))
-        ) : error ? (
-          <StateRow>
-            <Trans>Unable to load transactions, please try again later.</Trans>
-          </StateRow>
-        ) : !rows || rows.length === 0 ? (
-          <StateRow>{emptyLabel ?? <Trans>No transactions yet.</Trans>}</StateRow>
-        ) : (
-          rows.map(row => (
-            <div
-              key={rowKey(row)}
-              className="bg-container hover:bg-containerDark grid items-center gap-4 rounded-2xl px-4 py-3 transition-colors"
-              style={gridStyle}
-            >
-              {columns.map(column => (
-                <div key={column.id} className={cn(column.alignEnd && 'flex justify-end')}>
-                  {column.cell(row)}
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <div className="flex flex-col gap-4" style={{ minWidth }} data-testid={dataTestId}>
+          <div className="text-textSecondary grid items-center gap-4 px-4 text-xs" style={gridStyle}>
+            {columns.map(column => (
+              <span key={column.id} className={cn(column.alignEnd && 'text-right')}>
+                {column.header}
+              </span>
+            ))}
+          </div>
+
+          {/* Rows sit 2px apart (Figma); the gap-4 above keeps them off the header. */}
+          <div className="flex flex-col gap-0.5">
+            {isLoading ? (
+              Array.from({ length: 4 }).map((_, index) => (
+                <Skeleton key={index} className="h-[88px] rounded-[20px]" />
+              ))
+            ) : error ? (
+              <StateRow>
+                <Trans>Unable to load transactions, please try again later.</Trans>
+              </StateRow>
+            ) : allRows.length === 0 ? (
+              <StateRow>{emptyLabel ?? <Trans>No transactions yet.</Trans>}</StateRow>
+            ) : (
+              pageRows.map(row => (
+                <div
+                  key={rowKey(row)}
+                  // Figma C3 row: a glassmorphic card — translucent ink fill in dark,
+                  // a white gradient + white border in light (the `light:` scope), with
+                  // a 20px backdrop blur so the page shows through. (node 1:3906 / 67:4842)
+                  className="light:border-white light:from-white/40 light:to-white/60 light:hover:from-white/55 light:hover:to-white/70 grid min-h-[88px] items-center gap-4 rounded-[20px] border border-white/10 bg-linear-to-b from-[#0e0e20]/40 to-[#0e0e20]/40 px-4 py-3 backdrop-blur-[20px] transition-colors hover:from-[#0e0e20]/55 hover:to-[#0e0e20]/55"
+                  style={gridStyle}
+                >
+                  {columns.map(column => (
+                    <div key={column.id} className={cn(column.alignEnd && 'flex justify-end')}>
+                      {column.cell(row)}
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          ))
-        )}
+              ))
+            )}
+          </div>
+        </div>
       </div>
-    </div>
+      {showPagination && (
+        <CustomPagination dataLength={allRows.length} itemsPerPage={pageSize} onPageChange={setPage} />
+      )}
+    </>
   );
 }

--- a/apps/webapp/src/components/product/paginate.test.ts
+++ b/apps/webapp/src/components/product/paginate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { paginate } from './paginate';
+
+// C4: client-side slicing of the already-fetched product-detail history. The
+// arithmetic (slice bounds, page count, clamping) lives here so the component
+// only has to wire it to state + the pagination control.
+describe('paginate', () => {
+  it('returns the first pageSize rows on page 1', () => {
+    const rows = Array.from({ length: 15 }, (_, i) => i);
+    const { rows: pageRows } = paginate(rows, 10, 1);
+
+    expect(pageRows).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('reports totalPages as ceil(length / pageSize)', () => {
+    expect(paginate(Array.from({ length: 15 }), 10, 1).totalPages).toBe(2);
+    expect(paginate(Array.from({ length: 20 }), 10, 1).totalPages).toBe(2);
+    expect(paginate(Array.from({ length: 21 }), 10, 1).totalPages).toBe(3);
+  });
+
+  it('returns the trailing partial remainder on the last page', () => {
+    const rows = Array.from({ length: 15 }, (_, i) => i);
+    expect(paginate(rows, 10, 2).rows).toEqual([10, 11, 12, 13, 14]);
+  });
+
+  it('clamps an out-of-range page to a valid slice instead of going empty', () => {
+    const rows = Array.from({ length: 15 }, (_, i) => i);
+    // Above the last page falls back to the last page.
+    expect(paginate(rows, 10, 3).rows).toEqual([10, 11, 12, 13, 14]);
+    // Below the first page falls back to the first page.
+    expect(paginate(rows, 10, 0).rows).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('treats an empty set as a single empty page', () => {
+    const { rows, totalPages } = paginate([], 10, 1);
+    expect(rows).toEqual([]);
+    expect(totalPages).toBe(1);
+  });
+});

--- a/apps/webapp/src/components/product/paginate.ts
+++ b/apps/webapp/src/components/product/paginate.ts
@@ -1,0 +1,15 @@
+export interface PaginatedRows<T> {
+  /** The rows visible on the requested page. */
+  rows: T[];
+  /** Total number of pages for the full row set (always >= 1). */
+  totalPages: number;
+}
+
+/** Client-side slice of an already-fetched row set into one page (C4). */
+export function paginate<T>(rows: T[], pageSize: number, page: number): PaginatedRows<T> {
+  const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
+  // Clamp so a stale/out-of-range page still yields a real slice, never empty.
+  const current = Math.min(Math.max(page, 1), totalPages);
+  const start = (current - 1) * pageSize;
+  return { rows: rows.slice(start, start + pageSize), totalPages };
+}

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.test.tsx
@@ -1,6 +1,6 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 i18n.load('en', {});
@@ -92,5 +92,28 @@ describe('SavingsTransactionsTable — action-type filter', () => {
     expect(rowCount()).toBe(1);
     expect(withdrawRows()).toBe(1);
     expect(supplyRows()).toBe(0);
+  });
+});
+
+describe('SavingsTransactionsTable — pagination resets on filter change', () => {
+  afterEach(cleanup);
+
+  it('returns to the first page when the filter changes', () => {
+    // 9 supplies → two pages at the default page size of 7 (7 + 2).
+    h.history = Array.from({ length: 9 }, (_, i) => supply(`0x${i}`));
+    const { rerender } = renderTable('all');
+    expect(rowCount()).toBe(7);
+
+    // Advance to page 2 (the trailing 2 rows).
+    fireEvent.click(screen.getByLabelText('Go to next page'));
+    expect(rowCount()).toBe(2);
+
+    // Changing the filter must snap back to page 1, not strand the user on page 2.
+    rerender(
+      <I18nProvider i18n={i18n}>
+        <SavingsTransactionsTable filter="supply" />
+      </I18nProvider>
+    );
+    expect(rowCount()).toBe(7);
   });
 });

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.tsx
@@ -117,6 +117,9 @@ export function SavingsTransactionsTable({ filter = 'all' }: { filter?: SavingsT
 
   return (
     <ProductTransactionsTable
+      // Remount on filter change so pagination snaps back to page 1 (C4) — a
+      // changing key resets the table's page state without an effect.
+      key={filter}
       dataTestId="savings-transactions"
       columns={COLUMNS}
       rows={rows}


### PR DESCRIPTION
## C4 · Paginate the product-detail transactions table

Adds client-side pagination to the shared `ProductTransactionsTable` (the C3 component every product-detail history funnels through) and restyles the list chrome to the Figma C3 spec in both themes.

### What does this PR do?

**Pagination**

- The table renders at most **one page** of rows at a time (default **7**); the rest are reachable through the existing `CustomPagination` control, which only appears once the set exceeds a page.
- The slice / page-count / clamp math lives in a pure `paginate(rows, pageSize, page)` seam — unit-tested with plain arrays (no render), so the component just wires `state → paginate → control`.
- `SavingsTransactionsTable` snaps back to page 1 when the action-type filter changes, via a `key` remount (no effect, no stale-page flash). Future consumers (Vaults / Rewards / Stake) inherit pagination automatically because the change lives in the shared component.
- Client-side slicing of already-fetched history only — no server/cursor pagination, no change to the indexer query.

**Figma C3 restyle (light + dark)**

- Rows are glassmorphic cards: translucent ink fill in dark, white gradient + white border in light, `rounded-[20px]`, 20px backdrop blur, `min-h-[88px]`.
- Themed status pills — purple **Pending**, green **Completed** — with primary-text labels in both modes.
- Muted 12px column headers, 16px action labels, 2px between rows with a 16px header offset.
- Empty / loading / error states unchanged in behavior.

### Testing steps

1. Open a product-detail page with history (e.g. `/earn/savings` with a position that has **> 7** transactions).
2. The list shows 7 rows + a page control; paging through reveals the rest, and the final page shows the remainder.
3. With **≤ 7** transactions, no page control appears.
4. Change the Savings action filter (All / Supply / Withdraw) → the list resets to page 1 and paginates the filtered set.
5. Toggle light / dark — rows, pills, and headers match the Figma C3 styling in both.

### Screenshots

**Dark**

<!-- ⬇️ DRAG THE DARK SCREENSHOT HERE ⬇️ -->
<img width="1488" height="801" alt="image" src="https://github.com/user-attachments/assets/1ed4d33b-5990-4b66-a32e-bc573d99d1ad" />

**Light**

<!-- ⬇️ DRAG THE LIGHT SCREENSHOT HERE ⬇️ -->
<img width="1488" height="801" alt="image" src="https://github.com/user-attachments/assets/ddf5ec5a-3c2b-4124-a964-706a526cb1dd" />


### Notes

- Stacked on the B6 branch, so this PR's diff is only the C4 changes; it should merge after B6.
- Reuses the existing `CustomPagination` primitive (an unused copy in `modules/ui`) instead of introducing a new control.
