### PR TITLE
Adopt the DS Headers pattern across the five destination pages (H11)

### DIFF
--- a/apps/webapp/src/components/product/FilterSelect.tsx
+++ b/apps/webapp/src/components/product/FilterSelect.tsx
@@ -16,17 +16,20 @@ export function FilterSelect({
   selected,
   onChange,
   allLabel,
-  testId
+  testId,
+  size = 's'
 }: {
   options: FilterOption[];
   selected: string;
   onChange: (value: string) => void;
   allLabel: ReactNode;
   testId: string;
+  /** DS Button / Dropdown size: `s` for table filter bars, `m` for page headers. */
+  size?: 's' | 'm';
 }) {
   return (
     <Select value={selected} onValueChange={onChange}>
-      {/* Design-system Button / Dropdown, size S (Figma 5019:4105). The
+      {/* Design-system Button / Dropdown, sizes S/M (Figma 5019:4105). The
           shadcn trigger's own h-10/w-full/bg and its 16px half-opacity chevron
           are overridden here rather than editing the vendored component; the
           [&>svg] rules only reach the trigger's direct chevron child, not
@@ -34,8 +37,9 @@ export function FilterSelect({
       <SelectTrigger
         data-testid={testId}
         className={cn(
-          buttonVariants({ variant: 'dropdown', size: 'dropdownS' }),
-          'h-auto w-auto bg-transparent [&>svg]:size-3 [&>svg]:opacity-100 [&>svg]:transition-transform data-[state=open]:[&>svg]:rotate-180'
+          buttonVariants({ variant: 'dropdown', size: size === 'm' ? 'dropdownM' : 'dropdownS' }),
+          'h-auto w-auto bg-transparent [&>svg]:opacity-100 [&>svg]:transition-transform data-[state=open]:[&>svg]:rotate-180',
+          size === 'm' ? '[&>svg]:size-4' : '[&>svg]:size-3'
         )}
       >
         <SelectValue />

--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { AppLink } from '@/lib/navigation';
+import { IconboxStatus } from '@/components/ui/iconbox';
+import { PageHeading } from '@/components/ui/page-header';
 
 /**
  * The reusable product-detail layout (Track C, C3 — "the gate"). Earn products
@@ -21,7 +23,7 @@ import { AppLink } from '@/lib/navigation';
  */
 
 export interface ProductDetailToken {
-  /** Token image node injected by the module — a ringed `<ProductTokenIcon/>`. */
+  /** Token image node injected by the module — a bare 48px `<TokenIcon/>`; the template supplies the DS ring. */
   icon: ReactNode;
 }
 
@@ -73,13 +75,14 @@ export interface ProductDetailTemplateProps {
 }
 
 /**
- * Token title-icon slot. The module injects a ringed `<ProductTokenIcon/>`
- * (product-family outline); the template just positions it.
+ * Token title-icon slot. The module injects a bare 48px token logo; the
+ * template rings it with the DS 64px Iconbox / Status (Headers pattern,
+ * Figma 5039:35306) so the header ring treatment never drifts per product.
  */
 function ProductTitleIcon({ token }: { token: ProductDetailToken }) {
   return (
     <div className="shrink-0" data-testid="product-detail-token-icon">
-      {token.icon}
+      <IconboxStatus size="l">{token.icon}</IconboxStatus>
     </div>
   );
 }
@@ -171,20 +174,22 @@ export function ProductDetailTemplate({
 }: ProductDetailTemplateProps) {
   return (
     <div className="flex w-full flex-col gap-8 py-4 md:py-10" data-testid={dataTestId}>
-      {/* Header: back-link, token title (+glow), per-product network selector. */}
-      <div className="flex flex-col gap-5">
+      {/* Header (Patterns/Headers, Savings type 5039:35173): Label 5 back-link
+          over the ringed-icon + Heading 3 title row, network pill right. The
+          DS 17px icon-title gap is normalized to 16. */}
+      <div className="flex flex-col gap-8">
         <AppLink
           to={backHref}
-          className="text-textSecondary hover:text-text flex w-fit items-center gap-1 text-sm transition-colors"
+          className="text-fgSecondary hover:text-fgPrimary font-circle flex w-fit items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] transition-colors"
           data-testid="product-detail-back"
         >
-          <ChevronLeft className="h-4 w-4" />
+          <ChevronLeft className="size-4" />
           {backLabel ?? <Trans>Back to products</Trans>}
         </AppLink>
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-4">
             <ProductTitleIcon token={token} />
-            <h1 className="text-text font-circle text-3xl">{title}</h1>
+            <PageHeading size="md">{title}</PageHeading>
           </div>
           {networkSelector}
         </div>

--- a/apps/webapp/src/components/ui/page-header.tsx
+++ b/apps/webapp/src/components/ui/page-header.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { cn } from '@/lib/cn';
+
+/**
+ * Patterns / Headers (Figma 5178:37451, header set 5031:52346): the shared
+ * pieces of the five destination-page headers — Earn 5031:52345 and Convert
+ * 5044:35419 (centered heroes), Portfolio 5034:20993, Savings/product-detail
+ * 5039:35173 and Stake 5043:59183 (title rows). Layout differs per
+ * destination and stays with each page; these primitives pin the shared type
+ * scale and badge treatment so they can't drift. The title-icon ring is
+ * `IconboxStatus size="l"` (iconbox.tsx) and the network pill is the
+ * Button dropdown/dropdownM recipe (ChainModal / FilterSelect).
+ */
+
+const PAGE_HEADING_SIZES = {
+  /** Heading 2 (44/48, -0.88): the Earn/Convert hero and Stake titles. */
+  lg: 'text-[44px] leading-[48px] tracking-[-0.88px]',
+  /** Heading 3 (32/35, -0.64): the Portfolio and product-detail titles. */
+  md: 'text-[32px] leading-[35px] tracking-[-0.64px]'
+} as const;
+
+export function PageHeading({
+  size = 'md',
+  tag: Tag = 'h1',
+  className,
+  children
+}: {
+  size?: keyof typeof PAGE_HEADING_SIZES;
+  tag?: 'h1' | 'h2' | 'h3';
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tag className={cn('font-circle text-fgPrimary font-medium', PAGE_HEADING_SIZES[size], className)}>
+      {children}
+    </Tag>
+  );
+}
+
+const HEADER_BADGE_SIZES = {
+  /** Hero stat badge (5031:52321): 8px padding, Label 5 text. */
+  m: 'gap-1 p-2 text-sm leading-4 tracking-[-0.28px]',
+  /** Title suffix badge (5119:24064): tucked padding, Label 6 text. */
+  s: 'gap-1 py-1 pr-2 pl-1 text-xs leading-3.5 tracking-[-0.24px]'
+} as const;
+
+/**
+ * Badges / Illustration: the glass stat pill of the hero headers ("$11.02B in
+ * circulation") and, at `s`, the title-row suffix badge ("Powered by Morpho").
+ * `icon` renders at 16px.
+ */
+export function HeaderBadge({
+  icon,
+  size = 'm',
+  className,
+  children
+}: {
+  icon?: React.ReactNode;
+  size?: keyof typeof HEADER_BADGE_SIZES;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        'bg-glassBadge font-circle text-fgPrimary flex w-fit items-center rounded-full font-medium whitespace-nowrap',
+        HEADER_BADGE_SIZES[size],
+        className
+      )}
+    >
+      {icon && <span className="flex size-4 shrink-0 items-center justify-center">{icon}</span>}
+      {children}
+    </span>
+  );
+}
+
+/**
+ * The centered hero header (Earn 5031:52345 / Convert 5044:35419): stat
+ * badges over a Heading 2 title and a Body 6 subtitle. Vertical rhythm around
+ * the hero stays with the page shell.
+ */
+export function PageHeaderHero({
+  badges,
+  title,
+  subtitle,
+  subtitleClassName,
+  className
+}: {
+  badges?: React.ReactNode;
+  title: React.ReactNode;
+  subtitle: React.ReactNode;
+  /** DS caps the subtitle measure per page (Earn 513px, Convert 459px). */
+  subtitleClassName?: string;
+  className?: string;
+}) {
+  return (
+    <header className={cn('flex w-full flex-col items-center gap-5 text-center', className)}>
+      {badges && <div className="flex flex-wrap items-center justify-center gap-2">{badges}</div>}
+      <PageHeading size="lg" className="max-w-[685px]">
+        {title}
+      </PageHeading>
+      <p className={cn('text-fgSecondary max-w-[513px] text-xs leading-[18px]', subtitleClassName)}>
+        {subtitle}
+      </p>
+    </header>
+  );
+}

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -169,6 +169,10 @@
   --color-brand3-end: rgba(80, 77, 255, 0.1);
   --color-loader-brand-start: #949aff;
   --color-loader-brand-end: #504dff;
+  /* Design-system Patterns/Headers (Figma 5178:37451): the brand glow behind
+     the Stake header's Iconbox/Status (5043:59189). Figma types it as a raw
+     effect (no variable); same value in both themes for now. */
+  --shadow-brandGlow: 0px 4px 64px 0px rgba(98, 90, 254, 0.3);
   --color-border: var(--transparent-white-15);
   --color-borderActive: var(--transparent-white-25);
   --color-borderPurple: #4c4577;

--- a/apps/webapp/src/modules/convert/components/ConvertPage.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertPage.tsx
@@ -1,7 +1,9 @@
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { Button } from '@/components/ui/button';
-import { Heading, Text } from '@/modules/layout/components/Typography';
+import { HeaderBadge, PageHeaderHero } from '@/components/ui/page-header';
+import { IllustrationStaked, IllustrationStakingLogomark } from '@/modules/icons';
+import { Text } from '@/modules/layout/components/Typography';
 import { useConnectThenAct } from '@/modules/ui/context/ConnectThenActContext';
 import { useConvertForm } from '../hooks/useConvertForm';
 import { useConvertLaunch } from '../hooks/useConvertLaunch';
@@ -29,14 +31,6 @@ const getDisabledReasonText = (reason?: PsmConversionDisabledReason, targetToken
   }
 };
 
-function HeroBadge({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="bg-glassBadge rounded-full px-3 py-1.5 backdrop-blur-[20px]">
-      <Text className="text-text text-xs font-medium">{children}</Text>
-    </span>
-  );
-}
-
 /**
  * The /convert destination (E2): a full-width page-as-widget PSM swap surface
  * (Figma 486:31193). The form lives on the page; Review launches the shared
@@ -61,25 +55,27 @@ export function ConvertPage() {
 
   return (
     <div className="flex w-full flex-col items-center gap-8 py-4 md:py-14" data-testid="convert-page">
-      <div className="flex flex-col items-center gap-4 text-center">
-        <div className="flex items-center gap-2">
-          <HeroBadge>
-            <Trans>1:1 Exchange rate</Trans>
-          </HeroBadge>
-          <HeroBadge>
-            <Trans>$0.00 Fees paid</Trans>
-          </HeroBadge>
-        </div>
-        <Heading tag="h1" variant="large">
-          <Trans>Convert stablecoins</Trans>
-        </Heading>
-        <Text className="text-textSecondary max-w-md text-sm">
+      {/* Patterns/Headers, Convert type 5044:35419. */}
+      <PageHeaderHero
+        badges={
+          <>
+            <HeaderBadge icon={<IllustrationStakingLogomark boxSize={16} />}>
+              <Trans>1:1 Exchange rate</Trans>
+            </HeaderBadge>
+            <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>
+              <Trans>$0.00 Fees paid</Trans>
+            </HeaderBadge>
+          </>
+        }
+        title={<Trans>Convert stablecoins</Trans>}
+        subtitle={
           <Trans>
             Move between stablecoins with confidence. Conversions settle at a fixed 1:1 rate, with no fees and
             no slippage.
           </Trans>
-        </Text>
-      </div>
+        }
+        subtitleClassName="max-w-[459px]"
+      />
 
       {/* Form column: the middle 6 columns of the design grid (624px @1280)
           minus 48px breathing room each side, per the Convert mock. */}

--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -8,7 +8,8 @@ import { formatNumber, getChainIcon } from '@/utils';
 import { normalizeUrlParam } from '@/lib/helpers/string/normalizeUrlParam';
 import { QueryParams } from '@/lib/constants';
 import { retainOnNavigate, useAppSearchParams } from '@/lib/navigation';
-import { Heading } from '@/modules/layout/components/Typography';
+import { HeaderBadge, PageHeaderHero } from '@/components/ui/page-header';
+import { IllustrationStaked } from '@/modules/icons';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
 import { CellNetworks } from '@/components/ui/table-cells';
@@ -147,9 +148,30 @@ export function EarnPage() {
       className="desktop:px-[calc((100%+32px)/12)] flex w-full flex-col gap-5 py-4 md:py-10"
       data-testid="earn-opportunities"
     >
-      <Heading tag="h1" variant="large">
-        <Trans>Earn Opportunities</Trans>
-      </Heading>
+      {/* Patterns/Headers, Earn hero type 5031:52345. The badge stats are
+          static marketing copy, straight from the DS mock (same call as the
+          Convert hero's "$0.00 Fees paid") — revisit if a live-stats source
+          gets wired up. */}
+      <PageHeaderHero
+        className="py-4 md:py-10"
+        badges={
+          <>
+            <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>
+              <Trans>$11.02B in circulation</Trans>
+            </HeaderBadge>
+            <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>
+              <Trans>Operating for 7 years</Trans>
+            </HeaderBadge>
+          </>
+        }
+        title={<Trans>Your stablecoins, earning more</Trans>}
+        subtitle={
+          <Trans>
+            Sky Protocol is where stablecoins go to work and where they&apos;ve been going since 2017. $11B in
+            circulation. Multiple strategies, one place.
+          </Trans>
+        }
+      />
       <EarnTableFilters
         selectedRiskTiers={filters.risk}
         onRiskTierToggle={toggleRiskTier}

--- a/apps/webapp/src/modules/icons/IllustrationStaked.tsx
+++ b/apps/webapp/src/modules/icons/IllustrationStaked.tsx
@@ -1,0 +1,127 @@
+import { Icon, IconProps } from './Icon';
+
+/** Figma illustration-64/staked (coin stack), exported at the 16px badge size. */
+export const IllustrationStaked = (props: IconProps) => (
+  <Icon {...props} viewBox="0 0 16 16" fill="none">
+    <ellipse cx="7.99995" cy="11.2499" rx="6" ry="3.24998" fill="url(#paint0_linear_ill_staked)" />
+    <ellipse
+      cx="6"
+      cy="3.24998"
+      rx="6"
+      ry="3.24998"
+      transform="matrix(1 0 0 -1 1.99995 11.2499)"
+      fill="url(#paint1_linear_ill_staked)"
+    />
+    <ellipse
+      cx="6"
+      cy="3.24998"
+      rx="6"
+      ry="3.24998"
+      transform="matrix(1 0 0 -1 1.99995 7.99992)"
+      fill="url(#paint2_linear_ill_staked)"
+    />
+    <g>
+      <mask
+        id="mask0_ill_staked"
+        style={{ maskType: 'alpha' }}
+        maskUnits="userSpaceOnUse"
+        x="1"
+        y="1"
+        width="13"
+        height="7"
+      >
+        <ellipse
+          cx="6"
+          cy="3.24998"
+          rx="6"
+          ry="3.24998"
+          transform="matrix(1 0 0 -1 1.99989 7.99998)"
+          fill="url(#paint3_linear_ill_staked)"
+        />
+      </mask>
+      <g mask="url(#mask0_ill_staked)">
+        <g filter="url(#filter0_f_ill_staked)">
+          <ellipse
+            cx="6"
+            cy="3.62498"
+            rx="6"
+            ry="3.62498"
+            transform="matrix(1 0 0 -1 1.99989 11.25)"
+            fill="url(#paint4_linear_ill_staked)"
+          />
+        </g>
+      </g>
+    </g>
+    <defs>
+      <filter
+        id="filter0_f_ill_staked"
+        x="-8.00005"
+        y="-5.99993"
+        width="31.9999"
+        height="27.2498"
+        filterUnits="userSpaceOnUse"
+        colorInterpolationFilters="sRGB"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+        <feGaussianBlur stdDeviation="4.99997" result="effect1_foregroundBlur" />
+      </filter>
+      <linearGradient
+        id="paint0_linear_ill_staked"
+        x1="1.99995"
+        y1="11.4999"
+        x2="14"
+        y2="11.4999"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#A4E6E6" />
+        <stop offset="0.326775" stopColor="#97B8F8" />
+        <stop offset="0.849433" stopColor="#B061FF" />
+      </linearGradient>
+      <linearGradient
+        id="paint1_linear_ill_staked"
+        x1="0"
+        y1="3.24998"
+        x2="12"
+        y2="3.24998"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFCD6B" />
+        <stop offset="1" stopColor="#EB5EDF" />
+      </linearGradient>
+      <linearGradient
+        id="paint2_linear_ill_staked"
+        x1="6"
+        y1="-1.49999"
+        x2="6"
+        y2="22.6249"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#A273FF" />
+        <stop offset="1" stopColor="#4331E9" />
+      </linearGradient>
+      <linearGradient
+        id="paint3_linear_ill_staked"
+        x1="-1.625"
+        y1="3.87498"
+        x2="14"
+        y2="6.99999"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFE8D4" />
+        <stop offset="1" stopColor="#B68EFF" />
+      </linearGradient>
+      <linearGradient
+        id="paint4_linear_ill_staked"
+        x1="4.875"
+        y1="4.37497"
+        x2="9.12498"
+        y2="7.74998"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFCD6B" />
+        <stop offset="1" stopColor="#EB5EDF" />
+      </linearGradient>
+    </defs>
+  </Icon>
+);

--- a/apps/webapp/src/modules/icons/IllustrationStakingLogomark.tsx
+++ b/apps/webapp/src/modules/icons/IllustrationStakingLogomark.tsx
@@ -1,0 +1,99 @@
+import { Icon, IconProps } from './Icon';
+
+/** Figma illustration-64/Staking-Logomark (rainbow Sky pinwheel), exported at the 16px badge size. */
+export const IllustrationStakingLogomark = (props: IconProps) => (
+  <Icon {...props} viewBox="0 0 16 16" fill="none">
+    <path
+      d="M1.0718 3.9999C0.36965 5.21603 -2.50412e-07 6.59555 0 7.99981C2.50411e-07 9.40407 0.369651 10.7836 1.0718 11.9997C1.77394 13.2158 2.78385 14.2257 4 14.9278C5.21615 15.63 6.59571 15.9996 8 15.9996L8 11.9997C7.29785 11.9997 6.60808 11.8149 6 11.4638C5.39192 11.1128 4.88697 10.6078 4.5359 9.99976C4.18482 9.39169 4 8.70194 4 7.99981C4 7.29768 4.18482 6.60792 4.5359 5.99985L1.0718 3.9999Z"
+      fill="url(#paint0_radial_ill_logomark)"
+    />
+    <path
+      d="M8 0C6.5957 3.77721e-08 5.21615 0.369641 4 1.07177L6 4.53579C6.60807 4.18472 7.29785 3.9999 8 3.9999L8 0Z"
+      fill="url(#paint1_radial_ill_logomark)"
+    />
+    <path
+      d="M16.0004 8.00013C16.0004 6.94958 15.7935 5.90931 15.3914 4.93873C14.9894 3.96815 14.4001 3.08626 13.6573 2.34341C12.9144 1.60056 12.0325 1.0113 11.0619 0.609271C10.0913 0.207243 9.05099 0.000322239 8.00041 0.000322518L8.00041 4.00023C8.5257 4.00022 9.04584 4.10369 9.53115 4.3047C10.0164 4.50571 10.4574 4.80034 10.8288 5.17177C11.2003 5.54319 11.4949 5.98414 11.6959 6.46943C11.8969 6.95472 12.0004 7.47485 12.0004 8.00013L16.0004 8.00013Z"
+      fill="url(#paint2_radial_ill_logomark)"
+    />
+    <path
+      d="M14.9286 12C15.6308 10.7839 16.0004 9.40439 16.0004 8.00013L12.0004 8.00013C12.0004 8.70226 11.8156 9.39202 11.4645 10.0001L14.9286 12Z"
+      fill="url(#paint3_radial_ill_logomark)"
+    />
+    <path
+      d="M14.9286 12C15.6308 10.7839 16.0004 9.40439 16.0004 8.00013L12.0004 8.00013C12.0004 8.70226 11.8156 9.39202 11.4645 10.0001L14.9286 12Z"
+      fill="url(#paint4_radial_ill_logomark)"
+    />
+    <path
+      d="M8.00041 15.9999C9.40471 15.9999 10.7843 15.6303 12.0004 14.9282L10.0004 11.4641C9.39234 11.8152 8.70256 12 8.00041 12L8.00041 15.9999Z"
+      fill="url(#paint5_linear_ill_logomark)"
+    />
+    <defs>
+      <radialGradient
+        id="paint0_radial_ill_logomark"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientTransform="matrix(-7.96676 4.62254 -4.31842 -7.44214 8.52539 7.44213)"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#F2A4FF" />
+        <stop offset="1" stopColor="#6D28FF" />
+      </radialGradient>
+      <radialGradient
+        id="paint1_radial_ill_logomark"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientTransform="matrix(-1.37698 -6.39287 134.567 -28.9829 7.14842 5.6718)"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFCD6B" />
+        <stop offset="1" stopColor="#EA5DD3" />
+      </radialGradient>
+      <radialGradient
+        id="paint2_radial_ill_logomark"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientTransform="matrix(6.78279 -7.3599 7.36014 6.78257 8.00041 8.00012)"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#00DDFB" />
+        <stop offset="1" stopColor="#0075FF" />
+      </radialGradient>
+      <radialGradient
+        id="paint3_radial_ill_logomark"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientTransform="matrix(-8.25456 2.21231 -2.21236 -8.25436 8.00041 8.00014)"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#F2A4FF" />
+        <stop offset="1" stopColor="#5200FF" />
+      </radialGradient>
+      <radialGradient
+        id="paint4_radial_ill_logomark"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientTransform="matrix(7.96676 -4.62254 4.31842 7.44213 7.47502 8.5578)"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#F2A4FF" />
+        <stop offset="1" stopColor="#6D28FF" />
+      </radialGradient>
+      <linearGradient
+        id="paint5_linear_ill_logomark"
+        x1="8.91923"
+        y1="10.6878"
+        x2="9.50933"
+        y2="16.6873"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFD2B9" />
+        <stop offset="1" stopColor="#FF6D6D" />
+      </linearGradient>
+    </defs>
+  </Icon>
+);

--- a/apps/webapp/src/modules/icons/index.ts
+++ b/apps/webapp/src/modules/icons/index.ts
@@ -45,6 +45,8 @@ import { ConvertArrows } from './ConvertArrows';
 import { Wallet } from './Wallet';
 import { Pendle } from './Pendle';
 import { Merkl } from './Merkl';
+import { IllustrationStaked } from './IllustrationStaked';
+import { IllustrationStakingLogomark } from './IllustrationStakingLogomark';
 
 export {
   ArrowDown,
@@ -93,5 +95,7 @@ export {
   ConvertArrows,
   Wallet,
   Pendle,
-  Merkl
+  Merkl,
+  IllustrationStaked,
+  IllustrationStakingLogomark
 };

--- a/apps/webapp/src/modules/morpho/components/VaultProductDetail.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultProductDetail.tsx
@@ -12,10 +12,10 @@ import {
 } from '@/hooks';
 import { formatBigInt, formatDecimalPercentage, formatNumber } from '@/utils';
 import { Morpho } from '@/widgets';
-import { ProductTokenIcon } from '@/modules/ui/components/ProductTokenIcon';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
+import { HeaderBadge } from '@/components/ui/page-header';
 import { ProductDetailTemplate, ProductDetailRow } from '@/components/product/ProductDetailTemplate';
-import { RING_MORPHO } from '@/components/product/productVisuals';
 import { VaultDetailChart } from './VaultDetailChart';
 import { VaultStrategy } from './VaultStrategy';
 import { VaultPositionCard } from './VaultPositionCard';
@@ -106,22 +106,20 @@ export function VaultProductDetail({
       backHref={ROUTES.EARN}
       token={{
         icon: (
-          <ProductTokenIcon
-            symbol={vault.assetToken.symbol}
-            ringColor={RING_MORPHO}
-            glowColor={RING_MORPHO}
+          <TokenIcon
+            token={{ symbol: vault.assetToken.symbol }}
             width={48}
             className="h-12 w-12"
+            showChainIcon={false}
           />
         )
       }}
       title={
-        <span className="flex flex-wrap items-center gap-3">
+        <span className="flex flex-wrap items-center gap-2">
           {vault.name}
-          <span className="bg-surface text-textSecondary flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium">
-            <Morpho className="h-3 w-3 rounded-sm" />
+          <HeaderBadge size="s" icon={<Morpho className="size-4 rounded-sm" />}>
             <Trans>Powered by Morpho</Trans>
-          </span>
+          </HeaderBadge>
         </span>
       }
       networkSelector={<ChainModal chainIds={networks} dataTestId="vault-detail-network" />}

--- a/apps/webapp/src/modules/pendle/components/PendleProductDetail.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleProductDetail.tsx
@@ -7,11 +7,11 @@ import { ROUTES } from '@/lib/routes';
 import { Intent } from '@/lib/enums';
 import { productNetworks, usePendleMarketsApiData, type PendleMarketConfig } from '@/hooks';
 import { formatDecimalPercentage, formatNumber } from '@/utils';
-import { ProductTokenIcon } from '@/modules/ui/components/ProductTokenIcon';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
+import { HeaderBadge } from '@/components/ui/page-header';
 import { RiskTierMeter } from '@/components/product/RiskMeter';
 import { ProductDetailTemplate, ProductDetailRow } from '@/components/product/ProductDetailTemplate';
-import { RING_PENDLE } from '@/components/product/productVisuals';
 import { PendleDetailChart } from './PendleDetailChart';
 import { PendlePositionCard } from './PendlePositionCard';
 import { PendleTransactionsTable } from './PendleTransactionsTable';
@@ -105,27 +105,27 @@ export function PendleProductDetail({ market }: PendleProductDetailProps) {
       backHref={ROUTES.EARN}
       token={{
         icon: (
-          <ProductTokenIcon
-            symbol={`PT-${market.underlyingSymbol}`}
-            ringColor={RING_PENDLE}
-            glowColor={RING_PENDLE}
+          <TokenIcon
+            token={{ symbol: `PT-${market.underlyingSymbol}` }}
             width={48}
             className="h-12 w-12"
+            showChainIcon={false}
           />
         )
       }}
       title={
         <span className="flex flex-col gap-1">
-          <span className="flex flex-wrap items-center gap-3">
+          <span className="flex flex-wrap items-center gap-2">
             {market.name}
-            <span className="bg-surface text-textSecondary flex items-center gap-1 rounded-full py-1 pr-2 pl-1 text-xs font-medium">
-              {/* Brand-colored mark from the design system (a bitmap in Figma too) —
-                  the monochrome <Pendle /> glyph reads wrong at badge size. */}
-              <img src="/images/pendle_logo.png" alt="" className="h-4 w-4" />
+            {/* Brand-colored mark from the design system (a bitmap in Figma too) —
+                the monochrome <Pendle /> glyph reads wrong at badge size. */}
+            <HeaderBadge size="s" icon={<img src="/images/pendle_logo.png" alt="" className="size-4" />}>
               <Trans>Powered by Pendle</Trans>
-            </span>
+            </HeaderBadge>
           </span>
-          <span className="text-textSecondary text-sm font-normal">
+          {/* The DS date line under the title (5120:19542) is Body 6, so it
+              opts back out of the heading's Circular styling. */}
+          <span className="font-graphik text-fgSecondary text-xs leading-[18px] font-normal tracking-normal">
             {maturityDateLabel}
             {remainingSeconds > 0 && <> · {formatTimeLeft(remainingSeconds)}</>}
           </span>

--- a/apps/webapp/src/modules/portfolio/components/ConnectedPortfolio.tsx
+++ b/apps/webapp/src/modules/portfolio/components/ConnectedPortfolio.tsx
@@ -9,7 +9,7 @@ import { getSupportedChainIds } from '@/data/wagmi/config/chainFamily';
 import { ROUTES } from '@/lib/routes';
 import { retainOnNavigate } from '@/lib/navigation';
 import { FilterSelect, type FilterOption } from '@/components/product/FilterSelect';
-import { Heading, Text } from '@/modules/layout/components/Typography';
+import { PageHeading } from '@/components/ui/page-header';
 import { IconStack } from '@/modules/ui/components/TokenIconStack';
 import { buildSuppliedView } from '../helpers/suppliedView';
 import { buildIdleSupplyInfo, buildIdleView } from '../helpers/idleView';
@@ -71,11 +71,13 @@ export function ConnectedPortfolio() {
   const supportedChainIds = getSupportedChainIds(connectedChainId);
   const chainName = (id: number) => chains.find(chain => chain.id === id)?.name ?? `Chain ${id}`;
 
+  // 24px chain icons: the header filter is the DS Button / Dropdown at size M
+  // (Patterns/Headers 5034:21316), unlike the S-sized table filter bars.
   const networkOptions: FilterOption[] = supportedChainIds.map(id => ({
     value: String(id),
     label: (
       <span className="flex items-center gap-2">
-        {getChainIcon(id, 'h-4 w-4')}
+        {getChainIcon(id, 'h-6 w-6')}
         {chainName(id)}
       </span>
     )
@@ -83,7 +85,7 @@ export function ConnectedPortfolio() {
 
   const allNetworksLabel = (
     <span className="flex items-center gap-2">
-      <IconStack size={16}>{supportedChainIds.map(id => getChainIcon(id, 'h-full w-full'))}</IconStack>
+      <IconStack size={24}>{supportedChainIds.map(id => getChainIcon(id, 'h-full w-full'))}</IconStack>
       <Trans>All networks</Trans>
     </span>
   );
@@ -97,24 +99,27 @@ export function ConnectedPortfolio() {
       className="desktop:px-[calc((100%+32px)/12)] flex w-full flex-col gap-6 py-4 md:py-10"
       data-testid="portfolio-page"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          {displayName && (
-            <Text variant="medium" className="text-textSecondary">
-              <Trans>Welcome back, {displayName}</Trans>
-            </Text>
-          )}
-          <Heading tag="h1" variant="large" className="text-4xl leading-tight">
+      {/* Header (Patterns/Headers, Portfolio type 5034:20993): Label 5
+          eyebrow over the Heading 3 + network-dropdown row. */}
+      <div className="flex flex-col gap-2">
+        {displayName && (
+          <p className="font-circle text-fgSecondary text-sm leading-4 font-medium tracking-[-0.28px]">
+            <Trans>Welcome back, {displayName}</Trans>
+          </p>
+        )}
+        <div className="flex items-center justify-between gap-4">
+          <PageHeading size="md">
             <Trans>Your Stablecoin Earnings</Trans>
-          </Heading>
+          </PageHeading>
+          <FilterSelect
+            options={networkOptions}
+            selected={selectedNetwork}
+            onChange={setSelectedNetwork}
+            allLabel={allNetworksLabel}
+            testId="portfolio-network-filter"
+            size="m"
+          />
         </div>
-        <FilterSelect
-          options={networkOptions}
-          selected={selectedNetwork}
-          onChange={setSelectedNetwork}
-          allLabel={allNetworksLabel}
-          testId="portfolio-network-filter"
-        />
       </div>
 
       {callout === 'simulate' && <SavingsTvlCallout tvlUsd={savingsTvlUsd} savingsRate={savingsRate} />}

--- a/apps/webapp/src/modules/rewards/components/RewardsProductDetail.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsProductDetail.tsx
@@ -15,12 +15,10 @@ import {
 import { formatDecimalPercentage, formatNumber } from '@/utils';
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { getBannerById } from '@/data/banners/banners';
-import { resolveTokenColor } from '@/widgets/shared/constants';
-import { ProductTokenIcon } from '@/modules/ui/components/ProductTokenIcon';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
 import { RiskTierMeter } from '@/components/product/RiskMeter';
 import { ProductDetailTemplate, ProductDetailRow } from '@/components/product/ProductDetailTemplate';
-import { RING_DEFAULT } from '@/components/product/productVisuals';
 import { rewardContractDisplayName } from '../helpers/rewardContractDisplayName';
 import { RewardsDetailChart } from './RewardsDetailChart';
 import { RewardsPositionCard } from './RewardsPositionCard';
@@ -165,12 +163,11 @@ export function RewardsProductDetail({ contract }: { contract: RewardContract })
       backHref={ROUTES.EARN}
       token={{
         icon: (
-          <ProductTokenIcon
-            symbol={rewardSymbol}
-            ringColor={RING_DEFAULT}
-            glowColor={resolveTokenColor(rewardSymbol)}
+          <TokenIcon
+            token={{ symbol: rewardSymbol }}
             width={48}
             className="h-12 w-12"
+            showChainIcon={false}
           />
         )
       }}

--- a/apps/webapp/src/modules/savings/components/SavingsProductDetail.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsProductDetail.tsx
@@ -8,12 +8,10 @@ import { productNetworks, useOverallSkyData, useSavingsData, useSkySavingsRateHi
 import { formatDecimalPercentage, formatNumber } from '@/utils';
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { getBannerById } from '@/data/banners/banners';
-import { resolveTokenColor } from '@/widgets/shared/constants';
-import { ProductTokenIcon } from '@/modules/ui/components/ProductTokenIcon';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
 import { RiskTierMeter } from '@/components/product/RiskMeter';
 import { ProductDetailTemplate, ProductDetailRow } from '@/components/product/ProductDetailTemplate';
-import { RING_DEFAULT } from '@/components/product/productVisuals';
 import { SavingsDetailChart } from './SavingsDetailChart';
 import { SavingsPositionCard } from './SavingsPositionCard';
 import { SavingsTransactionsTable } from './SavingsTransactionsTable';
@@ -108,15 +106,7 @@ export function SavingsProductDetail() {
     <ProductDetailTemplate
       backHref={ROUTES.EARN}
       token={{
-        icon: (
-          <ProductTokenIcon
-            symbol="sUSDS"
-            ringColor={RING_DEFAULT}
-            glowColor={resolveTokenColor('sUSDS')}
-            width={48}
-            className="h-12 w-12"
-          />
-        )
+        icon: <TokenIcon token={{ symbol: 'sUSDS' }} width={48} className="h-12 w-12" showChainIcon={false} />
       }}
       title={<Trans>Sky Savings</Trans>}
       networkSelector={<ChainModal chainIds={networks} dataTestId="product-detail-network" />}

--- a/apps/webapp/src/modules/stake/components/StakeProductPage.test.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeProductPage.test.tsx
@@ -146,7 +146,7 @@ describe('StakeProductPage — shell header + URL-synced tabs', () => {
     expect(screen.getByTestId('stake-tab-content-positions')).toBeTruthy();
     expect(screen.getByTestId('stake-tab-content-statistics')).toBeTruthy();
     expect(screen.getByTestId('stake-tab-content-about')).toBeTruthy();
-    expect(screen.getByTestId('product-token-icon')).toBeTruthy();
+    expect(screen.getByTestId('stake-header-icon')).toBeTruthy();
     expect(screen.getByTestId('chain-modal-stub')).toBeTruthy();
     expect(screen.getByText('SKY Staking')).toBeTruthy();
   });

--- a/apps/webapp/src/modules/stake/components/StakeProductPage.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeProductPage.tsx
@@ -5,10 +5,10 @@ import { Intent } from '@/lib/enums';
 import { productNetworks } from '@/hooks';
 import { QueryParams } from '@/lib/constants';
 import { useAppSearchParams } from '@/lib/navigation';
-import { resolveTokenColor } from '@/widgets/shared/constants';
-import { ProductTokenIcon } from '@/modules/ui/components/ProductTokenIcon';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
-import { RING_DEFAULT } from '@/components/product/productVisuals';
+import { IconboxStatus } from '@/components/ui/iconbox';
+import { PageHeading } from '@/components/ui/page-header';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { StakeUserPosition, useStakeUserPositions } from '../hooks/useStakeUserPositions';
 import { StakeManageFlowInit } from '../hooks/useStakeManageFlowState';
@@ -99,18 +99,19 @@ export function StakeProductPage() {
 
   return (
     <div data-testid="stake-product-page" className="flex flex-col gap-6">
+      {/* Header (Patterns/Headers, Stake type 5043:59183): the DS 64px
+          Iconbox / Status with the brand glow (5043:59189) beside a Heading 2
+          title; the DS 17px icon-title gap is normalized to 16. */}
       <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <ProductTokenIcon
-            symbol="SKY"
-            ringColor={RING_DEFAULT}
-            glowColor={resolveTokenColor('SKY')}
-            width={48}
-            className="h-12 w-12"
-          />
-          <h1 className="text-text text-3xl font-medium">
+        <div className="flex items-center gap-4">
+          <div className="shrink-0" data-testid="stake-header-icon">
+            <IconboxStatus size="l" className="shadow-brandGlow">
+              <TokenIcon token={{ symbol: 'SKY' }} width={48} className="h-12 w-12" showChainIcon={false} />
+            </IconboxStatus>
+          </div>
+          <PageHeading size="lg">
             <Trans>SKY Staking</Trans>
-          </h1>
+          </PageHeading>
         </div>
         <ChainModal chainIds={networks} dataTestId="stake-network" />
       </div>

--- a/apps/webapp/src/modules/stusds/components/StUsdsProductDetail.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUsdsProductDetail.tsx
@@ -15,12 +15,10 @@ import {
 import { calculateApyFromStr, formatDecimalPercentage, formatNumber } from '@/utils';
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { getBannerByIdAndModule } from '@/data/banners/helpers';
-import { resolveTokenColor } from '@/widgets/shared/constants';
-import { ProductTokenIcon } from '@/modules/ui/components/ProductTokenIcon';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ChainModal } from '@/modules/ui/components/ChainModal';
 import { RiskTierMeter } from '@/components/product/RiskMeter';
 import { ProductDetailTemplate, ProductDetailRow } from '@/components/product/ProductDetailTemplate';
-import { RING_DEFAULT } from '@/components/product/productVisuals';
 import { StUsdsDetailChart } from './StUsdsDetailChart';
 import { StUsdsPositionCard } from './StUsdsPositionCard';
 import { StUsdsTransactionsTable } from './StUsdsTransactionsTable';
@@ -133,19 +131,15 @@ export function StUsdsProductDetail() {
       backHref={ROUTES.EARN}
       token={{
         icon: (
-          <ProductTokenIcon
-            symbol="stUSDS"
-            ringColor={RING_DEFAULT}
-            glowColor={resolveTokenColor('stUSDS')}
-            width={48}
-            className="h-12 w-12"
-          />
+          <TokenIcon token={{ symbol: 'stUSDS' }} width={48} className="h-12 w-12" showChainIcon={false} />
         )
       }}
       title={
         <span className="flex flex-col gap-1">
           <span>stUSDS</span>
-          <span className="text-textSecondary text-sm font-normal">
+          {/* The DS line under the title (5120:19542) is Body 6, so it opts
+              back out of the heading's Circular styling. */}
+          <span className="font-graphik text-fgSecondary text-xs leading-[18px] font-normal tracking-normal">
             <Trans>Access a variable reward rate on USDS by participating in SKY-backed borrowing</Trans>
           </span>
         </span>

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUpToLine,
   Check,
   ChevronDown,
+  ChevronLeft,
   Copy,
   LineChart,
   Network,
@@ -102,6 +103,8 @@ import {
 } from '@/components/ui/iconbox';
 import { Loader } from '@/components/ui/loader';
 import { ListWallet } from '@/components/ui/list';
+import { HeaderBadge, PageHeaderHero, PageHeading } from '@/components/ui/page-header';
+import { IllustrationStaked, IllustrationStakingLogomark } from '@/modules/icons';
 
 // Internal-only living style guide (route /design-system, hidden in production).
 // Shows every canonical components/ui primitive in its prop-reachable states;
@@ -119,6 +122,7 @@ const SECTIONS = [
   { id: 'overlays', title: 'Overlays' },
   { id: 'tables', title: 'Tables' },
   { id: 'iconbox', title: 'Iconbox' },
+  { id: 'headers', title: 'Headers' },
   { id: 'steps', title: 'Steps' },
   { id: 'feedback', title: 'Feedback' },
   { id: 'data', title: 'Data & misc' }
@@ -1659,6 +1663,108 @@ function IconboxSection() {
   );
 }
 
+// ─── Headers ──────────────────────────────────────────────────────────────────
+
+/** Static stand-in for the header network pill (ChainModal / FilterSelect at dropdownM). */
+function HeaderNetworkPill({ label }: { label: string }) {
+  return (
+    <Button variant="dropdown" size="dropdownM">
+      <MainnetChain className="h-6 w-6" />
+      {label}
+      <ChevronDown className="size-4" />
+    </Button>
+  );
+}
+
+function HeadersSection() {
+  return (
+    <Section
+      id="headers"
+      title="Headers"
+      note="Patterns/Headers (H11): the five destination-page header types. Earn and Convert share the centered hero (Heading 2 + Body 6 + stat badges); Portfolio, the product-detail pages and Stake are title rows on Heading 3/2 with the Iconbox/Status L ring and the dropdown-M network pill."
+    >
+      <SubSection title="Hero — Earn / Convert (5031:52345 / 5044:35419)">
+        <PageHeaderHero
+          badges={
+            <>
+              <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>$11.02B in circulation</HeaderBadge>
+              <HeaderBadge icon={<IllustrationStakingLogomark boxSize={16} />}>
+                Operating for 7 years
+              </HeaderBadge>
+            </>
+          }
+          title="Your stablecoins, earning more"
+          subtitle="Sky Protocol is where stablecoins go to work and where they've been going since 2017. $11B in circulation. Multiple strategies, one place."
+        />
+      </SubSection>
+
+      <SubSection title="Portfolio — eyebrow + Heading 3 + network dropdown (5034:20993)">
+        <div className="flex w-full flex-col gap-2">
+          <p className="font-circle text-fgSecondary text-sm leading-4 font-medium tracking-[-0.28px]">
+            Welcome back, bartoo.eth
+          </p>
+          <div className="flex items-center justify-between gap-4">
+            <PageHeading size="md" tag="h3">
+              Your Stablecoin Earnings
+            </PageHeading>
+            <HeaderNetworkPill label="All networks" />
+          </div>
+        </div>
+      </SubSection>
+
+      <SubSection title="Product detail — back link, Iconbox/Status L, title badge (5039:35173)">
+        <div className="flex w-full flex-col gap-8">
+          <span className="text-fgSecondary font-circle flex w-fit items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px]">
+            <ChevronLeft className="size-4" />
+            Back to products
+          </span>
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-4">
+              <IconboxStatus size="l">
+                <BoxToken symbol="sUSDS" px={48} className="size-12" />
+              </IconboxStatus>
+              <PageHeading size="md" tag="h3" className="flex flex-wrap items-center gap-2">
+                Sky Savings
+                <HeaderBadge size="s" icon={<IllustrationStakingLogomark boxSize={16} />}>
+                  Powered by Morpho
+                </HeaderBadge>
+              </PageHeading>
+            </div>
+            <HeaderNetworkPill label="Ethereum" />
+          </div>
+        </div>
+      </SubSection>
+
+      <SubSection title="Stake — brand-glow Iconbox/Status L + Heading 2 (5043:59183)">
+        <div className="flex w-full items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <IconboxStatus size="l" className="shadow-brandGlow">
+              <BoxToken symbol="SKY" px={48} className="size-12" />
+            </IconboxStatus>
+            <PageHeading size="lg" tag="h3">
+              SKY Staking
+            </PageHeading>
+          </div>
+          <HeaderNetworkPill label="Ethereum" />
+        </div>
+      </SubSection>
+
+      <SubSection title="Badges / Illustration — m (Label 5) / s (Label 6)">
+        <Row>
+          <Spec label="m — hero stat badge">
+            <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>$11.02B in circulation</HeaderBadge>
+          </Spec>
+          <Spec label="s — title suffix badge">
+            <HeaderBadge size="s" icon={<IllustrationStakingLogomark boxSize={16} />}>
+              Powered by Morpho
+            </HeaderBadge>
+          </Spec>
+        </Row>
+      </SubSection>
+    </Section>
+  );
+}
+
 // ─── Steps ────────────────────────────────────────────────────────────────────
 
 /** 14px chip icon for step specimens (chain overlay off — the chip is symbol-only). */
@@ -1983,6 +2089,7 @@ function DesignSystem() {
         <OverlaysSection />
         <TablesSection />
         <IconboxSection />
+        <HeadersSection />
         <StepsSection />
         <FeedbackSection />
         <DataSection />


### PR DESCRIPTION
Part of **Webapp V2 Redesign · Track H** ([APP-355](https://linear.app/ekliptyka/issue/APP-355)). Adopts the DS **Patterns / Headers** ([Figma 5178:37451](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/Sky-App--Design-system?node-id=5178-37451&m=dev), header set `5031:52346`) across the five destination pages. Stacked on the H14/H15 branch (PR #1723) — review this diff against `feature/app-358-h14-iconbox-family-tokenstatuspositionaction-icon-containers`.

## Shared primitives — `components/ui/page-header.tsx` (new)

- **`PageHeading`** — the two header type scales: Heading 2 (`44px/48px`, `-0.88px`) and Heading 3 (`32px/35px`, `-0.64px`), Circular Medium, fgPrimary.
- **`HeaderBadge`** — Badges / Illustration (`5031:52321` / `5119:24064`): the glassBadge pill with a 16px illustration slot; `m` = p-2 + Label 5 (hero stat badges), `s` = tucked 4/8 padding + Label 6 (title suffix badges).
- **`PageHeaderHero`** — the centered hero shared by Earn/Convert: badges row over a Heading 2 title (685px measure) and a Body 6 subtitle (513px, per-page override).
- New token: `--shadow-brandGlow: 0px 4px 64px rgba(98,90,254,0.3)` (the Stake iconbox glow, `5043:59189`).
- Two DS illustrations committed as icon components (clean 16-viewBox SVGs pulled from the pattern node): `IllustrationStaked`, `IllustrationStakingLogomark`.

## Per destination

- **Earn (hero `5031:52345`)** — replaces the `Earn Opportunities` h1 with the DS hero. ⚠️ The badge stats (**"$11.02B in circulation" / "Operating for 7 years"**) and the subtitle's "$11B" are **static marketing copy straight from the mock** — the same precedent as Convert's shipped "$0.00 Fees paid" badge, but they'll go stale; revisit if a live-stats source or content pass lands.
- **Convert (hero `5044:35419`)** — the local `HeroBadge` + hand-rolled hero collapse onto `PageHeaderHero`; copy unchanged; badges gain the DS illustration icons (logomark + staked, per the mock).
- **Product-detail template (Savings type `5039:35173`)** — back-link restyled to Label 5 fgSecondary (hover fgPrimary), title to Heading 3, and the template now rings the title icon with `IconboxStatus size="l"` (64px borderTertiary ring) itself — consumers inject a bare 48px `TokenIcon`, so the per-product colored ring + glow (`ProductTokenIcon`) is gone from headers per the DS (it remains on the portfolio/marketplace cards). The frozen C3 props interface is untouched — `token.icon` just receives a different node.
- **Savings / Vaults / Rewards / Pendle / stUSDS** — icon swap as above; the Morpho and Pendle "Powered by" pills become `HeaderBadge s` (`5119:24064`), and the Pendle date line / stUSDS descriptor under the title become Body 6 (`5120:19542`, opting back out of the heading's Circular styling).
- **Stake (`5043:59183`)** — 64px `IconboxStatus` with `shadow-brandGlow` beside a Heading 2 title (was a 48px glow icon + `text-3xl` sans font-circle). Header icon gets `data-testid="stake-header-icon"` (replaces the removed `product-token-icon` in the unit test — no e2e used it).
- **Portfolio (`5034:20993`)** — DS nesting: Label 5 eyebrow full-width, then Heading 3 + network dropdown on one row (was eyebrow+title stacked beside the filter). The network filter is promoted to the DS Button/Dropdown **M** (`5034:21316`): `FilterSelect` grows a `size` prop (`s` default keeps the Earn filter bar untouched), chain icons bump to 24px.
- **/design-system** — new **Headers** section galleries all five types plus the badge pair.

## Deviations

- The DS's odd **17px** icon–title gap is normalized to **16px** (gap-4) on the Savings/Stake rows.
- Page vertical rhythm (the 316/192/200/256px canvas heights) stays with the existing shell paddings — the pattern's inner geometry is what's pinned.
- The Sky App UI hi-fi file exposes only its Cover page to the MCP, so the pattern sheet was the sole reference; hi-fi cross-check pending access.
- Light theme uses the existing interim token values (G2 owns parity).

## Verification

- `pnpm typecheck` clean; eslint clean on all touched files (one pre-existing `react-hooks/purity` warning in PendleProductDetail); prettier applied; `pnpm messages` run (locales are gitignored build artifacts); **full unit suite 168 files / 1866 tests green**.
- Browser-measured in dark theme, exact against the pattern: hero title 44/48/−0.88 Circular 500 `#f2f3f7` @685px, subtitle 12/18 `#a1a6c4` @513px, badges `rgba(188,182,239,0.1)` p-8 gap-4 h-32 with 16px icons; detail back-link 14/16/−0.28, 64px ring `2px rgba(188,182,239,0.3)` with 48px logo, title 32/35/−0.64; Stake shadow `rgba(98,90,254,0.3) 0 4px 64px`; Portfolio eyebrow/8px gap/Heading 3 + pill (p-8, gap-8, glassBorder); Pendle badge s (4/8 padding, 12/14/−0.24, h-24) + Body 6 date line. Light theme sanity-checked on the gallery and Earn.
