### PR TITLE
Adopt the DS Steps pattern in the shared transaction modal (Standard + Bundle)

### DIFF
--- a/apps/webapp/src/components/ui/steps.tsx
+++ b/apps/webapp/src/components/ui/steps.tsx
@@ -1,0 +1,213 @@
+import { ReactNode, useId } from 'react';
+import { Trans } from '@lingui/react/macro';
+
+import { cn } from '@/lib/cn';
+
+// Design-system transaction-steps pattern (Figma "Patterns / Steps",
+// 5200:30907 / 5200:30561 / 5119:21048). `Steps` is the assembled container
+// (header badges + item list); `StepsItem` is one row (icon + connector +
+// title). The Bundle flavour of the pattern has no per-item variant — bundled
+// flows differ only in the header badge and in every step being active at
+// once, both driven by the caller.
+
+export type StepState = 'upcoming' | 'active' | 'completed';
+
+// Figma Steps Icon Item (5119:21048): a 30px circle per state. Ring + fill are
+// SVG (the active ring is a gradient stroke, which CSS borders can't do); the
+// number is an HTML overlay so it uses the app font stack. Gradient stops map
+// to existing tokens: ring = brandHover→fgBrand, fill = the button gradient
+// pair. The completed greens (Figma bg/border-system-success-primary) have no
+// theme token yet, so they stay literal.
+function StepIcon({ state, stepNumber }: { state: StepState; stepNumber: number }) {
+  const id = useId();
+
+  return (
+    <div className="relative size-[30px] shrink-0">
+      {state === 'completed' ? (
+        <svg viewBox="0 0 30 30" className="absolute inset-0 size-full" aria-hidden="true">
+          <circle cx="15" cy="15" r="14.5" fill="none" stroke="#02C2A1" />
+          <circle cx="15" cy="15" r="12" fill="#00A186" />
+          <path
+            d="M19 12L13.5 17.5L11 15"
+            fill="none"
+            className="stroke-fgConsistent"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <>
+          <svg viewBox="0 0 30 30" className="absolute inset-0 size-full" aria-hidden="true">
+            {state === 'active' && (
+              <defs>
+                <linearGradient
+                  id={`${id}-ring`}
+                  x1="15"
+                  y1="0"
+                  x2="15"
+                  y2="30"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stopColor="var(--color-brandHover)" />
+                  <stop offset="1" stopColor="var(--color-fgBrand)" />
+                </linearGradient>
+                <linearGradient
+                  id={`${id}-fill`}
+                  x1="15"
+                  y1="3"
+                  x2="15"
+                  y2="27"
+                  gradientUnits="userSpaceOnUse"
+                >
+                  <stop stopColor="var(--color-button-gradient-start)" />
+                  <stop offset="1" stopColor="var(--color-button-gradient-end)" />
+                </linearGradient>
+              </defs>
+            )}
+            <circle
+              cx="15"
+              cy="15"
+              r="14.5"
+              fill="none"
+              stroke={state === 'active' ? `url(#${id}-ring)` : 'var(--color-borderTertiary)'}
+            />
+            <circle
+              cx="15"
+              cy="15"
+              r="12"
+              fill={state === 'active' ? `url(#${id}-fill)` : 'rgba(188,182,239,0.2)'}
+            />
+          </svg>
+          <span
+            className={cn(
+              'font-circle absolute inset-0 flex items-center justify-center text-xs leading-3.5 font-medium tracking-[-0.24px]',
+              state === 'active' ? 'text-fgConsistent' : 'text-fgSecondary'
+            )}
+          >
+            {stepNumber}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+// The 2px connector under an item's icon fades from the item's state colour
+// into the idle track colour (Figma colors/bg/bg-quarternary).
+const connectorClasses: Record<StepState, string> = {
+  upcoming: 'bg-[rgba(188,182,239,0.2)]',
+  active: 'bg-linear-to-b from-brandHover to-[rgba(188,182,239,0.2)]',
+  completed: 'bg-linear-to-b from-[#00A186] to-[rgba(188,182,239,0.2)]'
+};
+
+export type StepsItemProps = {
+  stepNumber: number;
+  label: ReactNode;
+  /** Token rendered as a chip after the label (Figma Title's Token slot). */
+  tokenSymbol?: string;
+  /** 14px icon node for the token chip — supplied by the caller (the primitive stays icon-source agnostic). */
+  tokenIcon?: ReactNode;
+  state?: StepState;
+  /** Draw the connector line to the next item — every item except the last. */
+  showConnector?: boolean;
+  className?: string;
+};
+
+export function StepsItem({
+  stepNumber,
+  label,
+  tokenSymbol,
+  tokenIcon,
+  state = 'upcoming',
+  showConnector = false,
+  className
+}: StepsItemProps) {
+  return (
+    <li className={cn('flex w-full items-start gap-4', className)}>
+      <div className="flex w-[30px] flex-col items-center gap-1 self-stretch">
+        <StepIcon state={state} stepNumber={stepNumber} />
+        {showConnector && (
+          <div className={cn('min-h-px w-0.5 flex-1 rounded-full', connectorClasses[state])} />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="font-circle text-fgPrimary flex h-[30px] items-center gap-1.5 text-base leading-4.5 font-medium tracking-[-0.32px]">
+          <span className="truncate">{label}</span>
+          {tokenSymbol && (
+            <span className="flex shrink-0 items-center gap-[3px]">
+              {tokenIcon}
+              <span>{tokenSymbol}</span>
+            </span>
+          )}
+        </div>
+        {/* Spacer giving the connector its run to the next item (Figma 5205:31478). */}
+        {showConnector && <div className="h-5" aria-hidden="true" />}
+      </div>
+    </li>
+  );
+}
+
+/** Header pill (Figma Badge, h-24): `brand` is the Bundled treatment, `default` the neutral one. */
+export function StepsBadge({
+  variant = 'default',
+  children,
+  className
+}: {
+  variant?: 'brand' | 'default';
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'font-circle flex h-6 items-center gap-1 rounded-full px-2 text-xs leading-3.5 font-medium tracking-[-0.24px]',
+        // Figma components/status/bg-brand + fg-brand — not theme tokens yet.
+        variant === 'brand' ? 'bg-[rgba(156,160,229,0.1)] text-[#9CA9FF]' : 'bg-glassBadge text-fgSecondary',
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+// Figma Icons/Custom/lightning-filled (12px), inlined for the Bundled badge.
+function LightningIcon() {
+  return (
+    <svg viewBox="0 0 12 12" className="size-3 shrink-0" fill="currentColor" aria-hidden="true">
+      <path d="M7 4.96875L7.33333 0.5H6.66667L2 7.03125H5L4.66667 11.5H5.33333L10 4.96875H7Z" />
+    </svg>
+  );
+}
+
+export type StepsProps = {
+  /** Header title; defaults to "Actions". */
+  title?: ReactNode;
+  /** Show the "⚡ Bundled" badge next to the title (EIP-5792 batched flows). */
+  bundled?: boolean;
+  /** Right-aligned header badge content (e.g. "Confirm in the wallet"). */
+  badge?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+/** Assembled Steps Standard container (Figma 5200:30907): header row + item list. */
+export function Steps({ title, bundled = false, badge, children, className }: StepsProps) {
+  return (
+    <div className={cn('flex w-full flex-col gap-5', className)}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-fgSecondary text-sm leading-5.5">{title ?? <Trans>Actions</Trans>}</span>
+          {bundled && (
+            <StepsBadge variant="brand">
+              <LightningIcon />
+              <Trans>Bundled</Trans>
+            </StepsBadge>
+          )}
+        </div>
+        {badge && <StepsBadge>{badge}</StepsBadge>}
+      </div>
+      <ol className="flex flex-col gap-1">{children}</ol>
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
@@ -45,6 +45,7 @@ import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
 import { useModalEntryBody } from '@/modules/ui/hooks/useModalEntryBody';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 import { pendlePrepareErrorMessage } from '../utils/prepareErrorMessage';
 
 export type PendleModalFlow = 'supply' | 'withdraw';
@@ -150,11 +151,11 @@ export function PendleModalForm({
   });
   const needsAllowance = allowance !== undefined && amount > 0n && allowance < amount;
 
-  // Step labels mirror the engine's call count ([approve?, convert]) so the
+  // Steps mirror the engine's call count ([approve?, convert]) so the
   // indicator advances in lockstep with the sequential flow's onMutate bumps.
-  const steps = useMemo<string[]>(() => {
-    const convertStep = isSupply ? t`Supply ${inputSymbol}` : t`Withdraw ${inputSymbol}`;
-    return needsAllowance ? [t`Approve ${inputSymbol}`, convertStep] : [convertStep];
+  const steps = useMemo<TransactionStep[]>(() => {
+    const convertStep = { label: isSupply ? t`Supply` : t`Withdraw`, tokenSymbol: inputSymbol };
+    return needsAllowance ? [{ label: t`Approve`, tokenSymbol: inputSymbol }, convertStep] : [convertStep];
   }, [isSupply, needsAllowance, inputSymbol]);
 
   const { data: quote, isLoading: isFetchingQuote } = useQuotePendleConvert({

--- a/apps/webapp/src/modules/pendle/components/__tests__/PendleModalForm.test.tsx
+++ b/apps/webapp/src/modules/pendle/components/__tests__/PendleModalForm.test.tsx
@@ -312,7 +312,10 @@ describe('PendleModalForm', () => {
       renderForm('supply');
       typeAmount('100');
 
-      expect(lastEntryUpdate()?.steps).toEqual(['Approve USDG', 'Supply USDG']);
+      expect(lastEntryUpdate()?.steps).toEqual([
+        { label: 'Approve', tokenSymbol: 'USDG' },
+        { label: 'Supply', tokenSymbol: 'USDG' }
+      ]);
     });
 
     it('collapses to a single supply step once the allowance covers the amount', () => {
@@ -320,7 +323,7 @@ describe('PendleModalForm', () => {
       renderForm('supply');
       typeAmount('100');
 
-      expect(lastEntryUpdate()?.steps).toEqual(['Supply USDG']);
+      expect(lastEntryUpdate()?.steps).toEqual([{ label: 'Supply', tokenSymbol: 'USDG' }]);
     });
 
     it('pushes the SlippageMenu into the modal header', () => {
@@ -358,7 +361,10 @@ describe('PendleModalForm', () => {
       renderForm('withdraw');
       typeAmount('200');
 
-      expect(lastEntryUpdate()?.steps).toEqual(['Approve PT-USDG', 'Withdraw PT-USDG']);
+      expect(lastEntryUpdate()?.steps).toEqual([
+        { label: 'Approve', tokenSymbol: 'PT-USDG' },
+        { label: 'Withdraw', tokenSymbol: 'PT-USDG' }
+      ]);
     });
 
     it('fires withdraw-flavored analytics', () => {

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.dai.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.dai.test.tsx
@@ -341,7 +341,12 @@ describe('useSavingsLaunch — DAI upgrade-and-supply launch() config', () => {
     act(() => result.current.launch());
 
     const config = h.launchMock.mock.calls[0][0];
-    expect(config.steps).toEqual(['Approve DAI', 'Upgrade DAI to USDS', 'Approve USDS', 'Supply USDS']);
+    expect(config.steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'DAI' },
+      'Upgrade DAI to USDS',
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Supply', tokenSymbol: 'USDS' }
+    ]);
   });
 
   it('elides each approve step when its allowance is already present (steps match call count)', () => {
@@ -353,7 +358,7 @@ describe('useSavingsLaunch — DAI upgrade-and-supply launch() config', () => {
     act(() => result.current.launch());
 
     const config = h.launchMock.mock.calls[0][0];
-    expect(config.steps).toEqual(['Upgrade DAI to USDS', 'Supply USDS']);
+    expect(config.steps).toEqual(['Upgrade DAI to USDS', { label: 'Supply', tokenSymbol: 'USDS' }]);
   });
 
   it('routes onConfirm to the enabled upgrade engine (not the disabled supply engine, not withdraw)', () => {

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.l2.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.l2.test.tsx
@@ -331,7 +331,7 @@ describe('useSavingsLaunch — L2 supply launch() config', () => {
     expect(h.mockExecute).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the L2 supply steps generic ("Approve" / "Supply") — Figma is mainnet-only', () => {
+  it('labels the L2 supply steps with the origin token chip', () => {
     h.allowance = 0n;
     const a = renderHook(() =>
       useSavingsLaunch({
@@ -343,8 +343,11 @@ describe('useSavingsLaunch — L2 supply launch() config', () => {
       })
     );
     act(() => a.result.current.launch());
-    // L2 has no Figma frame; the labels intentionally stay token-agnostic.
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Approve', 'Supply']);
+    // DS Steps chips are token-derived (APP-354), so L2 flows carry the origin token too.
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Supply', tokenSymbol: 'USDS' }
+    ]);
     a.unmount();
     h.launchMock.mockClear();
 
@@ -359,7 +362,7 @@ describe('useSavingsLaunch — L2 supply launch() config', () => {
       })
     );
     act(() => b.result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Supply']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([{ label: 'Supply', tokenSymbol: 'USDS' }]);
     b.unmount();
   });
 });

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.test.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.test.tsx
@@ -327,7 +327,10 @@ describe('useSavingsLaunch — launch() config', () => {
     );
     act(() => a.result.current.launch());
     // Figma 527:8273 — the supply steps name their token; step count is unchanged.
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Approve USDS', 'Supply USDS']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Supply', tokenSymbol: 'USDS' }
+    ]);
     a.unmount();
     h.launchMock.mockClear();
 
@@ -336,7 +339,7 @@ describe('useSavingsLaunch — launch() config', () => {
       useSavingsLaunch({ flow: 'supply', originToken: TOKENS.usds, amount: AMOUNT, referralCode: REF })
     );
     act(() => b.result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Supply USDS']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([{ label: 'Supply', tokenSymbol: 'USDS' }]);
     b.unmount();
   });
 });

--- a/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.ts
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsLaunch.ts
@@ -21,6 +21,7 @@ import {
 import { formatNumber, isL2ChainId } from '@/utils';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 
 export type SavingsLaunchFlow = 'supply' | 'withdraw';
 
@@ -73,8 +74,8 @@ export interface UseSavingsLaunchResult {
    * re-launching. Same call as `launch()`'s `onConfirm`, so calldata is identical.
    */
   execute: () => void;
-  /** Step labels for the configured flow (e.g. ["Approve", "Supply"]); matches `launch()`. */
-  steps: string[];
+  /** Steps for the configured flow (e.g. ["Approve", "Supply"]); matches `launch()`. */
+  steps: TransactionStep[];
   /** Whether the routed call-builder hook is ready to execute. */
   prepared: boolean;
   isLoading: boolean;
@@ -246,24 +247,34 @@ export function useSavingsLaunch({
   //  - L2 PSM supply/withdraw: optional approve(assetIn → psm3L2) → swap
   // Hoisted from launch() so the editable modal entry body can pass them straight
   // to the shared modal; launch() consumes the same value (behaviour unchanged).
-  const steps = useMemo<string[]>(() => {
+  const steps = useMemo<TransactionStep[]>(() => {
     if (isSupply) {
       return isL2
         ? needsPsmApproval
-          ? [t`Approve`, t`Supply`]
-          : [t`Supply`]
+          ? [
+              { label: t`Approve`, tokenSymbol: originToken.symbol },
+              { label: t`Supply`, tokenSymbol: originToken.symbol }
+            ]
+          : [{ label: t`Supply`, tokenSymbol: originToken.symbol }]
         : isDai
           ? ([
-              needsDaiApproval && t`Approve DAI`,
+              needsDaiApproval && { label: t`Approve`, tokenSymbol: 'DAI' },
               t`Upgrade DAI to USDS`,
-              needsUsdsApproval && t`Approve USDS`,
-              t`Supply USDS`
-            ].filter(Boolean) as string[])
+              needsUsdsApproval && { label: t`Approve`, tokenSymbol: 'USDS' },
+              { label: t`Supply`, tokenSymbol: 'USDS' }
+            ].filter(Boolean) as TransactionStep[])
           : needsUsdsApproval
-            ? [t`Approve USDS`, t`Supply USDS`]
-            : [t`Supply USDS`];
+            ? [
+                { label: t`Approve`, tokenSymbol: 'USDS' },
+                { label: t`Supply`, tokenSymbol: 'USDS' }
+              ]
+            : [{ label: t`Supply`, tokenSymbol: 'USDS' }];
     }
-    return needsPsmWithdrawApproval ? [t`Approve`, t`Withdraw`] : [t`Withdraw`];
+    // The withdraw approval is for the sUSDS share token, not `originToken` —
+    // it keeps the bare label rather than a wrong chip.
+    return needsPsmWithdrawApproval
+      ? [t`Approve`, { label: t`Withdraw`, tokenSymbol: originToken.symbol }]
+      : [{ label: t`Withdraw`, tokenSymbol: originToken.symbol }];
   }, [
     isSupply,
     isL2,
@@ -271,7 +282,8 @@ export function useSavingsLaunch({
     needsPsmApproval,
     needsDaiApproval,
     needsUsdsApproval,
-    needsPsmWithdrawApproval
+    needsPsmWithdrawApproval,
+    originToken.symbol
   ]);
 
   const launch = useCallback(() => {

--- a/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.test.tsx
@@ -201,21 +201,28 @@ describe('buildStakeClaimSteps', () => {
   it('derives steps from the selection: Claim per token, then Restake SKY (UX 1050:23881)', () => {
     expect(
       buildStakeClaimSteps({ needsSkyAllowance: false, claimSymbols: ['SKY', 'SPK'], restake: false })
-    ).toEqual(['Claim SKY', 'Claim SPK']);
+    ).toEqual([
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
 
     expect(
       buildStakeClaimSteps({ needsSkyAllowance: false, claimSymbols: ['SKY', 'SPK'], restake: true })
-    ).toEqual(['Claim SKY', 'Claim SPK', 'Restake SKY']);
+    ).toEqual([
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
+    ]);
 
     expect(buildStakeClaimSteps({ needsSkyAllowance: true, claimSymbols: ['SKY'], restake: true })).toEqual([
-      'Approve SKY',
-      'Claim SKY',
-      'Restake SKY'
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
     ]);
 
     // Plain claim never needs an approval: nothing is pulled from the owner.
     expect(buildStakeClaimSteps({ needsSkyAllowance: true, claimSymbols: ['SPK'], restake: false })).toEqual([
-      'Claim SPK'
+      { label: 'Claim', tokenSymbol: 'SPK' }
     ]);
   });
 });
@@ -309,7 +316,10 @@ describe('useStakeClaimLaunch — launch() config', () => {
     expect(config.transactionTitle).toBe('Claim your rewards');
     expect(config.subtitles.loading).toBe('Your claim is being processed on the blockchain. Please wait.');
     expect(config.subtitles.success).toBe('You’ve claimed your rewards');
-    expect(config.steps).toEqual(['Claim SKY', 'Claim SPK']);
+    expect(config.steps).toEqual([
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
     expect(config.toast).toEqual({
       loading: 'Claiming rewards',
       success: 'Claim successful',
@@ -321,7 +331,12 @@ describe('useStakeClaimLaunch — launch() config', () => {
     const { result } = renderLaunch();
     act(() => result.current.launch(true));
 
-    expect(launchConfig().steps).toEqual(['Approve SKY', 'Claim SKY', 'Claim SPK', 'Restake SKY']);
+    expect(launchConfig().steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
+    ]);
   });
 
   it('fires legacy claim analytics: claimAll for a multi-token plain claim', () => {
@@ -357,7 +372,11 @@ describe('useStakeClaimLaunch — launch() config', () => {
     act(() => result.current.launch(true));
 
     expect(launchConfig().analytics.action).toBe('claimAndRestake');
-    expect(launchConfig().steps).toEqual(['Approve SKY', 'Claim SKY', 'Restake SKY']);
+    expect(launchConfig().steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Restake', tokenSymbol: 'SKY' }
+    ]);
   });
 
   it('exposes restake availability from the selection', () => {

--- a/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeClaimLaunch.ts
@@ -16,6 +16,7 @@ import {
 import { REFERRAL_CODE } from '@/lib/constants';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 import { parseStakeId, stakeAdapter } from '@/modules/claim/adapters/stakeAdapter';
 import type { ClaimableReward } from '@/modules/claim/types';
 // Legacy msgids double as e2e anchors — reused, not forked (UI Spec §3).
@@ -39,12 +40,12 @@ export function buildStakeClaimSteps({
   needsSkyAllowance: boolean;
   claimSymbols: string[];
   restake: boolean;
-}): string[] {
+}): TransactionStep[] {
   return [
-    restake && needsSkyAllowance && t`Approve SKY`,
-    ...claimSymbols.map(symbol => t`Claim ${symbol}`),
-    restake && t`Restake SKY`
-  ].filter(Boolean) as string[];
+    restake && needsSkyAllowance && { label: t`Approve`, tokenSymbol: 'SKY' },
+    ...claimSymbols.map(symbol => ({ label: t`Claim`, tokenSymbol: symbol })),
+    restake && { label: t`Restake`, tokenSymbol: 'SKY' }
+  ].filter(Boolean) as TransactionStep[];
 }
 
 export interface UseStakeClaimLaunchParams {

--- a/apps/webapp/src/modules/stake/hooks/useStakeLaunch.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeLaunch.test.tsx
@@ -171,17 +171,17 @@ const expectedCalldata = (usdsToBorrow: bigint, delegate?: `0x${string}`) =>
 describe('buildStakeOpenSteps', () => {
   it('derives the step list from the calldata set (A-Q3: delegate shown honestly)', () => {
     expect(buildStakeOpenSteps({ needsSkyAllowance: true, hasBorrow: true, hasDelegate: true })).toEqual([
-      'Approve SKY',
-      'Stake SKY',
-      'Borrow USDS',
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Stake', tokenSymbol: 'SKY' },
+      { label: 'Borrow', tokenSymbol: 'USDS' },
       'Delegate voting power'
     ]);
     expect(buildStakeOpenSteps({ needsSkyAllowance: false, hasBorrow: false, hasDelegate: false })).toEqual([
-      'Stake SKY'
+      { label: 'Stake', tokenSymbol: 'SKY' }
     ]);
     expect(buildStakeOpenSteps({ needsSkyAllowance: true, hasBorrow: false, hasDelegate: false })).toEqual([
-      'Approve SKY',
-      'Stake SKY'
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Stake', tokenSymbol: 'SKY' }
     ]);
   });
 });
@@ -247,7 +247,12 @@ describe('useStakeLaunch — launch() config', () => {
     const config = h.launchMock.mock.calls[0][0];
     expect(config.title).toBe('Confirm');
     expect(config.transactionTitle).toBe('Confirm your transaction');
-    expect(config.steps).toEqual(['Approve SKY', 'Stake SKY', 'Borrow USDS', 'Delegate voting power']);
+    expect(config.steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      { label: 'Stake', tokenSymbol: 'SKY' },
+      { label: 'Borrow', tokenSymbol: 'USDS' },
+      'Delegate voting power'
+    ]);
     expect(config.analytics.widgetName).toBe('stake');
     expect(config.analytics.flow).toBe('open');
     expect(config.analytics.action).toBe('multicall');

--- a/apps/webapp/src/modules/stake/hooks/useStakeLaunch.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeLaunch.ts
@@ -15,6 +15,7 @@ import { formatBigInt } from '@/utils';
 import { REFERRAL_CODE } from '@/lib/constants';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 // The legacy msgid generators double as e2e anchors — reused, not forked
 // (UI Spec §3). They survive F7 by relocation, not deletion.
 import { getStakeSubtitle, getStakeTitle, StakeFlow } from '../lib/constants';
@@ -38,13 +39,13 @@ export function buildStakeOpenSteps({
   needsSkyAllowance: boolean;
   hasBorrow: boolean;
   hasDelegate: boolean;
-}): string[] {
+}): TransactionStep[] {
   return [
-    needsSkyAllowance && t`Approve SKY`,
-    t`Stake SKY`,
-    hasBorrow && t`Borrow USDS`,
+    needsSkyAllowance && { label: t`Approve`, tokenSymbol: 'SKY' },
+    { label: t`Stake`, tokenSymbol: 'SKY' },
+    hasBorrow && { label: t`Borrow`, tokenSymbol: 'USDS' },
     hasDelegate && t`Delegate voting power`
-  ].filter(Boolean) as string[];
+  ].filter(Boolean) as TransactionStep[];
 }
 
 export interface UseStakeLaunchParams {

--- a/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.test.tsx
@@ -175,7 +175,11 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: false,
         hasDelegateChange: false
       })
-    ).toEqual(['Approve USDS', 'Repay USDS', 'Withdraw SKY']);
+    ).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Repay', tokenSymbol: 'USDS' },
+      { label: 'Withdraw', tokenSymbol: 'SKY' }
+    ]);
 
     expect(
       buildStakeManageSteps({
@@ -187,7 +191,12 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: true,
         hasDelegateChange: true
       })
-    ).toEqual(['Approve SKY', 'Change delegate', 'Stake SKY', 'Borrow USDS']);
+    ).toEqual([
+      { label: 'Approve', tokenSymbol: 'SKY' },
+      'Change delegate',
+      { label: 'Stake', tokenSymbol: 'SKY' },
+      { label: 'Borrow', tokenSymbol: 'USDS' }
+    ]);
 
     expect(
       buildStakeManageSteps({
@@ -199,7 +208,7 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: true,
         hasDelegateChange: false
       })
-    ).toEqual(['Borrow USDS']);
+    ).toEqual([{ label: 'Borrow', tokenSymbol: 'USDS' }]);
   });
 
   it('places one Claim {symbol} step per claimSymbols entry right after Withdraw SKY', () => {
@@ -214,7 +223,11 @@ describe('buildStakeManageSteps', () => {
         hasDelegateChange: false,
         claimSymbols: ['SKY', 'SPK']
       })
-    ).toEqual(['Withdraw SKY', 'Claim SKY', 'Claim SPK']);
+    ).toEqual([
+      { label: 'Withdraw', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
 
     // No claimSymbols — untouched (no Claim steps at all).
     expect(
@@ -227,7 +240,7 @@ describe('buildStakeManageSteps', () => {
         hasBorrow: false,
         hasDelegateChange: false
       })
-    ).toEqual(['Withdraw SKY']);
+    ).toEqual([{ label: 'Withdraw', tokenSymbol: 'SKY' }]);
   });
 });
 
@@ -343,7 +356,11 @@ describe('useStakeManageLaunch — launch() config', () => {
   it('derives the withdraw+repay steps from the calldata set, not the stale mock (M6)', () => {
     const { result } = renderLaunch();
     act(() => result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Approve USDS', 'Repay USDS', 'Withdraw SKY']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Approve', tokenSymbol: 'USDS' },
+      { label: 'Repay', tokenSymbol: 'USDS' },
+      { label: 'Withdraw', tokenSymbol: 'SKY' }
+    ]);
   });
 
   it('orders bundled claim steps after Withdraw SKY (recovery launch shape)', () => {
@@ -354,7 +371,11 @@ describe('useStakeManageLaunch — launch() config', () => {
       claimSymbols: ['SKY', 'SPK']
     });
     act(() => result.current.launch());
-    expect(h.launchMock.mock.calls[0][0].steps).toEqual(['Withdraw SKY', 'Claim SKY', 'Claim SPK']);
+    expect(h.launchMock.mock.calls[0][0].steps).toEqual([
+      { label: 'Withdraw', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SKY' },
+      { label: 'Claim', tokenSymbol: 'SPK' }
+    ]);
   });
 
   it('carries the legacy manage stakeData analytics shape (M15)', () => {

--- a/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeManageLaunch.ts
@@ -17,6 +17,7 @@ import { formatBigInt } from '@/utils';
 import { REFERRAL_CODE } from '@/lib/constants';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 // Legacy msgid generators double as e2e anchors — reused, not forked (UI Spec §3).
 import { getStakeSubtitle, getStakeTitle, StakeFlow } from '../lib/constants';
 import { TxStatus } from '@/widgets/shared/constants';
@@ -48,20 +49,20 @@ export function buildStakeManageSteps({
   hasDelegateChange: boolean;
   /** Display symbols for the getReward legs, aligned to the engine's free-before-claim order. */
   claimSymbols?: string[];
-}): string[] {
+}): TransactionStep[] {
   return [
     // Approval steps only render alongside the action that needs them, so a
     // still-loading allowance can't flash a phantom Approve step (the engine
     // still derives the real approve calls itself).
-    needsSkyAllowance && hasLock && t`Approve SKY`,
-    needsUsdsAllowance && hasWipe && t`Approve USDS`,
-    hasWipe && t`Repay USDS`,
-    hasFree && t`Withdraw SKY`,
-    ...(claimSymbols ?? []).map(symbol => t`Claim ${symbol}`),
+    needsSkyAllowance && hasLock && { label: t`Approve`, tokenSymbol: 'SKY' },
+    needsUsdsAllowance && hasWipe && { label: t`Approve`, tokenSymbol: 'USDS' },
+    hasWipe && { label: t`Repay`, tokenSymbol: 'USDS' },
+    hasFree && { label: t`Withdraw`, tokenSymbol: 'SKY' },
+    ...(claimSymbols ?? []).map(symbol => ({ label: t`Claim`, tokenSymbol: symbol })),
     hasDelegateChange && t`Change delegate`,
-    hasLock && t`Stake SKY`,
-    hasBorrow && t`Borrow USDS`
-  ].filter(Boolean) as string[];
+    hasLock && { label: t`Stake`, tokenSymbol: 'SKY' },
+    hasBorrow && { label: t`Borrow`, tokenSymbol: 'USDS' }
+  ].filter(Boolean) as TransactionStep[];
 }
 
 export interface UseStakeManageLaunchParams {

--- a/apps/webapp/src/modules/ui/components/TransactionModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TransactionModal.tsx
@@ -1,17 +1,10 @@
 import { useState, useCallback, useRef, ReactNode } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
-import {
-  TxStatus,
-  Clock,
-  InProgress,
-  SuccessCheck,
-  SuccessCheckSolidColor,
-  FailedX,
-  Cancel
-} from '@/widgets';
+import { TxStatus, Clock, InProgress, SuccessCheck, FailedX, Cancel } from '@/widgets';
 import { ChevronLeft } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Steps, StepsItem, type StepState } from '@/components/ui/steps';
 import { Switch } from '@/components/ui/switch';
 import { Close, Info } from '@/modules/icons';
 import { Text } from '@/modules/layout/components/Typography';
@@ -24,11 +17,20 @@ import { useIsSafeWallet } from '@/hooks';
 import { useIsBatchSupported } from '@/hooks';
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
 import { useChainId } from 'wagmi';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import type { TransactionEntry } from '@/modules/ui/context/transactionContract';
 
 // 'entry' is an editable first screen (the body owns its inputs); 'review' is the
 // read-only first screen. Both transition to the shared 'transaction' screen.
 type TransactionModalStep = 'entry' | 'review' | 'transaction';
+
+/**
+ * One entry of a flow's step list. The plain-string form is a bare label; the
+ * object form adds the token rendered as an icon+symbol chip after the label
+ * (DS Steps pattern, Figma 5200:30561) — e.g. `{ label: "Approve", tokenSymbol:
+ * "SKY" }` renders "Approve ◉ SKY".
+ */
+export type TransactionStep = string | { label: string; tokenSymbol?: string };
 
 export type TransactionSubtitles = {
   review?: string;
@@ -82,7 +84,7 @@ export type TransactionModalProps = {
   confirmDisabled?: boolean;
   successLabel?: string;
   errorLabel?: string;
-  steps?: string[];
+  steps?: TransactionStep[];
   currentStep?: number;
 };
 
@@ -138,6 +140,7 @@ export function TransactionModal({
   const isSafeWallet = useIsSafeWallet();
   const explorerName = getExplorerName(chainId, isSafeWallet);
   const { data: batchSupported } = useIsBatchSupported();
+  const [batchEnabled] = useBatchToggle();
 
   const isEntry = step === 'entry';
   const isReview = step === 'review';
@@ -147,6 +150,10 @@ export function TransactionModal({
   const isTransaction = step === 'transaction';
   const hasMultipleSteps = steps && steps.length > 1;
   const showBatchToggle = hasMultipleSteps && batchSupported;
+  // Same expression the launch hooks use for `shouldUseBatch` — when true the
+  // whole flow is one EIP-5792 bundle, rendered as the DS Bundle variant (all
+  // steps active together, "Bundled" header badge).
+  const isBundled = !!(hasMultipleSteps && batchEnabled && batchSupported);
   const isTransacting = txStatus === TxStatus.INITIALIZED || txStatus === TxStatus.LOADING;
 
   // The entry screen sources its label/gating from the entry descriptor (kept
@@ -283,27 +290,46 @@ export function TransactionModal({
             )}
           </AnimatePresence>
 
-          {/* Step indicators — Figma shows them only on the wallet/status screen,
-              not on the review/entry screen. */}
+          {/* Step list (DS Steps pattern) — Figma shows it only on the wallet/status
+              screen, not on the review/entry screen. Standard flows advance one step
+              per tx; bundled flows mark every step active while the single bundle is
+              in flight, then complete together. */}
           {hasMultipleSteps && isTransaction && (
-            <div className="flex flex-col">
-              {steps.map((label, i) => {
-                const allDone = isTransaction && txStatus === TxStatus.SUCCESS;
-                const isCompleted = isTransaction && (allDone || i < currentStep);
-                const isCurrent = isTransaction && !allDone && i === currentStep;
-                const stepTxStatus = isCompleted ? TxStatus.SUCCESS : isCurrent ? txStatus : TxStatus.IDLE;
+            <Steps
+              bundled={isBundled}
+              badge={txStatus === TxStatus.INITIALIZED ? <Trans>Confirm in the wallet</Trans> : undefined}
+            >
+              {steps.map((step, i) => {
+                const { label, tokenSymbol } = typeof step === 'string' ? { label: step } : step;
+                const allDone = txStatus === TxStatus.SUCCESS;
+                const state: StepState =
+                  allDone || (!isBundled && i < currentStep)
+                    ? 'completed'
+                    : isBundled || i === currentStep
+                      ? 'active'
+                      : 'upcoming';
 
                 return (
-                  <StepIndicator
+                  <StepsItem
                     key={i}
                     stepNumber={i + 1}
                     label={label}
-                    txStatus={stepTxStatus}
-                    active={isCurrent || (allDone && i === steps.length - 1)}
+                    tokenSymbol={tokenSymbol}
+                    tokenIcon={
+                      tokenSymbol && (
+                        <TokenIcon
+                          token={{ symbol: tokenSymbol }}
+                          className="h-3.5 w-3.5"
+                          showChainIcon={false}
+                        />
+                      )
+                    }
+                    state={state}
+                    showConnector={i < steps.length - 1}
                   />
                 );
               })}
-            </div>
+            </Steps>
           )}
 
           {/* The editable entry body stays MOUNTED for the modal's lifetime — it can
@@ -458,53 +484,6 @@ function BatchToggle() {
         onCheckedChange={setBatchEnabled}
         aria-label={t`Toggle bundled transactions`}
       />
-    </div>
-  );
-}
-
-function StepIndicator({
-  stepNumber,
-  label,
-  txStatus,
-  active
-}: {
-  stepNumber: number;
-  label: string;
-  txStatus: TxStatus;
-  active: boolean;
-}) {
-  return (
-    <div className="mt-4 flex items-center gap-3">
-      <div className="relative inline-flex h-5 w-5 items-center justify-center">
-        {active && txStatus === TxStatus.LOADING && (
-          <span className="absolute inset-0 flex items-center justify-center">
-            <svg className="h-5 w-5 animate-spin text-white" viewBox="0 0 20 20">
-              <circle
-                className="text-white/30"
-                cx="10"
-                cy="10"
-                r="9"
-                stroke="currentColor"
-                strokeWidth="2"
-                fill="none"
-              />
-              <path className="text-white" fill="none" stroke="currentColor" d="M10 1 A9 9 0 1 1 1 10" />
-            </svg>
-          </span>
-        )}
-        <span
-          className={`inline-flex h-5 w-5 items-center justify-center rounded-full border-2 text-xs ${
-            active
-              ? txStatus === TxStatus.LOADING
-                ? 'border-transparent text-white'
-                : 'border-white text-white'
-              : 'border-white/60 text-white/60'
-          }`}
-        >
-          {txStatus === TxStatus.SUCCESS ? <SuccessCheckSolidColor /> : stepNumber}
-        </span>
-      </div>
-      <Text className={active ? 'text-white' : 'text-white/60'}>{label}</Text>
     </div>
   );
 }

--- a/apps/webapp/src/modules/ui/context/transactionContract.ts
+++ b/apps/webapp/src/modules/ui/context/transactionContract.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { TransactionSubtitles } from '@/modules/ui/components/TransactionModal';
+import type { TransactionStep, TransactionSubtitles } from '@/modules/ui/components/TransactionModal';
 import type { TxStatus } from '@/widgets';
 
 /**
@@ -111,8 +111,11 @@ export type TransactionConfig = {
   errorLabel?: string;
   onSuccess?: () => void;
   onError?: () => void;
-  /** Step labels for multi-step transactions (e.g. ["Approve", "Supply"]). */
-  steps?: string[];
+  /**
+   * Steps for multi-step transactions — a bare label or `{ label, tokenSymbol }`
+   * to render the DS token chip (e.g. `{ label: "Approve", tokenSymbol: "USDS" }`).
+   */
+  steps?: TransactionStep[];
   /** Analytics metadata for tracking transaction lifecycle events. */
   analytics?: TransactionAnalytics;
   /** Identity used to gate updateModalContent calls to the active session. */

--- a/apps/webapp/src/modules/ui/hooks/useModalEntryBody.ts
+++ b/apps/webapp/src/modules/ui/hooks/useModalEntryBody.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useTransaction, useEntrySlot } from '@/modules/ui/context/TransactionContext';
 import type { TransactionConfig } from '@/modules/ui/context/transactionContract';
+import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 
 /**
  * The live fields an editable modal body keeps in sync after launch. `confirmDisabled`
@@ -13,8 +14,8 @@ type ModalEntryBodyLive = {
   confirmDisabled: boolean;
   /** Compact amount summary rendered on the wallet/status screen. */
   transactionScreenContent?: ReactNode;
-  /** Step labels for multi-step flows (e.g. ["Approve", "Supply"]). */
-  steps?: string[];
+  /** Steps for multi-step flows (labels or `{ label, tokenSymbol }` chips). */
+  steps?: TransactionStep[];
   /** Per-state minimized-toast titles. */
   toast?: TransactionConfig['toast'];
 };

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -90,6 +90,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { ChartSkeleton } from '@/components/ui/chart-skeleton';
 import { GainValue } from '@/components/ui/GainValue';
 import { SlippageMenu } from '@/components/ui/SlippageMenu';
+import { Steps, StepsItem } from '@/components/ui/steps';
 
 // Internal-only living style guide (route /design-system, hidden in production).
 // Shows every canonical components/ui primitive in its prop-reachable states;
@@ -106,6 +107,7 @@ const SECTIONS = [
   { id: 'cards', title: 'Cards' },
   { id: 'overlays', title: 'Overlays' },
   { id: 'tables', title: 'Tables' },
+  { id: 'steps', title: 'Steps' },
   { id: 'data', title: 'Data & misc' }
 ];
 
@@ -1535,6 +1537,144 @@ function DataSection() {
   );
 }
 
+// ─── Steps ────────────────────────────────────────────────────────────────────
+
+/** 14px chip icon for step specimens (chain overlay off — the chip is symbol-only). */
+function StepToken({ symbol }: { symbol: string }) {
+  return <TokenIcon token={{ symbol }} className="h-3.5 w-3.5" showChainIcon={false} />;
+}
+
+function StepsSection() {
+  return (
+    <Section
+      id="steps"
+      title="Steps"
+      note="Transaction-modal step list (Figma Patterns / Steps). Standard flows advance one step at a
+        time; Bundle flows (EIP-5792 batched) mark every step active while the single bundled
+        transaction is in flight, then complete together."
+    >
+      <SubSection title="Item states">
+        <ol className="flex max-w-xl flex-col gap-1">
+          <StepsItem
+            stepNumber={1}
+            label="Approve"
+            tokenSymbol="SKY"
+            tokenIcon={<StepToken symbol="SKY" />}
+            state="completed"
+            showConnector
+          />
+          <StepsItem
+            stepNumber={2}
+            label="Stake"
+            tokenSymbol="SKY"
+            tokenIcon={<StepToken symbol="SKY" />}
+            state="active"
+            showConnector
+          />
+          <StepsItem
+            stepNumber={3}
+            label="Borrow"
+            tokenSymbol="USDS"
+            tokenIcon={<StepToken symbol="USDS" />}
+            state="upcoming"
+            showConnector
+          />
+          <StepsItem stepNumber={4} label="Delegate voting power" state="upcoming" />
+        </ol>
+      </SubSection>
+
+      <SubSection title="Steps Standard — mid-flow, awaiting wallet">
+        <div className="max-w-xl">
+          <Steps badge="Confirm in the wallet">
+            <StepsItem
+              stepNumber={1}
+              label="Approve"
+              tokenSymbol="SKY"
+              tokenIcon={<StepToken symbol="SKY" />}
+              state="completed"
+              showConnector
+            />
+            <StepsItem
+              stepNumber={2}
+              label="Stake"
+              tokenSymbol="SKY"
+              tokenIcon={<StepToken symbol="SKY" />}
+              state="active"
+              showConnector
+            />
+            <StepsItem
+              stepNumber={3}
+              label="Borrow"
+              tokenSymbol="USDS"
+              tokenIcon={<StepToken symbol="USDS" />}
+              state="upcoming"
+            />
+          </Steps>
+        </div>
+      </SubSection>
+
+      <SubSection title="Steps Bundle — one confirmation covers every step">
+        <Row>
+          <Spec label="in flight — all active" className="w-96">
+            <Steps bundled badge="Confirm in the wallet">
+              <StepsItem
+                stepNumber={1}
+                label="Approve"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="active"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={2}
+                label="Stake"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="active"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={3}
+                label="Borrow"
+                tokenSymbol="USDS"
+                tokenIcon={<StepToken symbol="USDS" />}
+                state="active"
+              />
+            </Steps>
+          </Spec>
+          <Spec label="confirmed — all completed" className="w-96">
+            <Steps bundled>
+              <StepsItem
+                stepNumber={1}
+                label="Approve"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="completed"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={2}
+                label="Stake"
+                tokenSymbol="SKY"
+                tokenIcon={<StepToken symbol="SKY" />}
+                state="completed"
+                showConnector
+              />
+              <StepsItem
+                stepNumber={3}
+                label="Borrow"
+                tokenSymbol="USDS"
+                tokenIcon={<StepToken symbol="USDS" />}
+                state="completed"
+              />
+            </Steps>
+          </Spec>
+        </Row>
+      </SubSection>
+    </Section>
+  );
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 function DesignSystem() {
@@ -1593,6 +1733,7 @@ function DesignSystem() {
         <CardsSection />
         <OverlaysSection />
         <TablesSection />
+        <StepsSection />
         <DataSection />
       </main>
       <Toaster />


### PR DESCRIPTION
Closes APP-354 (H10 · Steps). Stacked on #1721 (H8 tables).

## What

- **New `components/ui/steps.tsx` primitive** — the DS transaction-steps pattern ([Figma Patterns / Steps](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5178-37445&m=dev)): `Steps` container (header with "Actions" title, ⚡ Bundled badge, right badge slot), `StepsItem` (upcoming/active/completed circle states, token chip, state-colored connector fades), `StepsBadge`. Active gradients map to existing tokens (`brandHover→fgBrand` ring, button-gradient fill); the completed greens (`#02C2A1`/`#00A186`) have no theme token yet and stay literal.
- **Showcase section on `/design-system`** — item states, a mid-flow Standard example, and in-flight/completed Bundle examples.
- **`TransactionModal` adopts the pattern** on the wallet/status screen, replacing the inline `StepIndicator`. Bundle rendering keys off the same `batchEnabled && batchSupported` expression the launch hooks use for `shouldUseBatch`: bundled flows show the ⚡ Bundled badge with every step active while the single EIP-5792 bundle is in flight, then all complete together. The "Confirm in the wallet" badge shows only while `txStatus === INITIALIZED`.
- **Step shape** — `TransactionConfig.steps` grows from `string[]` to `(string | { label, tokenSymbol })[]`. All five builders (stake open/manage/claim, savings, pendle) now emit token chips; embedded symbols moved out of the labels ("Approve SKY" → label "Approve" + SKY chip). The savings withdraw approval keeps a bare label since it approves the sUSDS share token, not the origin token.

## Decisions

- **No step descriptions** — the legacy widget `txDescription` copy is flow-wide (one status-keyed line per card), not per-step, so there was nothing to carry over; the field was omitted entirely.
- The old "L2 steps stay generic — Figma is mainnet-only" carve-out is superseded: chips are token-derived, so L2 flows carry them too (test retitled).
- The DS has no error step variant; the modal keeps its existing status row for errors.

## Testing

- `typecheck`, `lint`, full unit suite 1866/1866, prettier.
- Browser-verified dark-mode-first on a fresh Tenderly fork with the batch mock wallet: showcase matches the Figma states, savings supply exercised both variants — bundled (⚡ badge, both steps complete on the single confirmation) and sequential with the toggle off.