### PR TITLE
Adopt design-system primary/secondary button styles

### DIFF
--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -7,16 +7,22 @@ import { cn } from '@/lib/cn';
 // App look — canonical, unchanged.
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition-[background-color,background-image,opacity,border-color,color,box-shadow] duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primaryDisabled disabled:text-surfaceAlt light:disabled:text-textDimmed',
+  // --tw-gradient-from/to are @property-registered colors, so listing them
+  // here lets gradient-stop changes (the primary/secondary state fills)
+  // cross-fade; background-image itself never interpolates.
+  'inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition-[background-color,background-image,--tw-gradient-from,--tw-gradient-to,opacity,border-color,color,box-shadow] duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primaryDisabled disabled:text-surfaceAlt light:disabled:text-textDimmed',
   {
     variants: {
       variant: {
         default: 'bg-primary text-text hover:bg-primaryHover active:bg-primaryActive focus:bg-primaryFocus',
-        // Design-system recipes (Figma 5010:7958). Hover/pressed drop the
-        // gradient for a solid fill, so both need bg-none alongside the color.
-        // The focus ring hugs the edge (offset-0), overriding the base offset.
+        // Design-system recipes (Figma 5010:7958). Every state keeps the
+        // gradient and only moves the stop colors (solid fills = equal stops):
+        // background-image can't interpolate, so swapping the gradient out for
+        // a plain color would flash transparent mid-transition, while the
+        // @property-registered stops cross-fade. Focus ring hugs the edge
+        // (offset-0 overrides base).
         primary:
-          'rounded-full border border-glassBorder bg-linear-to-b from-button-gradient-start to-button-gradient-end text-fgConsistent hover:bg-none hover:bg-brandHover active:bg-none active:bg-brandPressed focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:bg-none disabled:border-transparent disabled:bg-glassSurface disabled:text-fgTertiary',
+          'rounded-full border border-glassBorder bg-linear-to-b from-button-gradient-start to-button-gradient-end text-fgConsistent hover:from-brandHover hover:to-brandHover active:from-brandPressed active:to-brandPressed focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
         primaryAlt:
           'bg-radial-(--gradient-position) from-primary-alt-start/100 to-primary-alt-end/100 border text-text hover:from-primary-alt-start/60 hover:to-primary-alt-end/60 active:from-primary-alt-start/45 active:to-primary-alt-end/45 focus:from-primary-alt-start/45 focus:to-primary-alt-end/45 disabled:from-primary-alt-start/35 disabled:to-primary-alt-end/35',
         connectPrimary:
@@ -24,7 +30,7 @@ const buttonVariants = cva(
         connect:
           'bg-radial-(--gradient-position) text-text border border-[rgb(127,92,246)] from-primary-bright-start/100 to-primary-bright-end/100 hover:from-primary-bright-start/60 hover:to-primary-bright-end/60 hover:border-[rgb(101,70,222)] focus:from-primary-bright-start/40 focus:to-primary-bright-end/40 focus:border-[rgb(92,62,209)]',
         secondary:
-          'rounded-full border border-glassBadge bg-linear-to-b from-white/0 to-white/8 text-text hover:bg-none hover:bg-glassBadge active:bg-none active:bg-glassBorder focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:bg-none disabled:border-transparent disabled:bg-glassSurface disabled:text-fgTertiary',
+          'rounded-full border border-glassBadge bg-linear-to-b from-white/0 to-white/8 text-text hover:from-glassBadge hover:to-glassBadge active:from-glassBorder active:to-glassBorder focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
         pill: 'bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 text-text rounded-full hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 bg-blend-overlay hover:bg-white/10 focus:border-transparent focus:bg-white/15 active:bg-white/15',
         chip: 'bg-secondary text-text rounded-full hover:bg-secondaryHover active:bg-secondaryActive, focus:bg-secondaryFocus',
         link: 'text-textSecondary no-underline hover:text-white light:hover:text-text active:text-[rgba(198,194,255,0.5)]',

--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -12,8 +12,11 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-text hover:bg-primaryHover active:bg-primaryActive focus:bg-primaryFocus',
+        // Design-system recipes (Figma 5010:7958). Hover/pressed drop the
+        // gradient for a solid fill, so both need bg-none alongside the color.
+        // The focus ring hugs the edge (offset-0), overriding the base offset.
         primary:
-          'bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 text-text hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 bg-blend-overlay hover:bg-white/10 focus:border-transparent focus:bg-white/15',
+          'rounded-full border border-glassBorder bg-linear-to-b from-button-gradient-start to-button-gradient-end text-fgConsistent hover:bg-none hover:bg-brandHover active:bg-none active:bg-brandPressed focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:bg-none disabled:border-transparent disabled:bg-glassSurface disabled:text-fgTertiary',
         primaryAlt:
           'bg-radial-(--gradient-position) from-primary-alt-start/100 to-primary-alt-end/100 border text-text hover:from-primary-alt-start/60 hover:to-primary-alt-end/60 active:from-primary-alt-start/45 active:to-primary-alt-end/45 focus:from-primary-alt-start/45 focus:to-primary-alt-end/45 disabled:from-primary-alt-start/35 disabled:to-primary-alt-end/35',
         connectPrimary:
@@ -21,7 +24,7 @@ const buttonVariants = cva(
         connect:
           'bg-radial-(--gradient-position) text-text border border-[rgb(127,92,246)] from-primary-bright-start/100 to-primary-bright-end/100 hover:from-primary-bright-start/60 hover:to-primary-bright-end/60 hover:border-[rgb(101,70,222)] focus:from-primary-bright-start/40 focus:to-primary-bright-end/40 focus:border-[rgb(92,62,209)]',
         secondary:
-          'bg-secondary text-text hover:bg-secondaryHover active:bg-secondaryActive, focus:bg-secondaryFocus',
+          'rounded-full border border-glassBadge bg-linear-to-b from-white/0 to-white/8 text-text hover:bg-none hover:bg-glassBadge active:bg-none active:bg-glassBorder focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:bg-none disabled:border-transparent disabled:bg-glassSurface disabled:text-fgTertiary',
         pill: 'bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 text-text rounded-full hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 bg-blend-overlay hover:bg-white/10 focus:border-transparent focus:bg-white/15 active:bg-white/15',
         chip: 'bg-secondary text-text rounded-full hover:bg-secondaryHover active:bg-secondaryActive, focus:bg-secondaryFocus',
         link: 'text-textSecondary no-underline hover:text-white light:hover:text-text active:text-[rgba(198,194,255,0.5)]',
@@ -44,7 +47,14 @@ const buttonVariants = cva(
         xs: 'h-6 rounded-full px-2 py-1 text-xs',
         sm: 'h-9 rounded-full px-2',
         large: 'p-4',
-        icon: 'h-10 w-10'
+        icon: 'h-10 w-10',
+        // Design-system scale (Figma XL/L/M/S). Figma pads icons tighter than
+        // text (icon inset 12px vs text 20px on xl/l), so edge svg children
+        // pull themselves in with negative margins instead of an icon-slot API.
+        xl: 'h-14 gap-2 rounded-full px-5 font-circle text-base leading-[18px] tracking-[-0.32px] [&>svg]:size-4 [&>svg]:shrink-0 [&>svg:first-child]:-ml-2 [&>svg:last-child]:-mr-2',
+        l: 'h-12 gap-2 rounded-full px-5 font-circle text-sm leading-4 tracking-[-0.28px] [&>svg]:size-4 [&>svg]:shrink-0 [&>svg:first-child]:-ml-2 [&>svg:last-child]:-mr-2',
+        m: 'h-10 gap-2 rounded-full px-4 font-circle text-sm leading-4 tracking-[-0.28px] [&>svg]:size-4 [&>svg]:shrink-0 [&>svg:first-child]:-ml-2 [&>svg:last-child]:-mr-2',
+        s: 'h-8 gap-1 rounded-full px-2.5 font-circle text-sm leading-4 tracking-[-0.28px] [&>svg]:size-4 [&>svg]:shrink-0 [&>svg:first-child]:-ml-1 [&>svg:last-child]:-mr-1'
       }
     },
     defaultVariants: {
@@ -54,15 +64,66 @@ const buttonVariants = cva(
   }
 );
 
+// Loading-state glyph (Figma "Loader"): the static Figma asset gives the
+// three-dot geometry; the staggered pulse makes it read as busy.
+const ButtonLoader = ({ className }: { className?: string }) => (
+  <svg
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    className={className}
+  >
+    <circle cx="2.667" cy="8.667" r="1.333" fill="currentColor" className="animate-pulse" />
+    <circle
+      cx="8"
+      cy="6.667"
+      r="1.333"
+      fill="currentColor"
+      className="animate-pulse [animation-delay:200ms]"
+    />
+    <circle
+      cx="13.333"
+      cy="8.667"
+      r="1.333"
+      fill="currentColor"
+      className="animate-pulse [animation-delay:400ms]"
+    />
+  </svg>
+);
+
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  /** Design-system loading state: disables the button (the disabled recipe
+   *  doubles as Figma State=Loading) and prepends the dots loader. */
+  loading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, loading = false, disabled, children, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        disabled={disabled || loading}
+        {...props}
+      >
+        {/* Slot requires a single element child, so the loader only renders on real buttons */}
+        {loading && !asChild ? (
+          <>
+            {/* span wrapper keeps the loader out of the [&>svg] icon sizing rules (xl uses a 24px loader) */}
+            <span className={cn('shrink-0', size === 's' ? '-ml-1' : '-ml-2')}>
+              <ButtonLoader className={size === 'xl' ? 'size-6' : 'size-4'} />
+            </span>
+            {children}
+          </>
+        ) : (
+          children
+        )}
+      </Comp>
+    );
   }
 );
 Button.displayName = 'Button';

--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -21,8 +21,12 @@ const buttonVariants = cva(
         // a plain color would flash transparent mid-transition, while the
         // @property-registered stops cross-fade. Focus ring hugs the edge
         // (offset-0 overrides base).
+        // bg-origin-border spans the gradient across the border box: the
+        // translucent border must blend over the local gradient color (Figma
+        // fill + inner stroke); by default the gradient tiles from the padding
+        // box, wrapping the opposite end's color into the border ring.
         primary:
-          'rounded-full border border-glassBorder bg-linear-to-b from-button-gradient-start to-button-gradient-end text-fgConsistent hover:from-brandHover hover:to-brandHover active:from-brandPressed active:to-brandPressed focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
+          'rounded-full border border-glassBorder bg-origin-border bg-linear-to-b from-button-gradient-start to-button-gradient-end text-fgConsistent hover:from-brandHover hover:to-brandHover active:from-brandPressed active:to-brandPressed focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
         primaryAlt:
           'bg-radial-(--gradient-position) from-primary-alt-start/100 to-primary-alt-end/100 border text-text hover:from-primary-alt-start/60 hover:to-primary-alt-end/60 active:from-primary-alt-start/45 active:to-primary-alt-end/45 focus:from-primary-alt-start/45 focus:to-primary-alt-end/45 disabled:from-primary-alt-start/35 disabled:to-primary-alt-end/35',
         connectPrimary:
@@ -30,7 +34,7 @@ const buttonVariants = cva(
         connect:
           'bg-radial-(--gradient-position) text-text border border-[rgb(127,92,246)] from-primary-bright-start/100 to-primary-bright-end/100 hover:from-primary-bright-start/60 hover:to-primary-bright-end/60 hover:border-[rgb(101,70,222)] focus:from-primary-bright-start/40 focus:to-primary-bright-end/40 focus:border-[rgb(92,62,209)]',
         secondary:
-          'rounded-full border border-glassBadge bg-linear-to-b from-white/0 to-white/8 text-text hover:from-glassBadge hover:to-glassBadge active:from-glassBorder active:to-glassBorder focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
+          'rounded-full border border-glassBadge bg-origin-border bg-linear-to-b from-white/0 to-white/8 text-text hover:from-glassBadge hover:to-glassBadge active:from-glassBorder active:to-glassBorder focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
         pill: 'bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 text-text rounded-full hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 bg-blend-overlay hover:bg-white/10 focus:border-transparent focus:bg-white/15 active:bg-white/15',
         chip: 'bg-secondary text-text rounded-full hover:bg-secondaryHover active:bg-secondaryActive, focus:bg-secondaryFocus',
         link: 'text-textSecondary no-underline hover:text-white light:hover:text-text active:text-[rgba(198,194,255,0.5)]',

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -75,6 +75,20 @@
   --color-glassBorder: rgba(188, 182, 239, 0.2);
   --color-flipSurface: #1b1735;
   --color-flipRing: #140f2b;
+  /* Design-system button tokens (Figma 5010:7958): dark values are the Figma
+     source values — colors/bg/bg-brand-primary + bg-brand-secondary (primary
+     hover/pressed fills), colors/border/border-focus (focus ring),
+     colors/fg/fg-tertiary (disabled/loading text) and the primary gradient
+     stops. None are overridden in the light scope: fgConsistent
+     (colors/fg/fg-text-consistent-light) stays light on the brand gradient in
+     both themes by design; the rest are interim (G2 owns full light parity). */
+  --color-brandHover: #504dff;
+  --color-brandPressed: #4836f5;
+  --color-focusRing: #c2ccff;
+  --color-fgTertiary: #636685;
+  --color-fgConsistent: #f2f3f7;
+  --color-button-gradient-start: #2a197d;
+  --color-button-gradient-end: #6a6cfb;
   --color-border: var(--transparent-white-15);
   --color-borderActive: var(--transparent-white-25);
   --color-borderPurple: #4c4577;

--- a/apps/webapp/src/modules/app/shell/WalletDrawerAssets.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletDrawerAssets.tsx
@@ -7,6 +7,7 @@ import { retainOnNavigate } from '@/lib/navigation';
 import { formatDecimalPercentage, formatNumber, formatUsd } from '@/utils';
 import { Text } from '@/modules/layout/components/Typography';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGeoConfig } from '@/modules/geo-config';
 import { useWalletDrawerAssets, type WalletDrawerAsset } from './useWalletDrawerAssets';
@@ -111,14 +112,15 @@ function AssetRow({
       {showEarnActions && (
         <div className="grid grid-rows-[0fr] opacity-0 transition-all duration-200 group-focus-within:grid-rows-[1fr] group-focus-within:opacity-100 group-hover:grid-rows-[1fr] group-hover:opacity-100">
           <div className="overflow-hidden">
-            <button
-              type="button"
+            <Button
+              variant="primary"
+              size="m"
+              className="mt-4 w-full"
               onClick={onStartEarning}
               data-testid={`wallet-drawer-earn-${asset.symbol.toLowerCase()}`}
-              className="font-circle mt-4 flex h-10 w-full items-center justify-center rounded-full border border-[#bcb6ef]/20 bg-gradient-to-b from-[#2a197d] to-[#6a6cfb] text-sm font-medium text-[#f2f3f7] transition-opacity hover:opacity-90"
             >
               <Trans>Start earning</Trans>
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/apps/webapp/src/modules/app/shell/WalletDrawerTabs.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletDrawerTabs.tsx
@@ -15,7 +15,8 @@ enum WalletDrawerTab {
 const pillTriggerClasses =
   'font-circle text-text rounded-full border px-3 py-2 text-sm font-medium leading-4 tracking-tight transition-colors ' +
   'border-[#bcb6ef]/20 hover:bg-white/5 light:border-[#1a1855]/20 light:hover:bg-[#1a1855]/5 ' +
-  'data-[state=active]:border-[#949aff]/40 data-[state=active]:bg-gradient-to-b data-[state=active]:from-[#949aff]/20 data-[state=active]:to-[#504dff]/20';
+  // bg-origin-border keeps the active gradient from tiling into the translucent border ring
+  'bg-origin-border data-[state=active]:border-[#949aff]/40 data-[state=active]:bg-gradient-to-b data-[state=active]:from-[#949aff]/20 data-[state=active]:to-[#504dff]/20';
 
 /** Assets/Activity tabs: wallet token balances with earn CTAs, and the shared history widget. */
 export function WalletDrawerTabs() {

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
@@ -56,7 +56,7 @@ export function WalletPreviewDrawer({
           <SheetClose
             data-testid="wallet-drawer-collapse"
             aria-label={t`Close`}
-            className="text-text light:border-[#1a1855]/15 light:hover:bg-[#1a1855]/5 flex size-10 items-center justify-center rounded-full border border-[#bcb6ef]/10 bg-gradient-to-b from-white/0 to-white/8 transition-colors hover:bg-white/10"
+            className="text-text light:border-[#1a1855]/15 light:hover:bg-[#1a1855]/5 flex size-10 items-center justify-center rounded-full border border-[#bcb6ef]/10 bg-gradient-to-b from-white/0 to-white/8 bg-origin-border transition-colors hover:bg-white/10"
           >
             <ChevronsRight className="size-4" />
           </SheetClose>

--- a/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
@@ -123,7 +123,7 @@ function HeaderIconButton({
       title={label}
       data-testid={testId}
       onClick={onClick}
-      className="flex size-8 items-center justify-center rounded-full border border-[#bcb6ef]/10 bg-gradient-to-b from-white/0 to-white/8 text-[#f2f3f7] transition-colors hover:bg-white/10"
+      className="flex size-8 items-center justify-center rounded-full border border-[#bcb6ef]/10 bg-gradient-to-b from-white/0 to-white/8 bg-origin-border text-[#f2f3f7] transition-colors hover:bg-white/10"
     >
       {children}
     </button>

--- a/apps/webapp/src/modules/convert/components/ConvertPage.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertPage.tsx
@@ -99,6 +99,7 @@ export function ConvertPage() {
 
         <Button
           variant="primary"
+          size="xl"
           className="w-full"
           disabled={reviewDisabled}
           onClick={launchOrConnect}

--- a/apps/webapp/src/modules/morpho/components/VaultPositionCard.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultPositionCard.tsx
@@ -132,6 +132,7 @@ export function VaultPositionCard({
         <div className="flex flex-col gap-3">
           <Button
             variant="primary"
+            size="l"
             className="w-full"
             onClick={() => openSupply(modalArgs)}
             disabled={!isConnected}
@@ -142,6 +143,7 @@ export function VaultPositionCard({
           {rewardsData?.hasClaimableRewards && (
             <Button
               variant="secondary"
+              size="l"
               className="w-full"
               onClick={() => openClaim({ kind: 'vault', vaultAddress })}
               data-testid="vault-position-claim"
@@ -151,6 +153,7 @@ export function VaultPositionCard({
           )}
           <Button
             variant="secondary"
+            size="l"
             className="w-full"
             onClick={() => openWithdraw(modalArgs)}
             disabled={!isConnected}

--- a/apps/webapp/src/modules/pendle/components/PendleMaturedPositionCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMaturedPositionCard.tsx
@@ -72,6 +72,7 @@ export const PendleMaturedPositionCard = ({ market, ptBalance }: PendleMaturedPo
         )}
         <Button
           variant="primary"
+          size="l"
           className="mt-4 w-full"
           onClick={openRedeemModal}
           disabled={!isRedeemable || !isPrepared || previewLoading}

--- a/apps/webapp/src/modules/pendle/components/PendlePositionCard.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendlePositionCard.tsx
@@ -132,6 +132,7 @@ function PendleSupplyCard({
 
       <Button
         variant="primary"
+        size="l"
         className="w-full"
         onClick={onSupplyOrConnect}
         data-testid="pendle-supply-cta"
@@ -222,6 +223,7 @@ export function PendlePositionCard({ market }: { market: PendleMarketConfig }) {
         <div className="flex flex-col gap-3">
           <Button
             variant="primary"
+            size="l"
             className="w-full"
             onClick={() => openSupply(market)}
             disabled={!isConnected}
@@ -231,6 +233,7 @@ export function PendlePositionCard({ market }: { market: PendleMarketConfig }) {
           </Button>
           <Button
             variant="secondary"
+            size="l"
             className="w-full"
             onClick={() => openWithdraw(market)}
             disabled={!isConnected}

--- a/apps/webapp/src/modules/pendle/components/PendleReadyToRedeemTable.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleReadyToRedeemTable.tsx
@@ -110,8 +110,7 @@ const PendleMaturedRow = ({ market, ptBalance }: RowProps) => {
       <TableCell className="text-right">
         <Button
           variant="primary"
-          size="sm"
-          className="rounded-xl px-4"
+          size="m"
           onClick={openRedeemModal}
           disabled={!isPrepared}
           data-testid="pendle-row-redeem-button"

--- a/apps/webapp/src/modules/portfolio/components/AllocateStablecoinsBanner.tsx
+++ b/apps/webapp/src/modules/portfolio/components/AllocateStablecoinsBanner.tsx
@@ -43,7 +43,7 @@ export function AllocateStablecoinsBanner({
         </Text>
       </div>
 
-      <Button variant="primary" className="shrink-0" onClick={onAllocate}>
+      <Button variant="primary" size="l" className="shrink-0" onClick={onAllocate}>
         <Trans>Allocate your stablecoins</Trans>
       </Button>
     </Card>

--- a/apps/webapp/src/modules/portfolio/components/ConnectWalletCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/ConnectWalletCard.tsx
@@ -26,7 +26,7 @@ export function ConnectWalletCard() {
           </Trans>
         </Text>
       </div>
-      <Button variant="connect" onClick={connect} data-testid="portfolio-connect-card-button">
+      <Button variant="primary" size="xl" onClick={connect} data-testid="portfolio-connect-card-button">
         <Trans>Connect wallet</Trans>
       </Button>
     </Card>

--- a/apps/webapp/src/modules/portfolio/components/EarnMarketplaceCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/EarnMarketplaceCard.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
-import { ArrowRight } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import type { EarnProductRow, EarnRiskTier } from '@/hooks';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Text } from '@/modules/layout/components/Typography';
 import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
@@ -58,15 +58,15 @@ export function EarnMarketplaceCard({ row, onStart }: { row: EarnProductRow; onS
         </Stat>
       </div>
 
-      <button
-        type="button"
+      <Button
+        variant="primary"
+        size="l"
+        className="w-full"
         onClick={onStart}
-        className="text-text hover:text-textSecondary flex w-full items-center justify-between border-t pt-4 text-sm font-medium transition-colors"
         data-testid="earn-marketplace-card-start"
       >
         <Trans>Start earning</Trans>
-        <ArrowRight className="h-4 w-4" />
-      </button>
+      </Button>
     </Card>
   );
 }

--- a/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
+++ b/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
@@ -78,7 +78,12 @@ export function IdleStablecoinsTable({
                 </Text>
               </div>
 
-              <Button variant="primary" className={ACTION_COL} onClick={() => onSupply(token.symbol)}>
+              <Button
+                variant="primary"
+                size="m"
+                className={ACTION_COL}
+                onClick={() => onSupply(token.symbol)}
+              >
                 <Trans>Supply</Trans>
               </Button>
             </div>

--- a/apps/webapp/src/modules/portfolio/components/PortfolioStatistics.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioStatistics.tsx
@@ -52,7 +52,7 @@ export function PortfolioStatistics() {
             <Stat label={<Trans>Savings TVL</Trans>} value={savingsTvl} />
             <Stat label={<Trans>Rewards TVL</Trans>} value={rewardsTvl} />
           </div>
-          <Button asChild variant="secondary" className="w-fit">
+          <Button asChild variant="primary" size="l" className="w-fit">
             <a href={INSIGHTS_URL} target="_blank" rel="noreferrer">
               <Trans>Get more insights</Trans>
             </a>

--- a/apps/webapp/src/modules/portfolio/components/PositionCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PositionCard.tsx
@@ -75,10 +75,22 @@ export function PositionCard({
       </div>
 
       <div className="mt-1 flex gap-2">
-        <Button variant="primary" className="flex-1" onClick={onSupply} data-testid="position-card-supply">
+        <Button
+          variant="primary"
+          size="l"
+          className="flex-1"
+          onClick={onSupply}
+          data-testid="position-card-supply"
+        >
           <Trans>Supply</Trans>
         </Button>
-        <Button variant="outline" className="flex-1" onClick={onManage} data-testid="position-card-manage">
+        <Button
+          variant="secondary"
+          size="l"
+          className="flex-1"
+          onClick={onManage}
+          data-testid="position-card-manage"
+        >
           <Trans>Manage</Trans>
         </Button>
       </div>

--- a/apps/webapp/src/modules/portfolio/components/SavingsTvlCallout.tsx
+++ b/apps/webapp/src/modules/portfolio/components/SavingsTvlCallout.tsx
@@ -34,7 +34,7 @@ export function SavingsTvlCallout({ tvlUsd, savingsRate }: { tvlUsd: number; sav
         </Text>
       </div>
 
-      <Button variant="primary" className="shrink-0" onClick={() => setOpen(true)}>
+      <Button variant="primary" size="l" className="shrink-0" onClick={() => setOpen(true)}>
         <Trans>Simulate earnings</Trans>
       </Button>
 

--- a/apps/webapp/src/modules/rewards/components/RewardsPositionCard.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsPositionCard.tsx
@@ -189,6 +189,7 @@ export function RewardsPositionCard({
           {!isDeprecated && (
             <Button
               variant="primary"
+              size="l"
               className="w-full"
               onClick={() => openSupply(modalArgs)}
               disabled={!isConnected}
@@ -200,6 +201,7 @@ export function RewardsPositionCard({
           {hasClaimable && (
             <Button
               variant="secondary"
+              size="l"
               className="w-full"
               onClick={() => openClaim({ kind: 'reward-contract', address: contractAddress })}
               data-testid="rewards-position-claim"
@@ -209,6 +211,7 @@ export function RewardsPositionCard({
           )}
           <Button
             variant="secondary"
+            size="l"
             className="w-full"
             onClick={() => openWithdraw(modalArgs)}
             disabled={!isConnected}

--- a/apps/webapp/src/modules/rewards/components/RewardsSupplyCard.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsSupplyCard.tsx
@@ -127,6 +127,7 @@ export function RewardsSupplyCard({
       {onSupply && (
         <Button
           variant="primary"
+          size="l"
           className="w-full"
           onClick={onSupply}
           disabled={!isConnected}

--- a/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
@@ -122,6 +122,7 @@ export function SavingsPositionCard() {
         <div className="flex gap-3">
           <Button
             variant="primary"
+            size="l"
             className="flex-1"
             onClick={() => openSupply()}
             disabled={!isConnected}
@@ -131,6 +132,7 @@ export function SavingsPositionCard() {
           </Button>
           <Button
             variant="secondary"
+            size="l"
             className="flex-1"
             onClick={() => openWithdraw()}
             disabled={!isConnected}

--- a/apps/webapp/src/modules/savings/components/SavingsSupplyCard.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsSupplyCard.tsx
@@ -124,6 +124,7 @@ export function SavingsSupplyCard({ onSupply }: { onSupply: () => void }) {
 
       <Button
         variant="primary"
+        size="l"
         className="w-full"
         onClick={onSupplyOrConnect}
         data-testid="savings-supply-cta"

--- a/apps/webapp/src/modules/stake/components/LiquidationPostMortemModal.tsx
+++ b/apps/webapp/src/modules/stake/components/LiquidationPostMortemModal.tsx
@@ -358,6 +358,7 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
 
           <Button
             variant="primary"
+            size="xl"
             className="w-full"
             onClick={() => recovery.launch()}
             disabled={ctaDisabled}

--- a/apps/webapp/src/modules/stake/components/ManagePositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/ManagePositionTakeover.tsx
@@ -320,6 +320,7 @@ export function ManagePositionTakeover({
           </p>
           <Button
             variant="primary"
+            size="xl"
             onClick={launch}
             disabled={confirmDisabled}
             data-testid="stake-manage-confirm"

--- a/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
@@ -286,6 +286,7 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
           </p>
           <Button
             variant="primary"
+            size="xl"
             onClick={launch}
             disabled={confirmDisabled}
             data-testid="stake-takeover-confirm"

--- a/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
@@ -598,7 +598,7 @@ export function PositionDetailsModal({
 
           <div className="flex flex-col gap-3">
             {detail.vaultLoading ? (
-              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-14 w-full rounded-full" />
             ) : isInactive ? (
               <Button
                 variant="primary"

--- a/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
@@ -602,6 +602,7 @@ export function PositionDetailsModal({
             ) : isInactive ? (
               <Button
                 variant="primary"
+                size="xl"
                 className="w-full"
                 onClick={() => onReopen(detail.hasBorrowHistory)}
                 data-testid="stake-manage-cta-reopen"
@@ -612,6 +613,7 @@ export function PositionDetailsModal({
               <>
                 <Button
                   variant="primary"
+                  size="xl"
                   className="w-full"
                   onClick={() => onAction('stake')}
                   data-testid="stake-manage-cta-stake"
@@ -621,6 +623,7 @@ export function PositionDetailsModal({
                 {!hasDebt && (
                   <Button
                     variant="secondary"
+                    size="xl"
                     className="w-full"
                     onClick={() => onAction('borrow')}
                     data-testid="stake-manage-cta-borrow"

--- a/apps/webapp/src/modules/stake/components/StakeAboutTab.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeAboutTab.tsx
@@ -77,13 +77,8 @@ export function StakeAboutTab() {
 
         <div data-testid="stake-about-links" className="grid grid-cols-3 gap-4">
           {links.map(({ label, href, icon }, i) => (
-            <Button
-              key={i}
-              variant="outline"
-              className="border-border h-12 w-full gap-2 rounded-full bg-white/[0.03] hover:bg-white/[0.06]"
-              asChild
-            >
-              <a href={href} target="_blank" rel="noopener noreferrer" className="justify-center gap-2">
+            <Button key={i} variant="secondary" size="l" className="w-full" asChild>
+              <a href={href} target="_blank" rel="noopener noreferrer">
                 {icon}
                 {label}
               </a>

--- a/apps/webapp/src/modules/stake/components/StakeClaimModal.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeClaimModal.tsx
@@ -223,6 +223,7 @@ export function StakeClaimModal({ urnIndex, onClose }: { urnIndex: number; onClo
         <div className="flex gap-3">
           <Button
             variant={restakeAvailable ? 'secondary' : 'primary'}
+            size="xl"
             className="flex-1"
             onClick={() => launch(false)}
             disabled={claimDisabled}
@@ -233,6 +234,7 @@ export function StakeClaimModal({ urnIndex, onClose }: { urnIndex: number; onClo
           {restakeAvailable && (
             <Button
               variant="primary"
+              size="xl"
               className="flex-1"
               onClick={() => launch(true)}
               disabled={restakeDisabled}

--- a/apps/webapp/src/modules/stake/components/StakeEngineCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeEngineCard.tsx
@@ -151,6 +151,7 @@ export function StakeEngineCard() {
 
       <Button
         variant="primary"
+        size="l"
         className="w-full"
         onClick={onOpenPosition}
         data-testid="stake-open-position-cta"

--- a/apps/webapp/src/modules/stake/components/StakePositionRowBanner.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionRowBanner.tsx
@@ -131,11 +131,17 @@ export function StakePositionRowBanner({
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        <Button variant="primary" onClick={() => onRemediate('stake')} data-testid="stake-warning-stake-cta">
+        <Button
+          variant="primary"
+          size="m"
+          onClick={() => onRemediate('stake')}
+          data-testid="stake-warning-stake-cta"
+        >
           <Trans>Stake SKY</Trans>
         </Button>
         <Button
           variant="secondary"
+          size="m"
           onClick={() => onRemediate('repay')}
           data-testid="stake-warning-repay-cta"
         >

--- a/apps/webapp/src/modules/stake/components/StakeSummaryCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeSummaryCard.tsx
@@ -226,6 +226,7 @@ export function StakeSummaryCard({ positions }: { positions?: StakeUserPosition[
 
       <Button
         variant="primary"
+        size="l"
         className="w-full"
         onClick={onOpenPosition}
         data-testid="stake-open-new-position-cta"

--- a/apps/webapp/src/modules/stusds/components/StUsdsPositionCard.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUsdsPositionCard.tsx
@@ -96,6 +96,7 @@ function StUsdsSupplyCard({ rate, onSupply }: { rate?: number; onSupply: () => v
 
       <Button
         variant="primary"
+        size="l"
         className="w-full"
         onClick={onSupplyOrConnect}
         data-testid="stusds-supply-cta"
@@ -166,6 +167,7 @@ export function StUsdsPositionCard() {
         <div className="flex flex-col gap-3">
           <Button
             variant="primary"
+            size="l"
             className="w-full"
             onClick={() => openSupply()}
             disabled={!isConnected}
@@ -175,6 +177,7 @@ export function StUsdsPositionCard() {
           </Button>
           <Button
             variant="secondary"
+            size="l"
             className="w-full"
             onClick={() => openWithdraw()}
             disabled={!isConnected}

--- a/apps/webapp/src/modules/ui/components/TransactionModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TransactionModal.tsx
@@ -343,7 +343,8 @@ export function TransactionModal({
               >
                 {showBatchToggle && <BatchToggle />}
                 <Button
-                  variant="primaryAlt"
+                  variant="primary"
+                  size="xl"
                   className="w-full"
                   onClick={handleConfirm}
                   disabled={firstScreenConfirmDisabled}
@@ -379,29 +380,29 @@ export function TransactionModal({
 
                 <div className="w-full">
                   {txStatus === TxStatus.INITIALIZED && (
-                    <Button variant="primaryAlt" className="w-full" disabled>
+                    <Button variant="primary" size="xl" className="w-full" loading>
                       <Trans>Waiting for confirmation</Trans>
                     </Button>
                   )}
 
                   {txStatus === TxStatus.LOADING && (
-                    <Button variant="primaryAlt" className="w-full" disabled>
+                    <Button variant="primary" size="xl" className="w-full" loading>
                       <Trans>Processing</Trans>
                     </Button>
                   )}
 
                   {(txStatus === TxStatus.SUCCESS || txStatus === TxStatus.CANCELLED) && (
-                    <Button variant="primaryAlt" className="w-full" onClick={handleClose}>
+                    <Button variant="primary" size="xl" className="w-full" onClick={handleClose}>
                       {successLabel ?? <Trans>Done</Trans>}
                     </Button>
                   )}
 
                   {txStatus === TxStatus.ERROR && (
                     <div className="flex w-full gap-3">
-                      <Button variant="outline" className="flex-1" onClick={handleBack}>
+                      <Button variant="secondary" size="xl" className="flex-1" onClick={handleBack}>
                         <Trans>Back</Trans>
                       </Button>
-                      <Button variant="primaryAlt" className="flex-1" onClick={handleRetry}>
+                      <Button variant="primary" size="xl" className="flex-1" onClick={handleRetry}>
                         {errorLabel ?? <Trans>Retry</Trans>}
                       </Button>
                     </div>

--- a/apps/webapp/src/modules/vaults/components/ClaimableRewardsTable.tsx
+++ b/apps/webapp/src/modules/vaults/components/ClaimableRewardsTable.tsx
@@ -169,6 +169,7 @@ export function ClaimableRewardsTable() {
       <div className="flex justify-end">
         <Button
           variant="primary"
+          size="m"
           disabled={!hasSelection || !claimRewards.prepared}
           onClick={() =>
             launch({


### PR DESCRIPTION
Stacked on #1714 (`redesign/card-styles`). First button batch from the design system (Figma 5010:7958): the plain **Button** component's Primary and Secondary types. `Button / Icon`, `Button / Dropdown` and `Button / Mini` are separate components and land in later PRs.

## Component

- `primary` / `secondary` variants of the canonical `Button` restyled in place: gradient pill (`#2a197d → #6a6cfb`) / white-veil pill, solid hover (`#504dff`) and pressed (`#4836f5`) fills, edge-hugging `#c2ccff` focus ring, shared disabled+loading recipe on `glassSurface` with `#636685` text.
- New size scale `xl | l | m | s` (56/48/40/32px, CircleStd Medium) alongside the legacy keys. Icons stay **children**: the size classes pull edge SVGs to the Figma 12px icon inset (vs 20px text inset) with negative margins, so no icon-slot API.
- New `loading` prop: disables the button and prepends the design-system 3-dot loader (static Figma glyph given a staggered pulse), 24px on xl / 16px otherwise.
- New tokens (dark = Figma source values; light interim, G2 owns parity): `brandHover`, `brandPressed`, `focusRing`, `fgTertiary`, `fgConsistent`, `button-gradient-start/end`. The existing glass tokens already matched the Figma button values exactly.

## App-wide sweep (mapped against the Sky App UI Figma, per-screen)

- **Transaction modal**: all CTAs primary xl; INITIALIZED/LOADING states use the `loading` prop; error footer Back = secondary xl, Retry = primary xl.
- **Product detail cards** (savings, vault, rewards, stUSDS, Pendle): Supply/Withdraw/Claim at l; Pendle redeem row + vault claim-table footer at m.
- **Portfolio**: connect hero `connect`→primary xl; position-card Manage `outline`→secondary l; "Get more insights" secondary→primary l per the mock; idle-stablecoin rows m; the earn-marketplace card's text+arrow footer becomes the mock's full-width primary l button.
- **Staking**: open-position CTAs l; takeover Confirms + all stake modals xl; liquidation-warning pair m; About links row drops its hand-rolled outline recipe for secondary l with icons.
- **Convert**: Review CTA xl. **Earn page**: no-op — it only uses the later-batch button components.

Deliberately untouched: chrome surfaces (Terms, ExternalLinkModal, NotFound, banners, FooterLinks) keep default sizing until their screens are redesigned; the Pendle "Max" chip; size S ships unused (no screen calls for it yet).

## Testing

- Full unit suite 1859/1859, typecheck + lint clean.
- Browser-verified on `dev:mock` in both themes: portfolio hero/marketplace cards, savings product page, and the supply modal's xl CTA + disabled/loading recipe.