### PR TITLE
Line chart post-cursor dimming (H13 follow-up, APP-363)

### DIFF
--- a/apps/webapp/src/modules/ui/components/Chart.test.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.test.tsx
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveTooltipLabel } from './Chart';
+import { HoverDimMask, resolveTooltipLabel } from './Chart';
+
+const h = vi.hoisted(() => ({
+  isActive: false,
+  coordinate: undefined as { x: number; y: number } | undefined
+}));
+
+// The mask reads the hover state through recharts' chart-context hooks; feed
+// it directly so the test doesn't need a live chart interaction.
+vi.mock('recharts', async importOriginal => {
+  const actual = await importOriginal<typeof import('recharts')>();
+  return {
+    ...actual,
+    useIsTooltipActive: () => h.isActive,
+    useActiveTooltipCoordinate: () => h.coordinate,
+    useChartWidth: () => 800,
+    useChartHeight: () => 240
+  };
+});
+
+afterEach(cleanup);
 
 const METRICS = [
   { value: 'rate', label: 'Rate' },
@@ -18,5 +39,39 @@ describe('resolveTooltipLabel', () => {
 
   it('resolves to nothing when there is neither label nor metric toggle', () => {
     expect(resolveTooltipLabel(undefined, undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('HoverDimMask', () => {
+  it('dims the plot past the hover cursor, full strength before it', () => {
+    h.isActive = true;
+    h.coordinate = { x: 300, y: 100 };
+    render(
+      <svg>
+        <HoverDimMask id="dim" />
+      </svg>
+    );
+
+    const lit = screen.getByTestId('chart-dim-mask-lit');
+    expect(lit.getAttribute('width')).toBe('300');
+    expect(lit.getAttribute('fill')).toBe('white');
+
+    const dimmed = screen.getByTestId('chart-dim-mask-dimmed');
+    expect(dimmed.getAttribute('x')).toBe('300');
+    expect(dimmed.getAttribute('width')).toBe('500');
+    expect(Number(dimmed.getAttribute('opacity'))).toBeLessThan(1);
+  });
+
+  it('shows the whole plot at full strength when nothing is hovered', () => {
+    h.isActive = false;
+    h.coordinate = undefined;
+    render(
+      <svg>
+        <HoverDimMask id="dim" />
+      </svg>
+    );
+
+    expect(screen.getByTestId('chart-dim-mask-lit').getAttribute('width')).toBe('800');
+    expect(screen.queryByTestId('chart-dim-mask-dimmed')).toBeNull();
   });
 });

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -5,7 +5,18 @@ import { cn } from '@/lib/cn';
 import { HStack } from '@/modules/layout/components/HStack';
 import { formatNumber } from '@/utils';
 import { useMemo, useState, useRef, useEffect, useId } from 'react';
-import { Area, AreaChart, XAxis, ResponsiveContainer, Tooltip, YAxis } from 'recharts';
+import {
+  Area,
+  AreaChart,
+  XAxis,
+  ResponsiveContainer,
+  Tooltip,
+  YAxis,
+  useActiveTooltipCoordinate,
+  useChartHeight,
+  useChartWidth,
+  useIsTooltipActive
+} from 'recharts';
 import { format } from 'date-fns';
 import { Text } from '@/modules/layout/components/Typography';
 import { ChartTooltip } from './ChartTooltip';
@@ -154,6 +165,52 @@ const CustomizedDot = ({
   // Only return a label for the max and min
   return <circle cx={cx} cy={cy} r="4" stroke={stroke} fillOpacity={1} strokeWidth="2" fill={stroke} />;
 };
+
+/** How much of the series' alpha survives past the hover cursor (DS Line hover). */
+const POST_CURSOR_ALPHA = 0.4;
+
+/**
+ * DS Line hover (Figma 5273:12162): the plotted series keeps full strength up
+ * to the hover cursor and dims past it. Implemented as a luminance mask on the
+ * Area — white keeps the series, gray fades stroke+fill together — so the
+ * dimming can't veil the glass card background the way an overlay rect would.
+ * Rendered inside the AreaChart, where recharts' chart-context hooks resolve.
+ */
+export function HoverDimMask({ id }: { id: string }) {
+  const isActive = useIsTooltipActive();
+  const coordinate = useActiveTooltipCoordinate();
+  const width = useChartWidth();
+  const height = useChartHeight();
+  // Pre-layout the chart has no dimensions (and no hover); fall back to a
+  // full-coverage white mask so the series never flashes hidden.
+  const cursorX = isActive && coordinate && width != null ? coordinate.x : null;
+
+  return (
+    <defs>
+      <mask id={id} maskUnits="userSpaceOnUse" x={0} y={0} width={width ?? '100%'} height={height ?? '100%'}>
+        <rect
+          data-testid="chart-dim-mask-lit"
+          x={0}
+          y={0}
+          width={cursorX ?? width ?? '100%'}
+          height={height ?? '100%'}
+          fill="white"
+        />
+        {cursorX != null && width != null && (
+          <rect
+            data-testid="chart-dim-mask-dimmed"
+            x={cursorX}
+            y={0}
+            width={Math.max(width - cursorX, 0)}
+            height={height ?? '100%'}
+            fill="white"
+            opacity={POST_CURSOR_ALPHA}
+          />
+        )}
+      </mask>
+    </defs>
+  );
+}
 
 const formatedXAxis = (data: Data[], tf: TimeFrame, bpi: BP) => {
   if (!data.length) {
@@ -422,6 +479,7 @@ function ChartContent({
 }) {
   const { bpi } = useBreakpointIndex();
   const gradientId = useId();
+  const dimMaskId = useId();
 
   // Single source of truth for the plot height so the loading skeleton
   // reserves the same space as the rendered chart (no layout shift on load).
@@ -461,6 +519,7 @@ function ChartContent({
               )}
             </linearGradient>
           </defs>
+          <HoverDimMask id={dimMaskId} />
           <YAxis domain={['dataMin', 'dataMax']} padding={{ top: 20, bottom: bpi > BP.md ? 20 : 40 }} hide />
           {/* We can't extract the XAxis component outside of the chart as in the designs */}
           <XAxis dataKey="date" axisLine={false} tickLine={false} tick={false} />
@@ -479,13 +538,15 @@ function ChartContent({
             }
           />
 
-          {/* 🔶 the mock dims the area past the hover cursor; not implemented (Recharts split-area). */}
           <Area
             dataKey="value"
             stroke={color ?? '#1DD9BA'}
             strokeWidth={2.5}
             type="monotone"
             fill={`url(#${gradientId})`}
+            // Dim the series past the hover cursor (mask above); the active dot
+            // and tooltip render outside the masked layer, so they stay lit.
+            mask={`url(#${dimMaskId})`}
             label={<CustomizedLabel /*data={data} stroke="var(--transparent-white-40)"*/ />}
             dot={<CustomizedDot data={data} stroke={color ?? '#1DD9BA'} />}
             // Ringed hover dot at the cursor point (Figma 5273:12162).


### PR DESCRIPTION
Follow-up to #1726 · [APP-363](https://linear.app/ekliptyka/issue/APP-363/h13-charts-follow-ups-line-details-component-adoption). Implements the ticket's one unblocked item; the other two stay blocked (details below). Presentational only — no data pipeline work.

## Line chart — post-cursor area dimming

Per the DS **Charts / Line** hover spec ([Figma 5273:12162](https://www.figma.com/design/yQTfE5x7NDhjj4vPMoQoEJ/?node-id=5273-12162)): the plotted series keeps full strength up to the hover cursor and dims past it.

**How:** a new `HoverDimMask` inside the shared `Chart` — an SVG **luminance mask** applied to the recharts `<Area>` (full-white rect up to the hovered point's x, 40%-white after it), driven by recharts v3's chart-context hooks (`useIsTooltipActive` / `useActiveTooltipCoordinate`). The dim boundary therefore snaps to the same data point as the dashed cursor.

Why a mask instead of the split-area approach the ticket sketched:

- Stroke **and** gradient fill fade together via their own alpha — no second `<Area>` to keep in animation/color sync, and no dark overlay veiling the glass card background (the fill gradient is vertical, so a horizontal fade can't compose into it directly).
- The active hover dot and tooltip render outside the masked layer (`ActivePoints` is a sibling of the masked curve in recharts internals — verified), so they stay fully lit on the boundary.
- No hover → the mask is a full-white rect (visual no-op); pre-layout (chart width still unknown) it falls back to `100%` coverage so the series never flashes hidden.

Applies to every chart through the shared `Chart` (Savings/Stake/Pendle/Rewards/stUSDS/Morpho details, totals charts), both themes. Removes the corresponding `🔶` design-gap marker from `Chart.tsx`.

## Deliberately not in this PR (still blocked, per ticket)

- **Tooltip trailing accent circle** — blocked on design: what green-vs-amber encodes is unconfirmed. `🔶` marker stays in `ChartTooltip.tsx`.
- **`TokensComposition` adoption** — blocked on product/design: no shipped or ticketed surface renders a "Strategy" token composition.

## Verification

- New tests in `Chart.test.tsx`: mask dims past the cursor / full strength when idle (chart-context hooks mocked). Full webapp unit suite **1913/1913**, typecheck / eslint / prettier clean.
- Browser-verified against the Figma hover frame: Savings detail chart (both Rate and TVL series) — dim boundary tracks the dashed cursor, active dot stays lit, mouse-out restores full strength.

## QA — use cases

- ✅ Hover any product-detail chart: series right of the dashed cursor dims to ~40%, left stays full
- ✅ Active dot + tooltip stay fully lit at the boundary
- ✅ Mouse leave → whole series back to full strength
- ⚠️ Sweep the other chart consumers visually (Stake indigo, Morpho, stUSDS, portfolio/overview totals) — same shared component, spot-check only
- ⚠️ Light theme + reduced-size viewports sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
