### PR TITLE
H8 · Tables — header, typed cells, per-surface table patterns (APP-352)

### DIFF
--- a/apps/webapp/src/components/product/EarnTable.tsx
+++ b/apps/webapp/src/components/product/EarnTable.tsx
@@ -30,8 +30,6 @@ export type EarnTableRowItem = {
   rate30d: string;
   tvl: string;
   position: string;
-  /** The user holds a position: mint iconbox border + status dot. */
-  hasPosition?: boolean;
   /** Numeric cells render skeletons while true. */
   isLoading?: boolean;
 };
@@ -125,10 +123,12 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
             onKeyDown={event => handleRowKeyDown(event, row.id)}
             className="cursor-pointer"
           >
+            {/* The Figma active-position iconbox (CellToken `active`) is not
+                wired here on purpose: its trigger follows product logic that
+                is not part of the H8 batch. */}
             <TableCell>
               <CellToken
                 icon={row.icon}
-                active={row.hasPosition}
                 title={row.name}
                 titleSuffix={row.nameSuffix}
                 subtitle={

--- a/apps/webapp/src/components/product/EarnTable.tsx
+++ b/apps/webapp/src/components/product/EarnTable.tsx
@@ -48,12 +48,13 @@ const COLUMNS: { key: EarnTableColumn; label: ReactNode }[] = [
 
 /**
  * Formatted numeric value → typed cell: percent strings get the dimmed unit
- * (Type=Percent), the en-dash placeholder gets Type=Empty, USD strings render
- * as the TableCell default (Type=Text).
+ * (Type=Percent), dash placeholders (EarnPage's en-dash, useEarnMarketplace's
+ * em-dash NO_RATE) get Type=Empty, USD strings render as the TableCell
+ * default (Type=Text).
  */
 function NumericValue({ value, isLoading }: { value: string; isLoading?: boolean }) {
   if (isLoading) return <Skeleton className="h-4 w-12" />;
-  if (value === '–') return <CellEmpty />;
+  if (value === '–' || value === '—') return <CellEmpty />;
   if (value.endsWith('%')) return <CellPercent value={value.slice(0, -1)} />;
   return value;
 }

--- a/apps/webapp/src/components/product/EarnTable.tsx
+++ b/apps/webapp/src/components/product/EarnTable.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { CellEmpty, CellPercent, CellToken } from '@/components/ui/table-cells';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { EarnRiskTier } from '@/hooks';
 import { RiskTierMeter } from './RiskMeter';
@@ -14,7 +15,7 @@ export type EarnTableSort = { column: EarnTableColumn; direction: 'asc' | 'desc'
 export type EarnTableRowItem = {
   id: string;
   name: string;
-  /** Product icon slot (the caller injects its TokenIcon). */
+  /** 28px product logo for the token iconbox (the caller injects its TokenIcon). */
   icon?: ReactNode;
   /** Optional glyph rendered after the name (e.g. a provider logo). */
   nameSuffix?: ReactNode;
@@ -29,6 +30,8 @@ export type EarnTableRowItem = {
   rate30d: string;
   tvl: string;
   position: string;
+  /** The user holds a position: mint iconbox border + status dot. */
+  hasPosition?: boolean;
   /** Numeric cells render skeletons while true. */
   isLoading?: boolean;
 };
@@ -43,20 +46,16 @@ const COLUMNS: { key: EarnTableColumn; label: ReactNode }[] = [
   { key: 'position', label: <Trans>My position</Trans> }
 ];
 
-// Card-style rows: the row spacing comes from border-separate on the table,
-// the card surface from the cells (rounded on the outer edges), so the ui
-// TableRow's own border/hover treatments are neutralized.
-const rowClasses =
-  'group/row cursor-pointer border-0 last:border-b-0 has-[td]:hover:bg-transparent has-[td]:active:bg-transparent has-[td]:focus:border-y-0';
-// Container-card surface for contrast against the page background, deepening
-// on hover (surface-tint hovers go nearly transparent over the bright bg).
-const cellClasses =
-  'bg-container group-hover/row:bg-containerDark transition-colors first:rounded-l-2xl last:rounded-r-2xl';
-
-function NumericCell({ value, isLoading }: { value: string; isLoading?: boolean }) {
-  return (
-    <TableCell className={cellClasses}>{isLoading ? <Skeleton className="h-4 w-12" /> : value}</TableCell>
-  );
+/**
+ * Formatted numeric value → typed cell: percent strings get the dimmed unit
+ * (Type=Percent), the en-dash placeholder gets Type=Empty, USD strings render
+ * as the TableCell default (Type=Text).
+ */
+function NumericValue({ value, isLoading }: { value: string; isLoading?: boolean }) {
+  if (isLoading) return <Skeleton className="h-4 w-12" />;
+  if (value === '–') return <CellEmpty />;
+  if (value.endsWith('%')) return <CellPercent value={value.slice(0, -1)} />;
+  return value;
 }
 
 export type EarnTableProps = {
@@ -67,8 +66,9 @@ export type EarnTableProps = {
 };
 
 /**
- * The Earn Opportunities table (L1): layout only — rows arrive filtered,
- * sorted and formatted; sorting/selection intent is reported via callbacks.
+ * The Earn Opportunities table (Figma Table/Earn 5178:37463): layout only —
+ * rows arrive filtered, sorted and formatted; sorting/selection intent is
+ * reported via callbacks. Surface, header and hover come from ui/table.
  */
 export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTableProps) {
   const handleRowKeyDown = (event: KeyboardEvent, id: string) => {
@@ -79,7 +79,7 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
   };
 
   return (
-    <Table className="border-separate border-spacing-y-2" data-testid="earn-opportunities-table">
+    <Table data-testid="earn-opportunities-table">
       <TableHeader>
         <TableRow>
           {COLUMNS.map(column => {
@@ -87,6 +87,7 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
             return (
               <TableHead
                 key={column.key}
+                className={cn(column.key === 'token' && 'w-[34%]')}
                 aria-sort={isSorted ? (sort.direction === 'asc' ? 'ascending' : 'descending') : undefined}
               >
                 <button
@@ -94,8 +95,8 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
                   data-testid={`earn-sort-${column.key}`}
                   onClick={() => onSortChange(column.key)}
                   className={cn(
-                    'hover:text-text inline-flex items-center gap-1 transition-colors',
-                    isSorted && 'text-text'
+                    'hover:text-fgPrimary inline-flex items-center gap-1 transition-colors',
+                    isSorted && 'text-fgPrimary'
                   )}
                 >
                   {column.label}
@@ -121,17 +122,16 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
             tabIndex={onRowSelect ? 0 : undefined}
             onClick={() => onRowSelect?.(row.id)}
             onKeyDown={event => handleRowKeyDown(event, row.id)}
-            className={rowClasses}
+            className="cursor-pointer"
           >
-            <TableCell className={cellClasses}>
-              <div className="flex items-center gap-3">
-                {row.icon}
-                <div className="flex flex-col gap-0.5">
-                  <span className="flex items-center gap-1.5 font-medium">
-                    {row.name}
-                    {row.nameSuffix}
-                  </span>
-                  <span className="text-textSecondary flex items-center gap-1.5 text-xs">
+            <TableCell>
+              <CellToken
+                icon={row.icon}
+                active={row.hasPosition}
+                title={row.name}
+                titleSuffix={row.nameSuffix}
+                subtitle={
+                  <>
                     <Trans>Supply:</Trans>
                     {row.supply}
                     {row.maturityLabel && (
@@ -140,18 +140,26 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
                         {row.maturityLabel}
                       </>
                     )}
-                  </span>
-                </div>
-              </div>
+                  </>
+                }
+              />
             </TableCell>
-            <TableCell className={cellClasses}>{row.network}</TableCell>
-            <TableCell className={cellClasses}>
+            <TableCell>{row.network}</TableCell>
+            <TableCell>
               <RiskTierMeter tier={row.risk} />
             </TableCell>
-            <NumericCell value={row.rate} isLoading={row.isLoading} />
-            <NumericCell value={row.rate30d} isLoading={row.isLoading} />
-            <NumericCell value={row.tvl} isLoading={row.isLoading} />
-            <NumericCell value={row.position} isLoading={row.isLoading} />
+            <TableCell>
+              <NumericValue value={row.rate} isLoading={row.isLoading} />
+            </TableCell>
+            <TableCell>
+              <NumericValue value={row.rate30d} isLoading={row.isLoading} />
+            </TableCell>
+            <TableCell>
+              <NumericValue value={row.tvl} isLoading={row.isLoading} />
+            </TableCell>
+            <TableCell>
+              <NumericValue value={row.position} isLoading={row.isLoading} />
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/apps/webapp/src/components/product/ProductTransactionsTable.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.tsx
@@ -121,12 +121,16 @@ export function ProductTransactionsTable<T>({
                 <Fragment key={rowKey(row)}>
                   <TableRow
                     data-testid={rowTestId?.(row)}
-                    role={onRowClick ? 'button' : undefined}
+                    // No role="button": overriding the native row role breaks
+                    // table navigation for assistive tech (CodeRabbit).
                     tabIndex={onRowClick ? 0 : undefined}
                     onClick={onRowClick ? () => onRowClick(row) : undefined}
                     onKeyDown={
                       onRowClick
                         ? event => {
+                            // Only activate on the row itself — Enter on a
+                            // nested link/button must keep its native action.
+                            if (event.target !== event.currentTarget) return;
                             if (event.key === 'Enter' || event.key === ' ') {
                               event.preventDefault();
                               onRowClick(row);

--- a/apps/webapp/src/components/product/ProductTransactionsTable.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.tsx
@@ -60,7 +60,7 @@ function columnWidths<T>(columns: ProductTransactionColumn<T>[]): string[] {
 function StateRow({ colSpan, children }: { colSpan: number; children: ReactNode }) {
   return (
     <TableRow className="pointer-events-none">
-      <TableCell colSpan={colSpan} className="text-fgSecondary text-center font-graphik tracking-normal">
+      <TableCell colSpan={colSpan} className="text-fgSecondary font-graphik text-center tracking-normal">
         {children}
       </TableCell>
     </TableRow>

--- a/apps/webapp/src/components/product/ProductTransactionsTable.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.tsx
@@ -1,17 +1,18 @@
 import { Fragment, ReactNode, useState } from 'react';
-import { ArrowUpRight } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { CustomPagination } from '@/modules/ui/components/CustomPagination';
 import { paginate } from './paginate';
 
 /**
- * Reusable transactions table for product-detail pages (Figma C3). Column-driven
- * so each module defines its own columns — Savings/Vaults/Rewards/Stake history
- * differ — while the shared chrome (rounded rows, loading/empty/error states,
- * status pill, common cells) lives here. components/product layer: module-specific
- * visuals are injected through the column `cell` renderers.
+ * Reusable transactions table for product-detail pages (Figma Table/
+ * Transactions 5178:37513 and its Min/Stake flavours). Column-driven so each
+ * module defines its own columns — Savings/Vaults/Rewards/Stake history
+ * differ — while the shared chrome (ui/table surface, loading/empty/error
+ * states, pagination) lives here. Cell contents come from the design-system
+ * typed cells (ui/table-cells) via the column `cell` renderers.
  */
 
 export type ProductTransactionStatus = 'pending' | 'completed';
@@ -19,11 +20,9 @@ export type ProductTransactionStatus = 'pending' | 'completed';
 export interface ProductTransactionColumn<T> {
   id: string;
   header: ReactNode;
-  /** CSS grid track for this column (e.g. '1.5fr', '1fr', '140px'). */
+  /** Width hint: `fr` weights are converted to percentages, px pass through. */
   width: string;
   cell: (row: T) => ReactNode;
-  /** Right-align the header + cell (e.g. amounts). */
-  alignEnd?: boolean;
 }
 
 export interface ProductTransactionsTableProps<T> {
@@ -46,119 +45,25 @@ export interface ProductTransactionsTableProps<T> {
   renderBelowRow?: (row: T) => ReactNode;
 }
 
-// --- Reusable cells (compose these in a column's `cell`, or build your own) ---
-
-// The user-supplied status SVGs (colors carried via currentColor).
-function DotsIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
-      <circle cx="2.66668" cy="8.66658" r="1.33333" fill="currentColor" />
-      <circle cx="7.99999" cy="6.66659" r="1.33333" fill="currentColor" />
-      <circle cx="13.3333" cy="8.66658" r="1.33333" fill="currentColor" />
-    </svg>
+// The legacy grid API declared tracks ('1.5fr', '140px'); a <table> wants
+// width hints instead, so fr weights become percentages of the fr total.
+function columnWidths<T>(columns: ProductTransactionColumn<T>[]): string[] {
+  const frTotal = columns.reduce(
+    (total, column) => total + (column.width.endsWith('fr') ? parseFloat(column.width) : 0),
+    0
+  );
+  return columns.map(column =>
+    column.width.endsWith('fr') ? `${(parseFloat(column.width) / frTotal) * 100}%` : column.width
   );
 }
 
-function CheckIcon() {
+function StateRow({ colSpan, children }: { colSpan: number; children: ReactNode }) {
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M11.3567 2.6484C11.5519 2.84366 11.5519 3.16024 11.3567 3.35551L5.35225 9.35992C5.15699 9.55519 4.84041 9.55519 4.64514 9.35993L0.633753 5.34858C0.43849 5.15332 0.438488 4.83673 0.633749 4.64147C0.82901 4.44621 1.14559 4.44621 1.34086 4.64147L4.99869 8.29926L10.6495 2.6484C10.8448 2.45314 11.1614 2.45314 11.3567 2.6484Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
-export function TxStatusBadge({ status }: { status: ProductTransactionStatus }) {
-  if (status === 'pending') {
-    // Figma: purple-tinted pill, accent dots, primary-text label (white in dark,
-    // ink in light via the `text-text` token). Border + tint carry across themes.
-    return (
-      <span className="text-text inline-flex w-fit items-center gap-1.5 rounded-full border border-[#9583ff]/20 bg-[#9583ff]/10 px-2.5 py-1 text-xs font-medium">
-        <span className="text-[#9583ff]">
-          <DotsIcon />
-        </span>
-        <Trans>Pending</Trans>
-      </span>
-    );
-  }
-  return (
-    <span className="text-text inline-flex w-fit items-center gap-1.5 rounded-full border border-[#5AD293]/40 bg-[#008f44]/15 px-2.5 py-1 text-xs font-medium">
-      <span className="text-[#5AD293]">
-        <CheckIcon />
-      </span>
-      <Trans>Completed</Trans>
-    </span>
-  );
-}
-
-/** Action cell: a circled glyph + label with an optional relative-time subline. */
-export function TxActionCell({
-  icon,
-  label,
-  timeAgo
-}: {
-  icon: ReactNode;
-  label: ReactNode;
-  timeAgo?: ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-3">
-      <span className="border-borderPrimary text-text flex h-9 w-9 shrink-0 items-center justify-center rounded-full border">
-        {icon}
-      </span>
-      <div className="flex flex-col">
-        <span className="text-text text-base font-medium tracking-[-0.16px]">{label}</span>
-        {timeAgo && <span className="text-textSecondary text-xs">{timeAgo}</span>}
-      </div>
-    </div>
-  );
-}
-
-/** Amount cell: an optional token icon + amount with an optional USD sub-value. */
-export function TxAmountCell({
-  icon,
-  amount,
-  usd
-}: {
-  icon?: ReactNode;
-  amount: ReactNode;
-  usd?: ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-2">
-      {icon && <span className="shrink-0">{icon}</span>}
-      <div className="flex flex-col">
-        <span className="text-text text-sm">{amount}</span>
-        {usd && <span className="text-textSecondary text-xs">{usd}</span>}
-      </div>
-    </div>
-  );
-}
-
-/** Truncated tx-hash with an external-explorer link. */
-export function TxHashLink({ label, href }: { label: ReactNode; href: string }) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      className="text-textSecondary hover:text-text flex w-fit items-center gap-1 text-sm transition-colors"
-    >
-      {label}
-      <ArrowUpRight className="h-3.5 w-3.5" />
-    </a>
-  );
-}
-
-function StateRow({ children }: { children: ReactNode }) {
-  return (
-    <div className="bg-container text-textSecondary rounded-[20px] px-4 py-8 text-center text-sm">
-      {children}
-    </div>
+    <TableRow className="pointer-events-none">
+      <TableCell colSpan={colSpan} className="text-fgSecondary text-center font-graphik tracking-normal">
+        {children}
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -176,80 +81,87 @@ export function ProductTransactionsTable<T>({
   rowTestId,
   renderBelowRow
 }: ProductTransactionsTableProps<T>) {
-  const gridStyle = { gridTemplateColumns: columns.map(column => column.width).join(' ') };
-
   const allRows = rows ?? [];
   const [page, setPage] = useState(1);
   const { rows: pageRows, totalPages } = paginate(allRows, pageSize, page);
   const showPagination = !isLoading && !error && totalPages > 1;
+  const widths = columnWidths(columns);
 
   return (
     <>
-      <div className="overflow-x-auto">
-        <div className="flex flex-col gap-4" style={{ minWidth }} data-testid={dataTestId}>
-          <div className="text-textSecondary grid items-center gap-4 px-4 text-xs" style={gridStyle}>
-            {columns.map(column => (
-              <span key={column.id} className={cn(column.alignEnd && 'text-right')}>
+      <Table style={{ minWidth }} data-testid={dataTestId}>
+        <TableHeader>
+          <TableRow>
+            {columns.map((column, index) => (
+              <TableHead key={column.id} style={{ width: widths[index] }}>
                 {column.header}
-              </span>
+              </TableHead>
             ))}
-          </div>
-
-          {/* Rows sit 2px apart (Figma); the gap-4 above keeps them off the header. */}
-          <div className="flex flex-col gap-0.5">
-            {isLoading ? (
-              Array.from({ length: 4 }).map((_, index) => (
-                <Skeleton key={index} className="h-[88px] rounded-[20px]" />
-              ))
-            ) : error ? (
-              <StateRow>
-                <Trans>Unable to load transactions, please try again later.</Trans>
-              </StateRow>
-            ) : allRows.length === 0 ? (
-              <StateRow>{emptyLabel ?? <Trans>No transactions yet.</Trans>}</StateRow>
-            ) : (
-              pageRows.map(row => {
-                const belowRow = renderBelowRow?.(row);
-                return (
-                  <Fragment key={rowKey(row)}>
-                    <div
-                      data-testid={rowTestId?.(row)}
-                      role={onRowClick ? 'button' : undefined}
-                      tabIndex={onRowClick ? 0 : undefined}
-                      onClick={onRowClick ? () => onRowClick(row) : undefined}
-                      onKeyDown={
-                        onRowClick
-                          ? event => {
-                              if (event.key === 'Enter' || event.key === ' ') {
-                                event.preventDefault();
-                                onRowClick(row);
-                              }
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading ? (
+            Array.from({ length: 4 }).map((_, index) => (
+              <TableRow key={index} className="pointer-events-none">
+                <TableCell colSpan={columns.length}>
+                  <Skeleton className="h-5 w-1/3" />
+                </TableCell>
+              </TableRow>
+            ))
+          ) : error ? (
+            <StateRow colSpan={columns.length}>
+              <Trans>Unable to load transactions, please try again later.</Trans>
+            </StateRow>
+          ) : allRows.length === 0 ? (
+            <StateRow colSpan={columns.length}>{emptyLabel ?? <Trans>No transactions yet.</Trans>}</StateRow>
+          ) : (
+            pageRows.map(row => {
+              const belowRow = renderBelowRow?.(row);
+              return (
+                <Fragment key={rowKey(row)}>
+                  <TableRow
+                    data-testid={rowTestId?.(row)}
+                    role={onRowClick ? 'button' : undefined}
+                    tabIndex={onRowClick ? 0 : undefined}
+                    onClick={onRowClick ? () => onRowClick(row) : undefined}
+                    onKeyDown={
+                      onRowClick
+                        ? event => {
+                            if (event.key === 'Enter' || event.key === ' ') {
+                              event.preventDefault();
+                              onRowClick(row);
                             }
-                          : undefined
-                      }
-                      // Figma C3 row: a glassmorphic card — translucent ink fill in dark,
-                      // a white gradient + white border in light (the `light:` scope), with
-                      // a 20px backdrop blur so the page shows through. (node 1:3906 / 67:4842)
-                      className={cn(
-                        'light:border-white light:from-white/40 light:to-white/60 light:hover:from-white/55 light:hover:to-white/70 grid min-h-[88px] items-center gap-4 rounded-[20px] border border-white/10 bg-linear-to-b from-[#0e0e20]/40 to-[#0e0e20]/40 px-4 py-3 backdrop-blur-[20px] transition-colors hover:from-[#0e0e20]/55 hover:to-[#0e0e20]/55',
-                        onRowClick && 'cursor-pointer'
-                      )}
-                      style={gridStyle}
-                    >
-                      {columns.map(column => (
-                        <div key={column.id} className={cn(column.alignEnd && 'flex justify-end')}>
-                          {column.cell(row)}
-                        </div>
-                      ))}
-                    </div>
-                    {belowRow && <div onClick={event => event.stopPropagation()}>{belowRow}</div>}
-                  </Fragment>
-                );
-              })
-            )}
-          </div>
-        </div>
-      </div>
+                          }
+                        : undefined
+                    }
+                    className={cn(onRowClick && 'cursor-pointer')}
+                  >
+                    {columns.map(column => (
+                      <TableCell key={column.id}>{column.cell(row)}</TableCell>
+                    ))}
+                  </TableRow>
+                  {belowRow && (
+                    // Chrome-less carrier row: transparent (the ! outranks the
+                    // row hover tint) and outside the clickable surface. If it
+                    // lands last it takes the last-row corner slot — banners
+                    // are rare and the radius loss is invisible on a
+                    // transparent cell.
+                    <TableRow>
+                      <TableCell
+                        colSpan={columns.length}
+                        className="h-auto bg-transparent! p-0"
+                        onClick={event => event.stopPropagation()}
+                      >
+                        {belowRow}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
       {showPagination && (
         <CustomPagination dataLength={allRows.length} itemsPerPage={pageSize} onPageChange={setPage} />
       )}

--- a/apps/webapp/src/components/product/RiskMeter.tsx
+++ b/apps/webapp/src/components/product/RiskMeter.tsx
@@ -17,15 +17,20 @@ export function RiskMeter({
   label?: string;
   className?: string;
 }) {
+  // Figma Badges/Risk (Table Cell Type=Risk): 15px bordered pill of three
+  // 8×3 segments; unlit segments are fg-quaternary at 40%.
   return (
     <div
       role={label ? 'img' : undefined}
       aria-label={label}
       aria-hidden={label ? undefined : true}
-      className={cn('bg-surface inline-flex items-center gap-0.5 rounded-full px-2 py-1.5', className)}
+      className={cn(
+        'border-glassBorder inline-flex h-[15px] items-center gap-px rounded-full border px-1.5',
+        className
+      )}
     >
       {segments.map((color, index) => (
-        <span key={index} className={cn('h-1 w-2.5 rounded-full', color ?? 'bg-text/10')} />
+        <span key={index} className={cn('h-[3px] w-2 rounded-[2px]', color ?? 'bg-fgQuaternary/40')} />
       ))}
     </div>
   );
@@ -33,10 +38,12 @@ export function RiskMeter({
 
 const TIERS: EarnRiskTier[] = ['low', 'moderate', 'advanced'];
 
+// Figma status palette: Low = fg-success, Medium = fg-warning. A 3-lit tier
+// never appears in the Figma patterns — error red pending design confirmation.
 const TIER_COLOR: Record<EarnRiskTier, string> = {
-  low: 'bg-green-400',
-  moderate: 'bg-orange-400',
-  advanced: 'bg-red-400'
+  low: 'bg-statusSuccess',
+  moderate: 'bg-statusWarning',
+  advanced: 'bg-error'
 };
 
 /** Compact product-risk indicator (Figma "Risk profile" cell): N segments lit in the tier color. */

--- a/apps/webapp/src/components/ui/steps.tsx
+++ b/apps/webapp/src/components/ui/steps.tsx
@@ -1,0 +1,213 @@
+import { ReactNode, useId } from 'react';
+import { Trans } from '@lingui/react/macro';
+
+import { cn } from '@/lib/cn';
+
+// Design-system transaction-steps pattern (Figma "Patterns / Steps",
+// 5200:30907 / 5200:30561 / 5119:21048). `Steps` is the assembled container
+// (header badges + item list); `StepsItem` is one row (icon + connector +
+// title). The Bundle flavour of the pattern has no per-item variant — bundled
+// flows differ only in the header badge and in every step being active at
+// once, both driven by the caller.
+
+export type StepState = 'upcoming' | 'active' | 'completed';
+
+// Figma Steps Icon Item (5119:21048): a 30px circle per state. Ring + fill are
+// SVG (the active ring is a gradient stroke, which CSS borders can't do); the
+// number is an HTML overlay so it uses the app font stack. Gradient stops map
+// to existing tokens: ring = brandHover→fgBrand, fill = the button gradient
+// pair. The completed greens (Figma bg/border-system-success-primary) have no
+// theme token yet, so they stay literal.
+function StepIcon({ state, stepNumber }: { state: StepState; stepNumber: number }) {
+  const id = useId();
+
+  return (
+    <div className="relative size-[30px] shrink-0">
+      {state === 'completed' ? (
+        <svg viewBox="0 0 30 30" className="absolute inset-0 size-full" aria-hidden="true">
+          <circle cx="15" cy="15" r="14.5" fill="none" stroke="#02C2A1" />
+          <circle cx="15" cy="15" r="12" fill="#00A186" />
+          <path
+            d="M19 12L13.5 17.5L11 15"
+            fill="none"
+            className="stroke-fgConsistent"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <>
+          <svg viewBox="0 0 30 30" className="absolute inset-0 size-full" aria-hidden="true">
+            {state === 'active' && (
+              <defs>
+                <linearGradient
+                  id={`${id}-ring`}
+                  x1="15"
+                  y1="0"
+                  x2="15"
+                  y2="30"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stopColor="var(--color-brandHover)" />
+                  <stop offset="1" stopColor="var(--color-fgBrand)" />
+                </linearGradient>
+                <linearGradient
+                  id={`${id}-fill`}
+                  x1="15"
+                  y1="3"
+                  x2="15"
+                  y2="27"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stopColor="var(--color-button-gradient-start)" />
+                  <stop offset="1" stopColor="var(--color-button-gradient-end)" />
+                </linearGradient>
+              </defs>
+            )}
+            <circle
+              cx="15"
+              cy="15"
+              r="14.5"
+              fill="none"
+              stroke={state === 'active' ? `url(#${id}-ring)` : 'var(--color-borderTertiary)'}
+            />
+            <circle
+              cx="15"
+              cy="15"
+              r="12"
+              fill={state === 'active' ? `url(#${id}-fill)` : 'rgba(188,182,239,0.2)'}
+            />
+          </svg>
+          <span
+            className={cn(
+              'font-circle absolute inset-0 flex items-center justify-center text-xs leading-3.5 font-medium tracking-[-0.24px]',
+              state === 'active' ? 'text-fgConsistent' : 'text-fgSecondary'
+            )}
+          >
+            {stepNumber}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+// The 2px connector under an item's icon fades from the item's state colour
+// into the idle track colour (Figma colors/bg/bg-quarternary).
+const connectorClasses: Record<StepState, string> = {
+  upcoming: 'bg-[rgba(188,182,239,0.2)]',
+  active: 'bg-linear-to-b from-brandHover to-[rgba(188,182,239,0.2)]',
+  completed: 'bg-linear-to-b from-[#00A186] to-[rgba(188,182,239,0.2)]'
+};
+
+export type StepsItemProps = {
+  stepNumber: number;
+  label: ReactNode;
+  /** Token rendered as a chip after the label (Figma Title's Token slot). */
+  tokenSymbol?: string;
+  /** 14px icon node for the token chip — supplied by the caller (the primitive stays icon-source agnostic). */
+  tokenIcon?: ReactNode;
+  state?: StepState;
+  /** Draw the connector line to the next item — every item except the last. */
+  showConnector?: boolean;
+  className?: string;
+};
+
+export function StepsItem({
+  stepNumber,
+  label,
+  tokenSymbol,
+  tokenIcon,
+  state = 'upcoming',
+  showConnector = false,
+  className
+}: StepsItemProps) {
+  return (
+    <li className={cn('flex w-full items-start gap-4', className)}>
+      <div className="flex w-[30px] flex-col items-center gap-1 self-stretch">
+        <StepIcon state={state} stepNumber={stepNumber} />
+        {showConnector && (
+          <div className={cn('min-h-px w-0.5 flex-1 rounded-full', connectorClasses[state])} />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="font-circle text-fgPrimary flex h-[30px] items-center gap-1.5 text-base leading-4.5 font-medium tracking-[-0.32px]">
+          <span className="truncate">{label}</span>
+          {tokenSymbol && (
+            <span className="flex shrink-0 items-center gap-[3px]">
+              {tokenIcon}
+              <span>{tokenSymbol}</span>
+            </span>
+          )}
+        </div>
+        {/* Spacer giving the connector its run to the next item (Figma 5205:31478). */}
+        {showConnector && <div className="h-5" aria-hidden="true" />}
+      </div>
+    </li>
+  );
+}
+
+/** Header pill (Figma Badge, h-24): `brand` is the Bundled treatment, `default` the neutral one. */
+export function StepsBadge({
+  variant = 'default',
+  children,
+  className
+}: {
+  variant?: 'brand' | 'default';
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'font-circle flex h-6 items-center gap-1 rounded-full px-2 text-xs leading-3.5 font-medium tracking-[-0.24px]',
+        // Figma components/status/bg-brand + fg-brand — not theme tokens yet.
+        variant === 'brand' ? 'bg-[rgba(156,160,229,0.1)] text-[#9CA9FF]' : 'bg-glassBadge text-fgSecondary',
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+// Figma Icons/Custom/lightning-filled (12px), inlined for the Bundled badge.
+function LightningIcon() {
+  return (
+    <svg viewBox="0 0 12 12" className="size-3 shrink-0" fill="currentColor" aria-hidden="true">
+      <path d="M7 4.96875L7.33333 0.5H6.66667L2 7.03125H5L4.66667 11.5H5.33333L10 4.96875H7Z" />
+    </svg>
+  );
+}
+
+export type StepsProps = {
+  /** Header title; defaults to "Actions". */
+  title?: ReactNode;
+  /** Show the "⚡ Bundled" badge next to the title (EIP-5792 batched flows). */
+  bundled?: boolean;
+  /** Right-aligned header badge content (e.g. "Confirm in the wallet"). */
+  badge?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+/** Assembled Steps Standard container (Figma 5200:30907): header row + item list. */
+export function Steps({ title, bundled = false, badge, children, className }: StepsProps) {
+  return (
+    <div className={cn('flex w-full flex-col gap-5', className)}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-fgSecondary text-sm leading-5.5">{title ?? <Trans>Actions</Trans>}</span>
+          {bundled && (
+            <StepsBadge variant="brand">
+              <LightningIcon />
+              <Trans>Bundled</Trans>
+            </StepsBadge>
+          )}
+        </div>
+        {badge && <StepsBadge>{badge}</StepsBadge>}
+      </div>
+      <ol className="flex flex-col gap-1">{children}</ol>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/ui/table-cells.tsx
+++ b/apps/webapp/src/components/ui/table-cells.tsx
@@ -1,0 +1,376 @@
+import { ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Trans } from '@lingui/react/macro';
+import { cn } from '@/lib/cn';
+import { IconStack } from '@/modules/ui/components/TokenIconStack';
+
+// Design-system typed table cells (Figma Table Cell 5032:9625, 17 types).
+// These are cell *contents*: the surface, height and padding live on the
+// ui/table TableCell (or an equivalent grid track), so the same components
+// serve both <table>- and grid-built tables. Two Figma types have no
+// component on purpose: Type=Text is the TableCell default (Label 5,
+// fg-primary — plain text needs no wrapper) and Type=Button is the existing
+// design-system <Button variant="primary" size="m"> rendered as-is.
+//
+// Typography per Figma: titles are Circular (Label 4 16/18 / Label 5 14/16),
+// secondary lines are Graphik (Body 6 12/18); the Hash cell is the only one
+// whose primary value uses the body font (Body 5 14/22).
+
+const label4 = 'font-circle text-base leading-[18px] font-medium tracking-[-0.32px]';
+const label5 = 'font-circle text-sm leading-4 font-medium tracking-[-0.28px]';
+const label6 = 'font-circle text-xs leading-[14px] font-medium tracking-[-0.24px]';
+const label7 = 'font-circle text-[11px] leading-3 font-medium tracking-[-0.22px]';
+const body6 = 'font-graphik text-xs leading-[18px] font-normal';
+
+// --- Small shared pieces ---------------------------------------------------
+
+/**
+ * The 36px circled-icon boxes the Token/Position/Action cells share
+ * (Figma Iconbox). `token` holds a 28px logo; `action`/`position` draw an
+ * inner 30px disc around a 16px glyph.
+ */
+export function TableIconBox({
+  variant = 'token',
+  active = false,
+  children,
+  className
+}: {
+  variant?: 'token' | 'action' | 'position';
+  /** Token-box "has a position" state: mint border + success status dot. */
+  active?: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  if (variant === 'token') {
+    return (
+      <span
+        className={cn(
+          'relative flex size-9 shrink-0 items-center justify-center rounded-full border-[1.5px]',
+          // The active border is a hardcoded hex in Figma too (no variable).
+          active ? 'border-[#8bf1ca]' : 'border-borderTertiary',
+          className
+        )}
+      >
+        {children}
+        {active && (
+          <span className="bg-statusSuccessSolid ring-pageBackground absolute top-0 right-0 size-2 rounded-full ring-2" />
+        )}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={cn(
+        'flex size-9 shrink-0 items-center justify-center rounded-full',
+        variant === 'action' ? 'border-glassBorder border p-[2px]' : 'border-statusSuccessBorder border-[1.5px] p-px',
+        className
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-full items-center justify-center rounded-full',
+          variant === 'action' ? 'bg-bgSecondary text-fgPrimary' : 'bg-statusSuccessBg text-statusSuccess'
+        )}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}
+
+/** Title-row chip of the Token Idle cell (rate / 1:1-parity badges). */
+export function CellBadge({
+  tone = 'neutral',
+  children
+}: {
+  tone?: 'success' | 'neutral';
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        label7,
+        'inline-flex h-[18px] shrink-0 items-center rounded-full px-1.5',
+        tone === 'success' ? 'bg-statusSuccessBg text-statusSuccess' : 'bg-bgTertiary text-fgSecondary'
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+// The Pending badge's three-dot glyph (Icons/Custom/dots).
+function DotsIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+      <circle cx="2" cy="6.5" r="1" fill="currentColor" />
+      <circle cx="6" cy="5" r="1" fill="currentColor" />
+      <circle cx="10" cy="6.5" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+      <path
+        d="M10 3L4.5 8.5L2 6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// Icons/General/move-up-right — the hash cell's external-link arrow.
+function MoveUpRightIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+      <path
+        d="M9.5 5.5V2.5H6.5M9.5 2.5L2.5 9.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// --- Typed cells -----------------------------------------------------------
+
+/** Type=Percent: numeric value with the `%` sign dimmed to fg-tertiary. */
+export function CellPercent({ value }: { value: ReactNode }) {
+  return (
+    <span className="flex items-center whitespace-nowrap">
+      {value}
+      <span className="text-fgTertiary">%</span>
+    </span>
+  );
+}
+
+/** Type=Empty: the en-dash placeholder for missing values. */
+export function CellEmpty() {
+  return <span className="text-fgTertiary">–</span>;
+}
+
+/** Type=Icon: the 16px row-link chevron (centered in fixed chevron columns). */
+export function CellChevron() {
+  return <ChevronRight className="text-fgTertiary size-4" aria-hidden />;
+}
+
+export type CellRiskTier = 'none' | 'low' | 'medium' | 'high';
+
+// Lit-segment colors per tier. High never appears in the Figma patterns —
+// error red is the working assumption, pending design confirmation.
+const RISK_SEGMENTS: Record<CellRiskTier, (string | null)[]> = {
+  none: [null, null, null],
+  low: ['bg-statusSuccess', null, null],
+  medium: ['bg-statusWarning', 'bg-statusWarning', null],
+  high: ['bg-error', 'bg-error', 'bg-error']
+};
+
+/** Type=Risk (Badges/Risk): bordered pill of three 8×3 segments. */
+export function CellRisk({ tier }: { tier: CellRiskTier }) {
+  return (
+    <span
+      data-testid="cell-risk"
+      data-tier={tier}
+      className="border-glassBorder inline-flex h-[15px] items-center gap-px rounded-full border px-1.5"
+    >
+      {RISK_SEGMENTS[tier].map((lit, index) => (
+        <span key={index} className={cn('h-[3px] w-2 rounded-[2px]', lit ?? 'bg-fgQuaternary/40')} />
+      ))}
+    </span>
+  );
+}
+
+export type CellStatusValue = 'pending' | 'completed';
+
+/** Type=Status: the Pending (brand) / Completed (success) pill. */
+export function CellStatus({ status }: { status: CellStatusValue }) {
+  return (
+    <span
+      className={cn(
+        label6,
+        'inline-flex h-6 items-center gap-1 rounded-full px-2',
+        status === 'pending' ? 'bg-statusBrandBg text-statusBrand' : 'bg-statusSuccessBg text-statusSuccess'
+      )}
+    >
+      {status === 'pending' ? (
+        <>
+          <DotsIcon />
+          <Trans>Pending</Trans>
+        </>
+      ) : (
+        <>
+          <CheckIcon />
+          <Trans>Completed</Trans>
+        </>
+      )}
+    </span>
+  );
+}
+
+/** Type=Networks: stack of 16px chain icons (size children `h-full w-full`). */
+export function CellNetworks({ children }: { children: ReactNode }) {
+  return <IconStack size={16}>{children}</IconStack>;
+}
+
+/**
+ * Type=Token: the main two-line product cell — 36px iconbox, Label 4 title
+ * (plus optional partner glyph) and a free-form Body 6 subtitle (the
+ * `Supply:` token stack, an optional `· date` suffix, …).
+ */
+export function CellToken({
+  icon,
+  title,
+  titleSuffix,
+  subtitle,
+  active
+}: {
+  /** 28px logo for the iconbox. */
+  icon: ReactNode;
+  title: ReactNode;
+  /** Optional 16px partner icon after the title (Figma `showMode`). */
+  titleSuffix?: ReactNode;
+  subtitle?: ReactNode;
+  /** Product has an active position: mint iconbox border + status dot. */
+  active?: boolean;
+}) {
+  return (
+    <span className="flex items-center gap-3">
+      <TableIconBox variant="token" active={active}>
+        {icon}
+      </TableIconBox>
+      <span className="flex flex-col gap-0.5">
+        <span className={cn(label4, 'text-fgPrimary flex items-center gap-1')}>
+          {title}
+          {titleSuffix}
+        </span>
+        {subtitle && (
+          <span className={cn(body6, 'text-fgSecondary flex items-center gap-1')}>{subtitle}</span>
+        )}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Type=Token Idle: token cell whose title row carries rate / parity badges
+ * (compose from CellBadge) and whose subtitle is the token's full name.
+ */
+export function CellTokenIdle({
+  icon,
+  symbol,
+  badges,
+  name
+}: {
+  /** 28px logo for the iconbox. */
+  icon: ReactNode;
+  symbol: ReactNode;
+  badges?: ReactNode;
+  name: ReactNode;
+}) {
+  return (
+    <span className="flex items-center gap-3">
+      <TableIconBox variant="token">{icon}</TableIconBox>
+      <span className="flex flex-col gap-0.5">
+        <span className={cn(label4, 'text-fgPrimary flex items-center gap-1')}>
+          {symbol}
+          {badges}
+        </span>
+        <span className={cn(body6, 'text-fgSecondary')}>{name}</span>
+      </span>
+    </span>
+  );
+}
+
+/** Type=Position: green position iconbox + Label 5 label (14px, not 16). */
+export function CellPosition({ icon, label }: { icon: ReactNode; label: ReactNode }) {
+  return (
+    <span className="flex items-center gap-3">
+      <TableIconBox variant="position">{icon}</TableIconBox>
+      <span className="text-fgPrimary">{label}</span>
+    </span>
+  );
+}
+
+/**
+ * Type=Action (and Type=Action and Position via `compact`): circled 16px
+ * action glyph + action name over a Body 6 subline (relative time, and for
+ * the compact stake flavour `· Position N`).
+ */
+export function CellAction({
+  icon,
+  label,
+  sublabel,
+  compact
+}: {
+  icon: ReactNode;
+  label: ReactNode;
+  sublabel?: ReactNode;
+  /** Label 5 title (Figma Type=Action and Position) instead of Label 4. */
+  compact?: boolean;
+}) {
+  return (
+    <span className="flex items-center gap-3">
+      <TableIconBox variant="action">{icon}</TableIconBox>
+      <span className="flex flex-col gap-0.5">
+        <span className={cn(compact ? label5 : label4, 'text-fgPrimary')}>{label}</span>
+        {sublabel && (
+          <span className={cn(body6, 'text-fgSecondary flex items-center gap-1')}>{sublabel}</span>
+        )}
+      </span>
+    </span>
+  );
+}
+
+/** Type=Product: 12px token logo + Label 5 product name. */
+export function CellProduct({ icon, label }: { icon?: ReactNode; label: ReactNode }) {
+  return (
+    <span className="flex items-center gap-1 whitespace-nowrap">
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+/** Type=Amount: two-line amount — 12px logo + value over a Body 6 USD line. */
+export function CellAmount({ icon, amount, usd }: { icon?: ReactNode; amount: ReactNode; usd?: ReactNode }) {
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="flex items-center gap-1 whitespace-nowrap">
+        {icon}
+        {amount}
+      </span>
+      {usd && <span className={cn(body6, 'text-fgSecondary')}>{usd}</span>}
+    </span>
+  );
+}
+
+/** Type=Amount with Token: USD value with a 12px token logo *after* it. */
+export function CellAmountWithToken({ amount, icon }: { amount: ReactNode; icon?: ReactNode }) {
+  return (
+    <span className="flex items-center gap-1 whitespace-nowrap">
+      {amount}
+      {icon}
+    </span>
+  );
+}
+
+/** Type=Hash: truncated tx hash linking to the explorer (Body 5 — the body font). */
+export function CellHash({ label, href }: { label: ReactNode; href: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={event => event.stopPropagation()}
+      className="text-fgSecondary hover:text-fgPrimary flex w-fit items-center gap-1 font-graphik text-sm leading-[22px] font-normal tracking-normal transition-colors"
+    >
+      {label}
+      <MoveUpRightIcon />
+    </a>
+  );
+}

--- a/apps/webapp/src/components/ui/table-cells.tsx
+++ b/apps/webapp/src/components/ui/table-cells.tsx
@@ -221,7 +221,7 @@ export function CellToken({
           {title}
           {titleSuffix}
         </span>
-        {subtitle && (
+        {subtitle != null && (
           <span className={cn(body6, 'text-fgSecondary flex items-center gap-1')}>{subtitle}</span>
         )}
       </span>
@@ -264,7 +264,7 @@ export function CellPosition({ icon, label }: { icon: ReactNode; label: ReactNod
   return (
     <span className="flex items-center gap-3">
       <TableIconBox variant="position">{icon}</TableIconBox>
-      <span className="text-fgPrimary">{label}</span>
+      <span className={cn(label5, 'text-fgPrimary')}>{label}</span>
     </span>
   );
 }
@@ -291,7 +291,7 @@ export function CellAction({
       <TableIconBox variant="action">{icon}</TableIconBox>
       <span className="flex flex-col gap-0.5">
         <span className={cn(compact ? label5 : label4, 'text-fgPrimary')}>{label}</span>
-        {sublabel && (
+        {sublabel != null && (
           <span className={cn(body6, 'text-fgSecondary flex items-center gap-1')}>{sublabel}</span>
         )}
       </span>
@@ -302,7 +302,7 @@ export function CellAction({
 /** Type=Product: 12px token logo + Label 5 product name. */
 export function CellProduct({ icon, label }: { icon?: ReactNode; label: ReactNode }) {
   return (
-    <span className="flex items-center gap-1 whitespace-nowrap">
+    <span className={cn(label5, 'text-fgPrimary flex items-center gap-1 whitespace-nowrap')}>
       {icon}
       {label}
     </span>
@@ -317,7 +317,7 @@ export function CellAmount({ icon, amount, usd }: { icon?: ReactNode; amount: Re
         {icon}
         {amount}
       </span>
-      {usd && <span className={cn(body6, 'text-fgSecondary')}>{usd}</span>}
+      {usd != null && <span className={cn(body6, 'text-fgSecondary')}>{usd}</span>}
     </span>
   );
 }

--- a/apps/webapp/src/components/ui/table-cells.tsx
+++ b/apps/webapp/src/components/ui/table-cells.tsx
@@ -7,10 +7,12 @@ import { IconStack } from '@/modules/ui/components/TokenIconStack';
 // Design-system typed table cells (Figma Table Cell 5032:9625, 17 types).
 // These are cell *contents*: the surface, height and padding live on the
 // ui/table TableCell (or an equivalent grid track), so the same components
-// serve both <table>- and grid-built tables. Two Figma types have no
-// component on purpose: Type=Text is the TableCell default (Label 5,
-// fg-primary — plain text needs no wrapper) and Type=Button is the existing
-// design-system <Button variant="primary" size="m"> rendered as-is.
+// serve both <table>- and grid-built tables. Three Figma types have no
+// component here on purpose: Type=Text is the TableCell default (Label 5,
+// fg-primary — plain text needs no wrapper), Type=Button is the existing
+// design-system <Button variant="primary" size="m"> rendered as-is, and
+// Type=Risk is the shared RiskMeter pill (components/product/RiskMeter —
+// one pill app-wide, restyled to the Figma Badges/Risk chrome).
 //
 // Typography per Figma: titles are Circular (Label 4 16/18 / Label 5 14/16),
 // secondary lines are Graphik (Body 6 12/18); the Hash cell is the only one
@@ -157,32 +159,6 @@ export function CellEmpty() {
 /** Type=Icon: the 16px row-link chevron (centered in fixed chevron columns). */
 export function CellChevron() {
   return <ChevronRight className="text-fgTertiary size-4" aria-hidden />;
-}
-
-export type CellRiskTier = 'none' | 'low' | 'medium' | 'high';
-
-// Lit-segment colors per tier. High never appears in the Figma patterns —
-// error red is the working assumption, pending design confirmation.
-const RISK_SEGMENTS: Record<CellRiskTier, (string | null)[]> = {
-  none: [null, null, null],
-  low: ['bg-statusSuccess', null, null],
-  medium: ['bg-statusWarning', 'bg-statusWarning', null],
-  high: ['bg-error', 'bg-error', 'bg-error']
-};
-
-/** Type=Risk (Badges/Risk): bordered pill of three 8×3 segments. */
-export function CellRisk({ tier }: { tier: CellRiskTier }) {
-  return (
-    <span
-      data-testid="cell-risk"
-      data-tier={tier}
-      className="border-glassBorder inline-flex h-[15px] items-center gap-px rounded-full border px-1.5"
-    >
-      {RISK_SEGMENTS[tier].map((lit, index) => (
-        <span key={index} className={cn('h-[3px] w-2 rounded-[2px]', lit ?? 'bg-fgQuaternary/40')} />
-      ))}
-    </span>
-  );
 }
 
 export type CellStatusValue = 'pending' | 'completed';

--- a/apps/webapp/src/components/ui/table-cells.tsx
+++ b/apps/webapp/src/components/ui/table-cells.tsx
@@ -64,7 +64,9 @@ export function TableIconBox({
     <span
       className={cn(
         'flex size-9 shrink-0 items-center justify-center rounded-full',
-        variant === 'action' ? 'border-glassBorder border p-[2px]' : 'border-statusSuccessBorder border-[1.5px] p-px',
+        variant === 'action'
+          ? 'border-glassBorder border p-[2px]'
+          : 'border-statusSuccessBorder border-[1.5px] p-px',
         className
       )}
     >
@@ -115,12 +117,7 @@ function DotsIcon() {
 function CheckIcon() {
   return (
     <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
-      <path
-        d="M10 3L4.5 8.5L2 6"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <path d="M10 3L4.5 8.5L2 6" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
@@ -343,7 +340,7 @@ export function CellHash({ label, href }: { label: ReactNode; href: string }) {
       target="_blank"
       rel="noreferrer"
       onClick={event => event.stopPropagation()}
-      className="text-fgSecondary hover:text-fgPrimary flex w-fit items-center gap-1 font-graphik text-sm leading-[22px] font-normal tracking-normal transition-colors"
+      className="text-fgSecondary hover:text-fgPrimary font-graphik flex w-fit items-center gap-1 text-sm leading-[22px] font-normal tracking-normal transition-colors"
     >
       {label}
       <MoveUpRightIcon />

--- a/apps/webapp/src/components/ui/table.tsx
+++ b/apps/webapp/src/components/ui/table.tsx
@@ -4,12 +4,28 @@ import { cn } from '@/lib/cn';
 import { HTMLMotionProps, motion } from 'motion/react';
 import { fadeAnimations } from '@/modules/ui/animation/presets';
 
+// Design-system table (Figma Patterns/Tables 5178:37455). The construction is
+// unusual: rows are separated by a 2px transparent gap (border-spacing, page
+// background showing through) instead of borders, cells carry the row surface
+// (bg-bgSecondary) so a row reads as one bar, and the *body* — not the table —
+// is a 24px-radius surface, so the outer corners live on the first/last data
+// row's edge cells. The header row is transparent and sits outside that
+// surface. All columns are left-aligned per Figma, including numeric ones.
+
 const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement> & { className?: string; wrapperClassName?: string }
 >(({ className, wrapperClassName, ...props }, ref) => (
   <div className={cn('relative w-full overflow-hidden', wrapperClassName)}>
-    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    <table
+      ref={ref}
+      className={cn(
+        'w-full border-separate border-spacing-y-[2px] caption-bottom',
+        '[&>tbody>tr:first-child>td:first-child]:rounded-tl-[24px] [&>tbody>tr:first-child>td:last-child]:rounded-tr-[24px] [&>tbody>tr:last-child>td:first-child]:rounded-bl-[24px] [&>tbody>tr:last-child>td:last-child]:rounded-br-[24px]',
+        className
+      )}
+      {...props}
+    />
   </div>
 ));
 Table.displayName = 'Table';
@@ -43,8 +59,12 @@ const TableRow = React.forwardRef<HTMLTableRowElement, HTMLMotionProps<'tr'>>(
     <motion.tr
       ref={ref}
       initial={false}
+      // The hover/selected tint must land on the cells (the row surface), not
+      // the tr: with border-separate a tr background would also paint under
+      // the 2px slits and the corner radii wouldn't clip it.
       className={cn(
-        'border-brandLight/20 has-[td]:hover:bg-brandLight/20 has-[td]:focus:border-brandLight/40 has-[td]:active:bg-brandLight/10 data-[state=selected]:bg-brandLight/10 border-t transition-colors last:border-b has-[td]:focus:border-y-2 has-[th]:border-0',
+        'group/row',
+        'has-[td]:hover:[&>td]:bg-bgTertiary data-[state=selected]:[&>td]:bg-bgTertiary',
         className
       )}
       variants={fadeAnimations}
@@ -60,8 +80,11 @@ const TableHead = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <th
     ref={ref}
+    // Body 6 label; 2px top + 12px bottom padding around the 18px line = the
+    // 32px Figma header row. First column indents 28px (24px cell inset + 4
+    // optical).
     className={cn(
-      'text-selectActive light:text-textSecondary h-4 px-4 py-2 text-left align-middle text-[13px] leading-none font-normal [&:has([role=checkbox])]:pr-0',
+      'text-fgSecondary px-2 pt-0.5 pb-3 text-left align-middle font-graphik text-xs leading-[18px] font-normal first:pl-7 [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}
@@ -75,8 +98,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
+    // Label 5 / fg-primary is the default cell value type; typed cells
+    // (table-cells.tsx) override locally. 24px first-column inset.
     className={cn(
-      'text-text h-14 p-4 align-middle text-base leading-normal font-normal [&:has([role=checkbox])]:pr-0',
+      'bg-bgSecondary text-fgPrimary font-circle h-[88px] px-2 align-middle text-sm leading-4 font-medium tracking-[-0.28px] transition-colors first:pl-6 [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}

--- a/apps/webapp/src/components/ui/table.tsx
+++ b/apps/webapp/src/components/ui/table.tsx
@@ -16,7 +16,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement> & { className?: string; wrapperClassName?: string }
 >(({ className, wrapperClassName, ...props }, ref) => (
-  <div className={cn('relative w-full overflow-hidden', wrapperClassName)}>
+  <div className={cn('relative w-full overflow-x-auto', wrapperClassName)}>
     <table
       ref={ref}
       className={cn(

--- a/apps/webapp/src/components/ui/table.tsx
+++ b/apps/webapp/src/components/ui/table.tsx
@@ -20,7 +20,7 @@ const Table = React.forwardRef<
     <table
       ref={ref}
       className={cn(
-        'w-full border-separate border-spacing-y-[2px] caption-bottom',
+        'w-full caption-bottom border-separate border-spacing-y-[2px]',
         '[&>tbody>tr:first-child>td:first-child]:rounded-tl-[24px] [&>tbody>tr:first-child>td:last-child]:rounded-tr-[24px] [&>tbody>tr:last-child>td:first-child]:rounded-bl-[24px] [&>tbody>tr:last-child>td:last-child]:rounded-br-[24px]',
         className
       )}
@@ -84,7 +84,7 @@ const TableHead = React.forwardRef<
     // 32px Figma header row. First column indents 28px (24px cell inset + 4
     // optical).
     className={cn(
-      'text-fgSecondary px-2 pt-0.5 pb-3 text-left align-middle font-graphik text-xs leading-[18px] font-normal first:pl-7 [&:has([role=checkbox])]:pr-0',
+      'text-fgSecondary font-graphik px-2 pt-0.5 pb-3 text-left align-middle text-xs leading-[18px] font-normal first:pl-7 [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -129,6 +129,23 @@
   /* colors/fg/fg-primary (navbar label + hovered nav icon, Figma 5010:29059).
      Interim light value mirrors --color-text (G2 owns full parity). */
   --color-fgPrimary: #f2f3f7;
+  /* Design-system table tokens (Figma Patterns/Tables 5178:37455): dark values
+     are the Figma source values — colors/bg/bg-secondary (row/cell surface),
+     colors/bg/bg-tertiary (hovered row) and the components/status palette
+     shared by the Status/Risk/Token-Idle cells: fg/bg/border-success,
+     fg-warning (risk Medium segments) and fg/bg-brand (Pending badge).
+     statusSuccessSolid is colors/system/success (#02c2a1), the active-position
+     dot; statusSuccessBorder doubles as the position-iconbox ring. None are
+     overridden in the light scope yet (G2 owns light parity). */
+  --color-bgSecondary: rgba(188, 182, 239, 0.05);
+  --color-bgTertiary: rgba(188, 182, 239, 0.1);
+  --color-statusSuccess: #40e3c8;
+  --color-statusSuccessBg: rgba(2, 194, 161, 0.1);
+  --color-statusSuccessBorder: rgba(2, 194, 161, 0.2);
+  --color-statusSuccessSolid: #02c2a1;
+  --color-statusWarning: #ffc044;
+  --color-statusBrand: #9ca9ff;
+  --color-statusBrandBg: rgba(156, 160, 229, 0.1);
   --color-border: var(--transparent-white-15);
   --color-borderActive: var(--transparent-white-25);
   --color-borderPurple: #4c4577;

--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -10,7 +10,8 @@ import { QueryParams } from '@/lib/constants';
 import { retainOnNavigate, useAppSearchParams } from '@/lib/navigation';
 import { Heading } from '@/modules/layout/components/Typography';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
-import { IconStack, TokenIconStack } from '@/modules/ui/components/TokenIconStack';
+import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
+import { CellNetworks } from '@/components/ui/table-cells';
 import { EarnTable, EarnTableRowItem } from '@/components/product/EarnTable';
 import { EarnTableFilters, EarnFilterOption } from '@/components/product/EarnTableFilters';
 import { productIconSymbol } from '@/components/product/productVisuals';
@@ -115,19 +116,20 @@ export function EarnPage() {
       visibleRows.map(row => ({
         id: row.id,
         name: row.name,
-        icon: <TokenIcon token={{ symbol: productIconSymbol(row) }} width={36} className="h-9 w-9" />,
+        icon: <TokenIcon token={{ symbol: productIconSymbol(row) }} width={28} className="h-7 w-7" />,
         nameSuffix:
           row.kind === 'vault' && row.id.startsWith('vault-morpho') ? (
-            <Morpho className="h-3 w-3 rounded-sm" />
+            <Morpho className="h-4 w-4 rounded-sm" />
           ) : undefined,
-        supply: <TokenIconStack symbols={row.supplyTokens} size={14} />,
+        supply: <TokenIconStack symbols={row.supplyTokens} size={12} />,
         maturityLabel: row.maturity ? maturityFormatter.format(new Date(row.maturity * 1000)) : undefined,
-        network: <IconStack size={20}>{row.networks.map(id => getChainIcon(id, 'h-full w-full'))}</IconStack>,
+        network: <CellNetworks>{row.networks.map(id => getChainIcon(id, 'h-full w-full'))}</CellNetworks>,
         risk: row.risk,
         rate: row.rate.formatted,
         rate30d: row.rate30d?.formatted ?? NO_VALUE,
         tvl: formatUsd(row.tvl?.totalUsd),
         position: formatUsd(row.position?.totalUsd),
+        hasPosition: (row.position?.totalUsd ?? 0) > 0,
         isLoading: row.isLoading
       })),
     [visibleRows]

--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -129,7 +129,6 @@ export function EarnPage() {
         rate30d: row.rate30d?.formatted ?? NO_VALUE,
         tvl: formatUsd(row.tvl?.totalUsd),
         position: formatUsd(row.position?.totalUsd),
-        hasPosition: (row.position?.totalUsd ?? 0) > 0,
         isLoading: row.isLoading
       })),
     [visibleRows]

--- a/apps/webapp/src/modules/morpho/components/VaultTransactionsTable.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultTransactionsTable.tsx
@@ -8,11 +8,9 @@ import { SavingsSupply, ArrowDown } from '@/modules/icons';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxActionCell,
-  TxAmountCell,
-  TxHashLink
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAction, CellAmount, CellHash } from '@/components/ui/table-cells';
 
 export type VaultTxFilter = 'all' | 'supply' | 'withdraw';
 
@@ -35,7 +33,7 @@ const COLUMNS: ProductTransactionColumn<VaultTxRow>[] = [
     header: <Trans>Transaction</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxActionCell
+      <CellAction
         icon={
           row.isSupply ? (
             <SavingsSupply width={16} height={15} />
@@ -52,9 +50,9 @@ const COLUMNS: ProductTransactionColumn<VaultTxRow>[] = [
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxAmountCell
+      <CellAmount
         icon={
-          <TokenIcon token={{ symbol: row.symbol }} width={20} showChainIcon={false} className="h-5 w-5" />
+          <TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
         }
         amount={`${row.amount} ${row.symbol}`}
         usd={row.usd}
@@ -65,7 +63,7 @@ const COLUMNS: ProductTransactionColumn<VaultTxRow>[] = [
     id: 'hash',
     header: <Trans>Txn hash</Trans>,
     width: '1fr',
-    cell: row => <TxHashLink label={row.txHashLabel} href={row.txHref} />
+    cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   },
   {
     id: 'time',

--- a/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
@@ -45,6 +45,7 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
 import { useModalEntryBody } from '@/modules/ui/hooks/useModalEntryBody';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 import { pendlePrepareErrorMessage } from '../utils/prepareErrorMessage';
 
 export type PendleModalFlow = 'supply' | 'withdraw';
@@ -150,11 +151,11 @@ export function PendleModalForm({
   });
   const needsAllowance = allowance !== undefined && amount > 0n && allowance < amount;
 
-  // Step labels mirror the engine's call count ([approve?, convert]) so the
+  // Steps mirror the engine's call count ([approve?, convert]) so the
   // indicator advances in lockstep with the sequential flow's onMutate bumps.
-  const steps = useMemo<string[]>(() => {
-    const convertStep = isSupply ? t`Supply ${inputSymbol}` : t`Withdraw ${inputSymbol}`;
-    return needsAllowance ? [t`Approve ${inputSymbol}`, convertStep] : [convertStep];
+  const steps = useMemo<TransactionStep[]>(() => {
+    const convertStep = { label: isSupply ? t`Supply` : t`Withdraw`, tokenSymbol: inputSymbol };
+    return needsAllowance ? [{ label: t`Approve`, tokenSymbol: inputSymbol }, convertStep] : [convertStep];
   }, [isSupply, needsAllowance, inputSymbol]);
 
   const { data: quote, isLoading: isFetchingQuote } = useQuotePendleConvert({

--- a/apps/webapp/src/modules/pendle/components/PendleTransactionsTable.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleTransactionsTable.tsx
@@ -7,11 +7,9 @@ import { formatNumber, getEtherscanLink, formatAddress } from '@/utils';
 import { SavingsSupply, ArrowDown } from '@/modules/icons';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxActionCell,
-  TxAmountCell,
-  TxHashLink
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAction, CellAmount, CellHash } from '@/components/ui/table-cells';
 
 type PendleTxRow = {
   id: string;
@@ -37,7 +35,7 @@ const COLUMNS: ProductTransactionColumn<PendleTxRow>[] = [
     header: <Trans>Transaction</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxActionCell
+      <CellAction
         icon={
           row.action === PendleHistoryAction.BUY_PT ? (
             <SavingsSupply width={16} height={15} />
@@ -53,13 +51,13 @@ const COLUMNS: ProductTransactionColumn<PendleTxRow>[] = [
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
-    cell: row => <TxAmountCell amount={`${row.amount} ${row.marketName}`} usd={row.usd} />
+    cell: row => <CellAmount amount={`${row.amount} ${row.marketName}`} usd={row.usd} />
   },
   {
     id: 'hash',
     header: <Trans>Txn hash</Trans>,
     width: '1fr',
-    cell: row => <TxHashLink label={row.txHashLabel} href={row.txHref} />
+    cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   },
   {
     id: 'time',

--- a/apps/webapp/src/modules/pendle/components/__tests__/PendleModalForm.test.tsx
+++ b/apps/webapp/src/modules/pendle/components/__tests__/PendleModalForm.test.tsx
@@ -312,7 +312,10 @@ describe('PendleModalForm', () => {
       renderForm('supply');
       typeAmount('100');
 
-      expect(lastEntryUpdate()?.steps).toEqual(['Approve USDG', 'Supply USDG']);
+      expect(lastEntryUpdate()?.steps).toEqual([
+        { label: 'Approve', tokenSymbol: 'USDG' },
+        { label: 'Supply', tokenSymbol: 'USDG' }
+      ]);
     });
 
     it('collapses to a single supply step once the allowance covers the amount', () => {
@@ -320,7 +323,7 @@ describe('PendleModalForm', () => {
       renderForm('supply');
       typeAmount('100');
 
-      expect(lastEntryUpdate()?.steps).toEqual(['Supply USDG']);
+      expect(lastEntryUpdate()?.steps).toEqual([{ label: 'Supply', tokenSymbol: 'USDG' }]);
     });
 
     it('pushes the SlippageMenu into the modal header', () => {
@@ -358,7 +361,10 @@ describe('PendleModalForm', () => {
       renderForm('withdraw');
       typeAmount('200');
 
-      expect(lastEntryUpdate()?.steps).toEqual(['Approve PT-USDG', 'Withdraw PT-USDG']);
+      expect(lastEntryUpdate()?.steps).toEqual([
+        { label: 'Approve', tokenSymbol: 'PT-USDG' },
+        { label: 'Withdraw', tokenSymbol: 'PT-USDG' }
+      ]);
     });
 
     it('fires withdraw-flavored analytics', () => {

--- a/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
+++ b/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
@@ -32,8 +32,13 @@ export function IdleStablecoinsTable({
             <TableHead className="w-[148px]">
               <Trans>Balance</Trans>
             </TableHead>
-            {/* The CTA column's header cell exists but stays empty (Figma). */}
-            <TableHead className="w-[148px]" />
+            {/* The CTA column's header stays visually empty (Figma) but keeps
+                an accessible name for screen readers. */}
+            <TableHead className="w-[148px]">
+              <span className="sr-only">
+                <Trans>Actions</Trans>
+              </span>
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
+++ b/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
@@ -1,21 +1,16 @@
-import { ReactNode } from 'react';
 import { Trans } from '@lingui/react/macro';
-import { cn } from '@/lib/cn';
 import { formatDecimalPercentage, formatNumber, formatUsd } from '@/utils';
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Text } from '@/modules/layout/components/Typography';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { CellAmount, CellBadge, CellTokenIdle } from '@/components/ui/table-cells';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { STABLECOIN_PEG_BADGE, type IdleSupplyInfo, type IdleToken } from '../helpers/idleView';
 
-// Fixed-width balance/action columns so the headers align over the row values.
-const BALANCE_COL = 'w-28 shrink-0 sm:w-32';
-const ACTION_COL = 'w-24 shrink-0 sm:w-28';
-
 /**
- * The Portfolio "Idle" view of the positions section: a row per held stablecoin
- * (balance + best supply rate + 1:1 conversion badge) with a Supply CTA that
- * deep-links to the Earn list filtered by that token.
+ * The Portfolio "Idle" view of the positions section (Figma Table/Idle
+ * 5178:37659): a row per held stablecoin (Token Idle cell with best-rate +
+ * 1:1-parity badges, Amount cell, full-width Supply CTA) that deep-links to
+ * the Earn list filtered by that token.
  */
 export function IdleStablecoinsTable({
   tokens,
@@ -27,75 +22,83 @@ export function IdleStablecoinsTable({
   onSupply: (symbol: string) => void;
 }) {
   return (
-    <div className="mt-6" data-testid="idle-stablecoins-table">
-      <div className="text-textSecondary flex items-center gap-4 px-6 pb-3">
-        <Text variant="medium" tag="span" className="flex-1">
-          <Trans>Token</Trans>
-        </Text>
-        <Text variant="medium" tag="span" className={cn(BALANCE_COL, 'text-right')}>
-          <Trans>Balance</Trans>
-        </Text>
-        <span className={ACTION_COL} aria-hidden />
-      </div>
-
-      <Card className="divide-borderPrimary divide-y p-0">
-        {tokens.map(token => {
-          const info = supplyInfo.get(token.symbol);
-          const pegBadge = STABLECOIN_PEG_BADGE[token.symbol];
-          return (
-            <div key={token.symbol} className="flex items-center gap-4 px-6 py-5" data-testid="idle-row">
-              <div className="flex min-w-0 flex-1 items-center gap-3">
-                <TokenIcon
-                  token={{ symbol: token.symbol }}
-                  width={40}
-                  showChainIcon={false}
-                  className="h-10 w-10 shrink-0"
-                />
-                <div className="flex min-w-0 flex-col gap-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-text font-medium">{token.symbol}</span>
-                    {info?.bestRate !== undefined && (
-                      <Badge>
-                        {info.venueCount > 1 ? (
-                          <Trans>up to {formatDecimalPercentage(info.bestRate)}</Trans>
-                        ) : (
-                          formatDecimalPercentage(info.bestRate)
+    <div className="mt-6">
+      <Table data-testid="idle-stablecoins-table">
+        <TableHeader>
+          <TableRow>
+            <TableHead>
+              <Trans>Token</Trans>
+            </TableHead>
+            <TableHead className="w-[148px]">
+              <Trans>Balance</Trans>
+            </TableHead>
+            {/* The CTA column's header cell exists but stays empty (Figma). */}
+            <TableHead className="w-[148px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {tokens.map(token => {
+            const info = supplyInfo.get(token.symbol);
+            const pegBadge = STABLECOIN_PEG_BADGE[token.symbol];
+            return (
+              <TableRow key={token.symbol} data-testid="idle-row">
+                <TableCell>
+                  <CellTokenIdle
+                    icon={
+                      <TokenIcon
+                        token={{ symbol: token.symbol }}
+                        width={28}
+                        showChainIcon={false}
+                        className="h-7 w-7"
+                      />
+                    }
+                    symbol={token.symbol}
+                    badges={
+                      <>
+                        {info?.bestRate !== undefined && (
+                          <CellBadge tone="success">
+                            {info.venueCount > 1 ? (
+                              <Trans>up to {formatDecimalPercentage(info.bestRate)}</Trans>
+                            ) : (
+                              formatDecimalPercentage(info.bestRate)
+                            )}
+                          </CellBadge>
                         )}
-                      </Badge>
-                    )}
-                    {pegBadge && <Badge>{pegBadge}</Badge>}
-                  </div>
-                  <Text variant="medium" tag="span" className="text-textSecondary truncate">
-                    {token.name}
-                  </Text>
-                </div>
-              </div>
-
-              <div className={cn(BALANCE_COL, 'flex flex-col items-end gap-0.5')}>
-                <span className="text-text font-medium">{formatNumber(token.amount)}</span>
-                <Text variant="medium" tag="span" className="text-textSecondary">
-                  {formatUsd(token.amountUsd)}
-                </Text>
-              </div>
-
-              <Button
-                variant="primary"
-                size="m"
-                className={ACTION_COL}
-                onClick={() => onSupply(token.symbol)}
-              >
-                <Trans>Supply</Trans>
-              </Button>
-            </div>
-          );
-        })}
-      </Card>
+                        {pegBadge && <CellBadge>{pegBadge}</CellBadge>}
+                      </>
+                    }
+                    name={token.name}
+                  />
+                </TableCell>
+                <TableCell>
+                  <CellAmount
+                    icon={
+                      <TokenIcon
+                        token={{ symbol: token.symbol }}
+                        width={12}
+                        showChainIcon={false}
+                        className="h-3 w-3"
+                      />
+                    }
+                    amount={formatNumber(token.amount)}
+                    usd={formatUsd(token.amountUsd)}
+                  />
+                </TableCell>
+                <TableCell className="px-4">
+                  <Button
+                    variant="primary"
+                    size="m"
+                    className="w-full"
+                    onClick={() => onSupply(token.symbol)}
+                  >
+                    <Trans>Supply</Trans>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
     </div>
-  );
-}
-
-function Badge({ children }: { children: ReactNode }) {
-  return (
-    <span className="bg-surface text-text rounded-full px-2 py-0.5 text-xs font-medium">{children}</span>
   );
 }

--- a/apps/webapp/src/modules/rewards/components/RewardsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsTransactionsTable.tsx
@@ -9,12 +9,9 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { useSubgraphUrl } from '@/modules/app/hooks/useSubgraphUrl';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxStatusBadge,
-  TxActionCell,
-  TxAmountCell,
-  TxHashLink
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAction, CellAmount, CellHash, CellStatus } from '@/components/ui/table-cells';
 
 type RewardsTxKind = 'supply' | 'withdraw' | 'claim';
 
@@ -44,7 +41,7 @@ const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
     header: <Trans>Action</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxActionCell
+      <CellAction
         icon={
           row.kind === 'supply' ? (
             <SavingsSupply width={16} height={15} />
@@ -55,7 +52,7 @@ const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
           )
         }
         label={ACTION_LABELS[row.kind]}
-        timeAgo={row.timeAgo}
+        sublabel={row.timeAgo}
       />
     )
   },
@@ -64,16 +61,16 @@ const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
     header: <Trans>Status</Trans>,
     width: '1fr',
     // Confirmed on-chain history only; pending in-flight txs are a later ticket.
-    cell: () => <TxStatusBadge status="completed" />
+    cell: () => <CellStatus status="completed" />
   },
   {
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxAmountCell
+      <CellAmount
         icon={
-          <TokenIcon token={{ symbol: row.symbol }} width={20} showChainIcon={false} className="h-5 w-5" />
+          <TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
         }
         amount={row.amount}
         usd={row.usd}
@@ -84,7 +81,7 @@ const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
     id: 'hash',
     header: <Trans>Txn hash</Trans>,
     width: '1fr',
-    cell: row => <TxHashLink label={row.txHashLabel} href={row.txHref} />
+    cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   }
 ];
 

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.tsx
@@ -10,12 +10,9 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { useSubgraphUrl } from '@/modules/app/hooks/useSubgraphUrl';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxStatusBadge,
-  TxActionCell,
-  TxAmountCell,
-  TxHashLink
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAction, CellAmount, CellHash, CellStatus } from '@/components/ui/table-cells';
 import { SavingsTxFilter } from './SavingsTransactionsFilter';
 
 type SavingsTxRow = {
@@ -37,7 +34,7 @@ const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
     header: <Trans>Action</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxActionCell
+      <CellAction
         icon={
           row.isSupply ? (
             <SavingsSupply width={16} height={15} />
@@ -46,7 +43,7 @@ const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
           )
         }
         label={row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdraw</Trans>}
-        timeAgo={row.timeAgo}
+        sublabel={row.timeAgo}
       />
     )
   },
@@ -55,16 +52,16 @@ const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
     header: <Trans>Status</Trans>,
     width: '1fr',
     // Confirmed on-chain history only; pending in-flight txs are a later ticket.
-    cell: () => <TxStatusBadge status="completed" />
+    cell: () => <CellStatus status="completed" />
   },
   {
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxAmountCell
+      <CellAmount
         icon={
-          <TokenIcon token={{ symbol: row.symbol }} width={20} showChainIcon={false} className="h-5 w-5" />
+          <TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
         }
         amount={row.amount}
         usd={row.usd}
@@ -75,7 +72,7 @@ const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
     id: 'hash',
     header: <Trans>Txn hash</Trans>,
     width: '1fr',
-    cell: row => <TxHashLink label={row.txHashLabel} href={row.txHref} />
+    cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   }
 ];
 

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.dai.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.dai.test.tsx
@@ -341,7 +341,12 @@ describe('useSavingsLaunch — DAI upgrade-and-supply launch() config', () => {
     act(() => result.current.launch());
 
     const config = h.launchMock.mock.calls[0][0];
-    expect(config.steps).toEqual(['Approve DAI', 'Upgrade DAI to USDS', 'Approve USDS', 'Supply USDS']);
+    expect(config.steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'DAI' },
+      'Upgrade DAI to USDS',
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Supply', tokenSymbol: 'USDS' }
+    ]);
   });
 
   it('elides each approve step when its allowance is already present (steps match call count)', () => {
@@ -353,7 +358,7 @@ describe('useSavingsLaunch — DAI upgrade-and-supply launch() config', () => {
     act(() => result.current.launch());
 
     const config = h.launchMock.mock.calls[0][0];
-    expect(config.steps).toEqual(['Upgrade DAI to USDS', 'Supply USDS']);
+    expect(config.steps).toEqual(['Upgrade DAI to USDS', { label: 'Supply', tokenSymbol: 'USDS' }]);
   });
 
   it('routes onConfirm to the enabled upgrade engine (not the disabled supply engine, not withdraw)', () => {

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.l2.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.l2.test.tsx
@@ -331,7 +331,7 @@ describe('useSavingsLaunch — L2 supply launch() config', () => {
     expect(h.mockExecute).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the L2 supply steps generic ("Approve" / "Supply") — Figma is mainnet-only', () => {
+  it('labels the L2 supply steps with the origin token chip', () => {
     h.allowance = 0n;
     const a = renderHook(() =>
       useSavingsLaunch({
@@ -343,8 +343,11 @@ describe('useSavingsLaunch — L2 supply launch() config', () => {
       })
     );
     act(() => a.result.current.launch());
-    // L2 has no Figma frame; the labels intentionally stay token-agnostic.
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Approve', 'Supply']);
+    // DS Steps chips are token-derived (APP-354), so L2 flows carry the origin token too.
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Supply', tokenSymbol: 'USDS' }
+    ]);
     a.unmount();
     h.launchMock.mockClear();
 
@@ -359,7 +362,7 @@ describe('useSavingsLaunch — L2 supply launch() config', () => {
       })
     );
     act(() => b.result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Supply']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([{ label: 'Supply', tokenSymbol: 'USDS' }]);
     b.unmount();
   });
 });

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.test.tsx
@@ -327,7 +327,10 @@ describe('useSavingsLaunch — launch() config', () => {
     );
     act(() => a.result.current.launch());
     // Figma 527:8273 — the supply steps name their token; step count is unchanged.
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Approve USDS', 'Supply USDS']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Supply', tokenSymbol: 'USDS' }
+    ]);
     a.unmount();
     h.launchMock.mockClear();
 
@@ -336,7 +339,7 @@ describe('useSavingsLaunch — launch() config', () => {
       useSavingsLaunch({ flow: 'supply', originToken: TOKENS.usds, amount: AMOUNT, referralCode: REF })
     );
     act(() => b.result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Supply USDS']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([{ label: 'Supply', tokenSymbol: 'USDS' }]);
     b.unmount();
   });
 });

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.ts
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.ts
@@ -21,6 +21,7 @@ import {
 import { formatNumber, isL2ChainId } from '@/utils';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 
 export type SavingsLaunchFlow = 'supply' | 'withdraw';
 
@@ -73,8 +74,8 @@ export interface UseSavingsLaunchResult {
    * re-launching. Same call as `launch()`'s `onConfirm`, so calldata is identical.
    */
   execute: () => void;
-  /** Step labels for the configured flow (e.g. ["Approve", "Supply"]); matches `launch()`. */
-  steps: string[];
+  /** Steps for the configured flow (e.g. ["Approve", "Supply"]); matches `launch()`. */
+  steps: TransactionStep[];
   /** Whether the routed call-builder hook is ready to execute. */
   prepared: boolean;
   isLoading: boolean;
@@ -246,24 +247,34 @@ export function useSavingsLaunch({
   //  - L2 PSM supply/withdraw: optional approve(assetIn → psm3L2) → swap
   // Hoisted from launch() so the editable modal entry body can pass them straight
   // to the shared modal; launch() consumes the same value (behaviour unchanged).
-  const steps = useMemo<string[]>(() => {
+  const steps = useMemo<TransactionStep[]>(() => {
     if (isSupply) {
       return isL2
         ? needsPsmApproval
-          ? [t`Approve`, t`Supply`]
-          : [t`Supply`]
+          ? [
+              { label: t`Approve`, tokenSymbol: originToken.symbol },
+              { label: t`Supply`, tokenSymbol: originToken.symbol }
+            ]
+          : [{ label: t`Supply`, tokenSymbol: originToken.symbol }]
         : isDai
           ? ([
-              needsDaiApproval && t`Approve DAI`,
+              needsDaiApproval && { label: t`Approve`, tokenSymbol: 'DAI' },
               t`Upgrade DAI to USDS`,
-              needsUsdsApproval && t`Approve USDS`,
-              t`Supply USDS`
-            ].filter(Boolean) as string[])
+              needsUsdsApproval && { label: t`Approve`, tokenSymbol: 'USDS' },
+              { label: t`Supply`, tokenSymbol: 'USDS' }
+            ].filter(Boolean) as TransactionStep[])
           : needsUsdsApproval
-            ? [t`Approve USDS`, t`Supply USDS`]
-            : [t`Supply USDS`];
+            ? [
+                { label: t`Approve`, tokenSymbol: 'USDS' },
+                { label: t`Supply`, tokenSymbol: 'USDS' }
+              ]
+            : [{ label: t`Supply`, tokenSymbol: 'USDS' }];
     }
-    return needsPsmWithdrawApproval ? [t`Approve`, t`Withdraw`] : [t`Withdraw`];
+    // The withdraw approval is for the sUSDS share token, not `originToken` —
+    // it keeps the bare label rather than a wrong chip.
+    return needsPsmWithdrawApproval
+      ? [t`Approve`, { label: t`Withdraw`, tokenSymbol: originToken.symbol }]
+      : [{ label: t`Withdraw`, tokenSymbol: originToken.symbol }];
   }, [
     isSupply,
     isL2,
@@ -271,7 +282,8 @@ export function useSavingsLaunch({
     needsPsmApproval,
     needsDaiApproval,
     needsUsdsApproval,
-    needsPsmWithdrawApproval
+    needsPsmWithdrawApproval,
+    originToken.symbol
   ]);
 
   const launch = useCallback(() => {

--- a/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
@@ -22,12 +22,9 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxStatusBadge,
-  TxActionCell,
-  TxAmountCell,
-  TxHashLink
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAction, CellAmount, CellHash, CellStatus } from '@/components/ui/table-cells';
 import { StakeUserPosition } from '../hooks/useStakeUserPositions';
 
 /**
@@ -185,10 +182,12 @@ const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
     header: <Trans>Action</Trans>,
     width: '1.6fr',
     cell: row => (
-      <TxActionCell
+      // Figma Type=Action and Position (Transaction Stake): Label 5 title.
+      <CellAction
+        compact
         icon={verbIcon(row.verb)}
         label={verbLabel(row.verb)}
-        timeAgo={
+        sublabel={
           <>
             {formatDistanceToNowStrict(row.blockTimestamp, { addSuffix: true })}
             {row.urnIndex !== undefined && <> · Position {row.urnIndex + 1}</>}
@@ -203,15 +202,15 @@ const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
     width: '1fr',
     // Subgraph history is confirmed-only; optimistic pending rows are an open
     // product decision (Ticket Breakdown) and would slot in via this badge.
-    cell: () => <TxStatusBadge status="completed" />
+    cell: () => <CellStatus status="completed" />
   },
   {
     id: 'sky',
     header: <Trans>Stake/unstake</Trans>,
     width: '1.2fr',
     cell: row => (
-      <TxAmountCell
-        icon={<TokenIcon token={{ symbol: 'SKY' }} width={20} className="h-5 w-5" showChainIcon={false} />}
+      <CellAmount
+        icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
         amount={formatStakeAmount(row.skyAmount)}
         usd={
           row.skyPrice !== null ? formatUsd(Number(formatUnits(row.skyAmount, 18)) * row.skyPrice) : undefined
@@ -224,8 +223,8 @@ const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
     header: <Trans>Borrow/repay</Trans>,
     width: '1.2fr',
     cell: row => (
-      <TxAmountCell
-        icon={<TokenIcon token={{ symbol: 'USDS' }} width={20} className="h-5 w-5" showChainIcon={false} />}
+      <CellAmount
+        icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
         amount={formatStakeAmount(row.usdsAmount)}
         usd={formatUsd(Number(formatUnits(row.usdsAmount, 18)))}
       />
@@ -236,7 +235,7 @@ const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
     header: <Trans>Txn hash</Trans>,
     width: '1fr',
     cell: row => (
-      <TxHashLink
+      <CellHash
         label={formatAddress(row.transactionHash, 6, 4)}
         href={getEtherscanLink(row.chainId, row.transactionHash, 'tx')}
       />

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.test.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.test.tsx
@@ -170,11 +170,12 @@ describe('StakePositionsTable', () => {
   it('renders the risk cell through the shared RiskMeter pill (review: one pill app-wide)', () => {
     renderTable();
 
+    // The design-system Badges/Risk chrome (Figma Table Cell Type=Risk).
     const meter = screen.getByTestId('stake-position-row-1').querySelector('div[aria-hidden]');
-    expect(meter?.className).toContain('bg-surface');
-    expect(meter?.className).toContain('gap-0.5');
+    expect(meter?.className).toContain('border-glassBorder');
+    expect(meter?.className).toContain('gap-px');
     const segment = meter?.querySelector('span');
-    expect(segment?.className).toContain('h-1 w-2.5');
+    expect(segment?.className).toContain('h-[3px] w-2');
   });
 
   it('renders a dash, not an unlit meter, when the vault read fails on a debt-carrying row', () => {

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
@@ -27,9 +27,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { RiskMeter } from '@/components/product/RiskMeter';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxAmountCell
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAmount } from '@/components/ui/table-cells';
 import {
   StakeUserPosition,
   isInactiveStakePosition,
@@ -104,8 +104,8 @@ function PositionBorrowedCell({ position }: { position: StakeUserPosition }) {
   const { data: vault } = useVault(urnAddress || ZERO_ADDRESS, getIlkName(2));
 
   return (
-    <TxAmountCell
-      icon={<TokenIcon token={{ symbol: 'USDS' }} width={20} className="h-5 w-5" showChainIcon={false} />}
+    <CellAmount
+      icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
       amount={formatStakeAmount(vault?.debtValue ?? position.usdsDebt)}
     />
   );
@@ -182,8 +182,8 @@ const COLUMNS: ProductTransactionColumn<StakeUserPosition>[] = [
     header: <Trans>Total staked (SKY)</Trans>,
     width: '1.2fr',
     cell: position => (
-      <TxAmountCell
-        icon={<TokenIcon token={{ symbol: 'SKY' }} width={20} className="h-5 w-5" showChainIcon={false} />}
+      <CellAmount
+        icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
         amount={formatStakeAmount(position.skyLocked)}
       />
     )

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useChainId } from 'wagmi';
 import { formatUnits } from 'viem';
-import { ChevronRight } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import {
   useStakeUrnAddress,
@@ -29,7 +28,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
-import { CellAmount } from '@/components/ui/table-cells';
+import { CellAmount, CellAmountWithToken, CellChevron, CellPosition } from '@/components/ui/table-cells';
 import {
   StakeUserPosition,
   isInactiveStakePosition,
@@ -38,15 +37,14 @@ import {
 import { StakePositionRowBanner } from './StakePositionRowBanner';
 
 // Liquidation-proximity mapping for the shared risk pill: more (and warmer)
-// lit segments = closer to liquidation; rows with no debt render unlit.
-// Colors follow the legacy risk convention (green/orange-400/red);
-// StakeDetailsStrip's legend uses different mid-tier tints — the canonical
-// palette is an open design question. The pill chrome is the shared
-// RiskMeter (review feedback: one pill app-wide), a deliberate divergence
-// from the bordered treatment in stake hi-fi 486:32084.
+// lit segments = closer to liquidation; rows with no debt render unlit
+// (Figma Type=Risk "None"). Colors are the design-system status palette the
+// pill uses everywhere; a 3-lit error tier never appears in the Figma
+// patterns — red pending design confirmation. The pill chrome is the shared
+// RiskMeter (review feedback: one pill app-wide).
 const RISK_SEGMENTS: Record<RiskLevel, { lit: number; color: string }> = {
-  [RiskLevel.LOW]: { lit: 1, color: 'bg-bullish' },
-  [RiskLevel.MEDIUM]: { lit: 2, color: 'bg-orange-400' },
+  [RiskLevel.LOW]: { lit: 1, color: 'bg-statusSuccess' },
+  [RiskLevel.MEDIUM]: { lit: 2, color: 'bg-statusWarning' },
   [RiskLevel.HIGH]: { lit: 3, color: 'bg-error' },
   [RiskLevel.LIQUIDATION]: { lit: 3, color: 'bg-error' }
 };
@@ -146,26 +144,18 @@ function PositionClaimableCell({ position }: { position: StakeUserPosition }) {
   const symbols = claimable.length > 0 ? claimable.map(reward => reward.rewardSymbol) : ['SKY'];
 
   return (
-    <span className="text-text flex items-center gap-1.5 text-sm">
-      {formatUsd(usdValue)}
-      <TokenIconStack symbols={symbols} size={16} />
-    </span>
+    <CellAmountWithToken amount={formatUsd(usdValue)} icon={<TokenIconStack symbols={symbols} size={12} />} />
   );
 }
 
 function PositionIdCell({ position }: { position: StakeUserPosition }) {
   const inactive = isInactiveStakePosition(position);
   return (
-    <div
-      data-testid={`stake-position-id-${position.index}`}
-      className={cn('flex items-center gap-3', inactive && 'opacity-50')}
-    >
-      <span className="border-borderPrimary text-bullish flex h-9 w-9 shrink-0 items-center justify-center rounded-full border">
-        <Stake width={18} height={18} />
-      </span>
-      <span className="text-text text-base font-medium">
-        <Trans>Position {position.index + 1}</Trans>
-      </span>
+    <div data-testid={`stake-position-id-${position.index}`} className={cn(inactive && 'opacity-50')}>
+      <CellPosition
+        icon={<Stake width={16} height={16} />}
+        label={<Trans>Position {position.index + 1}</Trans>}
+      />
     </div>
   );
 }
@@ -209,8 +199,12 @@ const COLUMNS: ProductTransactionColumn<StakeUserPosition>[] = [
   {
     id: 'chevron',
     header: null,
-    width: '24px',
-    cell: () => <ChevronRight className="text-textSecondary h-4 w-4" />
+    width: '64px',
+    cell: () => (
+      <span className="flex justify-center">
+        <CellChevron />
+      </span>
+    )
   }
 ];
 

--- a/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.test.tsx
@@ -201,21 +201,28 @@ describe('buildStakeClaimSteps', () => {
   it('derives steps from the selection: Claim per token, then Restake SKY (UX 1050:23881)', () => {
     expect(
       buildStakeClaimSteps({ needsSkyAllowance: false, claimSymbols: ['SKY', 'SPK'], restake: false })
-    ).toEqual(['Claim SKY', 'Claim SPK']);
+    ).toEqual([
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
 
     expect(
       buildStakeClaimSteps({ needsSkyAllowance: false, claimSymbols: ['SKY', 'SPK'], restake: true })
-    ).toEqual(['Claim SKY', 'Claim SPK', 'Restake SKY']);
+    ).toEqual([
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
+    ]);
 
     expect(buildStakeClaimSteps({ needsSkyAllowance: true, claimSymbols: ['SKY'], restake: true })).toEqual([
-      'Approve SKY',
-      'Claim SKY',
-      'Restake SKY'
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
     ]);
 
     // Plain claim never needs an approval: nothing is pulled from the owner.
     expect(buildStakeClaimSteps({ needsSkyAllowance: true, claimSymbols: ['SPK'], restake: false })).toEqual([
-      'Claim SPK'
+      { label: 'Claim', tokenSymbol: 'SPK' }
     ]);
   });
 });
@@ -309,7 +316,10 @@ describe('useStakeClaimLaunch — launch() config', () => {
     expect(config.transactionTitle).toBe('Claim your rewards');
     expect(config.subtitles.loading).toBe('Your claim is being processed on the blockchain. Please wait.');
     expect(config.subtitles.success).toBe('You’ve claimed your rewards');
-    expect(config.steps).toEqual(['Claim SKY', 'Claim SPK']);
+    expect(config.steps).toEqual([
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
     expect(config.toast).toEqual({
       loading: 'Claiming rewards',
       success: 'Claim successful',
@@ -321,7 +331,12 @@ describe('useStakeClaimLaunch — launch() config', () => {
     const { result } = renderLaunch();
     act(() => result.current.launch(true));
 
-    expect(launchConfig().steps).toEqual(['Approve SKY', 'Claim SKY', 'Claim SPK', 'Restake SKY']);
+    expect(launchConfig().steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
+    ]);
   });
 
   it('fires legacy claim analytics: claimAll for a multi-token plain claim', () => {
@@ -357,7 +372,11 @@ describe('useStakeClaimLaunch — launch() config', () => {
     act(() => result.current.launch(true));
 
     expect(launchConfig().analytics.action).toBe('claimAndRestake');
-    expect(launchConfig().steps).toEqual(['Approve SKY', 'Claim SKY', 'Restake SKY']);
+    expect(launchConfig().steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
+    ]);
   });
 
   it('exposes restake availability from the selection', () => {

--- a/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.ts
@@ -16,6 +16,7 @@ import {
 import { REFERRAL_CODE } from '@/lib/constants';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 import { parseStakeId, stakeAdapter } from '@/modules/claim/adapters/stakeAdapter';
 import type { ClaimableReward } from '@/modules/claim/types';
 // Legacy msgids double as e2e anchors — reused, not forked (UI Spec §3).
@@ -39,12 +40,12 @@ export function buildStakeClaimSteps({
   needsSkyAllowance: boolean;
   claimSymbols: string[];
   restake: boolean;
-}): string[] {
+}): TransactionStep[] {
   return [
-    restake && needsSkyAllowance && t`Approve SKY`,
-    ...claimSymbols.map(symbol => t`Claim ${symbol}`),
-    restake && t`Restake SKY`
-  ].filter(Boolean) as string[];
+    restake && needsSkyAllowance && { label: t`Approve`, tokenSymbol: 'SKY' },
+    ...claimSymbols.map(symbol => ({ label: t`Claim`, tokenSymbol: symbol })),
+    restake && { label: t`Restake`, tokenSymbol: 'SKY' }
+  ].filter(Boolean) as TransactionStep[];
 }
 
 export interface UseStakeClaimLaunchParams {

--- a/apps/webapp/src/modules/stake/hooks/useStakeLaunch.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeLaunch.test.tsx
@@ -171,17 +171,17 @@ const expectedCalldata = (usdsToBorrow: bigint, delegate?: `0x${string}`) =>
 describe('buildStakeOpenSteps', () => {
   it('derives the step list from the calldata set (A-Q3: delegate shown honestly)', () => {
     expect(buildStakeOpenSteps({ needsSkyAllowance: true, hasBorrow: true, hasDelegate: true })).toEqual([
-      'Approve SKY',
-      'Stake SKY',
-      'Borrow USDS',
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Stake', tokenSymbol: 'SKY' },
+      { label: 'Borrow', tokenSymbol: 'USDS' },
       'Delegate voting power'
     ]);
     expect(buildStakeOpenSteps({ needsSkyAllowance: false, hasBorrow: false, hasDelegate: false })).toEqual([
-      'Stake SKY'
+      { label: 'Stake', tokenSymbol: 'SKY' }
     ]);
     expect(buildStakeOpenSteps({ needsSkyAllowance: true, hasBorrow: false, hasDelegate: false })).toEqual([
-      'Approve SKY',
-      'Stake SKY'
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Stake', tokenSymbol: 'SKY' }
     ]);
   });
 });
@@ -247,7 +247,12 @@ describe('useStakeLaunch — launch() config', () => {
     const config = h.launchMock.mock.calls[0][0];
     expect(config.title).toBe('Confirm');
     expect(config.transactionTitle).toBe('Confirm your transaction');
-    expect(config.steps).toEqual(['Approve SKY', 'Stake SKY', 'Borrow USDS', 'Delegate voting power']);
+    expect(config.steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Stake', tokenSymbol: 'SKY' },
+      { label: 'Borrow', tokenSymbol: 'USDS' },
+      'Delegate voting power'
+    ]);
     expect(config.analytics.widgetName).toBe('stake');
     expect(config.analytics.flow).toBe('open');
     expect(config.analytics.action).toBe('multicall');

--- a/apps/webapp/src/modules/stake/hooks/useStakeLaunch.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeLaunch.ts
@@ -15,6 +15,7 @@ import { formatBigInt } from '@/utils';
 import { REFERRAL_CODE } from '@/lib/constants';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 // The legacy msgid generators double as e2e anchors — reused, not forked
 // (UI Spec §3). They survive F7 by relocation, not deletion.
 import { getStakeSubtitle, getStakeTitle, StakeFlow } from '../lib/constants';
@@ -38,13 +39,13 @@ export function buildStakeOpenSteps({
   needsSkyAllowance: boolean;
   hasBorrow: boolean;
   hasDelegate: boolean;
-}): string[] {
+}): TransactionStep[] {
   return [
-    needsSkyAllowance && t`Approve SKY`,
-    t`Stake SKY`,
-    hasBorrow && t`Borrow USDS`,
+    needsSkyAllowance && { label: t`Approve`, tokenSymbol: 'SKY' },
+    { label: t`Stake`, tokenSymbol: 'SKY' },
+    hasBorrow && { label: t`Borrow`, tokenSymbol: 'USDS' },
     hasDelegate && t`Delegate voting power`
-  ].filter(Boolean) as string[];
+  ].filter(Boolean) as TransactionStep[];
 }
 
 export interface UseStakeLaunchParams {

--- a/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.test.tsx
@@ -175,7 +175,11 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: false,
         hasDelegateChange: false
       })
-    ).toEqual(['Approve USDS', 'Repay USDS', 'Withdraw SKY']);
+    ).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Repay', tokenSymbol: 'USDS' },
+      { label: 'Withdraw', tokenSymbol: 'SKY' }
+    ]);
 
     expect(
       buildStakeManageSteps({
@@ -187,7 +191,12 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: true,
         hasDelegateChange: true
       })
-    ).toEqual(['Approve SKY', 'Change delegate', 'Stake SKY', 'Borrow USDS']);
+    ).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      'Change delegate',
+      { label: 'Stake', tokenSymbol: 'SKY' },
+      { label: 'Borrow', tokenSymbol: 'USDS' }
+    ]);
 
     expect(
       buildStakeManageSteps({
@@ -199,7 +208,7 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: true,
         hasDelegateChange: false
       })
-    ).toEqual(['Borrow USDS']);
+    ).toEqual([{ label: 'Borrow', tokenSymbol: 'USDS' }]);
   });
 
   it('places one Claim {symbol} step per claimSymbols entry right after Withdraw SKY', () => {
@@ -214,7 +223,11 @@ describe('buildStakeManageSteps', () => {
         hasDelegateChange: false,
         claimSymbols: ['SKY', 'SPK']
       })
-    ).toEqual(['Withdraw SKY', 'Claim SKY', 'Claim SPK']);
+    ).toEqual([
+      { label: 'Withdraw', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
 
     // No claimSymbols — untouched (no Claim steps at all).
     expect(
@@ -227,7 +240,7 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: false,
         hasDelegateChange: false
       })
-    ).toEqual(['Withdraw SKY']);
+    ).toEqual([{ label: 'Withdraw', tokenSymbol: 'SKY' }]);
   });
 });
 
@@ -343,7 +356,11 @@ describe('useStakeManageLaunch — launch() config', () => {
   it('derives the withdraw+repay steps from the calldata set, not the stale mock (M6)', () => {
     const { result } = renderLaunch();
     act(() => result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Approve USDS', 'Repay USDS', 'Withdraw SKY']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Repay', tokenSymbol: 'USDS' },
+      { label: 'Withdraw', tokenSymbol: 'SKY' }
+    ]);
   });
 
   it('orders bundled claim steps after Withdraw SKY (recovery launch shape)', () => {
@@ -354,7 +371,11 @@ describe('useStakeManageLaunch — launch() config', () => {
       claimSymbols: ['SKY', 'SPK']
     });
     act(() => result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Withdraw SKY', 'Claim SKY', 'Claim SPK']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Withdraw', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
   });
 
   it('carries the legacy manage stakeData analytics shape (M15)', () => {

--- a/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.ts
@@ -17,6 +17,7 @@ import { formatBigInt } from '@/utils';
 import { REFERRAL_CODE } from '@/lib/constants';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 // Legacy msgid generators double as e2e anchors — reused, not forked (UI Spec §3).
 import { getStakeSubtitle, getStakeTitle, StakeFlow } from '../lib/constants';
 import { TxStatus } from '@/widgets/shared/constants';
@@ -48,20 +49,20 @@ export function buildStakeManageSteps({
   hasDelegateChange: boolean;
   /** Display symbols for the getReward legs, aligned to the engine's free-before-claim order. */
   claimSymbols?: string[];
-}): string[] {
+}): TransactionStep[] {
   return [
     // Approval steps only render alongside the action that needs them, so a
     // still-loading allowance can't flash a phantom Approve step (the engine
     // still derives the real approve calls itself).
-    needsSkyAllowance && hasLock && t`Approve SKY`,
-    needsUsdsAllowance && hasWipe && t`Approve USDS`,
-    hasWipe && t`Repay USDS`,
-    hasFree && t`Withdraw SKY`,
-    ...(claimSymbols ?? []).map(symbol => t`Claim ${symbol}`),
+    needsSkyAllowance && hasLock && { label: t`Approve`, tokenSymbol: 'SKY' },
+    needsUsdsAllowance && hasWipe && { label: t`Approve`, tokenSymbol: 'USDS' },
+    hasWipe && { label: t`Repay`, tokenSymbol: 'USDS' },
+    hasFree && { label: t`Withdraw`, tokenSymbol: 'SKY' },
+    ...(claimSymbols ?? []).map(symbol => ({ label: t`Claim`, tokenSymbol: symbol })),
     hasDelegateChange && t`Change delegate`,
-    hasLock && t`Stake SKY`,
-    hasBorrow && t`Borrow USDS`
-  ].filter(Boolean) as string[];
+    hasLock && { label: t`Stake`, tokenSymbol: 'SKY' },
+    hasBorrow && { label: t`Borrow`, tokenSymbol: 'USDS' }
+  ].filter(Boolean) as TransactionStep[];
 }
 
 export interface UseStakeManageLaunchParams {

--- a/apps/webapp/src/modules/stusds/components/StUsdsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUsdsTransactionsTable.tsx
@@ -8,11 +8,9 @@ import { SavingsSupply, ArrowDown } from '@/modules/icons';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import {
   ProductTransactionsTable,
-  ProductTransactionColumn,
-  TxActionCell,
-  TxAmountCell,
-  TxHashLink
+  ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { CellAction, CellAmount, CellHash } from '@/components/ui/table-cells';
 
 type StUsdsTxRow = {
   id: string;
@@ -34,7 +32,7 @@ const COLUMNS: ProductTransactionColumn<StUsdsTxRow>[] = [
     header: <Trans>Transaction</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxActionCell
+      <CellAction
         icon={
           row.isSupply ? (
             <SavingsSupply width={16} height={15} />
@@ -60,8 +58,8 @@ const COLUMNS: ProductTransactionColumn<StUsdsTxRow>[] = [
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
     cell: row => (
-      <TxAmountCell
-        icon={<TokenIcon token={{ symbol: 'USDS' }} width={20} showChainIcon={false} className="h-5 w-5" />}
+      <CellAmount
+        icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} showChainIcon={false} className="h-3 w-3" />}
         amount={`${row.amount} USDS`}
         usd={row.usd}
       />
@@ -71,7 +69,7 @@ const COLUMNS: ProductTransactionColumn<StUsdsTxRow>[] = [
     id: 'hash',
     header: <Trans>Txn hash</Trans>,
     width: '1fr',
-    cell: row => <TxHashLink label={row.txHashLabel} href={row.txHref} />
+    cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   },
   {
     id: 'time',

--- a/apps/webapp/src/modules/ui/components/TransactionModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TransactionModal.tsx
@@ -1,17 +1,10 @@
 import { useState, useCallback, useRef, ReactNode } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
-import {
-  TxStatus,
-  Clock,
-  InProgress,
-  SuccessCheck,
-  SuccessCheckSolidColor,
-  FailedX,
-  Cancel
-} from '@/widgets';
+import { TxStatus, Clock, InProgress, SuccessCheck, FailedX, Cancel } from '@/widgets';
 import { ChevronLeft } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Steps, StepsItem, type StepState } from '@/components/ui/steps';
 import { Switch } from '@/components/ui/switch';
 import { Close, Info } from '@/modules/icons';
 import { Text } from '@/modules/layout/components/Typography';
@@ -24,11 +17,20 @@ import { useIsSafeWallet } from '@/hooks';
 import { useIsBatchSupported } from '@/hooks';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
 import { useChainId } from 'wagmi';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import type { TransactionEntry } from '@/modules/ui/context/transactionContract';
 
 // 'entry' is an editable first screen (the body owns its inputs); 'review' is the
 // read-only first screen. Both transition to the shared 'transaction' screen.
 type TransactionModalStep = 'entry' | 'review' | 'transaction';
+
+/**
+ * One entry of a flow's step list. The plain-string form is a bare label; the
+ * object form adds the token rendered as an icon+symbol chip after the label
+ * (DS Steps pattern, Figma 5200:30561) — e.g. `{ label: "Approve", tokenSymbol:
+ * "SKY" }` renders "Approve ◉ SKY".
+ */
+export type TransactionStep = string | { label: string; tokenSymbol?: string };
 
 export type TransactionSubtitles = {
   review?: string;
@@ -82,7 +84,7 @@ export type TransactionModalProps = {
   confirmDisabled?: boolean;
   successLabel?: string;
   errorLabel?: string;
-  steps?: string[];
+  steps?: TransactionStep[];
   currentStep?: number;
 };
 
@@ -138,6 +140,7 @@ export function TransactionModal({
   const isSafeWallet = useIsSafeWallet();
   const explorerName = getExplorerName(chainId, isSafeWallet);
   const { data: batchSupported } = useIsBatchSupported();
+  const [batchEnabled] = useBatchToggle();
 
   const isEntry = step === 'entry';
   const isReview = step === 'review';
@@ -147,6 +150,10 @@ export function TransactionModal({
   const isTransaction = step === 'transaction';
   const hasMultipleSteps = steps && steps.length > 1;
   const showBatchToggle = hasMultipleSteps && batchSupported;
+  // Same expression the launch hooks use for `shouldUseBatch` — when true the
+  // whole flow is one EIP-5792 bundle, rendered as the DS Bundle variant (all
+  // steps active together, "Bundled" header badge).
+  const isBundled = !!(hasMultipleSteps && batchEnabled && batchSupported);
   const isTransacting = txStatus === TxStatus.INITIALIZED || txStatus === TxStatus.LOADING;
 
   // The entry screen sources its label/gating from the entry descriptor (kept
@@ -283,27 +290,46 @@ export function TransactionModal({
             )}
           </AnimatePresence>
 
-          {/* Step indicators — Figma shows them only on the wallet/status screen,
-              not on the review/entry screen. */}
+          {/* Step list (DS Steps pattern) — Figma shows it only on the wallet/status
+              screen, not on the review/entry screen. Standard flows advance one step
+              per tx; bundled flows mark every step active while the single bundle is
+              in flight, then complete together. */}
           {hasMultipleSteps && isTransaction && (
-            <div className="flex flex-col">
-              {steps.map((label, i) => {
-                const allDone = isTransaction && txStatus === TxStatus.SUCCESS;
-                const isCompleted = isTransaction && (allDone || i < currentStep);
-                const isCurrent = isTransaction && !allDone && i === currentStep;
-                const stepTxStatus = isCompleted ? TxStatus.SUCCESS : isCurrent ? txStatus : TxStatus.IDLE;
+            <Steps
+              bundled={isBundled}
+              badge={txStatus === TxStatus.INITIALIZED ? <Trans>Confirm in the wallet</Trans> : undefined}
+            >
+              {steps.map((step, i) => {
+                const { label, tokenSymbol } = typeof step === 'string' ? { label: step } : step;
+                const allDone = txStatus === TxStatus.SUCCESS;
+                const state: StepState =
+                  allDone || (!isBundled && i < currentStep)
+                    ? 'completed'
+                    : isBundled || i === currentStep
+                      ? 'active'
+                      : 'upcoming';
 
                 return (
-                  <StepIndicator
+                  <StepsItem
                     key={i}
                     stepNumber={i + 1}
                     label={label}
-                    txStatus={stepTxStatus}
-                    active={isCurrent || (allDone && i === steps.length - 1)}
+                    tokenSymbol={tokenSymbol}
+                    tokenIcon={
+                      tokenSymbol && (
+                        <TokenIcon
+                          token={{ symbol: tokenSymbol }}
+                          className="h-3.5 w-3.5"
+                          showChainIcon={false}
+                        />
+                      )
+                    }
+                    state={state}
+                    showConnector={i < steps.length - 1}
                   />
                 );
               })}
-            </div>
+            </Steps>
           )}
 
           {/* The editable entry body stays MOUNTED for the modal's lifetime — it can
@@ -458,53 +484,6 @@ function BatchToggle() {
         onCheckedChange={setBatchEnabled}
         aria-label={t`Toggle bundled transactions`}
       />
-    </div>
-  );
-}
-
-function StepIndicator({
-  stepNumber,
-  label,
-  txStatus,
-  active
-}: {
-  stepNumber: number;
-  label: string;
-  txStatus: TxStatus;
-  active: boolean;
-}) {
-  return (
-    <div className="mt-4 flex items-center gap-3">
-      <div className="relative inline-flex h-5 w-5 items-center justify-center">
-        {active && txStatus === TxStatus.LOADING && (
-          <span className="absolute inset-0 flex items-center justify-center">
-            <svg className="h-5 w-5 animate-spin text-white" viewBox="0 0 20 20">
-              <circle
-                className="text-white/30"
-                cx="10"
-                cy="10"
-                r="9"
-                stroke="currentColor"
-                strokeWidth="2"
-                fill="none"
-              />
-              <path className="text-white" fill="none" stroke="currentColor" d="M10 1 A9 9 0 1 1 1 10" />
-            </svg>
-          </span>
-        )}
-        <span
-          className={`inline-flex h-5 w-5 items-center justify-center rounded-full border-2 text-xs ${
-            active
-              ? txStatus === TxStatus.LOADING
-                ? 'border-transparent text-white'
-                : 'border-white text-white'
-              : 'border-white/60 text-white/60'
-          }`}
-        >
-          {txStatus === TxStatus.SUCCESS ? <SuccessCheckSolidColor /> : stepNumber}
-        </span>
-      </div>
-      <Text className={active ? 'text-white' : 'text-white/60'}>{label}</Text>
     </div>
   );
 }

--- a/apps/webapp/src/modules/ui/context/transactionContract.ts
+++ b/apps/webapp/src/modules/ui/context/transactionContract.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { TransactionSubtitles } from '@/modules/ui/components/TransactionModal';
+import type { TransactionStep, TransactionSubtitles } from '@/modules/ui/components/TransactionModal';
 import type { TxStatus } from '@/widgets';
 
 /**
@@ -111,8 +111,11 @@ export type TransactionConfig = {
   errorLabel?: string;
   onSuccess?: () => void;
   onError?: () => void;
-  /** Step labels for multi-step transactions (e.g. ["Approve", "Supply"]). */
-  steps?: string[];
+  /**
+   * Steps for multi-step transactions — a bare label or `{ label, tokenSymbol }`
+   * to render the DS token chip (e.g. `{ label: "Approve", tokenSymbol: "USDS" }`).
+   */
+  steps?: TransactionStep[];
   /** Analytics metadata for tracking transaction lifecycle events. */
   analytics?: TransactionAnalytics;
   /** Identity used to gate updateModalContent calls to the active session. */

--- a/apps/webapp/src/modules/ui/hooks/useModalEntryBody.ts
+++ b/apps/webapp/src/modules/ui/hooks/useModalEntryBody.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useTransaction, useEntrySlot } from '@/modules/ui/context/TransactionContext';
 import type { TransactionConfig } from '@/modules/ui/context/transactionContract';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 
 /**
  * The live fields an editable modal body keeps in sync after launch. `confirmDisabled`
@@ -13,8 +14,8 @@ type ModalEntryBodyLive = {
   confirmDisabled: boolean;
   /** Compact amount summary rendered on the wallet/status screen. */
   transactionScreenContent?: ReactNode;
-  /** Step labels for multi-step flows (e.g. ["Approve", "Supply"]). */
-  steps?: string[];
+  /** Steps for multi-step flows (labels or `{ label, tokenSymbol }` chips). */
+  steps?: TransactionStep[];
   /** Per-state minimized-toast titles. */
   toast?: TransactionConfig['toast'];
 };

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -1,6 +1,16 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { ArrowRight, ChevronDown, Copy, LineChart, Settings2, Star, Wallet } from 'lucide-react';
+import {
+  ArrowDownToLine,
+  ArrowRight,
+  ArrowUpToLine,
+  ChevronDown,
+  Copy,
+  LineChart,
+  Settings2,
+  Star,
+  Wallet
+} from 'lucide-react';
 
 import { applyTheme } from '@/lib/theme';
 import { cn } from '@/lib/cn';
@@ -33,6 +43,26 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import {
+  CellAction,
+  CellAmount,
+  CellAmountWithToken,
+  CellBadge,
+  CellChevron,
+  CellEmpty,
+  CellHash,
+  CellNetworks,
+  CellPercent,
+  CellPosition,
+  CellProduct,
+  CellRisk,
+  CellStatus,
+  CellToken,
+  CellTokenIdle
+} from '@/components/ui/table-cells';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
+import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
+import { BaseChain, MainnetChain, OptimismChain, Pendle, Stake } from '@/modules/icons';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import {
   Pagination,
@@ -75,6 +105,7 @@ const SECTIONS = [
   { id: 'select', title: 'Select' },
   { id: 'cards', title: 'Cards' },
   { id: 'overlays', title: 'Overlays' },
+  { id: 'tables', title: 'Tables' },
   { id: 'data', title: 'Data & misc' }
 ];
 
@@ -847,35 +878,447 @@ function SlippageMenuDemo() {
   return <SlippageMenu value={slippage} defaultValue={0.002} onChange={setSlippage} />;
 }
 
+/** One primitive-built row per typed cell, so the table showcases itself. */
+function CellSpecimenRow({ name, children }: { name: string; children: React.ReactNode }) {
+  return (
+    <TableRow>
+      <TableCell className="text-fgSecondary w-64">{name}</TableCell>
+      <TableCell>{children}</TableCell>
+    </TableRow>
+  );
+}
+
+/** Sortable-header button as consumers build it (EarnTable pattern). */
+function SortableHead({ label, active }: { label: string; active?: boolean }) {
+  return (
+    <button
+      type="button"
+      className={cn('hover:text-fgPrimary inline-flex items-center gap-1 transition-colors')}
+    >
+      {label}
+      <ChevronDown size={12} className={cn(active ? 'rotate-180 opacity-100' : 'opacity-40')} />
+    </button>
+  );
+}
+
+function TablesSection() {
+  return (
+    <Section
+      id="tables"
+      title="Tables"
+      note="Patterns / Tables: transparent 32px Body-6 header, 88px rows separated by 2px slits, 24px corners on the body block only, bg-tertiary row hover. All columns left-aligned per Figma. Type=Text is the bare TableCell; Type=Button is the DS Button (primary, m)."
+    >
+      <SubSection title="Typed cells">
+        <Table className="max-w-3xl">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Type</TableHead>
+              <TableHead>Specimen</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <CellSpecimenRow name="Text (TableCell default)">$4.23b</CellSpecimenRow>
+            <CellSpecimenRow name="Percent">
+              <CellPercent value="3.75" />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Empty">
+              <CellEmpty />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Icon">
+              <CellChevron />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Risk (none / low / medium / high*)">
+              <span className="flex items-center gap-2">
+                <CellRisk tier="none" />
+                <CellRisk tier="low" />
+                <CellRisk tier="medium" />
+                <CellRisk tier="high" />
+              </span>
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Status">
+              <span className="flex items-center gap-2">
+                <CellStatus status="pending" />
+                <CellStatus status="completed" />
+              </span>
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Button (DS Button primary/m)">
+              <Button variant="primary" size="m">
+                Supply
+              </Button>
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Networks">
+              <CellNetworks>
+                <MainnetChain className="h-full w-full" />
+                <BaseChain className="h-full w-full" />
+                <OptimismChain className="h-full w-full" />
+              </CellNetworks>
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Token">
+              <CellToken
+                icon={<TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                title="Sky Savings"
+                subtitle={
+                  <>
+                    Supply: <TokenIconStack symbols={['USDS', 'USDC']} size={12} />
+                  </>
+                }
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Token (active position, showMode + showDate)">
+              <CellToken
+                active
+                icon={<TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                title="Pendle sUSDS"
+                titleSuffix={<Pendle className="h-4 w-4" />}
+                subtitle={
+                  <>
+                    Supply: <TokenIconStack symbols={['USDS']} size={12} />
+                    <span aria-hidden>·</span>
+                    18 Jun 2026
+                  </>
+                }
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Token Idle">
+              <CellTokenIdle
+                icon={<TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                symbol="USDS"
+                badges={
+                  <>
+                    <CellBadge tone="success">up to 4.75%</CellBadge>
+                    <CellBadge>1:1 USDC</CellBadge>
+                  </>
+                }
+                name="Sky USD"
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Position">
+              <CellPosition icon={<Stake width={16} height={16} />} label="Position 1" />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Action">
+              <CellAction icon={<ArrowDownToLine className="size-4" />} label="Supply" sublabel="35 min ago" />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Action and Position">
+              <CellAction
+                compact
+                icon={<ArrowUpToLine className="size-4" />}
+                label="Stake & Borrow"
+                sublabel={
+                  <>
+                    35 min ago <span aria-hidden>·</span> Position 1
+                  </>
+                }
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Product">
+              <CellProduct
+                icon={<TokenIcon token={{ symbol: 'stUSDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                label="Staked USDS"
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Amount with Token">
+              <CellAmountWithToken
+                amount="$128.90"
+                icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Amount">
+              <CellAmount
+                icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                amount="1,000.00"
+                usd="$1,000.00"
+              />
+            </CellSpecimenRow>
+            <CellSpecimenRow name="Hash">
+              <CellHash label="0xff9s...dsa6" href="https://etherscan.io" />
+            </CellSpecimenRow>
+          </TableBody>
+        </Table>
+      </SubSection>
+
+      <SubSection title="Table / Earn">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[34%]">
+                <SortableHead label="Token" active />
+              </TableHead>
+              <TableHead>
+                <SortableHead label="Network" />
+              </TableHead>
+              <TableHead>
+                <SortableHead label="Risk profile" />
+              </TableHead>
+              <TableHead>
+                <SortableHead label="Rate" />
+              </TableHead>
+              <TableHead>
+                <SortableHead label="30D Rate" />
+              </TableHead>
+              <TableHead>
+                <SortableHead label="TVL" />
+              </TableHead>
+              <TableHead>
+                <SortableHead label="My position" />
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow className="cursor-pointer">
+              <TableCell>
+                <CellToken
+                  active
+                  icon={
+                    <TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
+                  }
+                  title="Sky Savings"
+                  subtitle={
+                    <>
+                      Supply: <TokenIconStack symbols={['USDS', 'USDC']} size={12} />
+                    </>
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <CellNetworks>
+                  <MainnetChain className="h-full w-full" />
+                  <BaseChain className="h-full w-full" />
+                  <OptimismChain className="h-full w-full" />
+                </CellNetworks>
+              </TableCell>
+              <TableCell>
+                <CellRisk tier="low" />
+              </TableCell>
+              <TableCell>
+                <CellPercent value="3.75" />
+              </TableCell>
+              <TableCell>
+                <CellPercent value="3.81" />
+              </TableCell>
+              <TableCell>$4.23b</TableCell>
+              <TableCell>$2,500.00</TableCell>
+            </TableRow>
+            <TableRow className="cursor-pointer">
+              <TableCell>
+                <CellToken
+                  icon={
+                    <TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
+                  }
+                  title="Pendle sUSDS"
+                  titleSuffix={<Pendle className="h-4 w-4" />}
+                  subtitle={
+                    <>
+                      Supply: <TokenIconStack symbols={['USDS']} size={12} />
+                      <span aria-hidden>·</span>
+                      18 Jun 2026
+                    </>
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <CellNetworks>
+                  <MainnetChain className="h-full w-full" />
+                </CellNetworks>
+              </TableCell>
+              <TableCell>
+                <CellRisk tier="low" />
+              </TableCell>
+              <TableCell>
+                <CellPercent value="8.61" />
+              </TableCell>
+              <TableCell>
+                <CellEmpty />
+              </TableCell>
+              <TableCell>$78.9m</TableCell>
+              <TableCell>$0.00</TableCell>
+            </TableRow>
+            <TableRow className="cursor-pointer">
+              <TableCell>
+                <CellToken
+                  icon={
+                    <TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
+                  }
+                  title="USDS Flagship Vault"
+                  subtitle={
+                    <>
+                      Supply: <TokenIconStack symbols={['USDS']} size={12} />
+                    </>
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <CellNetworks>
+                  <BaseChain className="h-full w-full" />
+                </CellNetworks>
+              </TableCell>
+              <TableCell>
+                <CellRisk tier="medium" />
+              </TableCell>
+              <TableCell>
+                <CellPercent value="5.12" />
+              </TableCell>
+              <TableCell>
+                <CellPercent value="5.02" />
+              </TableCell>
+              <TableCell>$312.4m</TableCell>
+              <TableCell>
+                <CellEmpty />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </SubSection>
+
+      <SubSection title="Table / Transactions">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[23%]">Action</TableHead>
+              <TableHead>Network</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Product</TableHead>
+              <TableHead>Supplied</TableHead>
+              <TableHead>Txn hash</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <CellAction
+                  icon={<ArrowDownToLine className="size-4" />}
+                  label="Supply"
+                  sublabel="35 min ago"
+                />
+              </TableCell>
+              <TableCell>
+                <CellNetworks>
+                  <MainnetChain className="h-full w-full" />
+                </CellNetworks>
+              </TableCell>
+              <TableCell>
+                <CellStatus status="pending" />
+              </TableCell>
+              <TableCell>
+                <CellProduct
+                  icon={
+                    <TokenIcon token={{ symbol: 'stUSDS' }} width={12} className="h-3 w-3" showChainIcon={false} />
+                  }
+                  label="Staked USDS"
+                />
+              </TableCell>
+              <TableCell>
+                <CellAmount
+                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  amount="1,000.00"
+                  usd="$1,000.00"
+                />
+              </TableCell>
+              <TableCell>
+                <CellHash label="0xff9s...dsa6" href="https://etherscan.io" />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <CellAction
+                  icon={<ArrowUpToLine className="size-4" />}
+                  label="Withdraw"
+                  sublabel="2 days ago"
+                />
+              </TableCell>
+              <TableCell>
+                <CellNetworks>
+                  <BaseChain className="h-full w-full" />
+                </CellNetworks>
+              </TableCell>
+              <TableCell>
+                <CellStatus status="completed" />
+              </TableCell>
+              <TableCell>
+                <CellProduct
+                  icon={
+                    <TokenIcon token={{ symbol: 'sUSDS' }} width={12} className="h-3 w-3" showChainIcon={false} />
+                  }
+                  label="Sky Savings"
+                />
+              </TableCell>
+              <TableCell>
+                <CellAmount
+                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  amount="500.00"
+                  usd="$500.00"
+                />
+              </TableCell>
+              <TableCell>
+                <CellHash label="0x8a2b...41ce" href="https://etherscan.io" />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </SubSection>
+
+      <SubSection title="Table / Active Positions + Idle (excerpt)">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[40%]">Token</TableHead>
+              <TableHead>Supplied</TableHead>
+              <TableHead className="w-[148px]" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <CellTokenIdle
+                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                  symbol="USDS"
+                  badges={
+                    <>
+                      <CellBadge tone="success">up to 4.75%</CellBadge>
+                      <CellBadge>1:1 USDC</CellBadge>
+                    </>
+                  }
+                  name="Sky USD"
+                />
+              </TableCell>
+              <TableCell>
+                <CellAmount
+                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  amount="1,000.00"
+                  usd="$1,000.00"
+                />
+              </TableCell>
+              <TableCell className="px-4">
+                <Button variant="primary" size="m" className="w-full">
+                  Supply
+                </Button>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <CellPosition icon={<Stake width={16} height={16} />} label="Position 1" />
+              </TableCell>
+              <TableCell>
+                <CellAmountWithToken
+                  amount="$128.90"
+                  icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                />
+              </TableCell>
+              <TableCell>
+                <span className="flex justify-center">
+                  <CellChevron />
+                </span>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </SubSection>
+    </Section>
+  );
+}
+
 function DataSection() {
   return (
     <Section id="data" title="Data & misc">
-      <SubSection title="Table">
-        <div className="max-w-2xl">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Asset</TableHead>
-                <TableHead>Balance</TableHead>
-                <TableHead className="text-right">Value</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <TableRow>
-                <TableCell>USDS</TableCell>
-                <TableCell>12,400.00</TableCell>
-                <TableCell className="text-right">$12,400.00</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>SKY</TableCell>
-                <TableCell>850,000.00</TableCell>
-                <TableCell className="text-right">$44,795.00</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </div>
-      </SubSection>
-
       <SubSection title="Accordion">
         <Accordion type="single" collapsible className="max-w-2xl">
           <AccordionItem value="a">
@@ -1046,6 +1489,7 @@ function DesignSystem() {
         <SelectSection />
         <CardsSection />
         <OverlaysSection />
+        <TablesSection />
         <DataSection />
       </main>
       <Toaster />

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -90,6 +90,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { ChartSkeleton } from '@/components/ui/chart-skeleton';
 import { GainValue } from '@/components/ui/GainValue';
 import { SlippageMenu } from '@/components/ui/SlippageMenu';
+import { Steps, StepsItem } from '@/components/ui/steps';
 
 // Internal-only living style guide (route /design-system, hidden in production).
 // Shows every canonical components/ui primitive in its prop-reachable states;
@@ -106,6 +107,7 @@ const SECTIONS = [
   { id: 'cards', title: 'Cards' },
   { id: 'overlays', title: 'Overlays' },
   { id: 'tables', title: 'Tables' },
+  { id: 'steps', title: 'Steps' },
   { id: 'data', title: 'Data & misc' }
 ];
 
@@ -1535,6 +1537,144 @@ function DataSection() {
   );
 }
 
+// ─── Steps ────────────────────────────────────────────────────────────────────
+
+/** 14px chip icon for step specimens (chain overlay off — the chip is symbol-only). */
+function StepToken({ symbol }: { symbol: string }) {
+  return <TokenIcon token={{ symbol }} className="h-3.5 w-3.5" showChainIcon={false} />;
+}
+
+function StepsSection() {
+  return (
+    <Section
+      id="steps"
+      title="Steps"
+      note="Transaction-modal step list (Figma Patterns / Steps). Standard flows advance one step at a
+        time; Bundle flows (EIP-5792 batched) mark every step active while the single bundled
+        transaction is in flight, then complete together."
+    >
+      <SubSection title="Item states">
+        <ol className="flex max-w-xl flex-col gap-1">
+          <StepsItem
+            stepNumber={1}
+            label="Approve"
+            tokenSymbol="SKY"
+            tokenIcon={<StepToken symbol="SKY" />}
+            state="completed"
+            showConnector
+          />
+          <StepsItem
+            stepNumber={2}
+            label="Stake"
+            tokenSymbol="SKY"
+            tokenIcon={<StepToken symbol="SKY" />}
+            state="active"
+            showConnector
+          />
+          <StepsItem
+            stepNumber={3}
+            label="Borrow"
+            tokenSymbol="USDS"
+            tokenIcon={<StepToken symbol="USDS" />}
+            state="upcoming"
+            showConnector
+          />
+          <StepsItem stepNumber={4} label="Delegate voting power" state="upcoming" />
+        </ol>
+      </SubSection>
+
+      <SubSection title="Steps Standard — mid-flow, awaiting wallet">
+        <div className="max-w-xl">
+          <Steps badge="Confirm in the wallet">
+            <StepsItem
+              stepNumber={1}
+              label="Approve"
+              tokenSymbol="SKY"
+              tokenIcon={<StepToken symbol="SKY" />}
+              state="completed"
+              showConnector
+            />
+            <StepsItem
+              stepNumber={2}
+              label="Stake"
+              tokenSymbol="SKY"
+              tokenIcon={<StepToken symbol="SKY" />}
+              state="active"
+              showConnector
+            />
+            <StepsItem
+              stepNumber={3}
+              label="Borrow"
+              tokenSymbol="USDS"
+              tokenIcon={<StepToken symbol="USDS" />}
+              state="upcoming"
+            />
+          </Steps>
+        </div>
+      </SubSection>
+
+      <SubSection title="Steps Bundle — one confirmation covers every step">
+        <Row>
+          <Spec label="in flight — all active" className="w-96">
+            <Steps bundled badge="Confirm in the wallet">
+              <StepsItem
+                stepNumber={1}
+                label="Approve"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="active"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={2}
+                label="Stake"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="active"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={3}
+                label="Borrow"
+                tokenSymbol="USDS"
+                tokenIcon={<StepToken symbol="USDS" />}
+                state="active"
+              />
+            </Steps>
+          </Spec>
+          <Spec label="confirmed — all completed" className="w-96">
+            <Steps bundled>
+              <StepsItem
+                stepNumber={1}
+                label="Approve"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="completed"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={2}
+                label="Stake"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="completed"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={3}
+                label="Borrow"
+                tokenSymbol="USDS"
+                tokenIcon={<StepToken symbol="USDS" />}
+                state="completed"
+              />
+            </Steps>
+          </Spec>
+        </Row>
+      </SubSection>
+    </Section>
+  );
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 function DesignSystem() {
@@ -1593,6 +1733,7 @@ function DesignSystem() {
         <CardsSection />
         <OverlaysSection />
         <TablesSection />
+        <StepsSection />
         <DataSection />
       </main>
       <Toaster />

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -1342,7 +1342,9 @@ function TablesSection() {
             <TableRow>
               <TableHead className="w-[40%]">Token</TableHead>
               <TableHead>Supplied</TableHead>
-              <TableHead className="w-[148px]" />
+              <TableHead className="w-[148px]">
+                <span className="sr-only">Actions</span>
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -955,7 +955,14 @@ function TablesSection() {
             </CellSpecimenRow>
             <CellSpecimenRow name="Token">
               <CellToken
-                icon={<TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                icon={
+                  <TokenIcon
+                    token={{ symbol: 'sUSDS' }}
+                    width={28}
+                    className="h-7 w-7"
+                    showChainIcon={false}
+                  />
+                }
                 title="Sky Savings"
                 subtitle={
                   <>
@@ -967,7 +974,14 @@ function TablesSection() {
             <CellSpecimenRow name="Token (active position, showMode + showDate)">
               <CellToken
                 active
-                icon={<TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                icon={
+                  <TokenIcon
+                    token={{ symbol: 'sUSDS' }}
+                    width={28}
+                    className="h-7 w-7"
+                    showChainIcon={false}
+                  />
+                }
                 title="Pendle sUSDS"
                 titleSuffix={<Pendle className="h-4 w-4" />}
                 subtitle={
@@ -981,7 +995,14 @@ function TablesSection() {
             </CellSpecimenRow>
             <CellSpecimenRow name="Token Idle">
               <CellTokenIdle
-                icon={<TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                icon={
+                  <TokenIcon
+                    token={{ symbol: 'USDS' }}
+                    width={28}
+                    className="h-7 w-7"
+                    showChainIcon={false}
+                  />
+                }
                 symbol="USDS"
                 badges={
                   <>
@@ -996,7 +1017,11 @@ function TablesSection() {
               <CellPosition icon={<Stake width={16} height={16} />} label="Position 1" />
             </CellSpecimenRow>
             <CellSpecimenRow name="Action">
-              <CellAction icon={<ArrowDownToLine className="size-4" />} label="Supply" sublabel="35 min ago" />
+              <CellAction
+                icon={<ArrowDownToLine className="size-4" />}
+                label="Supply"
+                sublabel="35 min ago"
+              />
             </CellSpecimenRow>
             <CellSpecimenRow name="Action and Position">
               <CellAction
@@ -1012,19 +1037,35 @@ function TablesSection() {
             </CellSpecimenRow>
             <CellSpecimenRow name="Product">
               <CellProduct
-                icon={<TokenIcon token={{ symbol: 'stUSDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                icon={
+                  <TokenIcon
+                    token={{ symbol: 'stUSDS' }}
+                    width={12}
+                    className="h-3 w-3"
+                    showChainIcon={false}
+                  />
+                }
                 label="Staked USDS"
               />
             </CellSpecimenRow>
             <CellSpecimenRow name="Amount with Token">
               <CellAmountWithToken
                 amount="$128.90"
-                icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                icon={
+                  <TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />
+                }
               />
             </CellSpecimenRow>
             <CellSpecimenRow name="Amount">
               <CellAmount
-                icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                icon={
+                  <TokenIcon
+                    token={{ symbol: 'USDS' }}
+                    width={12}
+                    className="h-3 w-3"
+                    showChainIcon={false}
+                  />
+                }
                 amount="1,000.00"
                 usd="$1,000.00"
               />
@@ -1069,7 +1110,12 @@ function TablesSection() {
                 <CellToken
                   active
                   icon={
-                    <TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
+                    <TokenIcon
+                      token={{ symbol: 'sUSDS' }}
+                      width={28}
+                      className="h-7 w-7"
+                      showChainIcon={false}
+                    />
                   }
                   title="Sky Savings"
                   subtitle={
@@ -1102,7 +1148,12 @@ function TablesSection() {
               <TableCell>
                 <CellToken
                   icon={
-                    <TokenIcon token={{ symbol: 'sUSDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
+                    <TokenIcon
+                      token={{ symbol: 'sUSDS' }}
+                      width={28}
+                      className="h-7 w-7"
+                      showChainIcon={false}
+                    />
                   }
                   title="Pendle sUSDS"
                   titleSuffix={<Pendle className="h-4 w-4" />}
@@ -1136,7 +1187,12 @@ function TablesSection() {
               <TableCell>
                 <CellToken
                   icon={
-                    <TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
+                    <TokenIcon
+                      token={{ symbol: 'USDS' }}
+                      width={28}
+                      className="h-7 w-7"
+                      showChainIcon={false}
+                    />
                   }
                   title="USDS Flagship Vault"
                   subtitle={
@@ -1201,14 +1257,26 @@ function TablesSection() {
               <TableCell>
                 <CellProduct
                   icon={
-                    <TokenIcon token={{ symbol: 'stUSDS' }} width={12} className="h-3 w-3" showChainIcon={false} />
+                    <TokenIcon
+                      token={{ symbol: 'stUSDS' }}
+                      width={12}
+                      className="h-3 w-3"
+                      showChainIcon={false}
+                    />
                   }
                   label="Staked USDS"
                 />
               </TableCell>
               <TableCell>
                 <CellAmount
-                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  icon={
+                    <TokenIcon
+                      token={{ symbol: 'USDS' }}
+                      width={12}
+                      className="h-3 w-3"
+                      showChainIcon={false}
+                    />
+                  }
                   amount="1,000.00"
                   usd="$1,000.00"
                 />
@@ -1236,14 +1304,26 @@ function TablesSection() {
               <TableCell>
                 <CellProduct
                   icon={
-                    <TokenIcon token={{ symbol: 'sUSDS' }} width={12} className="h-3 w-3" showChainIcon={false} />
+                    <TokenIcon
+                      token={{ symbol: 'sUSDS' }}
+                      width={12}
+                      className="h-3 w-3"
+                      showChainIcon={false}
+                    />
                   }
                   label="Sky Savings"
                 />
               </TableCell>
               <TableCell>
                 <CellAmount
-                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  icon={
+                    <TokenIcon
+                      token={{ symbol: 'USDS' }}
+                      width={12}
+                      className="h-3 w-3"
+                      showChainIcon={false}
+                    />
+                  }
                   amount="500.00"
                   usd="$500.00"
                 />
@@ -1269,7 +1349,14 @@ function TablesSection() {
             <TableRow>
               <TableCell>
                 <CellTokenIdle
-                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />}
+                  icon={
+                    <TokenIcon
+                      token={{ symbol: 'USDS' }}
+                      width={28}
+                      className="h-7 w-7"
+                      showChainIcon={false}
+                    />
+                  }
                   symbol="USDS"
                   badges={
                     <>
@@ -1282,7 +1369,14 @@ function TablesSection() {
               </TableCell>
               <TableCell>
                 <CellAmount
-                  icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  icon={
+                    <TokenIcon
+                      token={{ symbol: 'USDS' }}
+                      width={12}
+                      className="h-3 w-3"
+                      showChainIcon={false}
+                    />
+                  }
                   amount="1,000.00"
                   usd="$1,000.00"
                 />
@@ -1300,7 +1394,14 @@ function TablesSection() {
               <TableCell>
                 <CellAmountWithToken
                   amount="$128.90"
-                  icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+                  icon={
+                    <TokenIcon
+                      token={{ symbol: 'SKY' }}
+                      width={12}
+                      className="h-3 w-3"
+                      showChainIcon={false}
+                    />
+                  }
                 />
               </TableCell>
               <TableCell>

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -55,11 +55,11 @@ import {
   CellPercent,
   CellPosition,
   CellProduct,
-  CellRisk,
   CellStatus,
   CellToken,
   CellTokenIdle
 } from '@/components/ui/table-cells';
+import { RiskMeter, RiskTierMeter } from '@/components/product/RiskMeter';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
 import { BaseChain, MainnetChain, OptimismChain, Pendle, Stake } from '@/modules/icons';
@@ -927,12 +927,12 @@ function TablesSection() {
             <CellSpecimenRow name="Icon">
               <CellChevron />
             </CellSpecimenRow>
-            <CellSpecimenRow name="Risk (none / low / medium / high*)">
+            <CellSpecimenRow name="Risk (none / low / moderate / advanced)">
               <span className="flex items-center gap-2">
-                <CellRisk tier="none" />
-                <CellRisk tier="low" />
-                <CellRisk tier="medium" />
-                <CellRisk tier="high" />
+                <RiskMeter segments={[null, null, null]} />
+                <RiskTierMeter tier="low" />
+                <RiskTierMeter tier="moderate" />
+                <RiskTierMeter tier="advanced" />
               </span>
             </CellSpecimenRow>
             <CellSpecimenRow name="Status">
@@ -1087,7 +1087,7 @@ function TablesSection() {
                 </CellNetworks>
               </TableCell>
               <TableCell>
-                <CellRisk tier="low" />
+                <RiskTierMeter tier="low" />
               </TableCell>
               <TableCell>
                 <CellPercent value="3.75" />
@@ -1121,7 +1121,7 @@ function TablesSection() {
                 </CellNetworks>
               </TableCell>
               <TableCell>
-                <CellRisk tier="low" />
+                <RiskTierMeter tier="low" />
               </TableCell>
               <TableCell>
                 <CellPercent value="8.61" />
@@ -1152,7 +1152,7 @@ function TablesSection() {
                 </CellNetworks>
               </TableCell>
               <TableCell>
-                <CellRisk tier="medium" />
+                <RiskTierMeter tier="moderate" />
               </TableCell>
               <TableCell>
                 <CellPercent value="5.12" />


### PR DESCRIPTION
Closes APP-352.

Builds the design-system table batch on the `ui/table.tsx` primitive and migrates every ticket-named surface in one PR, one commit per concern.

## What's here

- **Primitive restyle (`ui/table.tsx`)** — Figma Patterns/Tables construction: 2px transparent row slits via `border-spacing` (no borders), cells carry the row surface (`bg-bgSecondary`), 24px corners on the **body block only** (header is transparent, 32px, Body 6), 88px Label-5 cells, `bg-bgTertiary` hover/selected. All columns left-aligned per Figma — including numeric ones.
- **Typed cells (`ui/table-cells.tsx`)** — the 17 Figma `Table Cell` types. Three map to existing pieces by design: Type=Text is the bare `TableCell`, Type=Button is the DS `Button` (primary/m), Type=Risk is the shared `RiskMeter` (restyled in place to the Badges/Risk chrome — one pill app-wide, per earlier review feedback).
- **Tokens (`globals.css`)** — `bgSecondary`/`bgTertiary` surfaces + the `components/status` palette (success/warning/brand), dark = Figma source values, light deferred to G2 like the other batches.
- **Design-system page** — new Tables section: self-demonstrating typed-cells specimen table + assembled Earn / Transactions / Active-Positions-and-Idle samples.
- **Surface migrations** (a commit each):
  - `EarnTable` + `EarnPage` (Table/Earn): CellToken with active-position iconbox, CellPercent/CellEmpty, 16px CellNetworks
  - `ProductTransactionsTable` rebuilt on the primitive keeping its column-config API (fr widths → percentage hints); `Tx*` cells deleted in favor of typed cells across savings/rewards/pendle/morpho/stusds/stake-activity; stake activity uses the compact Action-and-Position title
  - `StakePositionsTable` (Table/Active Positions): CellPosition, CellAmountWithToken, centered 64px chevron column, risk tiers on status tokens
  - `IdleStablecoinsTable` (Table/Idle): CellTokenIdle + rate/parity CellBadges, full-width Supply CTA column

## Notes / open items

- **Risk "High" tier**: never appears in any Figma pattern — implemented as 3 error-red segments pending design confirmation (commented at both sites).
- The remaining `ui/table` consumers (historyTable framework, legacy details panes, Morpho allocations) live on parked/legacy widget-pane surfaces; they inherit the restyle and get deleted with their tracks.
- `alignEnd` dropped from the transactions-table API — Figma left-aligns every column and no consumer used it.
- e2e deferred per branch convention.

## QA

- `pnpm lint` 0 errors · `pnpm typecheck` clean · `pnpm test` green (unit + vnet hooks, 495/495 in hooks stage) · prettier clean · i18n catalogs unchanged
- Browser-verified on a fresh Tenderly fork, dark mode first: design-system Tables section (all 17 cells + patterns + row hover), /earn marketplace with live data (found & fixed the em-dash NO_RATE bypassing the Empty cell), portfolio Idle table with funded USDS/USDC balances, transactions empty state on a product page. Tx-history rows can't populate on ad-hoc forks (subgraph), covered by the DS samples + unit tests.