### PR TITLE
Grove copy, balances integration and new Tenderly testnet

### DIFF
--- a/apps/webapp/src/data/banners/banners.ts
+++ b/apps/webapp/src/data/banners/banners.ts
@@ -263,6 +263,14 @@ export const banners: Banner[] = [
     display: ['connected', 'disconnected']
   },
   {
+    id: 'about-the-grove-token',
+    title: 'About the Grove Token',
+    module: 'rewards-banners',
+    description:
+      'GROVE is the native token of the Sky Agent Grove, a credit infrastructure protocol bridging traditional capital with DeFi through credit and tokenized real-world assets. GROVE is expected to support Grove’s governance and community participation, with staking and voting mechanics being rolled out progressively. It is an ERC-20 token on the Ethereum blockchain. The GROVE token’s functionality may change and will be released subject to Grove and Sky Governance.',
+    display: ['connected', 'disconnected']
+  },
+  {
     id: 'vaults',
     title: 'Vaults',
     module: 'vaults-banners',

--- a/apps/webapp/src/data/faqs/getRewardsGroveFaqItems.ts
+++ b/apps/webapp/src/data/faqs/getRewardsGroveFaqItems.ts
@@ -1,0 +1,23 @@
+export const getRewardsGroveFaqItems = () => {
+  const items = [
+    {
+      question: 'What is Grove?',
+      answer:
+        "Grove is a Sky Agent, one of the independent capital allocators operating within the Sky ecosystem. Supplying USDS through this module accrues GROVE, allowing you to participate in that operator's growth.",
+      index: 0
+    },
+    {
+      question: 'How are GROVE rewards calculated?',
+      answer:
+        'The protocol distributes a set amount of GROVE to the pool over time. Your share is proportional to your portion of the total USDS supplied, so the rate moves as the pool grows or shrinks. It is not a fixed APY. The current rate is shown live in the module. Sky.money does not control the issuance, determination, price fluctuations of the GROVE token, or the distribution mechanics of these rewards.',
+      index: 1
+    },
+    {
+      question: 'Where can I learn more about Grove’s token and security?',
+      answer:
+        'Official information about GROVE is published through [Grove’s documentation](https://docs.grove.finance/). No GROVE sale or migration runs through Sky.money. [Verify the token contract before interacting.](https://etherscan.io/token/0xb30fe1cf884b48a22a50d22a9282004f2c5e9406)',
+      index: 2
+    }
+  ];
+  return items.sort((a, b) => a.index - b.index);
+};

--- a/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
+++ b/apps/webapp/src/data/wagmi/config/testTenderlyChain.ts
@@ -16,7 +16,7 @@ export const TENDERLY_CHAIN_ID = 314310;
 
 // only works if hardcoded, cannot be set via env variable. Corresponds to the public RPC of `nov-3-mainnet-fork`
 export const TENDERLY_RPC_URL =
-  'https://virtual.rpc.tenderly.co/jetstreamgg/jetstream/public/jetstream-testnet';
+  'https://virtual.mainnet.eu.rpc.tenderly.co/jetstreamgg/jetstream/jetstream-testnet';
 
 export const getTestTenderlyChains = () => {
   const mainnetData = vnetData.find(data => data.NETWORK === NetworkName.mainnet);

--- a/apps/webapp/src/hooks/index.ts
+++ b/apps/webapp/src/hooks/index.ts
@@ -470,6 +470,7 @@ export {
   usdcAddress,
   usdtAddress,
   spkAddress,
+  groveAddress,
   stakeModuleAddress,
   stakeModuleAbi,
   mcdVatAbi,

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
@@ -95,7 +95,7 @@ const STABLE_ACTIONS: BalancesAction[] = [
   },
   {
     label: 'Rewards and Points',
-    tokens: ['SPK', 'CLE'],
+    tokens: ['SPK', 'GROVE', 'CLE'],
     rateKey: 'rewards',
     subtitle: 'Rates up to {rate}',
     module: 'rewards',
@@ -269,6 +269,11 @@ function useActionRates(
     contract =>
       contract.supplyToken.symbol === TOKENS.usds.symbol && contract.rewardToken.symbol === TOKENS.cle.symbol
   );
+  const usdsGroveRewardContract = activeRewardContracts.find(
+    contract =>
+      contract.supplyToken.symbol === TOKENS.usds.symbol &&
+      contract.rewardToken.symbol === TOKENS.grove.symbol
+  );
 
   const { data: usdsSpkChartData, isLoading: spkLoading } = useRewardsChartInfo({
     rewardContractAddress: usdsSpkRewardContract?.contractAddress as string
@@ -276,8 +281,15 @@ function useActionRates(
   const { data: usdsCleChartData, isLoading: cleLoading } = useRewardsChartInfo({
     rewardContractAddress: usdsCleRewardContract?.contractAddress as string
   });
-  const rewardsHighestRate = useHighestRateFromChartData([usdsSpkChartData, usdsCleChartData]);
-  const rewardsLoading = spkLoading || cleLoading;
+  const { data: usdsGroveChartData, isLoading: groveLoading } = useRewardsChartInfo({
+    rewardContractAddress: usdsGroveRewardContract?.contractAddress as string
+  });
+  const rewardsHighestRate = useHighestRateFromChartData([
+    usdsSpkChartData,
+    usdsCleChartData,
+    usdsGroveChartData
+  ]);
+  const rewardsLoading = spkLoading || cleLoading || groveLoading;
 
   const { data: stakeRewardContracts, isLoading: stakeContractsLoading } = useStakeRewardContracts();
   const { data: stakeRewardsChartsInfoData, isLoading: stakeChartsLoading } = useMultipleRewardsChartInfo({

--- a/apps/webapp/src/modules/rewards/components/RewardsDetailsView.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsDetailsView.tsx
@@ -17,6 +17,7 @@ import { useUserSuggestedActions } from '@/modules/ui/hooks/useUserSuggestedActi
 import { RewardsOverviewAbout } from './RewardsOverviewAbout';
 import { filterActionsByIntent } from '@/lib/utils';
 import { AboutSpk } from '@/modules/ui/components/AboutSpk';
+import { AboutGrove } from '@/modules/ui/components/AboutGrove';
 
 export function RewardsDetailsView({ rewardContract }: { rewardContract?: RewardContract }) {
   const { isConnectedAndAcceptedTerms } = useConnectedContext();
@@ -71,6 +72,13 @@ export function RewardsDetailsView({ rewardContract }: { rewardContract?: Reward
         <DetailSection title={t`About the Spark Token`}>
           <DetailSectionRow>
             <AboutSpk />
+          </DetailSectionRow>
+        </DetailSection>
+      )}
+      {rewardContract.rewardToken.symbol === TOKENS.grove.symbol && (
+        <DetailSection title={t`About the Grove Token`}>
+          <DetailSectionRow>
+            <AboutGrove />
           </DetailSectionRow>
         </DetailSection>
       )}

--- a/apps/webapp/src/modules/rewards/components/RewardsFaq.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsFaq.tsx
@@ -3,6 +3,7 @@ import { getRewardsFaqItems } from '@/data/faqs/getRewardsFaqItems';
 import { FaqAccordion } from '@/modules/ui/components/FaqAccordion';
 import { getRewardsCleFaqItems } from '@/data/faqs/getRewardsCleFaqItems';
 import { getRewardsSpkFaqItems } from '@/data/faqs/getRewardsSpkFaqItems';
+import { getRewardsGroveFaqItems } from '@/data/faqs/getRewardsGroveFaqItems';
 
 export function RewardsFaq({ rewardContract }: { rewardContract?: RewardContract }) {
   const faqItems =
@@ -10,7 +11,9 @@ export function RewardsFaq({ rewardContract }: { rewardContract?: RewardContract
       ? getRewardsCleFaqItems()
       : rewardContract?.rewardToken.symbol === 'SPK'
         ? getRewardsSpkFaqItems()
-        : getRewardsFaqItems();
+        : rewardContract?.rewardToken.symbol === 'GROVE'
+          ? getRewardsGroveFaqItems()
+          : getRewardsFaqItems();
 
   return <FaqAccordion items={faqItems} />;
 }

--- a/apps/webapp/src/modules/ui/components/AboutGrove.tsx
+++ b/apps/webapp/src/modules/ui/components/AboutGrove.tsx
@@ -1,0 +1,29 @@
+import { getEtherscanLink } from '@/utils';
+import { useChainId } from 'wagmi';
+import { groveAddress } from '@/hooks';
+import { getBannerByIdAndModule } from '@/data/banners/helpers';
+import { parseBannerContent } from '@/utils/bannerContentParser';
+import { AboutCard } from './AboutCard';
+
+export const AboutGrove = ({ height }: { height?: number | undefined }) => {
+  const chainId = useChainId();
+
+  const groveEtherscanLink = getEtherscanLink(
+    chainId,
+    groveAddress[chainId as keyof typeof groveAddress],
+    'address'
+  );
+
+  const banner = getBannerByIdAndModule('about-the-grove-token', 'rewards-banners');
+  const contentText = banner?.description ? parseBannerContent(banner.description) : '';
+
+  return (
+    <AboutCard
+      tokenSymbol="GROVE"
+      description={contentText}
+      linkHref={groveEtherscanLink}
+      colorMiddle="linear-gradient(360deg, #E3D27A 0%, #04D19A 300%)"
+      height={height}
+    />
+  );
+};

--- a/apps/webapp/src/widgets/BalancesWidget/components/RewardsBalanceCard.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/RewardsBalanceCard.tsx
@@ -6,13 +6,7 @@ import {
   useHighestRateFromChartData,
   useRewardContractsToClaim
 } from '@/hooks';
-import {
-  formatBigInt,
-  formatDecimalPercentage,
-  formatNumber,
-  isMainnetId,
-  chainId
-} from '@/utils';
+import { formatBigInt, formatDecimalPercentage, formatNumber, isMainnetId, chainId } from '@/utils';
 import { Text } from '@/widgets/shared/components/ui/Typography';
 import { t } from '@lingui/core/macro';
 import { InteractiveStatsCard } from '@/widgets/shared/components/ui/card/InteractiveStatsCard';
@@ -46,7 +40,11 @@ export const RewardsBalanceCard = ({
     f => f.supplyToken.symbol === TOKENS.usds.symbol && f.rewardToken.symbol === TOKENS.spk.symbol
   );
 
-  // Fetch chart data for both reward contracts
+  const usdsGroveRewardContract = rewardContracts.find(
+    f => f.supplyToken.symbol === TOKENS.usds.symbol && f.rewardToken.symbol === TOKENS.grove.symbol
+  );
+
+  // Fetch chart data for the reward contracts
   const { data: usdsSkyChartData, isLoading: usdsSkyChartDataLoading } = useRewardsChartInfo({
     rewardContractAddress: usdsSkyRewardContract?.contractAddress as string,
     limit: 1
@@ -57,8 +55,17 @@ export const RewardsBalanceCard = ({
     limit: 1
   });
 
-  // Find the highest rate from both contracts
-  const highestRateData = useHighestRateFromChartData([usdsSkyChartData, usdsSpkChartData]);
+  const { data: usdsGroveChartData, isLoading: usdsGroveChartDataLoading } = useRewardsChartInfo({
+    rewardContractAddress: usdsGroveRewardContract?.contractAddress as string,
+    limit: 1
+  });
+
+  // Find the highest rate from all contracts
+  const highestRateData = useHighestRateFromChartData([
+    usdsSkyChartData,
+    usdsSpkChartData,
+    usdsGroveChartData
+  ]);
 
   const { data: pricesData, isLoading: pricesLoading } = usePrices();
 
@@ -79,7 +86,7 @@ export const RewardsBalanceCard = ({
     rewardChainId
   );
 
-  const chartDataLoading = usdsSkyChartDataLoading || usdsSpkChartDataLoading;
+  const chartDataLoading = usdsSkyChartDataLoading || usdsSpkChartDataLoading || usdsGroveChartDataLoading;
   const mostRecentRateNumber = highestRateData ? parseFloat(highestRateData.rate) : null;
 
   return variant === ModuleCardVariant.default ? (


### PR DESCRIPTION
Stacked on #app-331 Grove farm branch. Three commits:

## Update Tenderly testnet RPC URL
Points `testTenderlyChain.ts` at the new `jetstream-testnet` vnet public RPC (created 2026-07-03, forked at block 25452578). Grove farm emissions have been activated on it: 1M GROVE notified over 7 days (ends 2026-07-10), farm seeded with 10M GROVE for future re-notifies.

## Add Grove token banner and FAQs to Grove rewards page
- New `about-the-grove-token` banner entry in `banners.ts` (corpus copy)
- New `AboutGrove` card on the Grove rewards detail page, banner-sourced via `getBannerByIdAndModule` + `parseBannerContent` (same pattern as `AboutStUsds`), linking to the GROVE token contract on Etherscan
- Grove-specific FAQs (`getRewardsGroveFaqItems`) wired into `RewardsFaq`, replacing the generic set on the Grove farm page (same precedent as SPK/CLE)

## Include Grove farm in balances rewards rates and token icons
- GROVE icon added to the "Rewards and Points" suggested-action card
- Grove farm rate included in both "Rates up to" calculations (`RewardsBalanceCard` and `BalancesSuggestedActions`), which previously only considered SKY/SPK and SPK/CLE respectively
- Note: the "Unclaimed rewards" icons were already dynamic — GROVE shows up automatically once earned > 0 (no code change needed)