### PR TITLE
Adopt the DS Iconbox family (H14), feedback primitives (H9), and Lists + Accordion (H15)

### DIFF
--- a/apps/webapp/src/components/BatchTransactionsToggle.tsx
+++ b/apps/webapp/src/components/BatchTransactionsToggle.tsx
@@ -1,7 +1,7 @@
 import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
 import { Toggle } from './ui/toggle';
 import { Zap } from '@/modules/icons/Zap';
-import { Tooltip, TooltipArrow, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
 import { Text } from '@/modules/layout/components/Typography';
 import { t } from '@lingui/core/macro';
 import { useIsBatchSupported } from '@/hooks';
@@ -38,7 +38,7 @@ export function BatchTransactionsToggle() {
         </div>
       </TooltipTrigger>
       <TooltipPortal>
-        <TooltipContent arrowPadding={10} className="max-w-[260px]">
+        <TooltipContent className="max-w-[260px]">
           <Text variant="small">
             {batchNotSupported ? (
               <>
@@ -64,7 +64,6 @@ export function BatchTransactionsToggle() {
               <Trans>Legal Notice</Trans>
             </ExternalLink>
           </Text>
-          <TooltipArrow width={12} height={8} />
         </TooltipContent>
       </TooltipPortal>
     </Tooltip>

--- a/apps/webapp/src/components/InfoTooltip.tsx
+++ b/apps/webapp/src/components/InfoTooltip.tsx
@@ -1,6 +1,6 @@
 import { Info, X } from 'lucide-react';
-import { Tooltip, TooltipArrow, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
-import { Popover, PopoverArrow, PopoverClose, PopoverContent, PopoverTrigger } from './ui/popover';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
+import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from './ui/popover';
 import { useIsTouchDevice } from '@/hooks';
 
 export function InfoTooltip({
@@ -27,10 +27,11 @@ export function InfoTooltip({
       >
         <Info size={iconSize} className={iconClassName} />
       </PopoverTrigger>
+      {/* Touch fallback mirrors the DS tooltip chrome (Figma 5043:57748). */}
       <PopoverContent
         align="center"
         side="top"
-        className={`bg-containerDark rounded-xl backdrop-blur-[50px] ${contentClassname}`}
+        className={`bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[100px] ${contentClassname}`}
       >
         {shouldShowCloseButton && (
           <PopoverClose onClick={e => e.stopPropagation()} className="absolute top-4 right-4 z-10">
@@ -44,7 +45,6 @@ export function InfoTooltip({
         >
           {typeof content === 'string' ? <p>{content}</p> : content}
         </div>
-        <PopoverArrow />
       </PopoverContent>
     </Popover>
   ) : (
@@ -53,11 +53,10 @@ export function InfoTooltip({
         <Info size={iconSize} className={iconClassName} />
       </TooltipTrigger>
       <TooltipPortal>
-        <TooltipContent className={`max-w-[400px] ${contentClassname}`} arrowPadding={10}>
+        <TooltipContent className={contentClassname}>
           <div className="max-h-[calc(var(--radix-tooltip-content-available-height)-64px)] scrollbar-thin overflow-y-auto">
             {typeof content === 'string' ? <p>{content}</p> : content}
           </div>
-          <TooltipArrow width={12} height={8} />
         </TooltipContent>
       </TooltipPortal>
     </Tooltip>

--- a/apps/webapp/src/components/ThemeToggle.tsx
+++ b/apps/webapp/src/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 import { Moon, Sun } from 'lucide-react';
 import { Toggle } from './ui/toggle';
-import { Tooltip, TooltipArrow, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
 import { Text } from '@/modules/layout/components/Typography';
 import { t } from '@lingui/core/macro';
 import { useThemeToggle } from '@/modules/ui/hooks/useThemeToggle';
@@ -25,9 +25,8 @@ export function ThemeToggle() {
         </div>
       </TooltipTrigger>
       <TooltipPortal>
-        <TooltipContent arrowPadding={10} className="max-w-[220px]">
+        <TooltipContent className="max-w-[220px]">
           <Text variant="small">{isLight ? t`Switch to dark mode` : t`Switch to light mode`}</Text>
-          <TooltipArrow width={12} height={8} />
         </TooltipContent>
       </TooltipPortal>
     </Tooltip>

--- a/apps/webapp/src/components/product/FilterSelect.tsx
+++ b/apps/webapp/src/components/product/FilterSelect.tsx
@@ -24,10 +24,6 @@ export function FilterSelect({
   allLabel: ReactNode;
   testId: string;
 }) {
-  // Same surface/item treatment as the header's MoreMenu popover: container
-  // background, hover rows, selection shown by a prominent row background.
-  const itemClasses =
-    'text-textSecondary hover:text-text focus:text-text hover:bg-surfaceAlt focus:bg-surfaceAlt data-[state=checked]:bg-surface data-[state=checked]:text-text cursor-pointer rounded-md px-3 py-2 transition-colors';
   return (
     <Select value={selected} onValueChange={onChange}>
       {/* Design-system Button / Dropdown, size S (Figma 5019:4105). The
@@ -44,12 +40,11 @@ export function FilterSelect({
       >
         <SelectValue />
       </SelectTrigger>
-      <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
-        <SelectItem value="all" hideIndicator className={itemClasses}>
-          {allLabel}
-        </SelectItem>
+      {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+      <SelectContent>
+        <SelectItem value="all">{allLabel}</SelectItem>
         {options.map(option => (
-          <SelectItem key={option.value} value={option.value} hideIndicator className={itemClasses}>
+          <SelectItem key={option.value} value={option.value}>
             {option.label}
           </SelectItem>
         ))}

--- a/apps/webapp/src/components/ui/accordion.tsx
+++ b/apps/webapp/src/components/ui/accordion.tsx
@@ -4,15 +4,34 @@ import { ChevronDown } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 
-const Accordion = AccordionPrimitive.Root;
+// App look — design-system Accordion (Figma Patterns/Accordion 5386:66315,
+// container 5386:66597): a borderPrimary 24px-radius container of p-6 items
+// separated by borderPrimary hairlines. Titles are Label 4 fgPrimary with a
+// 16px fgPrimary chevron that flips while open; content is Body 6 fgSecondary
+// sitting 12px under the title row. Callers compose the title row (an
+// IconboxAction glyph is the documented leading slot).
 
-// App look — canonical, unchanged.
+const Accordion = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Root
+    ref={ref}
+    className={cn('border-borderPrimary overflow-hidden rounded-3xl border', className)}
+    {...props}
+  />
+));
+Accordion.displayName = 'Accordion';
 
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> & { className?: string }
 >(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item ref={ref} className={cn('px-5', className)} {...props} />
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn('border-borderPrimary border-b p-6 last:border-b-0', className)}
+    {...props}
+  />
 ));
 AccordionItem.displayName = 'AccordionItem';
 
@@ -24,13 +43,13 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'font-custom-450 text-selectActive light:text-text flex flex-1 items-center justify-between py-4 text-sm leading-none transition-all [&[data-state=open]>svg]:rotate-180',
+        'font-circle text-fgPrimary flex flex-1 items-center justify-between text-base leading-[18px] font-medium tracking-[-0.32px] transition-all [&[data-state=open]>svg]:rotate-180',
         className
       )}
       {...props}
     >
       {children}
-      <ChevronDown className="text-textSecondary h-6 w-6 shrink-0 transition-transform duration-200" />
+      <ChevronDown className="text-fgPrimary size-4 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));
@@ -42,17 +61,19 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="text-text data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm leading-none font-normal transition-all"
+    className="text-fgSecondary data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-xs leading-[18px] font-normal transition-all"
     {...props}
   >
-    <div className={cn('pt-0 pb-4', className)}>{children}</div>
+    <div className={cn('pt-3', className)}>{children}</div>
   </AccordionPrimitive.Content>
 ));
 
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
 // Widget look — relocated under AccordionWidget*; the widgets/accordion shim aliases it back.
-// (Accordion itself is shared — both trees use AccordionPrimitive.Root.)
+// (The widget root stays the bare Radix Root — no DS container.)
+
+const AccordionWidget = AccordionPrimitive.Root;
 
 const AccordionWidgetItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
@@ -98,4 +119,4 @@ const AccordionWidgetContent = React.forwardRef<
 AccordionWidgetContent.displayName = AccordionPrimitive.Content.displayName;
 
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
-export { AccordionWidgetItem, AccordionWidgetTrigger, AccordionWidgetContent };
+export { AccordionWidget, AccordionWidgetItem, AccordionWidgetTrigger, AccordionWidgetContent };

--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -3,6 +3,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/cn';
+import { Loader } from './loader';
 
 // App look — canonical, unchanged.
 
@@ -113,34 +114,6 @@ const buttonVariants = cva(
   }
 );
 
-// Loading-state glyph (Figma "Loader"): the static Figma asset gives the
-// three-dot geometry; the staggered pulse makes it read as busy.
-const ButtonLoader = ({ className }: { className?: string }) => (
-  <svg
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-    className={className}
-  >
-    <circle cx="2.667" cy="8.667" r="1.333" fill="currentColor" className="animate-pulse" />
-    <circle
-      cx="8"
-      cy="6.667"
-      r="1.333"
-      fill="currentColor"
-      className="animate-pulse [animation-delay:200ms]"
-    />
-    <circle
-      cx="13.333"
-      cy="8.667"
-      r="1.333"
-      fill="currentColor"
-      className="animate-pulse [animation-delay:400ms]"
-    />
-  </svg>
-);
-
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
@@ -164,7 +137,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           <>
             {/* span wrapper keeps the loader out of the [&>svg] icon sizing rules (xl uses a 24px loader) */}
             <span className={cn('shrink-0', size === 's' ? '-ml-1' : '-ml-2')}>
-              <ButtonLoader className={size === 'xl' ? 'size-6' : 'size-4'} />
+              <Loader size={size === 'xl' ? 'm' : 'xs'} />
             </span>
             {children}
           </>

--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -32,8 +32,6 @@ const buttonVariants = cva(
           'bg-radial-(--gradient-position) from-primary-alt-start/100 to-primary-alt-end/100 border text-text hover:from-primary-alt-start/60 hover:to-primary-alt-end/60 active:from-primary-alt-start/45 active:to-primary-alt-end/45 focus:from-primary-alt-start/45 focus:to-primary-alt-end/45 disabled:from-primary-alt-start/35 disabled:to-primary-alt-end/35',
         connectPrimary:
           'bg-radial-(--gradient-position) text-text border border-[rgb(127,92,246)] from-primary-start/100 to-primary-end/100 hover:from-primary-start/60 hover:to-primary-end/60 hover:border-[rgb(101,70,222)] focus:from-primary-start/40 focus:to-primary-end/40 focus:border-[rgb(92,62,209)]',
-        connect:
-          'bg-radial-(--gradient-position) text-text border border-[rgb(127,92,246)] from-primary-bright-start/100 to-primary-bright-end/100 hover:from-primary-bright-start/60 hover:to-primary-bright-end/60 hover:border-[rgb(101,70,222)] focus:from-primary-bright-start/40 focus:to-primary-bright-end/40 focus:border-[rgb(92,62,209)]',
         secondary:
           'rounded-full border border-glassBadge bg-origin-border bg-linear-to-b from-white/0 to-white/8 text-text hover:from-glassBadge hover:to-glassBadge active:from-glassBorder active:to-glassBorder focus-visible:ring-focusRing focus-visible:ring-offset-0 disabled:border-transparent disabled:from-glassSurface disabled:to-glassSurface disabled:text-fgTertiary',
         pill: 'bg-radial-(--gradient-position) from-primary-start/100 to-primary-end/100 text-text rounded-full hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 bg-blend-overlay hover:bg-white/10 focus:border-transparent focus:bg-white/15 active:bg-white/15',

--- a/apps/webapp/src/components/ui/iconbox.tsx
+++ b/apps/webapp/src/components/ui/iconbox.tsx
@@ -1,0 +1,227 @@
+import { ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/cn';
+
+// Design-system Iconbox family (Figma Components/Iconbox 5017:7668) — the
+// standardized circular icon containers shared by table cells, position
+// surfaces and activity rows:
+// - Iconbox         (5007:72698)  bare token / glyph-on-disc + network chip
+// - Iconbox2Tokens  (5007:73290)  the 4px-overlap token pair
+// - IconboxStatus   (5017:7858)   ringed token with optional status dot
+// - IconboxPosition (5051:145321) green (or inactive-neutral) position disc
+// - IconboxAction   (5034:42418)  bordered neutral disc around a 16px glyph
+//
+// Figma names the Status ring types by product (Pendle / Morpho); here they
+// are named by system color (success / info) since that is what the values
+// are — the dots are colors/system/success and border-system-info-primary.
+// Children are the caller's icons (TokenIcon, module glyphs); the box only
+// draws the container, so size the child to the inner hole it documents.
+
+// --- Iconbox (base) ----------------------------------------------------------
+
+export type IconboxSize = 'l' | 'm' | 's' | 'xs';
+
+// Box diameters L/M/S/XS = 40/32/28/24px.
+const iconboxSize: Record<IconboxSize, string> = {
+  l: 'size-10',
+  m: 'size-8',
+  s: 'size-7',
+  xs: 'size-6'
+};
+
+// Network chip diameter + overhang per box size (Figma: 16@-4, 14@-2,
+// 12.25@-1.75 — rounded to 12@-1.5 to stay on the pixel grid — 10@-2).
+const iconboxNetwork: Record<IconboxSize, string> = {
+  l: 'size-4 -right-1 -bottom-1',
+  m: 'size-3.5 -right-0.5 -bottom-0.5',
+  s: 'size-3 -right-[1.5px] -bottom-[1.5px]',
+  xs: 'size-2.5 -right-0.5 -bottom-0.5'
+};
+
+/**
+ * Base iconbox: a bare token logo (`type="token"`) or a glyph centered on a
+ * translucent disc (`type="icon"`), with an optional network chip overhanging
+ * bottom-right. Size the token child `h-full w-full`; glyphs stay 24px at `l`.
+ */
+export function Iconbox({
+  type = 'token',
+  size = 'l',
+  network,
+  children,
+  className
+}: {
+  type?: 'token' | 'icon';
+  size?: IconboxSize;
+  /** Chain icon for the bottom-right chip (sized `h-full w-full`). */
+  network?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={cn('relative inline-flex shrink-0', iconboxSize[size], className)}>
+      {type === 'icon' ? (
+        // The glyph disc is rgba(255,255,255,.1) in Figma with no variable.
+        <span className="flex size-full items-center justify-center rounded-full bg-white/10">
+          {children}
+        </span>
+      ) : (
+        children
+      )}
+      {network != null && <span className={cn('absolute inline-flex', iconboxNetwork[size])}>{network}</span>}
+    </span>
+  );
+}
+
+/**
+ * Iconbox / 2 Tokens: two 28px (`s`) tokens overlapping by 4px; the front
+ * (left) token is punched out of the back one with a page-background ring,
+ * and the network chip rides the back token.
+ */
+export function Iconbox2Tokens({
+  front,
+  back,
+  network,
+  className
+}: {
+  front: ReactNode;
+  back: ReactNode;
+  /** Chain icon for the back token's bottom-right chip. */
+  network?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={cn('flex items-center', className)}>
+      <span className="ring-pageBackground relative z-[1] -mr-1 inline-flex size-7 shrink-0 rounded-full ring-2">
+        {front}
+      </span>
+      <Iconbox size="s" network={network}>
+        {back}
+      </Iconbox>
+    </span>
+  );
+}
+
+// --- Iconbox / Status --------------------------------------------------------
+
+const iconboxStatusVariants = cva('relative inline-flex shrink-0 items-center justify-center rounded-full', {
+  variants: {
+    type: {
+      default: 'border-borderTertiary',
+      success: 'border-statusSuccessRing',
+      info: 'border-statusInfoRing'
+    },
+    size: {
+      l: 'size-16 border-2',
+      m: 'size-9 border-[1.5px]',
+      s: 'size-6 border',
+      xs: 'size-4 border',
+      '2xs': 'size-3 border'
+    }
+  },
+  defaultVariants: {
+    type: 'default',
+    size: 'm'
+  }
+});
+
+const iconboxStatusDot = cva('ring-pageBackground absolute rounded-full ring-2', {
+  variants: {
+    type: {
+      success: 'bg-statusSuccessSolid',
+      info: 'bg-statusInfoSolid'
+    },
+    size: {
+      l: 'top-0.5 right-0.5 size-2.5',
+      m: 'top-0 right-0 size-2',
+      s: 'top-0 right-0 size-1.5',
+      xs: '-top-px -right-px size-1',
+      // Figma draws no dot at 2XS; the box is barely bigger than a dot.
+      '2xs': 'hidden'
+    }
+  }
+});
+
+/**
+ * Iconbox / Status: the ringed token container. `default` is the resting
+ * borderTertiary ring; `success` / `info` tint the ring and (with `dot`)
+ * pin a solid status dot to the top-right. Inner logo per size: 48@l,
+ * 28@m, 18@s, 10@xs, 8@2xs.
+ */
+export function IconboxStatus({
+  type,
+  size,
+  dot = false,
+  children,
+  className
+}: VariantProps<typeof iconboxStatusVariants> & {
+  /** Show the status dot (success/info types only). */
+  dot?: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={cn(iconboxStatusVariants({ type, size }), className)}>
+      {children}
+      {dot && (type === 'success' || type === 'info') && (
+        <span className={iconboxStatusDot({ type, size })} />
+      )}
+    </span>
+  );
+}
+
+// --- Iconbox / Position ------------------------------------------------------
+
+/**
+ * Iconbox / Position: the 36px position marker — success-green ring and disc
+ * around a 16px glyph, or the neutral `inactive` treatment for closed/empty
+ * positions.
+ */
+export function IconboxPosition({
+  inactive = false,
+  children,
+  className
+}: {
+  inactive?: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'flex size-9 shrink-0 items-center justify-center rounded-full border-[1.5px] p-px',
+        inactive ? 'border-glassBorder' : 'border-statusSuccessBorder',
+        className
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-full items-center justify-center rounded-full',
+          inactive ? 'bg-bgTertiary text-fgSecondary' : 'bg-statusSuccessBg text-statusSuccess'
+        )}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}
+
+// --- Iconbox / Action --------------------------------------------------------
+
+/**
+ * Iconbox / Action: the 36px activity-row marker — glass border around a
+ * neutral 30px disc holding a 16px action glyph.
+ */
+export function IconboxAction({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'border-glassBorder flex size-9 shrink-0 items-center justify-center rounded-full border p-[2px]',
+        className
+      )}
+    >
+      <span className="bg-bgSecondary text-fgPrimary flex size-full items-center justify-center rounded-full">
+        {children}
+      </span>
+    </span>
+  );
+}

--- a/apps/webapp/src/components/ui/list.tsx
+++ b/apps/webapp/src/components/ui/list.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { Loader } from '@/components/ui/loader';
+
+/**
+ * List / Wallet (Figma Patterns/Lists 5209:36922, row 5209:38238): the
+ * whole-row wallet connect control — a p-4 borderPrimary hairline row
+ * (borderTertiary on hover) holding a 24px wallet icon and a Label 5 name,
+ * with an optional Label 6 badge ("Recent") and a 16px fgQuaternary chevron
+ * on the right. `active` (5209:38304) is the connecting state: brandBorder
+ * edge over the gradient-brand3 fill, the right side replaced by a 20px
+ * brand-gradient loader. Disabled has no Figma state; it reuses the resting
+ * row at half opacity.
+ */
+const ListWallet = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    /** Wallet logo, rendered at 24px. */
+    icon: React.ReactNode;
+    name: React.ReactNode;
+    /** Label 6 pill in the right slot (e.g. "Recent"). */
+    badge?: React.ReactNode;
+    /** Connecting state: brand border + fill, loader instead of the chevron. */
+    active?: boolean;
+  }
+>(({ icon, name, badge, active = false, className, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    className={cn(
+      'flex w-full items-center justify-between overflow-hidden rounded-2xl border p-4 text-left transition-colors disabled:pointer-events-none',
+      active
+        ? 'border-brandBorder from-brand3-start to-brand3-end bg-linear-to-b'
+        : 'border-borderPrimary hover:border-borderTertiary disabled:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="flex min-w-0 items-center gap-3">
+      <span className="flex size-6 shrink-0 items-center justify-center">{icon}</span>
+      <span className="font-circle text-fgPrimary truncate text-sm leading-4 font-medium tracking-[-0.28px]">
+        {name}
+      </span>
+    </span>
+    {active ? (
+      <Loader size="s" brand />
+    ) : (
+      <span className="flex shrink-0 items-center gap-2">
+        {badge != null && (
+          <span className="bg-glassBadge font-circle text-fgSecondary flex h-6 items-center rounded-full px-2 text-xs leading-3.5 font-medium tracking-[-0.24px] whitespace-nowrap">
+            {badge}
+          </span>
+        )}
+        <ChevronRight className="text-fgQuaternary size-4 shrink-0" />
+      </span>
+    )}
+  </button>
+));
+ListWallet.displayName = 'ListWallet';
+
+export { ListWallet };

--- a/apps/webapp/src/components/ui/loader.tsx
+++ b/apps/webapp/src/components/ui/loader.tsx
@@ -1,0 +1,55 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/cn';
+
+// Design-system Loader (Figma Components/Loading 5018:27948, Loader family
+// 5209:38588): the three-dot busy glyph, at the six documented diameters
+// 2XS/XS/S/M/L/XL = 12/16/20/24/32/40px. The dot geometry is the static Figma
+// asset (H4 first traced it for the button loading state); the staggered pulse
+// makes it read as busy. Color rides currentColor so the loader inherits the
+// surrounding text tone (buttons pass their label color, standalone loading
+// states typically sit in fg-secondary containers).
+const loaderVariants = cva('shrink-0', {
+  variants: {
+    size: {
+      '2xs': 'size-3',
+      xs: 'size-4',
+      s: 'size-5',
+      m: 'size-6',
+      l: 'size-8',
+      xl: 'size-10'
+    }
+  },
+  defaultVariants: {
+    size: 'm'
+  }
+});
+
+export type LoaderSize = NonNullable<VariantProps<typeof loaderVariants>['size']>;
+
+export function Loader({ size, className }: VariantProps<typeof loaderVariants> & { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className={cn(loaderVariants({ size }), className)}
+    >
+      <circle cx="2.667" cy="8.667" r="1.333" fill="currentColor" className="animate-pulse" />
+      <circle
+        cx="8"
+        cy="6.667"
+        r="1.333"
+        fill="currentColor"
+        className="animate-pulse [animation-delay:200ms]"
+      />
+      <circle
+        cx="13.333"
+        cy="8.667"
+        r="1.333"
+        fill="currentColor"
+        className="animate-pulse [animation-delay:400ms]"
+      />
+    </svg>
+  );
+}

--- a/apps/webapp/src/components/ui/loader.tsx
+++ b/apps/webapp/src/components/ui/loader.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/cn';
 
@@ -7,7 +8,9 @@ import { cn } from '@/lib/cn';
 // asset (H4 first traced it for the button loading state); the staggered pulse
 // makes it read as busy. Color rides currentColor so the loader inherits the
 // surrounding text tone (buttons pass their label color, standalone loading
-// states typically sit in fg-secondary containers).
+// states typically sit in fg-secondary containers); `brand` swaps the fill to
+// the loader's brand gradient, the coloring the Figma asset itself carries
+// (used by the selected wallet-list row, Patterns/Lists 5209:38763).
 const loaderVariants = cva('shrink-0', {
   variants: {
     size: {
@@ -26,7 +29,13 @@ const loaderVariants = cva('shrink-0', {
 
 export type LoaderSize = NonNullable<VariantProps<typeof loaderVariants>['size']>;
 
-export function Loader({ size, className }: VariantProps<typeof loaderVariants> & { className?: string }) {
+export function Loader({
+  size,
+  brand = false,
+  className
+}: VariantProps<typeof loaderVariants> & { brand?: boolean; className?: string }) {
+  const gradientId = useId();
+  const fill = brand ? `url(#${gradientId})` : 'currentColor';
   return (
     <svg
       viewBox="0 0 16 16"
@@ -35,19 +44,21 @@ export function Loader({ size, className }: VariantProps<typeof loaderVariants> 
       aria-hidden="true"
       className={cn(loaderVariants({ size }), className)}
     >
-      <circle cx="2.667" cy="8.667" r="1.333" fill="currentColor" className="animate-pulse" />
-      <circle
-        cx="8"
-        cy="6.667"
-        r="1.333"
-        fill="currentColor"
-        className="animate-pulse [animation-delay:200ms]"
-      />
+      {brand && (
+        <defs>
+          <linearGradient id={gradientId} x1="8" y1="5.333" x2="8" y2="10" gradientUnits="userSpaceOnUse">
+            <stop stopColor="var(--color-loader-brand-start)" />
+            <stop offset="1" stopColor="var(--color-loader-brand-end)" />
+          </linearGradient>
+        </defs>
+      )}
+      <circle cx="2.667" cy="8.667" r="1.333" fill={fill} className="animate-pulse" />
+      <circle cx="8" cy="6.667" r="1.333" fill={fill} className="animate-pulse [animation-delay:200ms]" />
       <circle
         cx="13.333"
         cy="8.667"
         r="1.333"
-        fill="currentColor"
+        fill={fill}
         className="animate-pulse [animation-delay:400ms]"
       />
     </svg>

--- a/apps/webapp/src/components/ui/select.tsx
+++ b/apps/webapp/src/components/ui/select.tsx
@@ -17,7 +17,11 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'border-input placeholder:text-muted-foreground focus:ring-ring bg-background ring-offset-background flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      // focusRing (DS token), not the shadcn `ring` slot: --color-ring is
+      // undefined in globals.css, so ring-ring painted in currentColor — a
+      // near-black outline in the light theme whenever Radix returns focus to
+      // the trigger after a selection. Matches the Button dropdown variants.
+      'border-input placeholder:text-muted-foreground bg-background focus-visible:ring-focusRing flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className
     )}
     {...props}

--- a/apps/webapp/src/components/ui/select.tsx
+++ b/apps/webapp/src/components/ui/select.tsx
@@ -69,7 +69,10 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md',
+        // Design-system Dropdown panel (Figma Components/Dropdown 5075:17292):
+        // bg-tertiary glass at 16px radius with a hairline 1px/4px inset, no
+        // border or shadow; rows are drawn full-bleed by SelectItem below.
+        'bg-bgTertiary text-fgPrimary data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-2xl backdrop-blur-[20px]',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
@@ -80,7 +83,7 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          'p-1',
+          'px-px py-1',
           position === 'popper' &&
             'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
         )}
@@ -117,21 +120,20 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50',
-      hideIndicator ? 'pl-3' : 'pl-8',
+      // Design-system Dropdown row: Label 5 on fg-primary with 16/12 padding;
+      // the focused and selected rows tint bg-secondary and the selected row
+      // pins a 16px check to the right edge.
+      'focus:bg-bgSecondary data-[state=checked]:bg-bgSecondary font-circle text-fgPrimary relative flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-sm leading-4 font-medium tracking-[-0.28px] outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50',
       className
     )}
     {...props}
   >
-    {!hideIndicator && (
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <Check className="h-4 w-4" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-    )}
-
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {!hideIndicator && (
+      <SelectPrimitive.ItemIndicator className="ml-auto flex size-4 items-center justify-center">
+        <Check className="size-4" />
+      </SelectPrimitive.ItemIndicator>
+    )}
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/apps/webapp/src/components/ui/sonner.tsx
+++ b/apps/webapp/src/components/ui/sonner.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react';
 import { Toaster as Sonner, type ToastClassnames } from 'sonner';
-import { Success, Failure } from '@/modules/icons';
-import { Info, X } from 'lucide-react';
+import { Failure } from '@/modules/icons';
+import { Check, Info, X } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useCookieConsent } from '@/modules/analytics/context/CookieConsentContext';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+// Design-system Toast (Figma Components/Toast 5075:17183): bg-tertiary glass
+// at 16px radius and 16px padding, a Label 4 title over a Body 7 fg-secondary
+// description, and the status icon on a 34px success disc (statusSuccessBg
+// fill, statusSuccessBorder ring, bare 16px check). The DS only draws the
+// success disc; error/info keep their existing glyphs until the DS types them.
+// Sonner's own stylesheet paints [data-sonner-toast][data-styled] with
+// var(--normal-bg)/border/shadow at higher specificity than one utility
+// class, so the properties it sets carry Tailwind's important marker.
 
 const SONNER_DEFAULT_OFFSET = 32;
 const BANNER_BOTTOM_MARGIN = 16; // banner's bottom-4
@@ -17,15 +26,16 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
     bannerHeight > 0 ? BANNER_BOTTOM_MARGIN + bannerHeight + BANNER_TOAST_GAP : SONNER_DEFAULT_OFFSET;
   const defaultClassNames: ToastClassnames = {
     toast:
-      'group flex items-start justify-between space-x-4 rounded-xl bg-container text-text p-6 pr-8 shadow-lg backdrop-blur-[50px] border border-border min-w-[356px] md:min-w-[420px] max-w-[420px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-bottom-full data-[expanded=false]:overflow-hidden',
-    title: 'text-sm leading-none',
-    description: 'text-sm opacity-90 mt-2 leading-normal',
+      'group flex items-start! gap-3! rounded-2xl! bg-bgTertiary! border-none! shadow-none! text-fgPrimary! p-4! pr-12! backdrop-blur-[20px] min-w-[356px] md:min-w-[420px] max-w-[420px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-bottom-full data-[expanded=false]:overflow-hidden',
+    title: 'font-circle text-base leading-[18px]! font-medium tracking-[-0.32px] text-fgPrimary!',
+    description: 'font-graphik text-[11px] leading-4! font-normal text-fgSecondary! mt-1',
+    icon: 'size-auto! shrink-0',
     actionButton:
       'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
     cancelButton:
       'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
     closeButton:
-      'text-foreground/50 hover:text-foreground absolute right-3 top-3 rounded-md p-1.5 opacity-100 transition-opacity hover:opacity-100 h-4 w-4',
+      'text-fgSecondary! hover:text-fgPrimary! absolute right-3! left-auto! top-3! translate-none! rounded-md bg-transparent! border-none! p-1.5 opacity-100 transition-colors hover:opacity-100 h-4! w-4!',
     content: ''
   };
 
@@ -33,6 +43,7 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
     toast: cn(defaultClassNames.toast, toastOptions?.classNames?.toast),
     title: cn(defaultClassNames.title, toastOptions?.classNames?.title),
     description: cn(defaultClassNames.description, toastOptions?.classNames?.description),
+    icon: cn(defaultClassNames.icon, toastOptions?.classNames?.icon),
     actionButton: cn(defaultClassNames.actionButton, toastOptions?.classNames?.actionButton),
     cancelButton: cn(defaultClassNames.cancelButton, toastOptions?.classNames?.cancelButton),
     closeButton: cn(defaultClassNames.closeButton, toastOptions?.classNames?.closeButton),
@@ -49,7 +60,11 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
       mobileOffset={{ bottom: bottomOffset }}
       closeButton={true}
       icons={{
-        success: <Success />,
+        success: (
+          <span className="border-statusSuccessBorder bg-statusSuccessBg text-statusSuccess flex items-center justify-center rounded-full border p-2">
+            <Check size={16} />
+          </span>
+        ),
         error: <Failure />,
         info: <Info size={20} className="text-textEmphasis" />,
         close: <X size={16} className="text-text" />

--- a/apps/webapp/src/components/ui/sonner.tsx
+++ b/apps/webapp/src/components/ui/sonner.tsx
@@ -34,8 +34,13 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
       'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
     cancelButton:
       'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
+    // transform-none (not translate-none): sonner hangs its close button off
+    // the corner via `transform: translate(-35%,-35%)`, which the translate
+    // property doesn't reset. 24px box at 12px insets = a 16px visual gap on
+    // both sides (matching the toast's p-4) with the icon centered on the
+    // title line.
     closeButton:
-      'text-fgSecondary! hover:text-fgPrimary! absolute right-3! left-auto! top-3! translate-none! rounded-md bg-transparent! border-none! p-1.5 opacity-100 transition-colors hover:opacity-100 h-4! w-4!',
+      'text-fgSecondary! hover:text-fgPrimary! absolute right-3! left-auto! top-3! transform-none! flex items-center justify-center rounded-md bg-transparent! border-none! p-1! opacity-100 transition-colors hover:opacity-100 h-6! w-6!',
     content: ''
   };
 

--- a/apps/webapp/src/components/ui/table-cells.tsx
+++ b/apps/webapp/src/components/ui/table-cells.tsx
@@ -3,6 +3,7 @@ import { ChevronRight } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
 import { IconStack } from '@/modules/ui/components/TokenIconStack';
+import { IconboxAction, IconboxPosition, IconboxStatus } from './iconbox';
 
 // Design-system typed table cells (Figma Table Cell 5032:9625, 17 types).
 // These are cell *contents*: the surface, height and padding live on the
@@ -25,62 +26,10 @@ const label7 = 'font-circle text-[11px] leading-3 font-medium tracking-[-0.22px]
 const body6 = 'font-graphik text-xs leading-[18px] font-normal';
 
 // --- Small shared pieces ---------------------------------------------------
-
-/**
- * The 36px circled-icon boxes the Token/Position/Action cells share
- * (Figma Iconbox). `token` holds a 28px logo; `action`/`position` draw an
- * inner 30px disc around a 16px glyph.
- */
-export function TableIconBox({
-  variant = 'token',
-  active = false,
-  children,
-  className
-}: {
-  variant?: 'token' | 'action' | 'position';
-  /** Token-box "has a position" state: mint border + success status dot. */
-  active?: boolean;
-  children: ReactNode;
-  className?: string;
-}) {
-  if (variant === 'token') {
-    return (
-      <span
-        className={cn(
-          'relative flex size-9 shrink-0 items-center justify-center rounded-full border-[1.5px]',
-          // The active border is a hardcoded hex in Figma too (no variable).
-          active ? 'border-[#8bf1ca]' : 'border-borderTertiary',
-          className
-        )}
-      >
-        {children}
-        {active && (
-          <span className="bg-statusSuccessSolid ring-pageBackground absolute top-0 right-0 size-2 rounded-full ring-2" />
-        )}
-      </span>
-    );
-  }
-  return (
-    <span
-      className={cn(
-        'flex size-9 shrink-0 items-center justify-center rounded-full',
-        variant === 'action'
-          ? 'border-glassBorder border p-[2px]'
-          : 'border-statusSuccessBorder border-[1.5px] p-px',
-        className
-      )}
-    >
-      <span
-        className={cn(
-          'flex size-full items-center justify-center rounded-full',
-          variant === 'action' ? 'bg-bgSecondary text-fgPrimary' : 'bg-statusSuccessBg text-statusSuccess'
-        )}
-      >
-        {children}
-      </span>
-    </span>
-  );
-}
+// The 36px circled-icon boxes the Token/Position/Action cells share come from
+// the design-system Iconbox family (ui/iconbox): IconboxStatus holds the 28px
+// token logo, IconboxAction/IconboxPosition draw an inner 30px disc around a
+// 16px glyph.
 
 /** Title-row chip of the Token Idle cell (rate / 1:1-parity badges). */
 export function CellBadge({
@@ -213,9 +162,9 @@ export function CellToken({
 }) {
   return (
     <span className="flex items-center gap-3">
-      <TableIconBox variant="token" active={active}>
+      <IconboxStatus type={active ? 'success' : 'default'} dot={active}>
         {icon}
-      </TableIconBox>
+      </IconboxStatus>
       <span className="flex flex-col gap-0.5">
         <span className={cn(label4, 'text-fgPrimary flex items-center gap-1')}>
           {title}
@@ -247,7 +196,7 @@ export function CellTokenIdle({
 }) {
   return (
     <span className="flex items-center gap-3">
-      <TableIconBox variant="token">{icon}</TableIconBox>
+      <IconboxStatus>{icon}</IconboxStatus>
       <span className="flex flex-col gap-0.5">
         <span className={cn(label4, 'text-fgPrimary flex items-center gap-1')}>
           {symbol}
@@ -263,7 +212,7 @@ export function CellTokenIdle({
 export function CellPosition({ icon, label }: { icon: ReactNode; label: ReactNode }) {
   return (
     <span className="flex items-center gap-3">
-      <TableIconBox variant="position">{icon}</TableIconBox>
+      <IconboxPosition>{icon}</IconboxPosition>
       <span className={cn(label5, 'text-fgPrimary')}>{label}</span>
     </span>
   );
@@ -288,7 +237,7 @@ export function CellAction({
 }) {
   return (
     <span className="flex items-center gap-3">
-      <TableIconBox variant="action">{icon}</TableIconBox>
+      <IconboxAction>{icon}</IconboxAction>
       <span className="flex flex-col gap-0.5">
         <span className={cn(compact ? label5 : label4, 'text-fgPrimary')}>{label}</span>
         {sublabel != null && (

--- a/apps/webapp/src/components/ui/tooltip.tsx
+++ b/apps/webapp/src/components/ui/tooltip.tsx
@@ -3,6 +3,13 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { useIsTouchDevice } from '@/hooks';
 import { cn } from '@/lib/cn';
 
+// Design-system Tooltip (Figma Components/Tooltip 5043:57748). The content
+// chrome is the shared recipe of every type — bg-tertiary glass at 16px
+// radius, 16px padding — and the base typography is the Simple type
+// (5043:58208): Body 7 on fg-primary, 260px max (228px text + padding).
+// Titled types (Default 5043:58197) compose a Label 5 heading above
+// fg-secondary body copy inside; the DS draws no arrow on any tooltip.
+
 const TooltipProvider = TooltipPrimitive.Provider;
 
 const Tooltip = ({ open, ...props }: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => {
@@ -16,13 +23,6 @@ const Tooltip = ({ open, ...props }: React.ComponentPropsWithoutRef<typeof Toolt
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
-const TooltipArrow = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Arrow>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Arrow>
->(({ className, ...props }, ref) => (
-  <TooltipPrimitive.Arrow ref={ref} className={cn('fill-container', className)} {...props} />
-));
-
 const TooltipPortal = TooltipPrimitive.Portal;
 
 const TooltipContent = React.forwardRef<
@@ -33,7 +33,10 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'bg-container text-text animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 rounded-md px-3 py-1.5 text-sm shadow-md backdrop-blur-[50px]',
+      // z-101: tooltips are the topmost transient layer — they must clear the
+      // app PopoverContent (z-100, e.g. the nav More menu hosting the theme
+      // and batch toggles), not just the z-50 dialog/sheet/select tier.
+      'bg-bgTertiary text-fgPrimary font-graphik animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-101 max-w-[260px] rounded-2xl p-4 text-[11px] leading-4 font-normal backdrop-blur-[100px]',
       className
     )}
     {...props}
@@ -41,4 +44,4 @@ const TooltipContent = React.forwardRef<
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, TooltipArrow, TooltipPortal };
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, TooltipPortal };

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -146,6 +146,15 @@
   --color-statusWarning: #ffc044;
   --color-statusBrand: #9ca9ff;
   --color-statusBrandBg: rgba(156, 160, 229, 0.1);
+  /* Iconbox status rings + info dot (Figma Components/Iconbox 5017:7858).
+     Figma types the rings by product — Pendle mint / Morpho blue — as raw
+     hexes (no variable); promoted here under the system color each pairs
+     with. statusInfoSolid is border-system-info-primary, the info dot
+     (statusSuccessSolid above doubles as the success dot). None are
+     overridden in the light scope yet (G2 owns light parity). */
+  --color-statusSuccessRing: #8bf1ca;
+  --color-statusInfoRing: #60a9ff;
+  --color-statusInfoSolid: #59b1ff;
   --color-border: var(--transparent-white-15);
   --color-borderActive: var(--transparent-white-25);
   --color-borderPurple: #4c4577;

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -155,6 +155,20 @@
   --color-statusSuccessRing: #8bf1ca;
   --color-statusInfoRing: #60a9ff;
   --color-statusInfoSolid: #59b1ff;
+  /* Design-system list + accordion tokens (Figma Patterns/Lists 5209:36922 /
+     Patterns/Accordion 5386:66315): colors/border/border-primary (container,
+     item and wallet-row hairlines — the `border-borderPrimary` utility
+     predates this token, so until now it silently fell back to the preflight
+     border color), gradient-brand-border + the gradient-brand3 stops (the
+     selected wallet row) and the loader's brand gradient stops. borderPrimary
+     gets an interim light value (G2 owns full parity); the brand-tinted ones
+     read on white as-is. */
+  --color-borderPrimary: rgba(188, 182, 239, 0.1);
+  --color-brandBorder: #504dff;
+  --color-brand3-start: rgba(148, 154, 255, 0.1);
+  --color-brand3-end: rgba(80, 77, 255, 0.1);
+  --color-loader-brand-start: #949aff;
+  --color-loader-brand-end: #504dff;
   --color-border: var(--transparent-white-15);
   --color-borderActive: var(--transparent-white-25);
   --color-borderPurple: #4c4577;
@@ -508,6 +522,8 @@
 
     /* H5 tabs tokens (interim light values; G2 owns parity) */
     --color-borderTertiary: rgba(26, 24, 85, 0.3);
+    /* H15 list/accordion border (interim light value; G2 owns parity) */
+    --color-borderPrimary: rgba(26, 24, 85, 0.1);
     --color-fgSecondary: rgba(26, 24, 85, 0.62);
     --color-fgPrimary: #1a1855;
     --color-flipSurface: rgba(255, 255, 255, 0.9);

--- a/apps/webapp/src/modules/app/shell/TopNav.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.tsx
@@ -83,8 +83,10 @@ function useActiveDestinationPath(): RoutePath | null {
 // styling keys off the link's aria-current="page".
 const navItemClasses = cn(buttonVariants({ variant: 'navbar', size: 'navbar' }), 'relative');
 
+// Design-system Dropdown row (Figma Components/Dropdown 5075:17292): Label 5
+// on fg-primary, 16/12 padding, hover rows tint bg-secondary.
 const moreItemClasses =
-  'text-textSecondary hover:text-text hover:bg-bgHover rounded-md px-3 py-2 text-left text-sm transition-colors';
+  'text-fgPrimary hover:bg-bgSecondary font-circle px-4 py-3 text-left text-sm leading-4 font-medium tracking-[-0.28px] transition-colors';
 
 /** Secondary actions that don't earn a destination: batch toggle, legal links. */
 function MoreMenu() {
@@ -104,8 +106,12 @@ function MoreMenu() {
       >
         {isOpen ? <X size={16} className="nav-menu-icon" /> : <Menu size={16} className="nav-menu-icon" />}
       </PopoverTrigger>
-      <PopoverContent align="end" className="flex w-60 flex-col gap-1 p-2">
-        <div className="flex items-center gap-1 px-1">
+      {/* DS Dropdown panel chrome (bg-tertiary glass, 16px radius, 1/4px inset). */}
+      <PopoverContent
+        align="end"
+        className="bg-bgTertiary flex w-60 flex-col rounded-2xl px-px py-1 shadow-none backdrop-blur-[20px]"
+      >
+        <div className="flex items-center gap-1 px-3 py-1">
           <ThemeToggle />
           {BATCH_TX_ENABLED && <BatchTransactionsToggle />}
         </div>

--- a/apps/webapp/src/modules/app/shell/WalletChip.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletChip.tsx
@@ -27,8 +27,10 @@ export function WalletChip() {
   const [showDrawer, setShowDrawer] = useState(false);
   const { isConnectedAndAcceptedTerms, isAuthorized, authData, vpnData } = useConnectedContext();
 
+  // Connect type of Navbar Item / Wallet Info (Figma 5069:27086): the DS
+  // primary button recipe at navbar height (40px, Label 5).
   const connectButton = (
-    <Button variant="connect" onClick={openConnectModal}>
+    <Button variant="primary" size="m" onClick={openConnectModal}>
       {t`Connect Wallet`}
     </Button>
   );

--- a/apps/webapp/src/modules/convert/components/ConvertTokenSelect.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertTokenSelect.tsx
@@ -33,9 +33,6 @@ export function ConvertTokenSelect({
   onChange: (next: ConvertTokenSymbol) => void;
   dataTestId: string;
 }) {
-  const itemClasses =
-    'text-textSecondary hover:text-text focus:text-text hover:bg-surfaceAlt focus:bg-surfaceAlt data-[state=checked]:bg-surface data-[state=checked]:text-text cursor-pointer rounded-md px-3 py-2 transition-colors';
-
   return (
     <Select value={value} onValueChange={next => onChange(next as ConvertTokenSymbol)}>
       {/* Design-system Button / Dropdown, size S (Figma 5019:4105); same
@@ -52,9 +49,10 @@ export function ConvertTokenSelect({
           <TokenOption symbol={value} />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
+      {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+      <SelectContent>
         {CONVERT_TOKEN_SYMBOLS.map(symbol => (
-          <SelectItem key={symbol} value={symbol} hideIndicator className={itemClasses}>
+          <SelectItem key={symbol} value={symbol}>
             <TokenOption symbol={symbol} />
           </SelectItem>
         ))}

--- a/apps/webapp/src/modules/morpho/components/MorphoVaultAllocationsDetails.tsx
+++ b/apps/webapp/src/modules/morpho/components/MorphoVaultAllocationsDetails.tsx
@@ -9,13 +9,7 @@ import {
 import { Text } from '@/modules/layout/components/Typography';
 import { Trans } from '@lingui/react/macro';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/ui/tooltip';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { PairTokenIcons } from '@/widgets';
 import { useChainId } from 'wagmi';
@@ -405,8 +399,7 @@ export function MorphoVaultAllocationsDetails({
                         </div>
                       </TooltipTrigger>
                       <TooltipContent>
-                        <Text className="text-sm">Liquidation Loan-To-Value (LLTV)</Text>
-                        <TooltipArrow width={12} height={8} />
+                        <Text className="text-sm">Liquidation Loan-To-Value (LLTV)</Text>{' '}
                       </TooltipContent>
                     </Tooltip>
                     <Tooltip>
@@ -431,8 +424,7 @@ export function MorphoVaultAllocationsDetails({
                       <Text className="text-text text-sm">{market.formattedAssets}</Text>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <Text className="text-sm">{market.formattedAssetsUsd}</Text>
-                      <TooltipArrow width={12} height={8} />
+                      <Text className="text-sm">{market.formattedAssetsUsd}</Text>{' '}
                     </TooltipContent>
                   </Tooltip>
                 </TableCell>
@@ -450,8 +442,7 @@ export function MorphoVaultAllocationsDetails({
                       <TooltipContent>
                         <Text className="text-sm">
                           {(market.absoluteCapUtilization * 100).toFixed(2)}% filled
-                        </Text>
-                        <TooltipArrow width={12} height={8} />
+                        </Text>{' '}
                       </TooltipContent>
                     </Tooltip>
                   )}
@@ -467,8 +458,7 @@ export function MorphoVaultAllocationsDetails({
                     <TooltipContent>
                       <Text className="text-sm">
                         {(market.relativeCapUtilization * 100).toFixed(2)}% filled
-                      </Text>
-                      <TooltipArrow width={12} height={8} />
+                      </Text>{' '}
                     </TooltipContent>
                   </Tooltip>
                 </TableCell>

--- a/apps/webapp/src/modules/pendle/components/PendleAboutContent.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleAboutContent.tsx
@@ -4,6 +4,7 @@ import { Activity, ArrowUpFromLine, AudioLines } from 'lucide-react';
 import { usePendleMarketsApiData, type PendleMarketConfig } from '@/hooks';
 import { formatDecimalPercentage, formatNumber } from '@/utils';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { IconboxAction } from '@/components/ui/iconbox';
 
 const SECONDS_PER_DAY = 86_400;
 const EXAMPLE_SUPPLY = 100;
@@ -99,30 +100,16 @@ export function PendleAboutContent({ market }: { market: PendleMarketConfig }) {
           </a>
         </Trans>
       </p>
-      <Accordion
-        type="multiple"
-        className="border-borderPrimary overflow-hidden rounded-xl border"
-        data-testid="pendle-detail-faq"
-      >
+      <Accordion type="multiple" data-testid="pendle-detail-faq">
         {items.map(item => (
-          <AccordionItem
-            key={item.id}
-            value={item.id}
-            className="border-borderPrimary border-b px-6 last:border-b-0"
-          >
-            <AccordionTrigger className="py-6 [&>svg]:h-4 [&>svg]:w-4">
+          <AccordionItem key={item.id} value={item.id}>
+            <AccordionTrigger>
               <span className="flex items-center gap-3">
-                <span className="border-borderPrimary flex h-9 w-9 items-center justify-center rounded-full border">
-                  <span className="bg-surface text-text flex h-[30px] w-[30px] items-center justify-center rounded-full">
-                    {item.icon}
-                  </span>
-                </span>
-                <span className="text-text text-base font-medium">{item.title}</span>
+                <IconboxAction>{item.icon}</IconboxAction>
+                {item.title}
               </span>
             </AccordionTrigger>
-            <AccordionContent className="text-textSecondary pb-6 text-xs leading-[18px]">
-              {item.body}
-            </AccordionContent>
+            <AccordionContent>{item.body}</AccordionContent>
           </AccordionItem>
         ))}
       </Accordion>

--- a/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
@@ -52,10 +52,6 @@ export type PendleModalFlow = 'supply' | 'withdraw';
 
 const NO_VALUE = '–';
 
-// Same option-row treatment as FilterSelect / the header MoreMenu popover.
-const selectItemClasses =
-  'text-textSecondary hover:text-text focus:text-text hover:bg-surfaceAlt focus:bg-surfaceAlt data-[state=checked]:bg-surface data-[state=checked]:text-text cursor-pointer rounded-md px-3 py-2 transition-colors';
-
 function Row({ label, value, dataTestId }: { label: ReactNode; value: ReactNode; dataTestId?: string }) {
   return (
     <div className="flex items-center justify-between" data-testid={dataTestId}>
@@ -399,14 +395,10 @@ export function PendleModalForm({
                   </span>
                 </SelectValue>
               </SelectTrigger>
-              <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
+              {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+              <SelectContent>
                 {tokenOptions.map(option => (
-                  <SelectItem
-                    key={option.symbol}
-                    value={option.symbol}
-                    hideIndicator
-                    className={selectItemClasses}
-                  >
+                  <SelectItem key={option.symbol} value={option.symbol}>
                     <span className="flex items-center gap-1.5">
                       <TokenIcon
                         token={{ symbol: option.symbol }}
@@ -494,14 +486,10 @@ export function PendleModalForm({
                     </span>
                   </SelectValue>
                 </SelectTrigger>
-                <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
+                {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+                <SelectContent>
                   {tokenOptions.map(option => (
-                    <SelectItem
-                      key={option.symbol}
-                      value={option.symbol}
-                      hideIndicator
-                      className={selectItemClasses}
-                    >
+                    <SelectItem key={option.symbol} value={option.symbol}>
                       <span className="flex items-center gap-1.5">
                         <TokenIcon
                           token={{ symbol: option.symbol }}

--- a/apps/webapp/src/modules/savings/components/SavingsOriginSelect.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsOriginSelect.tsx
@@ -65,9 +65,6 @@ export function SavingsOriginSelect({
     );
   }
 
-  const itemClasses =
-    'text-textSecondary hover:text-text focus:text-text hover:bg-surfaceAlt focus:bg-surfaceAlt data-[state=checked]:bg-surface data-[state=checked]:text-text cursor-pointer rounded-md px-3 py-2 transition-colors';
-
   return (
     <Select value={value} onValueChange={next => onChange(next as OriginSymbol)} disabled={disabled}>
       {/* Design-system Button / Dropdown, size S (Figma 5019:4105); same
@@ -84,15 +81,10 @@ export function SavingsOriginSelect({
           <OriginOption symbol={value} />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
+      {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+      <SelectContent>
         {options.map(symbol => (
-          <SelectItem
-            key={symbol}
-            value={symbol}
-            hideIndicator
-            data-testid={`savings-origin-${symbol.toLowerCase()}`}
-            className={itemClasses}
-          >
+          <SelectItem key={symbol} value={symbol} data-testid={`savings-origin-${symbol.toLowerCase()}`}>
             <OriginOption symbol={symbol} />
           </SelectItem>
         ))}

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
@@ -39,7 +39,7 @@ export function SavingsTransactionsFilter({
       <SelectTrigger
         data-testid="savings-transactions-filter"
         aria-label={t`Filter transactions`}
-        className="text-textSecondary hover:text-text h-auto w-auto shrink-0 gap-1.5 rounded-full border-none bg-transparent p-0 text-sm font-medium transition-colors focus:ring-0 focus:ring-offset-0"
+        className="text-textSecondary hover:text-text h-auto w-auto shrink-0 gap-1.5 rounded-full border-none bg-transparent p-0 text-sm font-medium transition-colors focus-visible:ring-0"
       >
         <SelectValue>
           <FilterLabel value={value} />

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
@@ -34,9 +34,6 @@ export function SavingsTransactionsFilter({
   value: SavingsTxFilter;
   onChange: (next: SavingsTxFilter) => void;
 }): ReactNode {
-  const itemClasses =
-    'text-textSecondary hover:text-text focus:text-text hover:bg-surfaceAlt focus:bg-surfaceAlt data-[state=checked]:bg-surface data-[state=checked]:text-text cursor-pointer rounded-md px-3 py-2 transition-colors';
-
   return (
     <Select value={value} onValueChange={next => onChange(next as SavingsTxFilter)}>
       <SelectTrigger
@@ -48,15 +45,10 @@ export function SavingsTransactionsFilter({
           <FilterLabel value={value} />
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
+      {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+      <SelectContent>
         {SAVINGS_TX_FILTERS.map(filter => (
-          <SelectItem
-            key={filter}
-            value={filter}
-            hideIndicator
-            data-testid={`savings-transactions-filter-${filter}`}
-            className={itemClasses}
-          >
+          <SelectItem key={filter} value={filter} data-testid={`savings-transactions-filter-${filter}`}>
             <FilterLabel value={filter} />
           </SelectItem>
         ))}

--- a/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
@@ -275,7 +275,7 @@ export function StakeActivityTable({ positions }: { positions?: StakeUserPositio
             <SelectTrigger
               data-testid="stake-activity-filter"
               aria-label={t`Filter activity by position`}
-              className="text-textSecondary hover:text-text h-auto w-auto shrink-0 gap-1.5 rounded-full border-none bg-transparent p-0 text-sm font-medium transition-colors focus:ring-0 focus:ring-offset-0"
+              className="text-textSecondary hover:text-text h-auto w-auto shrink-0 gap-1.5 rounded-full border-none bg-transparent p-0 text-sm font-medium transition-colors focus-visible:ring-0"
             >
               <SelectValue>
                 {filter === 'all' ? <Trans>All positions</Trans> : <Trans>Position {filter + 1}</Trans>}

--- a/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
@@ -261,9 +261,6 @@ export function StakeActivityTable({ positions }: { positions?: StakeUserPositio
     return filtered.map(group => ({ ...group, skyPrice, chainId }));
   }, [stakeHistory, filter, skyPrice, chainId]);
 
-  const itemClasses =
-    'text-textSecondary hover:text-text focus:text-text hover:bg-surfaceAlt focus:bg-surfaceAlt data-[state=checked]:bg-surface data-[state=checked]:text-text cursor-pointer rounded-md px-3 py-2 transition-colors';
-
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-4">
@@ -284,22 +281,16 @@ export function StakeActivityTable({ positions }: { positions?: StakeUserPositio
                 {filter === 'all' ? <Trans>All positions</Trans> : <Trans>Position {filter + 1}</Trans>}
               </SelectValue>
             </SelectTrigger>
-            <SelectContent className="bg-containerDark border-borderPrimary rounded-xl p-1.5 backdrop-blur-[50px]">
-              <SelectItem
-                value="all"
-                hideIndicator
-                data-testid="stake-activity-filter-all"
-                className={itemClasses}
-              >
+            {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}
+            <SelectContent>
+              <SelectItem value="all" data-testid="stake-activity-filter-all">
                 <Trans>All positions</Trans>
               </SelectItem>
               {(positions ?? []).map(position => (
                 <SelectItem
                   key={position.index}
                   value={String(position.index)}
-                  hideIndicator
                   data-testid={`stake-activity-filter-${position.index}`}
-                  className={itemClasses}
                 >
                   <Trans>Position {position.index + 1}</Trans>
                 </SelectItem>

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -73,7 +73,8 @@ export function ChainModal({
   // Non-widget trigger = design-system Button / Dropdown, Network M (Figma
   // 5019:4105): 24px chain icon, 16px chevron that flips while open (Radix
   // DialogTrigger supplies data-state). The widget look keeps its legacy
-  // connect recipe untouched.
+  // recipe untouched — connectPrimary is just the text-color base; the
+  // className below overrides every gradient/border stop it sets.
   return (
     <Dialog open={open} onOpenChange={disabled ? undefined : setOpen}>
       <DialogTrigger asChild disabled={disabled}>
@@ -81,7 +82,7 @@ export function ChainModal({
           <button className="h-full w-full">{children}</button>
         ) : (
           <Button
-            variant={variant === ChainModalVariant.widget ? 'connect' : 'dropdown'}
+            variant={variant === ChainModalVariant.widget ? 'connectPrimary' : 'dropdown'}
             size={variant === ChainModalVariant.widget ? 'default' : 'dropdownM'}
             className={cn(
               variant === ChainModalVariant.widget

--- a/apps/webapp/src/modules/ui/components/ConnectModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ConnectModal.tsx
@@ -9,6 +9,7 @@ import {
 } from 'wagmi';
 import { Dialog, DialogClose, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { ListWallet } from '@/components/ui/list';
 import { Text } from '@/modules/layout/components/Typography';
 import { Close } from '@/modules/icons';
 import { t } from '@lingui/core/macro';
@@ -189,6 +190,10 @@ export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
     return false;
   });
 
+  // Rows are the design-system List / Wallet (Figma 5209:38238): the whole
+  // row is the connect button. The legacy "Connecting..." subtitle maps to the
+  // active (loader) state; "Connected" and "Connect via QR" move into the
+  // Label 6 badge slot ("Recent" in Figma — we don't track recency).
   const renderConnectorButton = (connector: Connector) => {
     const isConnecting =
       (connect.isPending && connect.variables?.connector === connector) ||
@@ -198,33 +203,25 @@ export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
     const isCurrentConnectedConnector = connectedConnector?.uid === connector.uid;
 
     return (
-      <div key={connector.uid} className="flex items-center justify-between gap-3 px-3">
-        <div className="flex items-center gap-3">
-          <WalletIcon connector={connector} iconUrl={icons[connector.uid]} />
-          <div className="flex flex-col items-start">
-            <Text className="text-text text-base font-medium">{connector.name}</Text>
-            {isConnecting && <Text className="text-textSecondary text-sm">{t`Connecting...`}</Text>}
-            {!isReady && !isConnecting && alwaysAvailable.includes(connector.id) && (
-              <Text className="text-textSecondary text-sm">{t`Connect via QR`}</Text>
-            )}
-          </div>
-        </div>
-        <Button
-          key={connector.uid}
-          onClick={() =>
-            isConnectorConnected
-              ? switchConnection.switchConnection({ connector })
-              : connect.connect({ connector })
-          }
-          disabled={
-            !isReady || connect.isPending || switchConnection.isPending || isCurrentConnectedConnector
-          }
-          variant="pill"
-          size="xs"
-        >
-          {isCurrentConnectedConnector ? t`Connected` : t`Connect`}
-        </Button>
-      </div>
+      <ListWallet
+        key={connector.uid}
+        icon={<WalletIcon connector={connector} iconUrl={icons[connector.uid]} className="h-6 w-6" />}
+        name={connector.name}
+        badge={
+          isCurrentConnectedConnector
+            ? t`Connected`
+            : !isReady && !isConnecting && alwaysAvailable.includes(connector.id)
+              ? t`Connect via QR`
+              : undefined
+        }
+        active={isConnecting}
+        onClick={() =>
+          isConnectorConnected
+            ? switchConnection.switchConnection({ connector })
+            : connect.connect({ connector })
+        }
+        disabled={!isReady || connect.isPending || switchConnection.isPending || isCurrentConnectedConnector}
+      />
     );
   };
 
@@ -302,8 +299,11 @@ export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
         <div className="flex flex-col gap-6">
           {installedWallets.length > 0 && (
             <>
-              <Text className="text-textSecondary text-md font-medium uppercase">{t`Installed Wallets`}</Text>
-              <div className="flex flex-col gap-6">{installedWallets.map(renderConnectorButton)}</div>
+              {/* Section labels are the pattern's Body 6 fg-secondary list titles (Figma 5209:38849). */}
+              <div className="flex flex-col gap-2">
+                <Text className="text-fgSecondary text-xs leading-[18px]">{t`Installed Wallets`}</Text>
+                {installedWallets.map(renderConnectorButton)}
+              </div>
               <Text className="text-textSecondary text-center text-[13px] leading-4">
                 {t`By connecting, you agree to our Terms of Service`}
               </Text>
@@ -311,10 +311,10 @@ export function ConnectModal({ open, onOpenChange }: ConnectModalProps) {
           )}
 
           {suggestedWallets.length > 0 && (
-            <>
-              <Text className="text-textSecondary text-md font-medium uppercase">{t`Suggested Wallets`}</Text>
-              <div className="flex flex-col gap-6">{suggestedWallets.map(renderConnectorButton)}</div>
-            </>
+            <div className="flex flex-col gap-2">
+              <Text className="text-fgSecondary text-xs leading-[18px]">{t`Suggested Wallets`}</Text>
+              {suggestedWallets.map(renderConnectorButton)}
+            </div>
           )}
         </div>
 

--- a/apps/webapp/src/modules/ui/components/FaqAccordion.tsx
+++ b/apps/webapp/src/modules/ui/components/FaqAccordion.tsx
@@ -1,6 +1,4 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { Card } from '@/components/ui/card';
-import { Heading } from '@/modules/layout/components/Typography';
 import { SafeMarkdownRenderer } from './markdown/SafeMarkdownRenderer';
 import { ExternalLink } from '@/modules/layout/components/ExternalLink';
 import { PopoverRateInfo, PopoverInfo, getTooltipById, resolvePopoverTooltipKey } from '@/widgets';
@@ -15,67 +13,59 @@ export function FaqAccordion({ items }: { items: Item[] }): React.ReactElement {
   return (
     <Accordion type="multiple" className="w-full">
       {parsedItems.map(({ title, content }) => (
-        <Card key={title} className="mb-3">
-          <AccordionItem value={title} className="p-0">
-            <AccordionTrigger className="p-0 text-left">
-              <Heading variant="extraSmall">{title}</Heading>
-            </AccordionTrigger>
-            <AccordionContent className="space-y-4 pt-4 pr-5 pb-0 leading-5">
-              <SafeMarkdownRenderer
-                markdown={content}
-                components={{
-                  a: ({ children, href, ...props }) => {
-                    // Handle tooltip syntax: [text](#tooltip-type)
-                    if (href?.startsWith('#tooltip-')) {
-                      const tooltipId = href.replace('#tooltip-', '');
+        <AccordionItem key={title} value={title}>
+          <AccordionTrigger className="gap-4 text-left">{title}</AccordionTrigger>
+          <AccordionContent className="space-y-4">
+            <SafeMarkdownRenderer
+              markdown={content}
+              components={{
+                a: ({ children, href, ...props }) => {
+                  // Handle tooltip syntax: [text](#tooltip-type)
+                  if (href?.startsWith('#tooltip-')) {
+                    const tooltipId = href.replace('#tooltip-', '');
 
-                      const popoverKey = resolvePopoverTooltipKey(tooltipId);
-                      if (popoverKey) {
-                        return (
-                          <span className="inline-flex items-center gap-1">
-                            {children}
-                            <PopoverRateInfo type={popoverKey} />
-                          </span>
-                        );
-                      }
-
-                      // Fall back to the dynamic tooltip system for ids without
-                      // a PopoverRateInfo equivalent (e.g. gas-fee, sealed).
-                      const tooltip = getTooltipById(tooltipId);
-                      if (tooltip) {
-                        return (
-                          <span className="inline-flex items-center gap-1">
-                            {children}
-                            <PopoverInfo
-                              title={tooltip.title}
-                              description={tooltip.tooltip}
-                              iconSize="large"
-                            />
-                          </span>
-                        );
-                      }
-
-                      // If tooltip not found, just render the text without tooltip
-                      return <>{children}</>;
+                    const popoverKey = resolvePopoverTooltipKey(tooltipId);
+                    if (popoverKey) {
+                      return (
+                        <span className="inline-flex items-center gap-1">
+                          {children}
+                          <PopoverRateInfo type={popoverKey} />
+                        </span>
+                      );
                     }
 
-                    // Handle regular links
-                    return (
-                      <ExternalLink
-                        href={href || ''}
-                        className="text-blue-500 hover:underline"
-                        showIcon={false}
-                        {...props}
-                      >
-                        {children}
-                      </ExternalLink>
-                    );
+                    // Fall back to the dynamic tooltip system for ids without
+                    // a PopoverRateInfo equivalent (e.g. gas-fee, sealed).
+                    const tooltip = getTooltipById(tooltipId);
+                    if (tooltip) {
+                      return (
+                        <span className="inline-flex items-center gap-1">
+                          {children}
+                          <PopoverInfo title={tooltip.title} description={tooltip.tooltip} iconSize="large" />
+                        </span>
+                      );
+                    }
+
+                    // If tooltip not found, just render the text without tooltip
+                    return <>{children}</>;
                   }
-                }}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        </Card>
+
+                  // Handle regular links
+                  return (
+                    <ExternalLink
+                      href={href || ''}
+                      className="text-blue-500 hover:underline"
+                      showIcon={false}
+                      {...props}
+                    >
+                      {children}
+                    </ExternalLink>
+                  );
+                }
+              }}
+            />
+          </AccordionContent>
+        </AccordionItem>
       ))}
     </Accordion>
   );

--- a/apps/webapp/src/modules/ui/components/TermsModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TermsModal.tsx
@@ -210,8 +210,10 @@ export function TermsModal() {
     </div>
   );
 
+  // Renders in the navbar wallet slot, so it wears the same DS connect recipe
+  // as WalletChip (Figma 5069:27086): primary button at navbar height.
   const triggerButton = (
-    <Button variant="connect" onClick={termsCheckError ? retryTermsCheck : openModal}>
+    <Button variant="primary" size="m" onClick={termsCheckError ? retryTermsCheck : openModal}>
       <Trans>Connect Wallet</Trans>
     </Button>
   );

--- a/apps/webapp/src/modules/ui/components/historyTable/HistoryRow.tsx
+++ b/apps/webapp/src/modules/ui/components/historyTable/HistoryRow.tsx
@@ -12,13 +12,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { LoadingErrorWrapper } from '../LoadingErrorWrapper';
 import { Fragment, useMemo } from 'react';
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/ui/tooltip';
 
 type HistoryRowProps = {
   row?: HistoryRowType;
@@ -144,7 +138,7 @@ const HistoryRowContent = ({ row, chainId, index, typeColumn, statusColumn }: Hi
               />
             </TooltipTrigger>
             <TooltipPortal>
-              <TooltipContent arrowPadding={10}>
+              <TooltipContent>
                 <Text variant="small">
                   {row?.useCowExplorer ? (
                     <Trans>View transaction on CoW Explorer</Trans>
@@ -152,7 +146,6 @@ const HistoryRowContent = ({ row, chainId, index, typeColumn, statusColumn }: Hi
                     t`View transaction on ${explorerName}`
                   )}
                 </Text>
-                <TooltipArrow width={12} height={8} />
               </TooltipContent>
             </TooltipPortal>
           </Tooltip>
@@ -161,11 +154,10 @@ const HistoryRowContent = ({ row, chainId, index, typeColumn, statusColumn }: Hi
               <CopyToClipboard text={row?.transactionHash || ''} />
             </TooltipTrigger>
             <TooltipPortal>
-              <TooltipContent arrowPadding={10}>
+              <TooltipContent>
                 <Text variant="small">
                   <Trans>Copy transaction hash</Trans>
                 </Text>
-                <TooltipArrow width={12} height={8} />
               </TooltipContent>
             </TooltipPortal>
           </Tooltip>

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -439,9 +439,6 @@ function ButtonsSection() {
           <Spec label="outline">
             <Button variant="outline">Outline</Button>
           </Spec>
-          <Spec label="connect">
-            <Button variant="connect">Connect</Button>
-          </Spec>
           <Spec label="connectPrimary">
             <Button variant="connectPrimary">Connect</Button>
           </Spec>

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -4,9 +4,11 @@ import {
   ArrowDownToLine,
   ArrowRight,
   ArrowUpToLine,
+  Check,
   ChevronDown,
   Copy,
   LineChart,
+  Network,
   Settings2,
   Star,
   Wallet
@@ -98,6 +100,7 @@ import {
   IconboxPosition,
   IconboxStatus
 } from '@/components/ui/iconbox';
+import { Loader } from '@/components/ui/loader';
 
 // Internal-only living style guide (route /design-system, hidden in production).
 // Shows every canonical components/ui primitive in its prop-reachable states;
@@ -116,6 +119,7 @@ const SECTIONS = [
   { id: 'tables', title: 'Tables' },
   { id: 'iconbox', title: 'Iconbox' },
   { id: 'steps', title: 'Steps' },
+  { id: 'feedback', title: 'Feedback' },
   { id: 'data', title: 'Data & misc' }
 ];
 
@@ -713,7 +717,7 @@ function SelectSection() {
     <Section
       id="select"
       title="Select"
-      note="Known issue in dark: --background/--foreground are light-only tokens, so the trigger/content surfaces are transparent with dark text (THEMING.md, deferred bug 4). Shown as-is on purpose."
+      note="Panel and rows are the DS Dropdown recipe (H9): bg-tertiary glass, 16px radius, Label-5 rows, selected row tinted with a right-edge check. Known issue in dark: --background/--foreground are light-only tokens, so the trigger surface is transparent with dark text (THEMING.md, deferred bug 4). Shown as-is on purpose."
     >
       <Row>
         <Spec label="default">
@@ -1768,6 +1772,133 @@ function StepsSection() {
   );
 }
 
+// ─── Feedback (H9) ────────────────────────────────────────────────────────────
+
+// Static replica of the TooltipContent recipe so both themes can be inspected
+// without hovering (the live primitive portals to its trigger).
+function TooltipReplica({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <div
+      className={cn(
+        'bg-bgTertiary text-fgPrimary font-graphik max-w-[260px] rounded-2xl p-4 text-[11px] leading-4 font-normal backdrop-blur-[100px]',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+const DROPDOWN_REPLICA_ROWS = [
+  { label: 'All networks', icon: <Network className="size-4 shrink-0" />, selected: false },
+  { label: 'Ethereum', icon: <MainnetChain className="size-4 shrink-0" />, selected: true },
+  { label: 'Base', icon: <BaseChain className="size-4 shrink-0" />, selected: false },
+  { label: 'OP Mainnet', icon: <OptimismChain className="size-4 shrink-0" />, selected: false }
+];
+
+function FeedbackSection() {
+  return (
+    <Section
+      id="feedback"
+      title="Feedback"
+      note="Components/Tooltip, Toast, Dropdown and Loading (H9): the small feedback primitives share the bg-tertiary glass surface at 16px radius. Tooltips draw no arrow; the dropdown panel and rows are the SelectContent/SelectItem defaults (live in the Select section); the loader generalizes the H4 button glyph to six sizes."
+    >
+      <SubSection title="Tooltip — Simple / Default (titled) / Short">
+        <Row>
+          <Spec label="simple">
+            <TooltipReplica>
+              Tooltips are used to describe or identify an element. In most scenarios, tooltips help the user
+              understand meaning, function or alt-text.
+            </TooltipReplica>
+          </Spec>
+          <Spec label="default — titled">
+            <TooltipReplica>
+              <p className="font-circle text-fgPrimary mb-2 text-sm leading-4 font-medium tracking-[-0.28px]">
+                This is a tooltip
+              </p>
+              <p className="text-fgSecondary">
+                Tooltips are used to describe or identify an element. In most scenarios, tooltips help the
+                user understand meaning, function or alt-text.
+              </p>
+            </TooltipReplica>
+          </Spec>
+          <Spec label="short">
+            <TooltipReplica className="font-circle w-fit text-xs leading-[14px] font-medium tracking-[-0.24px]">
+              This is a tooltip
+            </TooltipReplica>
+          </Spec>
+          <Spec label="live (hover)">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="secondary" size="m">
+                    Hover me
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>This is a tooltip</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </Spec>
+        </Row>
+      </SubSection>
+
+      <SubSection title="Toast — success disc / description / error (pre-DS glyph)">
+        <Row>
+          <Spec label="simple success">
+            <Button variant="secondary" size="m" onClick={() => toast.success('Filters applied')}>
+              Fire success
+            </Button>
+          </Spec>
+          <Spec label="transaction — title + description">
+            <Button
+              variant="secondary"
+              size="m"
+              onClick={() => toast.success('10,000.00 USDC supplied!', { description: '0xff9s...dsa6' })}
+            >
+              Fire transaction
+            </Button>
+          </Spec>
+          <Spec label="error">
+            <Button variant="secondary" size="m" onClick={() => toast.error('Transaction failed')}>
+              Fire error
+            </Button>
+          </Spec>
+        </Row>
+      </SubSection>
+
+      <SubSection title="Dropdown — static panel replica (Networks type)">
+        <div className="bg-bgTertiary w-[220px] overflow-hidden rounded-2xl px-px py-1 backdrop-blur-[20px]">
+          {DROPDOWN_REPLICA_ROWS.map(row => (
+            <div
+              key={row.label}
+              className={cn(
+                'text-fgPrimary font-circle flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-sm leading-4 font-medium tracking-[-0.28px]',
+                row.selected && 'bg-bgSecondary'
+              )}
+            >
+              {row.icon}
+              {row.label}
+              {row.selected && <Check className="ml-auto size-4 shrink-0" />}
+            </div>
+          ))}
+        </div>
+      </SubSection>
+
+      <SubSection title="Loader — 2XS / XS / S / M / L / XL (12–40px, currentColor)">
+        <Row>
+          {(['2xs', 'xs', 's', 'm', 'l', 'xl'] as const).map(size => (
+            <Spec key={size} label={size.toUpperCase()}>
+              <span className="text-fgSecondary inline-flex">
+                <Loader size={size} />
+              </span>
+            </Spec>
+          ))}
+        </Row>
+      </SubSection>
+    </Section>
+  );
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 function DesignSystem() {
@@ -1828,6 +1959,7 @@ function DesignSystem() {
         <TablesSection />
         <IconboxSection />
         <StepsSection />
+        <FeedbackSection />
         <DataSection />
       </main>
       <Toaster />

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -101,6 +101,7 @@ import {
   IconboxStatus
 } from '@/components/ui/iconbox';
 import { Loader } from '@/components/ui/loader';
+import { ListWallet } from '@/components/ui/list';
 
 // Internal-only living style guide (route /design-system, hidden in production).
 // Shows every canonical components/ui primitive in its prop-reachable states;
@@ -1436,18 +1437,45 @@ function DataSection() {
       <SubSection title="Accordion">
         <Accordion type="single" collapsible className="max-w-2xl">
           <AccordionItem value="a">
-            <AccordionTrigger>What is the Sky Protocol?</AccordionTrigger>
-            <AccordionContent>
-              <Text variant="medium">A decentralized, non-custodial DeFi protocol.</Text>
-            </AccordionContent>
+            <AccordionTrigger>
+              <span className="flex items-center gap-3">
+                <IconboxAction>
+                  <Star className="size-4" />
+                </IconboxAction>
+                What is the Sky Protocol?
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>A decentralized, non-custodial DeFi protocol.</AccordionContent>
           </AccordionItem>
           <AccordionItem value="b">
-            <AccordionTrigger>How do rewards work?</AccordionTrigger>
-            <AccordionContent>
-              <Text variant="medium">Rewards accrue per block and can be claimed at any time.</Text>
-            </AccordionContent>
+            <AccordionTrigger>
+              <span className="flex items-center gap-3">
+                <IconboxAction>
+                  <LineChart className="size-4" />
+                </IconboxAction>
+                How do rewards work?
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>Rewards accrue per block and can be claimed at any time.</AccordionContent>
           </AccordionItem>
         </Accordion>
+      </SubSection>
+
+      <SubSection title="List / Wallet">
+        <div className="flex max-w-md flex-col gap-4">
+          <Spec label="default (hover for borderTertiary)">
+            <ListWallet icon={<Wallet className="text-fgPrimary size-6" />} name="Metamask" />
+          </Spec>
+          <Spec label="badge">
+            <ListWallet icon={<Wallet className="text-fgPrimary size-6" />} name="Metamask" badge="Recent" />
+          </Spec>
+          <Spec label="active (connecting)">
+            <ListWallet icon={<Wallet className="text-fgPrimary size-6" />} name="Coinbase Wallet" active />
+          </Spec>
+          <Spec label="disabled">
+            <ListWallet icon={<Wallet className="text-fgPrimary size-6" />} name="Safe" disabled />
+          </Spec>
+        </div>
       </SubSection>
 
       <SubSection title="Pagination">

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -91,6 +91,13 @@ import { ChartSkeleton } from '@/components/ui/chart-skeleton';
 import { GainValue } from '@/components/ui/GainValue';
 import { SlippageMenu } from '@/components/ui/SlippageMenu';
 import { Steps, StepsItem } from '@/components/ui/steps';
+import {
+  Iconbox,
+  Iconbox2Tokens,
+  IconboxAction,
+  IconboxPosition,
+  IconboxStatus
+} from '@/components/ui/iconbox';
 
 // Internal-only living style guide (route /design-system, hidden in production).
 // Shows every canonical components/ui primitive in its prop-reachable states;
@@ -107,6 +114,7 @@ const SECTIONS = [
   { id: 'cards', title: 'Cards' },
   { id: 'overlays', title: 'Overlays' },
   { id: 'tables', title: 'Tables' },
+  { id: 'iconbox', title: 'Iconbox' },
   { id: 'steps', title: 'Steps' },
   { id: 'data', title: 'Data & misc' }
 ];
@@ -1537,6 +1545,91 @@ function DataSection() {
   );
 }
 
+// ─── Iconbox ──────────────────────────────────────────────────────────────────
+
+/** Token logo filling its iconbox slot (chain overlay off — the box owns the chip). */
+function BoxToken({ symbol, px, className }: { symbol: string; px: number; className?: string }) {
+  return (
+    <TokenIcon token={{ symbol }} width={px} className={className ?? 'h-full w-full'} showChainIcon={false} />
+  );
+}
+
+const ICONBOX_SIZES = ['l', 'm', 's', 'xs'] as const;
+const STATUS_SIZES = ['l', 'm', 's', 'xs', '2xs'] as const;
+// Inner logo per Status ring size (48/28/18/10/8px).
+const STATUS_LOGO: Record<(typeof STATUS_SIZES)[number], { px: number; className: string }> = {
+  l: { px: 48, className: 'size-12' },
+  m: { px: 28, className: 'size-7' },
+  s: { px: 18, className: 'size-[18px]' },
+  xs: { px: 10, className: 'size-2.5' },
+  '2xs': { px: 8, className: 'size-2' }
+};
+
+function IconboxSection() {
+  return (
+    <Section
+      id="iconbox"
+      title="Iconbox"
+      note="Components/Iconbox (H14): the circular icon containers shared by the table cells, position surfaces and activity rows. Figma names the Status ring types by product (Pendle/Morpho); code names them by system color (success/info)."
+    >
+      <SubSection title="Base — Token / Icon × L / M / S / XS, network chip">
+        <div className="flex items-end gap-6">
+          {ICONBOX_SIZES.map(size => (
+            <Iconbox key={size} size={size} network={<BaseChain className="h-full w-full" />}>
+              <BoxToken symbol="ETH" px={40} />
+            </Iconbox>
+          ))}
+          <Iconbox type="icon" size="l">
+            <Star className="size-6" />
+          </Iconbox>
+          <Iconbox type="icon" size="m" network={<BaseChain className="h-full w-full" />}>
+            <Star className="size-4" />
+          </Iconbox>
+        </div>
+      </SubSection>
+
+      <SubSection title="2 Tokens — 4px overlap pair, network chip on the back token">
+        <Iconbox2Tokens
+          front={<BoxToken symbol="USDS" px={28} />}
+          back={<BoxToken symbol="SKY" px={28} />}
+          network={<BaseChain className="h-full w-full" />}
+        />
+      </SubSection>
+
+      <SubSection title="Status — default / success / info × L / M / S / XS / 2XS, status dot">
+        <div className="flex flex-col gap-4">
+          {(['default', 'success', 'info'] as const).map(type => (
+            <div key={type} className="flex items-center gap-6">
+              {STATUS_SIZES.map(size => (
+                <IconboxStatus key={size} type={type} size={size} dot={type !== 'default'}>
+                  <BoxToken symbol="sUSDS" {...STATUS_LOGO[size]} />
+                </IconboxStatus>
+              ))}
+            </div>
+          ))}
+        </div>
+      </SubSection>
+
+      <SubSection title="Position — default / inactive">
+        <div className="flex items-center gap-6">
+          <IconboxPosition>
+            <Stake width={16} height={16} />
+          </IconboxPosition>
+          <IconboxPosition inactive>
+            <Stake width={16} height={16} />
+          </IconboxPosition>
+        </div>
+      </SubSection>
+
+      <SubSection title="Action">
+        <IconboxAction>
+          <ArrowDownToLine className="size-4" />
+        </IconboxAction>
+      </SubSection>
+    </Section>
+  );
+}
+
 // ─── Steps ────────────────────────────────────────────────────────────────────
 
 /** 14px chip icon for step specimens (chain overlay off — the chip is symbol-only). */
@@ -1733,6 +1826,7 @@ function DesignSystem() {
         <CardsSection />
         <OverlaysSection />
         <TablesSection />
+        <IconboxSection />
         <StepsSection />
         <DataSection />
       </main>

--- a/apps/webapp/src/widgets/BalancesWidget/components/SwitchAccountButton.tsx
+++ b/apps/webapp/src/widgets/BalancesWidget/components/SwitchAccountButton.tsx
@@ -1,10 +1,4 @@
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '@/widgets/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/widgets/components/ui/tooltip';
 import { ArrowLeftRight } from '@/widgets/shared/components/icons/ArrowLeftRight';
 import { Text } from '@/widgets/shared/components/ui/Typography';
 
@@ -19,7 +13,6 @@ export const SwitchAccountButton = ({ onSwitchAccountClick }: { onSwitchAccountC
       <TooltipPortal>
         <TooltipContent>
           <Text>Switch account</Text>
-          <TooltipArrow />
         </TooltipContent>
       </TooltipPortal>
     </Tooltip>

--- a/apps/webapp/src/widgets/VaultWidget/components/MorphoVaultBadge.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/MorphoVaultBadge.tsx
@@ -1,11 +1,5 @@
 import { Trans } from '@lingui/react/macro';
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '@/widgets/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/widgets/components/ui/tooltip';
 import { cn } from '@/widgets/lib/utils';
 import { Morpho as MorphoIcon } from '@/widgets/shared/components/icons/Morpho';
 import { Sky as SkyIcon } from '@/widgets/shared/components/icons/Sky';
@@ -31,11 +25,10 @@ export const VaultPoweredByBadge = ({ provider, className }: VaultPoweredByBadge
             <SkyIcon className={cn('h-4.5 w-4.5 rounded-full', className)} />
           </TooltipTrigger>
           <TooltipPortal>
-            <TooltipContent arrowPadding={10} className="max-w-[260px]">
+            <TooltipContent className="max-w-[260px]">
               <Text variant="small">
                 <Trans>Vault powered by Sky</Trans>
               </Text>
-              <TooltipArrow width={12} height={8} />
             </TooltipContent>
           </TooltipPortal>
         </Tooltip>
@@ -48,11 +41,10 @@ export const VaultPoweredByBadge = ({ provider, className }: VaultPoweredByBadge
             <MorphoIcon className={cn('h-4.5 w-4.5 rounded-sm', className)} />
           </TooltipTrigger>
           <TooltipPortal>
-            <TooltipContent arrowPadding={10} className="max-w-[260px]">
+            <TooltipContent className="max-w-[260px]">
               <Text variant="small">
                 <Trans>Vault powered by Morpho</Trans>
               </Text>
-              <TooltipArrow width={12} height={8} />
             </TooltipContent>
           </TooltipPortal>
         </Tooltip>

--- a/apps/webapp/src/widgets/components/ui/accordion.tsx
+++ b/apps/webapp/src/widgets/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
 // Shim → @/components/ui/accordion (widget look = AccordionWidget*).
 export {
-  Accordion,
+  AccordionWidget as Accordion,
   AccordionWidgetItem as AccordionItem,
   AccordionWidgetTrigger as AccordionTrigger,
   AccordionWidgetContent as AccordionContent

--- a/apps/webapp/src/widgets/components/ui/input.tsx
+++ b/apps/webapp/src/widgets/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/widgets/lib/utils';
 import { HStack } from '@/widgets/shared/components/ui/layout/HStack';
 import { Text } from '@/widgets/shared/components/ui/Typography';
 import { Warning } from '@/widgets/shared/components/icons/Warning';
-import { Tooltip, TooltipArrow, TooltipContent, TooltipPortal, TooltipTrigger } from './tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './tooltip';
 import { useState } from 'react';
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -29,7 +29,6 @@ const ErrorTooltip = ({ tooltipMessage, error }: { tooltipMessage: string; error
     <TooltipPortal>
       <TooltipContent side="bottom" align="start" className="max-w-64">
         <Text variant="small">{tooltipMessage}</Text>
-        <TooltipArrow width={12} height={8} />
       </TooltipContent>
     </TooltipPortal>
   </Tooltip>

--- a/apps/webapp/src/widgets/shared/components/ui/CopyToClipboard.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/CopyToClipboard.tsx
@@ -1,10 +1,4 @@
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '@/widgets/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/widgets/components/ui/tooltip';
 import { useClipboard } from '@/widgets/shared/hooks/useClipboard';
 import { Text } from './Typography';
 import { Copy } from '@/widgets/shared/components/icons/Icons';
@@ -32,7 +26,6 @@ export function CopyToClipboard({ text }: { text: string }) {
       <TooltipPortal>
         <TooltipContent>
           <Text>Copied</Text>
-          <TooltipArrow />
         </TooltipContent>
       </TooltipPortal>
     </Tooltip>

--- a/apps/webapp/src/widgets/shared/components/ui/RiskSlider.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/RiskSlider.tsx
@@ -327,7 +327,7 @@ const RiskSlider = React.forwardRef<React.ComponentRef<typeof SliderPrimitive.Ro
                 </SliderPrimitive.Thumb>
               </TooltipTrigger>
               <TooltipPortal>
-                <TooltipContent arrowPadding={10} className="max-w-75">
+                <TooltipContent className="max-w-75">
                   {isRepayMode ? riskSliderRepayTooltip?.tooltip : riskSliderBorrowTooltip?.tooltip}
                 </TooltipContent>
               </TooltipPortal>

--- a/apps/webapp/src/widgets/shared/components/ui/tooltip/InfoTooltip.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/tooltip/InfoTooltip.tsx
@@ -1,18 +1,6 @@
 import { Info, X } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger
-} from '../../../../components/ui/tooltip';
-import {
-  Popover,
-  PopoverArrow,
-  PopoverClose,
-  PopoverContent,
-  PopoverTrigger
-} from '../../../../components/ui/popover';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '../../../../components/ui/tooltip';
+import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from '../../../../components/ui/popover';
 import { Text } from '@/widgets/shared/components/ui/Typography';
 import { useIsTouchDevice } from '@/hooks';
 
@@ -42,10 +30,11 @@ export function InfoTooltip({
       >
         {trigger || <Info size={iconSize} className={iconClassName} />}
       </PopoverTrigger>
+      {/* Touch fallback mirrors the DS tooltip chrome (Figma 5043:57748). */}
       <PopoverContent
         align="center"
         side="top"
-        className={`bg-containerDark rounded-xl backdrop-blur-[50px] ${contentClassname}`}
+        className={`bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[100px] ${contentClassname}`}
       >
         {shouldShowCloseButton && (
           <PopoverClose onClick={e => e.stopPropagation()} className="absolute top-4 right-4 z-10">
@@ -59,7 +48,6 @@ export function InfoTooltip({
         >
           {typeof content === 'string' ? <Text>{content}</Text> : content}
         </div>
-        <PopoverArrow />
       </PopoverContent>
     </Popover>
   ) : (
@@ -68,11 +56,10 @@ export function InfoTooltip({
         {trigger || <Info size={iconSize} className={iconClassName} />}
       </TooltipTrigger>
       <TooltipPortal>
-        <TooltipContent className={`max-w-[400px] ${contentClassname}`} arrowPadding={10}>
+        <TooltipContent className={contentClassname}>
           <div className="max-h-[calc(var(--radix-tooltip-content-available-height)-64px)] scrollbar-thin overflow-y-auto">
             {typeof content === 'string' ? <Text>{content}</Text> : content}
           </div>
-          <TooltipArrow width={12} height={8} />
         </TooltipContent>
       </TooltipPortal>
     </Tooltip>


### PR DESCRIPTION
Part of **Webapp V2 Redesign · Track H** ([APP-344](https://linear.app/ekliptyka/issue/APP-344)). Three component-family batches plus a header fix, one commit each:

- [APP-358](https://linear.app/ekliptyka/issue/APP-358) — H14 · Iconbox family
- [APP-353](https://linear.app/ekliptyka/issue/APP-353) — H9 · Feedback primitives (Tooltip, Toast, Dropdown, Loader)
- Header Connect Wallet button onto the DS navbar connect recipe (commit 3)
- [APP-359](https://linear.app/ekliptyka/issue/APP-359) — H15 · Lists (wallet connect) + Accordion

## H14 — Iconbox family (commit 1)

New `components/ui/iconbox.tsx` implementing the five Figma components ([Iconbox 5017:7668](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5017-7668&m=dev)): base `Iconbox` (token/glyph disc + network chip, 5007:72698), `Iconbox2Tokens` (4px-overlap pair, 5007:73290), `IconboxStatus` (ringed token + status dot, 5017:7858), `IconboxPosition` (5051:145321), `IconboxAction` (5034:42418).

- Promoted the status ring/dot hexes to semantic tokens: `statusSuccessRing` (#8bf1ca), `statusInfoRing` (#60a9ff), `statusInfoSolid` (#59b1ff). Named by system color (success/info) rather than Figma's product names (Pendle/Morpho) since the dot values are `colors/system/success` and `border-system-info-primary`.
- `table-cells.tsx` drops its hand-rolled `TableIconBox` for the family — class output is byte-identical at M size, so dark parity is preserved.

**Deviations:** S-size network chip 12.25px@-1.75 rounded to 12px@-1.5 (pixel grid); base `Iconbox`/`Iconbox2Tokens` are gallery-only for now (converging `TokenIcon`'s chain overlay and `ProductTokenIcon` is a follow-up); EarnTable's `active` iconbox stays unwired per the H8 precedent.

## H9 — Feedback primitives (commit 2)

- **Loader** ([Loading 5018:27948](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5018-27948&m=dev), Loader 5209:38588): new `ui/loader.tsx` — the 3-dot glyph at 2XS/XS/S/M/L/XL (12–40px), currentColor + staggered pulse. The button loading state now renders it (H4's local copy deleted), so there is one loader recipe.
- **Tooltip** ([5043:57748](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5043-57748&m=dev)): `TooltipContent` → bg-tertiary glass, 16px radius/padding, Body 7, 260px max, blur(100px). The DS draws no arrow, so `TooltipArrow` is deleted and every consumer swept (both InfoTooltips incl. their touch-popover fallbacks, ThemeToggle, BatchTransactionsToggle, HistoryRow, Morpho allocations, CopyToClipboard, widget input, SwitchAccountButton, RiskSlider). Tooltips move to `z-101` — they previously painted behind the nav More menu popover (`z-100`) when fired from the toggles inside it.
- **Toast** ([5075:17183](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5075-17183&m=dev)): sonner classNames → glass panel, Label 4 title, Body 7 fg-secondary description, success icon on the 34px statusSuccessBg/Border disc. Sonner's stylesheet paints `[data-sonner-toast][data-styled]` at higher specificity than one utility class, so the DS overrides carry Tailwind's `!` marker (commented in the file).
- **Dropdown** ([5075:17292](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5075-17292&m=dev)): `SelectContent`/`SelectItem` defaults become the DS panel — bg-tertiary glass, 16px radius, 1/4px inset, full-bleed Label 5 rows, focus/selected rows tinted bg-secondary, selected check moved to the right edge. The identical copy-pasted override block was deleted from six surfaces (earn FilterSelect, savings tx filter + origin select, stake activity filter, convert token select, Pendle modal ×2), and the TopNav More menu adopts the same panel/row recipe.

**Deviations:** toast error/info keep their pre-DS glyphs (the DS only types the success disc; no error-status tokens exist yet); sonner keeps min/max width for stacking (Figma toasts hug content); Chart's timeframe select keeps its `bg-chartSelect` panel (chart surfaces are H12/H13), rows inherit the recipe; the Figma Dropdown/Slippage type is not rebuilt — the shipped SlippageMenu is the E1 tabs composition and reshaping it is behavioral.

## Header Connect Wallet button (commit 3)

- **Connect** ([Navbar Item / Wallet Info, Type=connect 5069:27086](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5069-27086&m=dev)): the DS navbar connect state is the primary button at navbar height, so `WalletChip` and the `TermsModal` trigger (same header slot) swap `variant="connect"` for `primary` + `size="m"` — 40px brand1-gradient pill, glassBorder ring, Label 5 on fgConsistent. The legacy `connect` variant (radial gradient, hardcoded `rgb(127,92,246)` borders) is deleted along with its gallery entry; `ChainModal`'s widget-look trigger, whose className already overrode every property the variant set, moves to `connectPrimary` with no visual change.

**Deviations:** copy stays "Connect Wallet" (Figma sample text is "Connect wallet") — the capitalization is shared with every widget CTA and asserted in tests; changing it is an app-wide copy call.

## H15 — Lists (wallet connect) + Accordion (commit 4)

[APP-359](https://linear.app/ekliptyka/issue/APP-359) · Figma: Patterns/Accordion `5386:66315`, Patterns/Lists `5209:36922` (row `5209:38238`, active `5209:38304`)

- **Accordion** (`components/ui/accordion.tsx`, app look): root now carries the DS container (borderPrimary hairline, 24px radius, overflow clip); items are `p-6` with borderPrimary separators; triggers are Label 4 fgPrimary with a 16px fgPrimary flipping chevron; content is Body 6 fgSecondary, 12px under the title. Widgets keep the bare Radix root via a new `AccordionWidget` export through the shim — widget accordions unchanged.
- **Call-site sweeps**: `PendleAboutContent` collapses onto the primitives + `IconboxAction` (it is the literal content of the Figma pattern); `FaqAccordion` drops its card-per-item wrappers for the single-container pattern — all seven product FAQs inherit it.
- **`ListWallet`** (new `components/ui/list.tsx`): whole-row wallet connect button — 24px icon + Label 5 name, borderPrimary → borderTertiary hover, optional Label 6 badge (`bg-glassBadge`), 16px fgQuaternary chevron-right; `active` = brandBorder edge + gradient-brand3 fill + 20px brand loader.
- **`ConnectModal`**: connector rows rebuilt on `ListWallet` (the per-row "Connect" pill is gone — the row is the button). "Connecting..." subtitle → active/loader state; "Connected" / "Connect via QR" → badge slot; section labels restyled to Body 6 fgSecondary.
- **`Loader`**: new `brand` prop fills the dots with the #949aff→#504dff gradient the Figma loader asset itself carries (used by the active wallet row).
- **Tokens**: added `--color-borderPrimary` (border-primary, rgba(188,182,239,.1); interim light value) — **the `border-borderPrimary` utility was already used in 9 files but the token was never defined**, so those borders silently fell back to the preflight color (white 15%); they now render the intended DS hairline. Also `--color-brandBorder`, `--color-brand3-start/end`, `--color-loader-brand-start/end`.
- **Gallery**: accordion demo rebuilt with IconboxAction items; new "List / Wallet" section (default / badge / active / disabled).

**Deviations:** Figma stacks a border-b on every accordion item — we keep `last:border-b-0` to avoid doubling the container's bottom edge. `ListWallet` disabled state has no Figma spec (resting row at 50% opacity). ConnectModal keeps its existing section copy ("Installed Wallets"/"Suggested Wallets") vs the Figma example's sample copy ("Connect with"/"Other wallets"). Tailwind interpolates the active-row gradient in oklab vs Figma's sRGB — imperceptible at 10% alpha, consistent with the H4 button gradients.

## Verification

- `pnpm typecheck` clean; eslint 0 errors on touched files (2 pre-existing warnings); prettier applied; unit suite 168 files / 1866 tests green after each batch (H15: 43/43 across the 8 affected test files; e2e unaffected — it connects via the dedicated `MockConnectButton`).
- Browser-verified in both themes on /design-system (new Iconbox + Feedback + List/Wallet sections, DS accordion demo), /earn (table iconboxes, filter dropdowns), TopNav More menu (dropdown recipe + tooltip stacking fix), convert token select, live toasts (success disc, close button, glass chrome), the live connect modal (ListWallet rows), the /earn/fixed FAQs, and the /earn/fixed/pt-susds About accordion. H15 computed styles measured exact in dark: container border rgba(188,182,239,0.1) @ 24px radius, item p-24, Label 4 trigger, Body 6 content; list row 16px radius p-16, badge h-24 glassBadge Label 6, active border #504dff + brand3 gradient + 20px gradient loader.
- Dark theme values are pixel-per-Figma; light gets the interim token values (G2/APP-315 owns light parity). No engine hooks or behavior touched; testids preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

