### PR TITLE
feat(vaults): move Tether Savings (sUSDT) vault to top of vaults list

### DIFF
--- a/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.test.tsx
+++ b/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.test.tsx
@@ -125,6 +125,12 @@ function renderComponent(ui: ReactNode) {
   };
 }
 
+function getButtonTexts(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('button'))
+    .map(node => (node.textContent || '').trim())
+    .filter(Boolean);
+}
+
 function clickButtonByText(container: HTMLElement, matcher: RegExp) {
   const button = Array.from(container.querySelectorAll('button')).find(node =>
     matcher.test(node.textContent || '')
@@ -166,5 +172,20 @@ describe('VaultsWidgetPane card-select URL build', () => {
     clickButtonByText(container, /USDS Flagship/i);
 
     expect(mockSearchParams.get('vault_module')).toBe('morpho');
+  });
+
+  it('lists the Sky (Tether Savings) vault first, ahead of the Morpho vaults', () => {
+    const { container } = renderComponent(
+      <VaultsWidgetPane {...({ rightHeaderComponent: <div /> } as any)} />
+    );
+
+    // With no user balances every vault renders in "All vaults"; each card is a
+    // button labelled by its name, so button order is the list order.
+    const vaultNames = getButtonTexts(container);
+
+    expect(vaultNames.length).toBeGreaterThan(1);
+    expect(vaultNames[0]).toMatch(/Tether Savings/i);
+    // The Sky vault is the only one at the top — no Morpho vault precedes it.
+    expect(vaultNames.slice(1).some(name => /Tether Savings/i.test(name))).toBe(false);
   });
 });

--- a/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.tsx
+++ b/apps/webapp/src/modules/vaults/components/VaultsWidgetPane.tsx
@@ -29,12 +29,19 @@ export function VaultsWidgetPane(sharedProps: SharedProps) {
 
   const { data: userVaultsData } = useAllMorphoVaultsUserAssets();
 
-  // Separate vaults into "My Vaults" (user has balance) and "All Vaults"
+  // Separate vaults into "My Vaults" (user has balance) and "All Vaults",
+  // surfacing the Sky (Tether Savings) vault at the top of each list ahead of the
+  // third-party Morpho vaults.
   const [myVaults, allVaults] = useMemo(() => {
     const myVaults: typeof VAULTS = [];
     const allVaults: typeof VAULTS = [];
 
-    VAULTS.forEach(vault => {
+    // Sky vaults first; otherwise preserve registry order (Array.sort is stable).
+    const orderedVaults = [...VAULTS].sort((a, b) =>
+      a.provider === b.provider ? 0 : a.provider === 'sky' ? -1 : 1
+    );
+
+    orderedVaults.forEach(vault => {
       const vaultAddressForChain = vault.vaultAddress[chainId];
       if (!vaultAddressForChain) return;
 


### PR DESCRIPTION
## Summary

Moves the **Sky/Spark Tether Savings (sUSDT)** vault to the **top** of the Vaults module list. Previously it rendered last, because the unified `VAULTS` registry is built as `[...MORPHO_VAULTS, ...SPARK_VAULTS]` and the list display follows registry order.

## Changes

- **`modules/vaults/components/VaultsWidgetPane.tsx`** — when partitioning `VAULTS` into "My vaults" / "All vaults", sort `provider === 'sky'` vaults to the front first (stable sort, so Morpho vaults keep their relative order). The Tether Savings vault now leads whichever section it lands in.
- **`VaultsWidgetPane.test.tsx`** — add a test asserting the Sky vault renders first, ahead of the Morpho vaults.

## Scope / why this approach

Scoped deliberately to the **vaults module list rendering** rather than reordering the global `VAULTS` registry. Reordering the registry (`[...SPARK_VAULTS, ...MORPHO_VAULTS]`) would also change:
- the order of vault cards in the **balances** widget, and
- the `VAULTS[0]` fallback (the default selected vault for deep-link resolution).

Keeping the change local to `VaultsWidgetPane` avoids those side effects. If a registry-wide reorder is actually preferred, happy to switch.

> `provider === 'sky'` is the discriminator — today that's exactly the Tether Savings (sUSDT) vault, and it's future-proof if more Sky vaults are added (they'd all surface above the third-party Morpho vaults).

## Verification

- `VaultsWidgetPane.test.tsx` — **3/3 pass** (2 existing + new ordering test)
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- prettier — clean