### PR TITLE
feat(terms): version-aware terms re-prompt — surface latest version (APP-330)

### DIFF
--- a/apps/webapp/src/modules/ui/components/TermsModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TermsModal.tsx
@@ -23,7 +23,8 @@ export function TermsModal() {
     termsCheckError,
     retryTermsCheck,
     isConnectedAndAcceptedTerms,
-    setHasAcceptedTerms
+    setHasAcceptedTerms,
+    latestTermsVersion
   } = useConnectedContext();
   const [isChecked, setIsChecked] = useState(false);
   const [signStatus, setSignStatus] = useState<'idle' | 'loading' | 'signing' | 'error'>('idle');
@@ -221,6 +222,7 @@ export function TermsModal() {
       isOpen={isModalOpen}
       onOpenChange={handleOpenChange}
       title={<Trans>Legal Terms</Trans>}
+      termsVersion={latestTermsVersion}
       content={termsContent}
       additionalContent={checkboxContent}
       customError={errorContent}

--- a/apps/webapp/src/modules/ui/context/ConnectedContext.test.tsx
+++ b/apps/webapp/src/modules/ui/context/ConnectedContext.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Shared spies/state between the mocks and assertions.
+const mocks = vi.hoisted(() => ({
+  checkTermsWithRetry: vi.fn(),
+  trackVpnCheckCompleted: vi.fn(),
+  reportError: vi.fn(),
+  isPrivateDeployment: vi.fn(() => false)
+}));
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useChainId: () => 1,
+    useConnection: () => ({ isConnected: true, address: '0x1234567890123456789012345678901234567890' })
+  };
+});
+
+vi.mock('@/hooks', () => ({
+  useRestrictedAddressCheck: () => ({ data: { addressAllowed: true }, isLoading: false, error: undefined }),
+  useVpnCheck: () => ({
+    data: { isConnectedToVpn: false, isRestrictedRegion: false, countryCode: 'US' },
+    isLoading: false,
+    error: undefined
+  })
+}));
+
+vi.mock('@/lib/isPrivateDeployment', () => ({
+  isPrivateDeployment: () => mocks.isPrivateDeployment()
+}));
+
+vi.mock('@/modules/analytics/hooks/useVpnAnalytics', () => ({
+  useVpnAnalytics: () => ({ trackVpnCheckCompleted: mocks.trackVpnCheckCompleted })
+}));
+
+vi.mock('@/modules/sentry/reportError', () => ({
+  reportError: mocks.reportError
+}));
+
+vi.mock('@/modules/ui/lib/checkTermsWithRetry', () => ({
+  checkTermsWithRetry: mocks.checkTermsWithRetry
+}));
+
+import { ConnectedProvider, useConnectedContext } from './ConnectedContext';
+
+function Consumer() {
+  const { isConnectedAndAcceptedTerms, latestTermsVersion } = useConnectedContext();
+  return (
+    <div>
+      <span data-testid="accepted">{String(isConnectedAndAcceptedTerms)}</span>
+      <span data-testid="version">{latestTermsVersion ?? 'none'}</span>
+    </div>
+  );
+}
+
+describe('ConnectedContext — version-aware terms gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isPrivateDeployment.mockReturnValue(false);
+    vi.stubEnv('VITE_SKIP_AUTH_CHECK', 'false');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('stays gated (re-prompts) when the wallet has not accepted the current terms version', async () => {
+    mocks.checkTermsWithRetry.mockResolvedValue({
+      termsAccepted: false,
+      error: false,
+      latestVersion: '2026-02-01'
+    });
+
+    render(
+      <ConnectedProvider>
+        <Consumer />
+      </ConnectedProvider>
+    );
+
+    // Once the version-aware check resolves, the current version is surfaced (for the modal)...
+    await waitFor(() => expect(screen.getByTestId('version').textContent).toBe('2026-02-01'));
+    // ...and the wallet remains gated, so the terms modal stays up for re-signing.
+    expect(screen.getByTestId('accepted').textContent).toBe('false');
+  });
+
+  it('opens the gate (no re-prompt) when the wallet has accepted the current terms version', async () => {
+    mocks.checkTermsWithRetry.mockResolvedValue({
+      termsAccepted: true,
+      error: false,
+      latestVersion: '2026-02-01'
+    });
+
+    render(
+      <ConnectedProvider>
+        <Consumer />
+      </ConnectedProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('accepted').textContent).toBe('true'));
+    expect(screen.getByTestId('version').textContent).toBe('2026-02-01');
+  });
+});

--- a/apps/webapp/src/modules/ui/context/ConnectedContext.tsx
+++ b/apps/webapp/src/modules/ui/context/ConnectedContext.tsx
@@ -14,6 +14,8 @@ interface ConnectedContextType {
   isCheckingTerms: boolean;
   termsCheckError: boolean;
   retryTermsCheck: () => void;
+  // Current wallet terms version reported by the last successful check, surfaced in the terms modal.
+  latestTermsVersion?: string;
   authData: {
     addressAllowed?: boolean;
     authIsLoading: boolean;
@@ -50,6 +52,7 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const [hasAcceptedTerms, setHasAcceptedTerms] = useState(false);
   const [isCheckingTerms, setIsCheckingTerms] = useState(false);
   const [termsCheckError, setTermsCheckError] = useState(false);
+  const [latestTermsVersion, setLatestTermsVersion] = useState<string | undefined>(undefined);
   const [enabled, setEnabled] = useState(false);
 
   const skipAuthCheck =
@@ -126,8 +129,10 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       // 403 is an intentional access denial (VPN/region or sanctioned address).
       // The VPN/address hooks handle the blocked UI — just mark terms as not accepted.
       setHasAcceptedTerms(false);
+      setLatestTermsVersion(result.latestVersion);
     } else {
       setHasAcceptedTerms(result.termsAccepted);
+      setLatestTermsVersion(result.latestVersion);
     }
   }, []);
 
