### PR TITLE
Nav Menu dropdown per the DS comp: switch rows for bundling & dark mode, iconed legal links

### DIFF
--- a/apps/webapp/src/components/BatchTransactionsToggle.test.tsx
+++ b/apps/webapp/src/components/BatchTransactionsToggle.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { BATCH_TX_LEGAL_NOTICE_URL } from '@/lib/constants';
+import { BatchTransactionsToggle } from './BatchTransactionsToggle';
+
+const mocks = vi.hoisted(() => ({
+  batchEnabled: false,
+  setBatchEnabled: vi.fn(),
+  isConnected: false,
+  batchSupported: true as boolean | undefined
+}));
+
+vi.mock('@/modules/ui/hooks/useBatchToggle', () => ({
+  useBatchToggle: () => [mocks.batchEnabled, mocks.setBatchEnabled] as const
+}));
+
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return { ...actual, useIsBatchSupported: () => ({ data: mocks.batchSupported }) };
+});
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return { ...actual, useConnection: () => ({ isConnected: mocks.isConnected }) };
+});
+
+function renderToggle() {
+  render(
+    <I18nWidgetProvider locale="en">
+      <BatchTransactionsToggle />
+    </I18nWidgetProvider>
+  );
+}
+
+beforeEach(() => {
+  mocks.batchEnabled = false;
+  mocks.isConnected = false;
+  mocks.batchSupported = true;
+  mocks.setBatchEnabled.mockClear();
+});
+
+describe('BatchTransactionsToggle', () => {
+  it('renders the row with the explainer and the Legal Notice link', async () => {
+    renderToggle();
+    expect(await screen.findByText('Bundle transactions')).toBeTruthy();
+    expect(screen.getByText(/Save on gas and skip extra confirmations/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Legal Notice/ }).getAttribute('href')).toBe(
+      BATCH_TX_LEGAL_NOTICE_URL
+    );
+  });
+
+  it('turns bundling on through the switch', async () => {
+    renderToggle();
+    fireEvent.click(await screen.findByRole('switch'));
+    expect(mocks.setBatchEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('reflects an enabled setting on the switch', async () => {
+    mocks.batchEnabled = true;
+    renderToggle();
+    expect((await screen.findByRole('switch')).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('disables the switch and swaps in the unsupported notice for connected wallets without support', async () => {
+    mocks.isConnected = true;
+    mocks.batchSupported = false;
+    renderToggle();
+    expect((await screen.findByRole('switch')).hasAttribute('disabled')).toBe(true);
+    expect(screen.getByText(/does not currently support bundled transactions/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: /View supporting wallets/ })).toBeTruthy();
+    expect(screen.queryByText(/Save on gas/)).toBeNull();
+  });
+});

--- a/apps/webapp/src/components/BatchTransactionsToggle.tsx
+++ b/apps/webapp/src/components/BatchTransactionsToggle.tsx
@@ -1,15 +1,22 @@
-import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
-import { Toggle } from './ui/toggle';
-import { Zap } from '@/modules/icons/Zap';
-import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
-import { Text } from '@/modules/layout/components/Typography';
-import { t } from '@lingui/core/macro';
-import { useIsBatchSupported } from '@/hooks';
-import { useConnection } from 'wagmi';
+import { Zap } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
+import { t } from '@lingui/core/macro';
+import { useConnection } from 'wagmi';
+import { Switch } from './ui/switch';
+import { useBatchToggle } from '@/modules/ui/hooks/useBatchToggle';
+import { useIsBatchSupported } from '@/hooks';
 import { BATCH_TX_LEGAL_NOTICE_URL, BATCH_TX_SUPPORTED_WALLETS_URL } from '@/lib/constants';
 import { ExternalLink } from '@/modules/layout/components/ExternalLink';
 
+const explainerLinkClasses = 'text-fgPrimary hover:underline';
+
+/**
+ * "Bundle transactions" section of the nav Menu dropdown (Figma 5069:27496):
+ * 16px zap glyph + Label 5 text + S-size switch, Body 7 explainer underneath.
+ * The comp shows only the explainer, but the Legal Notice link (and the
+ * unsupported-wallet notice with its supporting-wallets link) carry over from
+ * the old tooltip — they're disclosures, not decoration.
+ */
 export function BatchTransactionsToggle() {
   const [batchEnabled, setBatchEnabled] = useBatchToggle();
   const { isConnected } = useConnection();
@@ -17,55 +24,43 @@ export function BatchTransactionsToggle() {
 
   const batchNotSupported = isConnected && !batchSupported;
 
-  const handleToggle = (checked: boolean) => {
-    setBatchEnabled(checked);
-  };
-
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div>
-          <Toggle
-            variant="singleSwitcherBright"
-            className="hidden h-10 w-10 rounded-xl p-0 md:flex"
-            pressed={batchEnabled}
-            onPressedChange={handleToggle}
-            aria-label="Toggle bundled transactions"
-            disabled={batchNotSupported}
-          >
-            <Zap width={28} height={28} />
-          </Toggle>
-        </div>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent className="max-w-[260px]">
-          <Text variant="small">
-            {batchNotSupported ? (
-              <>
-                {t`Your wallet does not currently support bundled transactions`}
-                <ExternalLink
-                  href={BATCH_TX_SUPPORTED_WALLETS_URL}
-                  className="text-textEmphasis hover:text-textEmphasis hover:underline"
-                  showIcon={false}
-                >
-                  <Trans>View supporting wallets</Trans>
-                </ExternalLink>
-              </>
-            ) : (
-              t`Bundled transactions ${batchEnabled ? 'enabled' : 'disabled'}`
-            )}
-          </Text>
-          <Text variant="small">
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-fgPrimary font-circle flex items-center gap-2 text-sm leading-4 font-medium tracking-[-0.28px]">
+          <Zap size={16} className="text-fgBrand shrink-0" />
+          <Trans>Bundle transactions</Trans>
+        </span>
+        <Switch
+          size="sm"
+          checked={batchEnabled}
+          onCheckedChange={setBatchEnabled}
+          disabled={batchNotSupported}
+          aria-label={t`Toggle bundled transactions`}
+          data-testid="batch-transactions-switch"
+        />
+      </div>
+      <p className="text-fgSecondary max-w-[216px] text-[11px] leading-4">
+        {batchNotSupported ? (
+          <>
+            <Trans>Your wallet does not currently support bundled transactions.</Trans>{' '}
             <ExternalLink
-              href={BATCH_TX_LEGAL_NOTICE_URL}
-              className="text-textEmphasis hover:text-textEmphasis self-start hover:underline"
+              href={BATCH_TX_SUPPORTED_WALLETS_URL}
               showIcon={false}
+              className={explainerLinkClasses}
             >
-              <Trans>Legal Notice</Trans>
+              <Trans>View supporting wallets</Trans>
             </ExternalLink>
-          </Text>
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+          </>
+        ) : (
+          <Trans>
+            Save on gas and skip extra confirmations by grouping related actions into one transaction.
+          </Trans>
+        )}{' '}
+        <ExternalLink href={BATCH_TX_LEGAL_NOTICE_URL} showIcon={false} className={explainerLinkClasses}>
+          <Trans>Legal Notice</Trans>
+        </ExternalLink>
+      </p>
+    </div>
   );
 }

--- a/apps/webapp/src/components/ThemeToggle.test.tsx
+++ b/apps/webapp/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { I18nWidgetProvider } from '@/widgets/context/I18nWidgetProvider';
+import { ThemeToggle } from './ThemeToggle';
+
+const mocks = vi.hoisted(() => ({
+  theme: 'dark' as 'dark' | 'light',
+  toggleTheme: vi.fn()
+}));
+
+vi.mock('@/modules/ui/hooks/useThemeToggle', () => ({
+  useThemeToggle: () => ({ theme: mocks.theme, toggleTheme: mocks.toggleTheme })
+}));
+
+function renderToggle() {
+  render(
+    <I18nWidgetProvider locale="en">
+      <ThemeToggle />
+    </I18nWidgetProvider>
+  );
+}
+
+beforeEach(() => {
+  mocks.theme = 'dark';
+  mocks.toggleTheme.mockClear();
+});
+
+describe('ThemeToggle', () => {
+  it('renders the Dark mode row with the switch on while the theme is dark', async () => {
+    renderToggle();
+    expect(await screen.findByText('Dark mode')).toBeTruthy();
+    expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('shows the switch off in light mode', async () => {
+    mocks.theme = 'light';
+    renderToggle();
+    expect((await screen.findByRole('switch')).getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('toggles the theme when the switch is clicked', async () => {
+    renderToggle();
+    fireEvent.click(await screen.findByRole('switch'));
+    expect(mocks.toggleTheme).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/src/components/ThemeToggle.tsx
+++ b/apps/webapp/src/components/ThemeToggle.tsx
@@ -5,7 +5,7 @@ import { Switch } from './ui/switch';
 import { useThemeToggle } from '@/modules/ui/hooks/useThemeToggle';
 
 /**
- * "Dark mode" row of the nav Menu dropdown (Figma 5233:10233): 12px moon
+ * "Dark mode" row of the nav Menu dropdown (Figma 5233:10233): 16px moon
  * glyph + Label 5 text left, S-size switch right — on while dark mode is.
  */
 export function ThemeToggle() {

--- a/apps/webapp/src/components/ThemeToggle.tsx
+++ b/apps/webapp/src/components/ThemeToggle.tsx
@@ -1,34 +1,29 @@
-import { Moon, Sun } from 'lucide-react';
-import { Toggle } from './ui/toggle';
-import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
-import { Text } from '@/modules/layout/components/Typography';
+import { Moon } from 'lucide-react';
+import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
+import { Switch } from './ui/switch';
 import { useThemeToggle } from '@/modules/ui/hooks/useThemeToggle';
 
+/**
+ * "Dark mode" row of the nav Menu dropdown (Figma 5233:10233): 12px moon
+ * glyph + Label 5 text left, S-size switch right — on while dark mode is.
+ */
 export function ThemeToggle() {
   const { theme, toggleTheme } = useThemeToggle();
-  const isLight = theme === 'light';
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div>
-          <Toggle
-            variant="singleSwitcherBright"
-            className="hidden h-10 w-10 rounded-xl p-0 md:flex"
-            pressed={isLight}
-            onPressedChange={toggleTheme}
-            aria-label={t`Toggle light and dark theme`}
-          >
-            {isLight ? <Sun width={20} height={20} /> : <Moon width={20} height={20} />}
-          </Toggle>
-        </div>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent className="max-w-[220px]">
-          <Text variant="small">{isLight ? t`Switch to dark mode` : t`Switch to light mode`}</Text>
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+    <div className="flex w-full items-center justify-between">
+      <span className="text-fgPrimary font-circle flex items-center gap-2 text-sm leading-4 font-medium tracking-[-0.28px]">
+        <Moon size={16} className="text-fgBrand shrink-0" />
+        <Trans>Dark mode</Trans>
+      </span>
+      <Switch
+        size="sm"
+        checked={theme === 'dark'}
+        onCheckedChange={toggleTheme}
+        aria-label={t`Toggle light and dark theme`}
+        data-testid="dark-mode-switch"
+      />
+    </div>
   );
 }

--- a/apps/webapp/src/modules/app/shell/TopNav.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, MouseEvent, ReactNode, useCallback, useState } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { useChainId, useChains } from 'wagmi';
-import { Menu, X } from 'lucide-react';
+import { Cookie, FileText, FileWarning, Menu, Shield, X } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
 import { buttonVariants } from '@/components/ui/button';
@@ -83,12 +83,21 @@ function useActiveDestinationPath(): RoutePath | null {
 // styling keys off the link's aria-current="page".
 const navItemClasses = cn(buttonVariants({ variant: 'navbar', size: 'navbar' }), 'relative');
 
-// Design-system Dropdown row (Figma Components/Dropdown 5075:17292): Label 5
-// on fg-primary, 16/12 padding, hover rows tint bg-secondary.
+// Menu dropdown row (Figma 5069:27509): 16px glyph + Label 5 on fg-primary,
+// 8px apart; rows sit bare on the panel (no pill/tint), 20px between them.
 const moreItemClasses =
-  'text-fgPrimary hover:bg-bgSecondary font-circle px-4 py-3 text-left text-sm leading-4 font-medium tracking-[-0.28px] transition-colors';
+  'text-fgPrimary hover:text-fgSecondary font-circle flex items-center gap-2 text-left text-sm leading-4 font-medium tracking-[-0.28px] transition-colors';
 
-/** Secondary actions that don't earn a destination: batch toggle, legal links. */
+// Env-driven legal links pick their DS glyph by name (User Risk Documentation /
+// Terms of Use / Privacy Policy in the comp); anything else gets the document glyph.
+function linkIcon(name: string) {
+  const lower = name.toLowerCase();
+  if (lower.includes('risk')) return FileWarning;
+  if (lower.includes('privacy')) return Shield;
+  return FileText;
+}
+
+/** Secondary actions that don't earn a destination: toggles, legal links. */
 function MoreMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const { showBanner } = useCookieConsent();
@@ -106,36 +115,51 @@ function MoreMenu() {
       >
         {isOpen ? <X size={16} className="nav-menu-icon" /> : <Menu size={16} className="nav-menu-icon" />}
       </PopoverTrigger>
-      {/* DS Dropdown panel chrome (bg-tertiary glass, 16px radius, 1/4px inset). */}
+      {/* Menu dropdown panel (Figma 5069:27495): 274px glass panel — bg-secondary
+          over a 100px backdrop blur, 24px radius, 20px padding, 24px between
+          sections with a hairline divider after the bundling block. The comp's
+          Upgrade DAI/MKR row is omitted: the upgrade surface is parked (E2). */}
       <PopoverContent
         align="end"
-        className="bg-bgTertiary flex w-60 flex-col rounded-2xl px-px py-1 shadow-none backdrop-blur-[20px]"
+        className="bg-bgSecondary flex w-[274px] flex-col gap-6 rounded-3xl p-5 shadow-none backdrop-blur-[100px]"
       >
-        <div className="flex items-center gap-1 px-3 py-1">
-          <ThemeToggle />
-          {BATCH_TX_ENABLED && <BatchTransactionsToggle />}
-        </div>
-        {footerLinks.map(link => {
-          const url = sanitizeUrl(link.url);
-          if (!url) return null;
-          return (
-            <ExternalLink key={url} href={url} showIcon={false} className={moreItemClasses}>
-              {link.name}
-            </ExternalLink>
-          );
-        })}
-        {POSTHOG_ENABLED && (
-          <button
-            data-testid="nav-more-cookie-settings"
-            onClick={() => {
-              closeMenu();
-              showBanner();
-            }}
-            className={moreItemClasses}
-          >
-            <Trans>Cookie settings</Trans>
-          </button>
+        {BATCH_TX_ENABLED && (
+          <>
+            <BatchTransactionsToggle />
+            <div className="bg-glassBorder h-px w-full" />
+          </>
         )}
+        <div className="flex flex-col gap-5">
+          <ThemeToggle />
+          {footerLinks.map(link => {
+            const url = sanitizeUrl(link.url);
+            if (!url) return null;
+            const Icon = linkIcon(link.name);
+            return (
+              <ExternalLink key={url} href={url} showIcon={false} className={moreItemClasses}>
+                {/* Single child: ExternalLink HStack-wraps element children, which
+                    would swallow the anchor's gap and leave the glyph flush. */}
+                <span className="flex items-center gap-2">
+                  <Icon size={16} className="text-fgBrand shrink-0" />
+                  {link.name}
+                </span>
+              </ExternalLink>
+            );
+          })}
+          {POSTHOG_ENABLED && (
+            <button
+              data-testid="nav-more-cookie-settings"
+              onClick={() => {
+                closeMenu();
+                showBanner();
+              }}
+              className={moreItemClasses}
+            >
+              <Cookie size={16} className="text-fgBrand shrink-0" />
+              <Trans>Cookie settings</Trans>
+            </button>
+          )}
+        </div>
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
### What does this PR do?

<img width="292" height="456" alt="image" src="https://github.com/user-attachments/assets/48112120-9136-4d52-85ab-acfa7f7473e9" />


Rebuilds the top-nav hamburger (More) menu to the design-system Navbar Menu comp (DS file, dropdown node 5069:27495):

- **Panel**: 274px glass panel — `bg-secondary` over a 100px backdrop blur, 24px radius, 20px padding, 24px between sections, hairline `border-secondary` divider.
- **Bundle transactions** (`BatchTransactionsToggle` rewritten): 16px zap glyph + Label 5 + S-size DS `Switch`, with the 216px Body-7 explainer underneath. The Legal Notice link and the unsupported-wallet notice (+ supporting-wallets link) carry over from the old tooltip — the comp omits them, but they're disclosures, so they stay; when a connected wallet lacks batch support the switch disables and the explainer swaps to the notice.
- **Dark mode** (`ThemeToggle` rewritten): moon glyph + label + switch row instead of the old icon-button toggle; flips the theme live with the menu open.
- **Legal links & Cookie settings**: Label-5 rows with 16px `fg-brand` glyphs mapped by link name (risk → file-warning, privacy → shield, else file-text; cookie for Cookie settings). Link rows wrap icon+label in a single span because `ExternalLink` HStack-wraps element children, which swallowed the flex gap.
- Icon size note: the Figma MCP codegen for the comp claims 12px icons, but the node metadata has 16×16 frames and the exported SVG assets are 16-viewBox lucide paths at stroke 1.333 — lucide at `size={16}` reproduces them exactly.
- The comp's **Upgrade DAI/MKR row is omitted**: the upgrade surface is parked (`/convert/upgrade` redirects to `/convert`, E2), so the shortcut stays out until that product decision changes.

Rendered values audited against the node metadata + variable defs (panel 274/20/24, row pitch 36, icon→label gap 8, Label 5 at 14/16 −0.28px, Body 7 at 11/16, switch 28×16 with 12px thumb) via computed styles in Chrome.

### Testing steps:

1. `pnpm dev:mock`, open the hamburger menu top right.
2. Compare against the DS comp (node 5178-37443): 274px glass panel; Bundle transactions row with switch + explainer + Legal Notice; divider; Dark mode row; iconed legal links; Cookie settings.
3. Toggle Dark mode — theme flips live, switch state tracks it, panel stays open. Both themes render the glyphs in brand purple.
4. Toggle Bundle transactions — persists via user config (same behavior as the old topbar toggle). With a connected wallet that lacks EIP-5792 support, the switch disables and the unsupported notice appears.
5. Cookie settings closes the menu and reopens the consent banner (PostHog-gated, unchanged behavior).
6. `pnpm exec vitest run` in `apps/webapp` — suite green (1918 tests + 7 new on the two rewritten components).