@@ -200,6 +205,7 @@ export const ConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         isCheckingTerms,
         termsCheckError,
         retryTermsCheck,
+        latestTermsVersion,
         authData: {
           addressAllowed: authData?.addressAllowed,
           authIsLoading,

--- a/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.test.ts
+++ b/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.test.ts
@@ -21,15 +21,15 @@ describe('checkTermsWithRetry', () => {
     vi.unstubAllEnvs();
   });
 
-  it('returns termsAccepted on successful response', async () => {
+  it('returns termsAccepted and latestVersion on successful response', async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ termsAccepted: true })
+      json: () => Promise.resolve({ termsAccepted: true, latestVersion: '2026-01-15' })
     });
 
     const result = await checkTermsWithRetry(TEST_ADDRESS);
 
-    expect(result).toEqual({ termsAccepted: true, error: false });
+    expect(result).toEqual({ termsAccepted: true, error: false, latestVersion: '2026-01-15' });
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.ts
+++ b/apps/webapp/src/modules/ui/lib/checkTermsWithRetry.ts
@@ -7,6 +7,8 @@ export interface TermsCheckResult {
   termsAccepted: boolean;
   error: false;
   accessDenied?: boolean;
+  // The current wallet terms version `termsAccepted` was evaluated against (when the API returns it).
+  latestVersion?: string;
 }
 
 export interface TermsCheckError {
@@ -41,7 +43,7 @@ export async function checkTermsWithRetry(address: string): Promise<TermsCheckOu
 
       if (response.ok) {
         const res = await response.json();
-        return { termsAccepted: res.termsAccepted, error: false };
+        return { termsAccepted: res.termsAccepted, error: false, latestVersion: res.latestVersion };
       }
 
       // 403 is a deliberate access denial (VPN/restricted region or sanctioned address) — not an error


### PR DESCRIPTION
## What

Frontend half of version-aware wallet terms (APP-330, parent APP-152). Threads the `latestVersion` returned by `/terms-acceptance/check` through `checkTermsWithRetry` → `ConnectedContext` → `TermsModal`, populating `TermsDialog`'s **existing** `termsVersion` prop (which already renders "Terms version: {version}").

The terms gate already keys purely off the `check` result (`ConnectedContext` sets `hasAcceptedTerms` from it on every connect — no persistence), so no gating change is needed: once the backend is version-aware, a stale wallet's `check` returns `false` and the existing modal flow re-prompts it automatically. This PR surfaces *which* version is being requested and locks the behavior with tests.

## ⚠️ Depends on two other PRs

This is the last of three and is **inert until the other two ship** — on its own, the backend still returns `termsAccepted: true` for any prior acceptance, so nothing re-prompts.

1. **DB** — `sky-money-supabase` #10 (APP-328): adds the `version` column + composite `(address, version)` PK to `terms-acceptance`.
2. **Backend** — `api-workers` #103 (APP-329): makes `/terms-acceptance/check` and `/add` version-aware and returns `latestVersion`.
3. **Frontend** — this PR (APP-330).

Roll out in that order: DB → api-workers → this. End-to-end staging verification requires #10 merged to the supabase `staging` branch and #103 deployed to `staging-api.sky.money`.

## Expected behavior once all three are implemented

| Scenario | `check` result | UX |
| --- | --- | --- |
| New wallet, never accepted | `termsAccepted: false` | Terms modal opens (shows current version). Sign → `/add` stores acceptance at current version → `check` true → modal closes. |
| Wallet already accepted the **current** version | `termsAccepted: true` | No prompt. (Existing acceptances are backfilled to the current version by APP-328, so the rollout itself does **not** re-prompt anyone.) |
| Terms version bumped, wallet accepted an **older** version | `termsAccepted: false` | On next connect/load the modal **re-opens** showing the new version. Re-sign → `/add` inserts a **new** row keyed on `(address, newVersion)`; the prior signature is retained as an audit trail → `check` true → modal closes and stays closed. |
| VPN / restricted region / sanctioned | 403 `accessDenied` | Blocked UI (unchanged). |

Re-prompting happens on the next connect/load (the check isn't re-run mid-session), which matches the intended behavior.

## Tests

- `ConnectedContext.test.tsx` (new): `termsAccepted:false` → wallet stays gated (re-prompt); `termsAccepted:true` → gate opens. Also asserts `latestVersion` is surfaced.
- `checkTermsWithRetry.test.ts`: locks the `latestVersion` passthrough.
- 16 tests pass; typecheck, lint, prettier clean.

## Note

Per the agreed scope this is frontend-only — no "your terms were updated" differentiation messaging (that would need an additive backend signal to tell stale from never-accepted). The returning user sees the standard modal with the version label. Easy follow-up if we want richer copy.

Closes APP-330.
