### PR TITLE
M5: reflow redesigned tables into stacked cards below 768px

### DIFF
--- a/apps/webapp/src/components/product/EarnTable.test.tsx
+++ b/apps/webapp/src/components/product/EarnTable.test.tsx
@@ -1,0 +1,117 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EarnTable, EarnTableRowItem } from './EarnTable';
+
+// Pin the JS breakpoint per test (happy-dom's 1024 viewport = table mode).
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const ROWS: EarnTableRowItem[] = [
+  {
+    id: 'savings',
+    name: 'Sky Savings',
+    risk: 'low',
+    rate: '3.75%',
+    rate30d: '3.70%',
+    tvl: '$4.23b',
+    position: '$0.00'
+  },
+  {
+    id: 'spk',
+    name: 'Earn SPK',
+    risk: 'moderate',
+    rate: '5.00%',
+    rate30d: '4.90%',
+    tvl: '$1.00b',
+    position: '$10.00'
+  }
+];
+
+const renderEarn = (onRowSelect = vi.fn()) => {
+  render(
+    <I18nProvider i18n={i18n}>
+      <EarnTable
+        rows={ROWS}
+        sort={{ column: 'rate', direction: 'desc' }}
+        onSortChange={vi.fn()}
+        onRowSelect={onRowSelect}
+      />
+    </I18nProvider>
+  );
+  return onRowSelect;
+};
+
+describe('EarnTable — mobile accordion cards (M5)', () => {
+  beforeEach(() => {
+    breakpoint.isMobile = true;
+  });
+  afterEach(() => {
+    breakpoint.isMobile = false;
+    cleanup();
+  });
+
+  it('renders a card per row instead of the table, collapsed with name and rate', () => {
+    renderEarn();
+
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getByText('Sky Savings')).toBeTruthy();
+    expect(screen.getByText('Earn SPK')).toBeTruthy();
+    // Collapsed: detail fields hidden.
+    expect(screen.queryByText('TVL')).toBeNull();
+  });
+
+  it('expands a card to the detail grid and both action buttons', () => {
+    renderEarn();
+
+    fireEvent.click(screen.getByTestId('earn-card-toggle-savings'));
+
+    expect(screen.getByText('TVL')).toBeTruthy();
+    expect(screen.getByText('$4.23b')).toBeTruthy();
+    expect(screen.getByText('My position')).toBeTruthy();
+    expect(screen.getByText('30D Rate')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Supply' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'View details' })).toBeTruthy();
+  });
+
+  it('collapses an expanded card on a second toggle', () => {
+    renderEarn();
+
+    fireEvent.click(screen.getByTestId('earn-card-toggle-savings'));
+    fireEvent.click(screen.getByTestId('earn-card-toggle-savings'));
+    expect(screen.queryByText('TVL')).toBeNull();
+  });
+
+  it('reports the row through onRowSelect from both expanded buttons', () => {
+    const onRowSelect = renderEarn();
+
+    fireEvent.click(screen.getByTestId('earn-card-toggle-savings'));
+    fireEvent.click(screen.getByRole('button', { name: 'View details' }));
+    expect(onRowSelect).toHaveBeenCalledWith('savings');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Supply' }));
+    expect(onRowSelect).toHaveBeenCalledWith('savings');
+    expect(onRowSelect).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EarnTable — desktop table unchanged', () => {
+  afterEach(cleanup);
+
+  it('renders the sortable table at md and above', () => {
+    renderEarn();
+
+    expect(screen.getByRole('table')).toBeTruthy();
+    expect(screen.getByTestId('earn-sort-rate')).toBeTruthy();
+  });
+});

--- a/apps/webapp/src/components/product/EarnTable.tsx
+++ b/apps/webapp/src/components/product/EarnTable.tsx
@@ -1,11 +1,14 @@
-import { KeyboardEvent, ReactNode } from 'react';
+import { KeyboardEvent, ReactNode, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
+import { BP, useBreakpointIndex } from '@/hooks';
+import type { EarnRiskTier } from '@/hooks';
+import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { CellEmpty, CellPercent, CellToken } from '@/components/ui/table-cells';
 import { Skeleton } from '@/components/ui/skeleton';
-import type { EarnRiskTier } from '@/hooks';
+import { TransactionCardFieldGrid } from './TransactionCard';
 import { RiskTierMeter } from './RiskMeter';
 
 export type EarnTableColumn = 'token' | 'network' | 'risk' | 'rate' | 'rate30d' | 'tvl' | 'position';
@@ -64,18 +67,142 @@ export type EarnTableProps = {
   onRowSelect?: (id: string) => void;
 };
 
+/** The Type=Token cell / accordion-card header: iconbox, name, Supply: subline. */
+function TokenCell({ row }: { row: EarnTableRowItem }) {
+  return (
+    <CellToken
+      icon={row.icon}
+      title={row.name}
+      titleSuffix={row.nameSuffix}
+      subtitle={
+        <>
+          <Trans>Supply:</Trans>
+          {row.supply}
+          {row.maturityLabel && (
+            <>
+              <span aria-hidden>·</span>
+              {row.maturityLabel}
+            </>
+          )}
+        </>
+      }
+    />
+  );
+}
+
+/**
+ * M5 mobile rendering (Figma mobile Table Section 486:22119): one accordion
+ * card per opportunity — collapsed shows the token cell + Rate + chevron,
+ * expanded adds the remaining columns as a field grid and the Supply / View
+ * details actions. Both actions report through onRowSelect (the product page
+ * hosts the supply widget); a dedicated supply deep-link is a design/product
+ * follow-up flagged on APP-371. Sorting has no mobile affordance in the comp,
+ * so the sort headers are desktop-only.
+ */
+function EarnCardList({ rows, onRowSelect }: Pick<EarnTableProps, 'rows' | 'onRowSelect'>) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  return (
+    <div data-testid="earn-opportunities-table" className="flex w-full flex-col gap-0.5">
+      {rows.map((row, index) => {
+        const isExpanded = expandedId === row.id;
+        return (
+          <div
+            key={row.id}
+            data-testid={`earn-row-${row.id}`}
+            className={cn(
+              'bg-bgSecondary flex flex-col gap-6 p-5 backdrop-blur-[20px]',
+              index === 0 && 'rounded-t-[20px]',
+              index === rows.length - 1 && 'rounded-b-[20px]'
+            )}
+          >
+            <button
+              type="button"
+              data-testid={`earn-card-toggle-${row.id}`}
+              aria-expanded={isExpanded}
+              onClick={() => setExpandedId(isExpanded ? null : row.id)}
+              className="flex w-full items-center justify-between gap-3 text-left"
+            >
+              <TokenCell row={row} />
+              <span className="flex shrink-0 items-center gap-3">
+                <span className="flex flex-col items-end gap-1">
+                  <span className="font-graphik text-fgSecondary text-xs leading-[18px]">
+                    <Trans>Rate</Trans>
+                  </span>
+                  <span className="font-circle text-fgPrimary text-sm leading-4 font-medium tracking-[-0.28px]">
+                    <NumericValue value={row.rate} isLoading={row.isLoading} />
+                  </span>
+                </span>
+                <ChevronDown
+                  size={16}
+                  className={cn('text-fgSecondary transition-transform', isExpanded && 'rotate-180')}
+                  aria-hidden
+                />
+              </span>
+            </button>
+            {isExpanded && (
+              <>
+                <TransactionCardFieldGrid
+                  fields={[
+                    ...(row.network ? [{ label: <Trans>Network</Trans>, value: row.network }] : []),
+                    { label: <Trans>Risk</Trans>, value: <RiskTierMeter tier={row.risk} /> },
+                    {
+                      label: <Trans>Rate</Trans>,
+                      value: <NumericValue value={row.rate} isLoading={row.isLoading} />
+                    },
+                    {
+                      label: <Trans>30D Rate</Trans>,
+                      value: <NumericValue value={row.rate30d} isLoading={row.isLoading} />
+                    },
+                    {
+                      label: <Trans>TVL</Trans>,
+                      value: <NumericValue value={row.tvl} isLoading={row.isLoading} />
+                    },
+                    {
+                      label: <Trans>My position</Trans>,
+                      value: <NumericValue value={row.position} isLoading={row.isLoading} />
+                    }
+                  ]}
+                />
+                <div className="flex w-full items-center gap-3">
+                  <Button variant="primary" size="m" className="flex-1" onClick={() => onRowSelect?.(row.id)}>
+                    <Trans>Supply</Trans>
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="m"
+                    className="flex-1"
+                    onClick={() => onRowSelect?.(row.id)}
+                  >
+                    <Trans>View details</Trans>
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 /**
  * The Earn Opportunities table (Figma Table/Earn 5178:37463): layout only —
  * rows arrive filtered, sorted and formatted; sorting/selection intent is
  * reported via callbacks. Surface, header and hover come from ui/table.
+ * Below the md tier it reflows into accordion cards (EarnCardList).
  */
 export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTableProps) {
+  const { bpi } = useBreakpointIndex();
+
   const handleRowKeyDown = (event: KeyboardEvent, id: string) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onRowSelect?.(id);
     }
   };
+
+  if (bpi < BP.md) return <EarnCardList rows={rows} onRowSelect={onRowSelect} />;
 
   return (
     <Table data-testid="earn-opportunities-table">
@@ -127,23 +254,7 @@ export function EarnTable({ rows, sort, onSortChange, onRowSelect }: EarnTablePr
                 wired here on purpose: its trigger follows product logic that
                 is not part of the H8 batch. */}
             <TableCell>
-              <CellToken
-                icon={row.icon}
-                title={row.name}
-                titleSuffix={row.nameSuffix}
-                subtitle={
-                  <>
-                    <Trans>Supply:</Trans>
-                    {row.supply}
-                    {row.maturityLabel && (
-                      <>
-                        <span aria-hidden>·</span>
-                        {row.maturityLabel}
-                      </>
-                    )}
-                  </>
-                }
-              />
+              <TokenCell row={row} />
             </TableCell>
             <TableCell>{row.network}</TableCell>
             <TableCell>

--- a/apps/webapp/src/components/product/ProductTransactionsTable.test.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.test.tsx
@@ -1,8 +1,19 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProductTransactionsTable, ProductTransactionColumn } from './ProductTransactionsTable';
+
+// Pin the JS breakpoint per test (happy-dom's viewport is 1024, i.e. table
+// mode) — same pattern as responsive-modal.test.tsx.
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
 
 i18n.load('en', {});
 i18n.activate('en');
@@ -90,5 +101,79 @@ describe('ProductTransactionsTable — renderBelowRow', () => {
   it('leaves existing consumers byte-identical when renderBelowRow is omitted', () => {
     renderTable(makeRows(3));
     expect(visibleRows()).toHaveLength(3);
+  });
+});
+
+describe('ProductTransactionsTable — mobile cards (M5)', () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    breakpoint.isMobile = true;
+  });
+
+  const renderWithCards = (rows: Row[], pageSize?: number) =>
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProductTransactionsTable
+          columns={COLUMNS}
+          rows={rows}
+          rowKey={row => row.id}
+          pageSize={pageSize}
+          renderCard={row => <div>{`card-${row.id}`}</div>}
+        />
+      </I18nProvider>
+    );
+
+  it('renders cards instead of the table below the md tier when renderCard is provided', () => {
+    renderWithCards(makeRows(3));
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getAllByText(/^card-/)).toHaveLength(3);
+  });
+
+  it('keeps the table at the md tier and above', () => {
+    breakpoint.isMobile = false;
+    renderWithCards(makeRows(3));
+    expect(screen.getByRole('table')).toBeTruthy();
+    expect(screen.queryByText(/^card-/)).toBeNull();
+  });
+
+  it('keeps the (scrollable) table below md when no renderCard is provided', () => {
+    renderTable(makeRows(3));
+    expect(screen.getByRole('table')).toBeTruthy();
+  });
+
+  it('paginates cards exactly like table rows', () => {
+    renderWithCards(makeRows(15));
+    expect(screen.getAllByText(/^card-/)).toHaveLength(7);
+    fireEvent.click(screen.getByLabelText('Go to next page'));
+    expect(screen.getAllByText(/^card-/).map(el => el.textContent)).toEqual([
+      'card-7',
+      'card-8',
+      'card-9',
+      'card-10',
+      'card-11',
+      'card-12',
+      'card-13'
+    ]);
+  });
+
+  it('renders below-row content after the matching card', () => {
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProductTransactionsTable
+          columns={COLUMNS}
+          rows={makeRows(3)}
+          rowKey={row => row.id}
+          renderCard={row => <div>{`card-${row.id}`}</div>}
+          renderBelowRow={row => (row.id === '1' ? <div data-testid="below-1">below</div> : null)}
+        />
+      </I18nProvider>
+    );
+    expect(screen.getByTestId('below-1')).toBeTruthy();
+  });
+
+  it('shows the empty state on a card surface', () => {
+    renderWithCards([]);
+    expect(screen.getByText('No transactions yet.')).toBeTruthy();
+    expect(screen.queryByRole('table')).toBeNull();
   });
 });

--- a/apps/webapp/src/components/product/ProductTransactionsTable.tsx
+++ b/apps/webapp/src/components/product/ProductTransactionsTable.tsx
@@ -1,6 +1,7 @@
 import { Fragment, ReactNode, useState } from 'react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
+import { BP, useBreakpointIndex } from '@/hooks';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { CustomPagination } from '@/modules/ui/components/CustomPagination';
@@ -13,6 +14,10 @@ import { paginate } from './paginate';
  * differ — while the shared chrome (ui/table surface, loading/empty/error
  * states, pagination) lives here. Cell contents come from the design-system
  * typed cells (ui/table-cells) via the column `cell` renderers.
+ *
+ * M5: below the md tier (768, the ResponsiveModal switch) a consumer-supplied
+ * `renderCard` swaps the <table> for a stacked card list (Figma mobile Table
+ * Sections, e.g. 486:20827) — same rows, loading/empty/error and pagination.
  */
 
 export type ProductTransactionStatus = 'pending' | 'completed';
@@ -43,6 +48,8 @@ export interface ProductTransactionsTableProps<T> {
   rowTestId?: (row: T) => string;
   /** Full-width content rendered as a sibling right after a matching row, outside its click/hover surface. */
   renderBelowRow?: (row: T) => ReactNode;
+  /** Mobile card for a row; providing it swaps the table for a card list below the md tier. */
+  renderCard?: (row: T) => ReactNode;
 }
 
 // The legacy grid API declared tracks ('1.5fr', '140px'); a <table> wants
@@ -67,6 +74,15 @@ function StateRow({ colSpan, children }: { colSpan: number; children: ReactNode 
   );
 }
 
+/** Card-mode stand-in for StateRow: the message on a single card surface. */
+function StateCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-bgSecondary text-fgSecondary font-graphik rounded-[20px] p-5 text-center text-sm">
+      {children}
+    </div>
+  );
+}
+
 export function ProductTransactionsTable<T>({
   columns,
   rows,
@@ -79,13 +95,79 @@ export function ProductTransactionsTable<T>({
   pageSize = 7,
   onRowClick,
   rowTestId,
-  renderBelowRow
+  renderBelowRow,
+  renderCard
 }: ProductTransactionsTableProps<T>) {
   const allRows = rows ?? [];
   const [page, setPage] = useState(1);
   const { rows: pageRows, totalPages } = paginate(allRows, pageSize, page);
   const showPagination = !isLoading && !error && totalPages > 1;
   const widths = columnWidths(columns);
+  const { bpi } = useBreakpointIndex();
+
+  if (renderCard && bpi < BP.md) {
+    return (
+      <>
+        {/* 2px gaps + outer-corners-only rounding mirror the desktop table
+            surface (border-spacing-y + first/last cell radii). */}
+        <div data-testid={dataTestId} className="flex w-full flex-col gap-0.5">
+          {isLoading ? (
+            Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className={cn(
+                  'bg-bgSecondary p-5',
+                  index === 0 && 'rounded-t-[20px]',
+                  index === 3 && 'rounded-b-[20px]'
+                )}
+              >
+                <Skeleton className="h-5 w-1/3" />
+              </div>
+            ))
+          ) : error ? (
+            <StateCard>
+              <Trans>Unable to load transactions, please try again later.</Trans>
+            </StateCard>
+          ) : allRows.length === 0 ? (
+            <StateCard>{emptyLabel ?? <Trans>No transactions yet.</Trans>}</StateCard>
+          ) : (
+            pageRows.map((row, index) => (
+              <Fragment key={rowKey(row)}>
+                <div
+                  data-testid={rowTestId?.(row)}
+                  tabIndex={onRowClick ? 0 : undefined}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  onKeyDown={
+                    onRowClick
+                      ? event => {
+                          if (event.target !== event.currentTarget) return;
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            onRowClick(row);
+                          }
+                        }
+                      : undefined
+                  }
+                  className={cn(
+                    'overflow-hidden',
+                    index === 0 && 'rounded-t-[20px]',
+                    index === pageRows.length - 1 && 'rounded-b-[20px]',
+                    onRowClick && 'cursor-pointer'
+                  )}
+                >
+                  {renderCard(row)}
+                </div>
+                {renderBelowRow?.(row)}
+              </Fragment>
+            ))
+          )}
+        </div>
+        {showPagination && (
+          <CustomPagination dataLength={allRows.length} itemsPerPage={pageSize} onPageChange={setPage} />
+        )}
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/webapp/src/components/product/TransactionCard.test.tsx
+++ b/apps/webapp/src/components/product/TransactionCard.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TransactionCard } from './TransactionCard';
+
+describe('TransactionCard', () => {
+  afterEach(cleanup);
+
+  it('renders the header, badge, all fields and their labels', () => {
+    render(
+      <TransactionCard
+        header={<span>Supply</span>}
+        badge={<span>Completed</span>}
+        fields={[
+          { label: 'From', value: '1,000.00' },
+          { label: 'To', value: '999.00' },
+          { label: 'Time', value: '35 min ago' }
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Supply')).toBeTruthy();
+    expect(screen.getByText('Completed')).toBeTruthy();
+    for (const text of ['From', '1,000.00', 'To', '999.00', 'Time', '35 min ago']) {
+      expect(screen.getByText(text)).toBeTruthy();
+    }
+  });
+
+  it('renders the footer link as a new-tab anchor that does not bubble clicks', () => {
+    const onCardClick = vi.fn();
+    render(
+      <div onClick={onCardClick}>
+        <TransactionCard
+          header={<span>Supply</span>}
+          link={{ label: 'View transaction', href: 'https://example.com/tx' }}
+        />
+      </div>
+    );
+
+    const anchor = screen.getByRole('link', { name: /View transaction/ });
+    expect(anchor.getAttribute('href')).toBe('https://example.com/tx');
+    expect(anchor.getAttribute('target')).toBe('_blank');
+    fireEvent.click(anchor);
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it('renders no footer button when no link is given', () => {
+    render(<TransactionCard header={<span>Supply</span>} fields={[{ label: 'Amount', value: '1.00' }]} />);
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+});

--- a/apps/webapp/src/components/product/TransactionCard.tsx
+++ b/apps/webapp/src/components/product/TransactionCard.tsx
@@ -1,0 +1,90 @@
+import { ReactNode } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Mobile stand-in for a transactions-table row (Figma mobile Table Section
+ * cards, 486:20827 / 486:20198): bg-secondary surface, 20px padding, 24px
+ * between header / field grid / footer. Fields lay out two per row — a 112px
+ * left column and a flexible right one split by a hairline — with Body 6
+ * labels over Label 5 values, matching the desktop typed cells.
+ *
+ * Corners stay square on purpose: the comp stacks cards flush with 2px gaps
+ * (the desktop table's border-spacing) and rounds only the list's outer
+ * corners, so the list container owns the radius — same scheme as ui/table.
+ */
+
+export type TransactionCardField = { label: ReactNode; value: ReactNode };
+
+function Field({ field, className }: { field: TransactionCardField; className?: string }) {
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <span className="font-graphik text-fgSecondary text-xs leading-[18px]">{field.label}</span>
+      <span className="font-circle text-fgPrimary flex min-h-4 items-center text-sm leading-4 font-medium tracking-[-0.28px]">
+        {field.value}
+      </span>
+    </div>
+  );
+}
+
+/** The card's 2-per-row label/value grid — also the accordion cards' detail body. */
+export function TransactionCardFieldGrid({ fields }: { fields: TransactionCardField[] }) {
+  const rows: TransactionCardField[][] = [];
+  for (let i = 0; i < fields.length; i += 2) rows.push(fields.slice(i, i + 2));
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      {rows.map((pair, index) => (
+        <div key={index} className="flex w-full items-center gap-5">
+          <Field field={pair[0]} className="w-28 shrink-0" />
+          {pair[1] && (
+            <>
+              <div className="bg-glassBorder h-[30px] w-px shrink-0" aria-hidden />
+              <Field field={pair[1]} className="min-w-0 flex-1" />
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TransactionCard({
+  header,
+  badge,
+  fields = [],
+  link,
+  footer
+}: {
+  /** Left header content — typically the table's CellAction (icon + verb + time). */
+  header: ReactNode;
+  /** Optional right header slot — typically CellStatus. */
+  badge?: ReactNode;
+  fields?: TransactionCardField[];
+  /** Footer "View transaction ↗" secondary button. */
+  link?: { label: ReactNode; href: string };
+  /** Free-form footer slot for non-link CTAs (used instead of `link`). */
+  footer?: ReactNode;
+}) {
+  return (
+    <div className="bg-bgSecondary flex w-full flex-col gap-6 p-5 backdrop-blur-[20px]">
+      <div className="flex items-center justify-between gap-3">
+        {header}
+        {badge}
+      </div>
+      {fields.length > 0 && <TransactionCardFieldGrid fields={fields} />}
+      {link && (
+        <Button asChild variant="secondary" size="m" className="w-full">
+          <a href={link.href} target="_blank" rel="noreferrer" onClick={event => event.stopPropagation()}>
+            {/* Real element, not a bare text node: Chrome skips flex `gap`
+                between an anonymous text item and the icon. */}
+            <span>{link.label}</span>
+            <ExternalLink aria-hidden />
+          </a>
+        </Button>
+      )}
+      {footer}
+    </div>
+  );
+}

--- a/apps/webapp/src/modules/morpho/components/MorphoVaultAllocationsDetails.tsx
+++ b/apps/webapp/src/modules/morpho/components/MorphoVaultAllocationsDetails.tsx
@@ -165,6 +165,10 @@ function NormalizedVaultAllocations({
   );
 }
 
+// M5 note: this table deliberately keeps horizontal scroll on phones (the
+// scrollbar-thin-always wrapper is the visible affordance) instead of a card
+// collapse — it's a dense analytical grid with section-header rows and no
+// mobile comp. Revisit if design ships one (flagged on APP-371).
 export function MorphoVaultAllocationsDetails({
   vaultAddress,
   provider = 'morpho',

--- a/apps/webapp/src/modules/morpho/components/VaultTransactionsTable.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultTransactionsTable.tsx
@@ -10,6 +10,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAction, CellAmount, CellHash } from '@/components/ui/table-cells';
 
 export type VaultTxFilter = 'all' | 'supply' | 'withdraw';
@@ -27,37 +28,40 @@ type VaultTxRow = {
 
 // The vault design's columns: Transaction / Amount / Txn hash / Time (no Status,
 // absolute Time column). Column-driven, so it diverges from Savings freely.
+const actionCell = (row: VaultTxRow, sublabel?: string) => (
+  <CellAction
+    icon={
+      row.isSupply ? (
+        <SavingsSupply width={16} height={15} />
+      ) : (
+        <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
+      )
+    }
+    label={row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdrawal</Trans>}
+    sublabel={sublabel}
+  />
+);
+
+const amountCell = (row: VaultTxRow) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />}
+    amount={`${row.amount} ${row.symbol}`}
+    usd={row.usd}
+  />
+);
+
 const COLUMNS: ProductTransactionColumn<VaultTxRow>[] = [
   {
     id: 'action',
     header: <Trans>Transaction</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAction
-        icon={
-          row.isSupply ? (
-            <SavingsSupply width={16} height={15} />
-          ) : (
-            <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
-          )
-        }
-        label={row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdrawal</Trans>}
-      />
-    )
+    cell: row => actionCell(row)
   },
   {
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAmount
-        icon={
-          <TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
-        }
-        amount={`${row.amount} ${row.symbol}`}
-        usd={row.usd}
-      />
-    )
+    cell: amountCell
   },
   {
     id: 'hash',
@@ -72,6 +76,16 @@ const COLUMNS: ProductTransactionColumn<VaultTxRow>[] = [
     cell: row => <span className="text-textSecondary text-sm">{row.time}</span>
   }
 ];
+
+// M5 mobile card (Figma 486:20827 pattern): the Time column folds into the
+// header subline, the hash becomes the View transaction button.
+const renderCard = (row: VaultTxRow) => (
+  <TransactionCard
+    header={actionCell(row, row.time)}
+    fields={[{ label: <Trans>Amount</Trans>, value: amountCell(row) }]}
+    link={{ label: <Trans>View transaction</Trans>, href: row.txHref }}
+  />
+);
 
 /**
  * Morpho vault deposit/withdraw history mapped onto the shared (column-driven)
@@ -123,6 +137,7 @@ export function VaultTransactionsTable({
       rowKey={row => row.id}
       isLoading={isLoading}
       error={error}
+      renderCard={renderCard}
     />
   );
 }

--- a/apps/webapp/src/modules/pendle/components/PendleTransactionsTable.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleTransactionsTable.tsx
@@ -9,6 +9,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAction, CellAmount, CellHash } from '@/components/ui/table-cells';
 
 type PendleTxRow = {
@@ -29,29 +30,36 @@ const ACTION_LABEL: Record<PendleHistoryAction, React.ReactNode> = {
 };
 
 // Same column shape as the vault table: Transaction / Amount / Txn hash / Time.
+const actionCell = (row: PendleTxRow, sublabel?: string) => (
+  <CellAction
+    icon={
+      row.action === PendleHistoryAction.BUY_PT ? (
+        <SavingsSupply width={16} height={15} />
+      ) : (
+        <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
+      )
+    }
+    label={ACTION_LABEL[row.action]}
+    sublabel={sublabel}
+  />
+);
+
+const amountCell = (row: PendleTxRow) => (
+  <CellAmount amount={`${row.amount} ${row.marketName}`} usd={row.usd} />
+);
+
 const COLUMNS: ProductTransactionColumn<PendleTxRow>[] = [
   {
     id: 'action',
     header: <Trans>Transaction</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAction
-        icon={
-          row.action === PendleHistoryAction.BUY_PT ? (
-            <SavingsSupply width={16} height={15} />
-          ) : (
-            <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
-          )
-        }
-        label={ACTION_LABEL[row.action]}
-      />
-    )
+    cell: row => actionCell(row)
   },
   {
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
-    cell: row => <CellAmount amount={`${row.amount} ${row.marketName}`} usd={row.usd} />
+    cell: amountCell
   },
   {
     id: 'hash',
@@ -66,6 +74,16 @@ const COLUMNS: ProductTransactionColumn<PendleTxRow>[] = [
     cell: row => <span className="text-textSecondary text-sm">{row.time}</span>
   }
 ];
+
+// M5 mobile card (Figma 486:20827 pattern): the Time column folds into the
+// header subline, the hash becomes the View transaction button.
+const renderCard = (row: PendleTxRow) => (
+  <TransactionCard
+    header={actionCell(row, row.time)}
+    fields={[{ label: <Trans>Amount</Trans>, value: amountCell(row) }]}
+    link={{ label: <Trans>View transaction</Trans>, href: row.txHref }}
+  />
+);
 
 /**
  * Per-market Pendle trade history (buy/sell/redeem) mapped onto the shared
@@ -98,6 +116,7 @@ export function PendleTransactionsTable({ market }: { market: PendleMarketConfig
       rowKey={row => row.id}
       isLoading={isLoading}
       error={error}
+      renderCard={renderCard}
     />
   );
 }

--- a/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.test.tsx
@@ -1,0 +1,78 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IdleSupplyInfo, IdleToken } from '../helpers/idleView';
+
+// Pin the JS breakpoint per test (happy-dom's 1024 viewport = table mode).
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
+vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
+
+import { IdleStablecoinsTable } from './IdleStablecoinsTable';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const TOKENS: IdleToken[] = [
+  { symbol: 'USDS', name: 'USDS Stablecoin', amount: 1000, amountUsd: 1000, color: '#888', share: 0.95 },
+  { symbol: 'USDC', name: 'USD Coin', amount: 50, amountUsd: 50, color: '#999', share: 0.05 }
+];
+
+const SUPPLY_INFO = new Map<string, IdleSupplyInfo>([
+  ['USDS', { bestRate: 0.0475, venueCount: 3 }],
+  ['USDC', { bestRate: 0.04, venueCount: 1 }]
+]);
+
+const renderIdle = (onSupply = vi.fn()) => {
+  render(
+    <I18nProvider i18n={i18n}>
+      <IdleStablecoinsTable tokens={TOKENS} supplyInfo={SUPPLY_INFO} onSupply={onSupply} />
+    </I18nProvider>
+  );
+  return onSupply;
+};
+
+describe('IdleStablecoinsTable — desktop table', () => {
+  afterEach(cleanup);
+
+  it('renders the table with a row per token', () => {
+    renderIdle();
+    expect(screen.getByRole('table')).toBeTruthy();
+    expect(screen.getAllByTestId('idle-row')).toHaveLength(2);
+  });
+});
+
+describe('IdleStablecoinsTable — mobile cards (M5)', () => {
+  beforeEach(() => {
+    breakpoint.isMobile = true;
+  });
+  afterEach(() => {
+    breakpoint.isMobile = false;
+    cleanup();
+  });
+
+  it('renders a card per token with the balance and a Supply CTA', () => {
+    renderIdle();
+
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getAllByTestId('idle-row')).toHaveLength(2);
+    expect(screen.getByText('USDS Stablecoin')).toBeTruthy();
+    expect(screen.getAllByText('Balance')).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Supply' })).toHaveLength(2);
+  });
+
+  it('routes the card Supply CTA through onSupply with the token symbol', () => {
+    const onSupply = renderIdle();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Supply' })[1]);
+    expect(onSupply).toHaveBeenCalledWith('USDC');
+  });
+});

--- a/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
+++ b/apps/webapp/src/modules/portfolio/components/IdleStablecoinsTable.tsx
@@ -1,16 +1,60 @@
 import { Trans } from '@lingui/react/macro';
+import { cn } from '@/lib/cn';
+import { BP, useBreakpointIndex } from '@/hooks';
 import { formatDecimalPercentage, formatNumber, formatUsd } from '@/utils';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { CellAmount, CellBadge, CellTokenIdle } from '@/components/ui/table-cells';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { STABLECOIN_PEG_BADGE, type IdleSupplyInfo, type IdleToken } from '../helpers/idleView';
+
+function tokenCell(token: IdleToken, info: IdleSupplyInfo | undefined) {
+  const pegBadge = STABLECOIN_PEG_BADGE[token.symbol];
+  return (
+    <CellTokenIdle
+      icon={
+        <TokenIcon token={{ symbol: token.symbol }} width={28} showChainIcon={false} className="h-7 w-7" />
+      }
+      symbol={token.symbol}
+      badges={
+        <>
+          {info?.bestRate !== undefined && (
+            <CellBadge tone="success">
+              {info.venueCount > 1 ? (
+                <Trans>up to {formatDecimalPercentage(info.bestRate)}</Trans>
+              ) : (
+                formatDecimalPercentage(info.bestRate)
+              )}
+            </CellBadge>
+          )}
+          {pegBadge && <CellBadge>{pegBadge}</CellBadge>}
+        </>
+      }
+      name={token.name}
+    />
+  );
+}
+
+function balanceCell(token: IdleToken) {
+  return (
+    <CellAmount
+      icon={
+        <TokenIcon token={{ symbol: token.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
+      }
+      amount={formatNumber(token.amount)}
+      usd={formatUsd(token.amountUsd)}
+    />
+  );
+}
 
 /**
  * The Portfolio "Idle" view of the positions section (Figma Table/Idle
  * 5178:37659): a row per held stablecoin (Token Idle cell with best-rate +
  * 1:1-parity badges, Amount cell, full-width Supply CTA) that deep-links to
- * the Earn list filtered by that token.
+ * the Earn list filtered by that token. Below the md tier each row becomes a
+ * TransactionCard (no Idle-specific mobile comp — the shared card pattern,
+ * flagged on APP-371 for design review).
  */
 export function IdleStablecoinsTable({
   tokens,
@@ -21,6 +65,36 @@ export function IdleStablecoinsTable({
   supplyInfo: Map<string, IdleSupplyInfo>;
   onSupply: (symbol: string) => void;
 }) {
+  const { bpi } = useBreakpointIndex();
+
+  if (bpi < BP.md) {
+    return (
+      <div data-testid="idle-stablecoins-table" className="mt-6 flex w-full flex-col gap-0.5">
+        {tokens.map((token, index) => (
+          <div
+            key={token.symbol}
+            data-testid="idle-row"
+            className={cn(
+              'overflow-hidden',
+              index === 0 && 'rounded-t-[20px]',
+              index === tokens.length - 1 && 'rounded-b-[20px]'
+            )}
+          >
+            <TransactionCard
+              header={tokenCell(token, supplyInfo.get(token.symbol))}
+              fields={[{ label: <Trans>Balance</Trans>, value: balanceCell(token) }]}
+              footer={
+                <Button variant="primary" size="m" className="w-full" onClick={() => onSupply(token.symbol)}>
+                  <Trans>Supply</Trans>
+                </Button>
+              }
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="mt-6">
       <Table data-testid="idle-stablecoins-table">
@@ -42,66 +116,17 @@ export function IdleStablecoinsTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {tokens.map(token => {
-            const info = supplyInfo.get(token.symbol);
-            const pegBadge = STABLECOIN_PEG_BADGE[token.symbol];
-            return (
-              <TableRow key={token.symbol} data-testid="idle-row">
-                <TableCell>
-                  <CellTokenIdle
-                    icon={
-                      <TokenIcon
-                        token={{ symbol: token.symbol }}
-                        width={28}
-                        showChainIcon={false}
-                        className="h-7 w-7"
-                      />
-                    }
-                    symbol={token.symbol}
-                    badges={
-                      <>
-                        {info?.bestRate !== undefined && (
-                          <CellBadge tone="success">
-                            {info.venueCount > 1 ? (
-                              <Trans>up to {formatDecimalPercentage(info.bestRate)}</Trans>
-                            ) : (
-                              formatDecimalPercentage(info.bestRate)
-                            )}
-                          </CellBadge>
-                        )}
-                        {pegBadge && <CellBadge>{pegBadge}</CellBadge>}
-                      </>
-                    }
-                    name={token.name}
-                  />
-                </TableCell>
-                <TableCell>
-                  <CellAmount
-                    icon={
-                      <TokenIcon
-                        token={{ symbol: token.symbol }}
-                        width={12}
-                        showChainIcon={false}
-                        className="h-3 w-3"
-                      />
-                    }
-                    amount={formatNumber(token.amount)}
-                    usd={formatUsd(token.amountUsd)}
-                  />
-                </TableCell>
-                <TableCell className="px-4">
-                  <Button
-                    variant="primary"
-                    size="m"
-                    className="w-full"
-                    onClick={() => onSupply(token.symbol)}
-                  >
-                    <Trans>Supply</Trans>
-                  </Button>
-                </TableCell>
-              </TableRow>
-            );
-          })}
+          {tokens.map(token => (
+            <TableRow key={token.symbol} data-testid="idle-row">
+              <TableCell>{tokenCell(token, supplyInfo.get(token.symbol))}</TableCell>
+              <TableCell>{balanceCell(token)}</TableCell>
+              <TableCell className="px-4">
+                <Button variant="primary" size="m" className="w-full" onClick={() => onSupply(token.symbol)}>
+                  <Trans>Supply</Trans>
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
         </TableBody>
       </Table>
     </div>

--- a/apps/webapp/src/modules/rewards/components/RewardsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsTransactionsTable.tsx
@@ -11,6 +11,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAction, CellAmount, CellHash, CellStatus } from '@/components/ui/table-cells';
 
 type RewardsTxKind = 'supply' | 'withdraw' | 'claim';
@@ -35,26 +36,36 @@ const ACTION_LABELS: Record<RewardsTxKind, ReturnType<typeof Trans>> = {
 // Rewards' columns — same shape as Savings' plus a third action type: reward
 // claims, denominated in the reward token (no USD subvalue; only the $1-pegged
 // supply token doubles as its own USD figure).
+const actionCell = (row: RewardsTxRow) => (
+  <CellAction
+    icon={
+      row.kind === 'supply' ? (
+        <SavingsSupply width={16} height={15} />
+      ) : row.kind === 'withdraw' ? (
+        <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
+      ) : (
+        <Reward width={14} height={14} />
+      )
+    }
+    label={ACTION_LABELS[row.kind]}
+    sublabel={row.timeAgo}
+  />
+);
+
+const amountCell = (row: RewardsTxRow) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />}
+    amount={row.amount}
+    usd={row.usd}
+  />
+);
+
 const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
   {
     id: 'action',
     header: <Trans>Action</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAction
-        icon={
-          row.kind === 'supply' ? (
-            <SavingsSupply width={16} height={15} />
-          ) : row.kind === 'withdraw' ? (
-            <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
-          ) : (
-            <Reward width={14} height={14} />
-          )
-        }
-        label={ACTION_LABELS[row.kind]}
-        sublabel={row.timeAgo}
-      />
-    )
+    cell: actionCell
   },
   {
     id: 'status',
@@ -67,15 +78,7 @@ const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAmount
-        icon={
-          <TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
-        }
-        amount={row.amount}
-        usd={row.usd}
-      />
-    )
+    cell: amountCell
   },
   {
     id: 'hash',
@@ -84,6 +87,17 @@ const COLUMNS: ProductTransactionColumn<RewardsTxRow>[] = [
     cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   }
 ];
+
+// M5 mobile card (Figma 486:20827 pattern): action cell as the header, status
+// as the header badge, hash as the View transaction button.
+const renderCard = (row: RewardsTxRow) => (
+  <TransactionCard
+    header={actionCell(row)}
+    badge={<CellStatus status="completed" />}
+    fields={[{ label: <Trans>Amount</Trans>, value: amountCell(row) }]}
+    link={{ label: <Trans>View transaction</Trans>, href: row.txHref }}
+  />
+);
 
 /**
  * Per-farm user history mapped onto the shared (column-driven)
@@ -133,6 +147,7 @@ export function RewardsTransactionsTable({ contract }: { contract: RewardContrac
       rowKey={row => row.id}
       isLoading={isLoading}
       error={error}
+      renderCard={renderCard}
     />
   );
 }

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.test.tsx
@@ -9,6 +9,16 @@ i18n.activate('en');
 // Mutable history fed to the mocked useSavingsHistory — set per test before render.
 const h = vi.hoisted(() => ({ history: [] as unknown[] }));
 
+// Pin the JS breakpoint per test (happy-dom's 1024 viewport = table mode).
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
 vi.mock('wagmi', async importOriginal => {
   const actual = await importOriginal<typeof import('wagmi')>();
   return { ...actual, useChainId: () => 1 };
@@ -90,6 +100,36 @@ describe('SavingsTransactionsTable — action-type filter', () => {
     renderTable('withdraw');
 
     expect(rowCount()).toBe(1);
+    expect(withdrawRows()).toBe(1);
+    expect(supplyRows()).toBe(0);
+  });
+});
+
+describe('SavingsTransactionsTable — mobile cards (M5)', () => {
+  afterEach(() => {
+    breakpoint.isMobile = false;
+    cleanup();
+  });
+
+  it('renders each transaction as a card with action, status, amount and explorer link', () => {
+    breakpoint.isMobile = true;
+    h.history = [supply('0xaaa1')];
+    renderTable();
+
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getByText('Supply')).toBeTruthy();
+    expect(screen.getByText('Completed')).toBeTruthy();
+    expect(screen.getByText('Amount')).toBeTruthy();
+    expect(screen.getByText('100')).toBeTruthy();
+    const link = screen.getByRole('link', { name: /View transaction/ });
+    expect(link.getAttribute('href')).toContain('0xaaa1');
+  });
+
+  it('keeps filtering working in card mode', () => {
+    breakpoint.isMobile = true;
+    h.history = [supply('0xaaa1'), withdraw('0xbbb2')];
+    renderTable('withdraw');
+
     expect(withdrawRows()).toBe(1);
     expect(supplyRows()).toBe(0);
   });

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsTable.tsx
@@ -12,6 +12,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAction, CellAmount, CellHash, CellStatus } from '@/components/ui/table-cells';
 import { SavingsTxFilter } from './SavingsTransactionsFilter';
 
@@ -28,24 +29,34 @@ type SavingsTxRow = {
 
 // Savings' columns. Other modules define their own — the table is column-driven.
 // Single USDS Amount column for now (no historical share data — see APP-300).
+const actionCell = (row: SavingsTxRow) => (
+  <CellAction
+    icon={
+      row.isSupply ? (
+        <SavingsSupply width={16} height={15} />
+      ) : (
+        <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
+      )
+    }
+    label={row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdraw</Trans>}
+    sublabel={row.timeAgo}
+  />
+);
+
+const amountCell = (row: SavingsTxRow) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />}
+    amount={row.amount}
+    usd={row.usd}
+  />
+);
+
 const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
   {
     id: 'action',
     header: <Trans>Action</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAction
-        icon={
-          row.isSupply ? (
-            <SavingsSupply width={16} height={15} />
-          ) : (
-            <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
-          )
-        }
-        label={row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdraw</Trans>}
-        sublabel={row.timeAgo}
-      />
-    )
+    cell: actionCell
   },
   {
     id: 'status',
@@ -58,15 +69,7 @@ const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAmount
-        icon={
-          <TokenIcon token={{ symbol: row.symbol }} width={12} showChainIcon={false} className="h-3 w-3" />
-        }
-        amount={row.amount}
-        usd={row.usd}
-      />
-    )
+    cell: amountCell
   },
   {
     id: 'hash',
@@ -75,6 +78,19 @@ const COLUMNS: ProductTransactionColumn<SavingsTxRow>[] = [
     cell: row => <CellHash label={row.txHashLabel} href={row.txHref} />
   }
 ];
+
+// M5 mobile card of the same row (Figma 486:20827): action cell as the
+// header, status as the header badge, hash as the View transaction button.
+// The comp's From/To amount pair needs the historical share data we don't
+// have yet (APP-300), so the single Amount field stands in.
+const renderCard = (row: SavingsTxRow) => (
+  <TransactionCard
+    header={actionCell(row)}
+    badge={<CellStatus status="completed" />}
+    fields={[{ label: <Trans>Amount</Trans>, value: amountCell(row) }]}
+    link={{ label: <Trans>View transaction</Trans>, href: row.txHref }}
+  />
+);
 
 /**
  * Savings history mapped onto the shared (column-driven) ProductTransactionsTable
@@ -123,6 +139,7 @@ export function SavingsTransactionsTable({ filter = 'all' }: { filter?: SavingsT
       rowKey={row => row.id}
       isLoading={isLoading}
       error={error}
+      renderCard={renderCard}
     />
   );
 }

--- a/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
@@ -24,6 +24,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAction, CellAmount, CellHash, CellStatus } from '@/components/ui/table-cells';
 import { StakeUserPosition } from '../hooks/useStakeUserPositions';
 
@@ -176,25 +177,43 @@ function verbIcon(verb: StakeActivityVerb) {
 
 type ActivityRow = StakeActivityGroup & { skyPrice: number | null; chainId: number };
 
+// Figma Type=Action and Position (Transaction Stake): Label 5 title.
+const actionCell = (row: ActivityRow) => (
+  <CellAction
+    compact
+    icon={verbIcon(row.verb)}
+    label={verbLabel(row.verb)}
+    sublabel={
+      <>
+        {formatDistanceToNowStrict(row.blockTimestamp, { addSuffix: true })}
+        {row.urnIndex !== undefined && <> · Position {row.urnIndex + 1}</>}
+      </>
+    }
+  />
+);
+
+const skyCell = (row: ActivityRow) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+    amount={formatStakeAmount(row.skyAmount)}
+    usd={row.skyPrice !== null ? formatUsd(Number(formatUnits(row.skyAmount, 18)) * row.skyPrice) : undefined}
+  />
+);
+
+const usdsCell = (row: ActivityRow) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+    amount={formatStakeAmount(row.usdsAmount)}
+    usd={formatUsd(Number(formatUnits(row.usdsAmount, 18)))}
+  />
+);
+
 const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
   {
     id: 'action',
     header: <Trans>Action</Trans>,
     width: '1.6fr',
-    cell: row => (
-      // Figma Type=Action and Position (Transaction Stake): Label 5 title.
-      <CellAction
-        compact
-        icon={verbIcon(row.verb)}
-        label={verbLabel(row.verb)}
-        sublabel={
-          <>
-            {formatDistanceToNowStrict(row.blockTimestamp, { addSuffix: true })}
-            {row.urnIndex !== undefined && <> · Position {row.urnIndex + 1}</>}
-          </>
-        }
-      />
-    )
+    cell: actionCell
   },
   {
     id: 'status',
@@ -208,27 +227,13 @@ const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
     id: 'sky',
     header: <Trans>Stake/unstake</Trans>,
     width: '1.2fr',
-    cell: row => (
-      <CellAmount
-        icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
-        amount={formatStakeAmount(row.skyAmount)}
-        usd={
-          row.skyPrice !== null ? formatUsd(Number(formatUnits(row.skyAmount, 18)) * row.skyPrice) : undefined
-        }
-      />
-    )
+    cell: skyCell
   },
   {
     id: 'usds',
     header: <Trans>Borrow/repay</Trans>,
     width: '1.2fr',
-    cell: row => (
-      <CellAmount
-        icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />}
-        amount={formatStakeAmount(row.usdsAmount)}
-        usd={formatUsd(Number(formatUnits(row.usdsAmount, 18)))}
-      />
-    )
+    cell: usdsCell
   },
   {
     id: 'hash',
@@ -242,6 +247,23 @@ const COLUMNS: ProductTransactionColumn<ActivityRow>[] = [
     )
   }
 ];
+
+// M5 mobile card (Figma 486:20827 pattern, no stake-specific comp yet —
+// flagged on APP-371 for design review): both amount columns become fields.
+const renderCard = (row: ActivityRow) => (
+  <TransactionCard
+    header={actionCell(row)}
+    badge={<CellStatus status="completed" />}
+    fields={[
+      { label: <Trans>Stake/unstake</Trans>, value: skyCell(row) },
+      { label: <Trans>Borrow/repay</Trans>, value: usdsCell(row) }
+    ]}
+    link={{
+      label: <Trans>View transaction</Trans>,
+      href: getEtherscanLink(row.chainId, row.transactionHash, 'tx')
+    }}
+  />
+);
 
 /**
  * "My activity" table (hi-fi 486:31830): stake history grouped per transaction
@@ -310,6 +332,7 @@ export function StakeActivityTable({ positions }: { positions?: StakeUserPositio
         isLoading={isLoading}
         error={error}
         minWidth={720}
+        renderCard={renderCard}
         emptyLabel={
           <span data-testid="stake-activity-empty" className="flex flex-col items-center gap-4 py-8">
             <span className="bg-textSecondary/20 h-10 w-10 rounded-full" aria-hidden />

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.test.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.test.tsx
@@ -36,6 +36,16 @@ const h = vi.hoisted(() => ({
   claimError: null as Error | null
 }));
 
+// Pin the JS breakpoint per test (happy-dom's 1024 viewport = table mode).
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
 // Per-row reads: urn address, vault risk, claimable rewards, prices — all
 // mocked to fixed values so the table logic is what's under test.
 vi.mock('@/hooks', async importOriginal => {
@@ -246,5 +256,43 @@ describe('StakePositionsTable', () => {
 
     fireEvent.click(screen.getAllByTestId('stake-warning-repay-cta')[0]);
     expect(onRemediate).toHaveBeenCalledWith(POSITIONS[0], 'repay');
+  });
+});
+
+describe('StakePositionsTable — mobile cards (M5)', () => {
+  beforeEach(() => {
+    breakpoint.isMobile = true;
+    mockSearchParams = new URLSearchParams();
+    setSearchParamsMock.mockClear();
+    h.vault = { riskLevel: 'LOW' };
+    h.vaultError = null;
+    h.claimError = null;
+  });
+
+  afterEach(() => {
+    breakpoint.isMobile = false;
+    cleanup();
+  });
+
+  it('renders position cards with the column data and keeps tap-to-manage', () => {
+    renderTable();
+
+    expect(screen.queryByRole('table')).toBeNull();
+    // One field-label pair per visible position card.
+    expect(screen.getAllByText('Total staked (SKY)')).toHaveLength(2);
+    expect(screen.getAllByText('Total borrowed (USDS)')).toHaveLength(2);
+
+    fireEvent.click(screen.getByTestId('stake-position-row-0'));
+    expect(mockSearchParams.get('flow')).toBe('manage');
+    expect(mockSearchParams.get('urn_index')).toBe('0');
+  });
+
+  it('keeps the liquidation banner under its matching card', () => {
+    const positions: StakeUserPosition[] = [
+      { index: 0, skyLocked: 0n, usdsDebt: 0n, barks: [bark()], lastMutationTimestamp: undefined }
+    ];
+    renderTable(positions);
+
+    expect(screen.getByTestId('stake-position-liquidated-banner')).toBeTruthy();
   });
 });

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
@@ -28,6 +28,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAmount, CellAmountWithToken, CellChevron, CellPosition } from '@/components/ui/table-cells';
 import {
   StakeUserPosition,
@@ -160,6 +161,13 @@ function PositionIdCell({ position }: { position: StakeUserPosition }) {
   );
 }
 
+const stakedCell = (position: StakeUserPosition) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
+    amount={formatStakeAmount(position.skyLocked)}
+  />
+);
+
 const COLUMNS: ProductTransactionColumn<StakeUserPosition>[] = [
   {
     id: 'position',
@@ -171,12 +179,7 @@ const COLUMNS: ProductTransactionColumn<StakeUserPosition>[] = [
     id: 'staked',
     header: <Trans>Total staked (SKY)</Trans>,
     width: '1.2fr',
-    cell: position => (
-      <CellAmount
-        icon={<TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />}
-        amount={formatStakeAmount(position.skyLocked)}
-      />
-    )
+    cell: stakedCell
   },
   {
     id: 'borrowed',
@@ -207,6 +210,23 @@ const COLUMNS: ProductTransactionColumn<StakeUserPosition>[] = [
     )
   }
 ];
+
+// M5 mobile card (Figma 486:20827 pattern, no stake-specific comp yet —
+// flagged on APP-371 for design review). The card keeps the row's tap-to-
+// manage behavior (the engine wires onRowClick to the card wrapper), so the
+// chevron moves into the header as the affordance.
+const renderCard = (position: StakeUserPosition) => (
+  <TransactionCard
+    header={<PositionIdCell position={position} />}
+    badge={<CellChevron />}
+    fields={[
+      { label: <Trans>Total staked (SKY)</Trans>, value: stakedCell(position) },
+      { label: <Trans>Total borrowed (USDS)</Trans>, value: <PositionBorrowedCell position={position} /> },
+      { label: <Trans>Liquidation risk</Trans>, value: <PositionRiskCell position={position} /> },
+      { label: <Trans>Claimable rewards</Trans>, value: <PositionClaimableCell position={position} /> }
+    ]}
+  />
+);
 
 /**
  * Active-positions table (hi-fi 486:31830 / component 486:32084): one row per
@@ -295,6 +315,7 @@ export function StakePositionsTable({
           error={error}
           emptyLabel={<Trans>No active positions.</Trans>}
           minWidth={720}
+          renderCard={renderCard}
           renderBelowRow={position => (
             <StakePositionRowBanner
               position={position}

--- a/apps/webapp/src/modules/stusds/components/StUsdsTransactionsTable.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUsdsTransactionsTable.tsx
@@ -10,6 +10,7 @@ import {
   ProductTransactionsTable,
   ProductTransactionColumn
 } from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
 import { CellAction, CellAmount, CellHash } from '@/components/ui/table-cells';
 
 type StUsdsTxRow = {
@@ -26,44 +27,49 @@ type StUsdsTxRow = {
 // Same columns as the vault design: Transaction / Amount / Txn hash / Time.
 // Curve-routed rows carry a "via Curve" hint under the action label — the
 // history hook merges native module events and Curve pool swaps.
+const actionCell = (row: StUsdsTxRow, sublabel?: string) => (
+  <CellAction
+    icon={
+      row.isSupply ? (
+        <SavingsSupply width={16} height={15} />
+      ) : (
+        <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
+      )
+    }
+    label={
+      <span className="flex items-center gap-1.5">
+        {row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdrawal</Trans>}
+        {row.viaCurve && (
+          <span className="text-textSecondary text-xs">
+            <Trans>via Curve</Trans>
+          </span>
+        )}
+      </span>
+    }
+    sublabel={sublabel}
+  />
+);
+
+const amountCell = (row: StUsdsTxRow) => (
+  <CellAmount
+    icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} showChainIcon={false} className="h-3 w-3" />}
+    amount={`${row.amount} USDS`}
+    usd={row.usd}
+  />
+);
+
 const COLUMNS: ProductTransactionColumn<StUsdsTxRow>[] = [
   {
     id: 'action',
     header: <Trans>Transaction</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAction
-        icon={
-          row.isSupply ? (
-            <SavingsSupply width={16} height={15} />
-          ) : (
-            <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
-          )
-        }
-        label={
-          <span className="flex items-center gap-1.5">
-            {row.isSupply ? <Trans>Supply</Trans> : <Trans>Withdrawal</Trans>}
-            {row.viaCurve && (
-              <span className="text-textSecondary text-xs">
-                <Trans>via Curve</Trans>
-              </span>
-            )}
-          </span>
-        }
-      />
-    )
+    cell: row => actionCell(row)
   },
   {
     id: 'amount',
     header: <Trans>Amount</Trans>,
     width: '1.5fr',
-    cell: row => (
-      <CellAmount
-        icon={<TokenIcon token={{ symbol: 'USDS' }} width={12} showChainIcon={false} className="h-3 w-3" />}
-        amount={`${row.amount} USDS`}
-        usd={row.usd}
-      />
-    )
+    cell: amountCell
   },
   {
     id: 'hash',
@@ -78,6 +84,16 @@ const COLUMNS: ProductTransactionColumn<StUsdsTxRow>[] = [
     cell: row => <span className="text-textSecondary text-sm">{row.time}</span>
   }
 ];
+
+// M5 mobile card (Figma 486:20827 pattern): the Time column folds into the
+// header subline, the hash becomes the View transaction button.
+const renderCard = (row: StUsdsTxRow) => (
+  <TransactionCard
+    header={actionCell(row, row.time)}
+    fields={[{ label: <Trans>Amount</Trans>, value: amountCell(row) }]}
+    link={{ label: <Trans>View transaction</Trans>, href: row.txHref }}
+  />
+);
 
 /**
  * stUSDS supply/withdraw history (native module events + Curve pool swaps,
@@ -113,6 +129,7 @@ export function StUsdsTransactionsTable() {
       rowKey={row => row.id}
       isLoading={isLoading}
       error={error}
+      renderCard={renderCard}
     />
   );
 }

--- a/docs/responsive-breakpoints.md
+++ b/docs/responsive-breakpoints.md
@@ -59,6 +59,27 @@ ordinal mirrors the legacy Tailwind scale (`sm 0 … 2xl 5`); for new code
 compare against `BP.md` (mobile cutoff) or `BP.desktop` only, matching the
 three-tier strategy above.
 
+## Tables on narrow viewports (M5, APP-371)
+
+Redesigned tables never squish or overflow the page on phones. Below `BP.md`
+(768 — the same JS cutoff `ResponsiveModal` uses for Dialog → bottom sheet)
+they reflow; from 768 up the `<table>` renders unchanged. Per-table pattern:
+
+| Table                                                                                     | Pattern below 768                                                                                                                                                          |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Earn marketplace (`EarnTable`)                                                            | Accordion cards (Figma 486:22119): token + Rate collapsed, field grid + Supply/View details expanded. Sort headers are desktop-only.                                       |
+| Product transactions (Savings/Vault/Pendle/Rewards/StUsds via `ProductTransactionsTable`) | `TransactionCard` list (Figma 486:20827): action header (+status badge), label/value field grid, "View transaction" button. A `time` column folds into the header subline. |
+| Stake activity + positions                                                                | Same `TransactionCard` collapse (no stake mobile comp yet — inferred; positions keep tap-to-manage and the liquidation banner).                                            |
+| Portfolio Idle (`IdleStablecoinsTable`)                                                   | `TransactionCard` with a Balance field and the Supply CTA (inferred, no comp).                                                                                             |
+| Morpho vault allocations (legacy surface)                                                 | Horizontal scroll with `scrollbar-thin-always` — dense analytical grid, no comp; the redesigned vault page uses `VaultStrategy` instead.                                   |
+
+Mechanics: `ProductTransactionsTable` accepts `renderCard` — when provided and
+`bpi < BP.md`, the table swaps for a card list with the same pagination,
+loading/empty/error states, `onRowClick` and `renderBelowRow`. Cards stack
+flush with 2px gaps and round only the list's outer corners (20px), mirroring
+the desktop table surface. Shared primitives live in
+`components/product/TransactionCard.tsx`.
+
 ## Viewport height units (`dvh` / `svh`)
 
 On mobile browsers the URL bar and toolbars collapse as you scroll, so the


### PR DESCRIPTION
### What does this PR do?

Reflows every redesigned table into stacked cards below 768px (APP-371 / APP-385 — M5 of Track M). Desktop tables are unchanged from 768px up.

- **Mechanism (once, at the shared primitive):** `ProductTransactionsTable` gains a `renderCard` prop — below `BP.md` (768, the same JS cutoff `ResponsiveModal` uses) the `<table>` swaps for a card list that keeps pagination, loading/empty/error states, `onRowClick` and `renderBelowRow`.
- **Shared `TransactionCard`** (Figma mobile Table Sections 486:20827 / 486:20198): action header with optional status badge, two-per-row label/value field grid with hairline dividers, "View transaction ↗" secondary button. Card lists stack flush with 2px gaps and round only the list's outer corners (20px), mirroring the desktop table surface — measured from the comps' rendered pixels (codegen omits the radius).
- **Consumer sweep (7 tables):** Savings, Vault, Pendle, Rewards, stUSDS (their `Time` column folds into the card header subline), Stake activity, Stake positions (keeps tap-to-manage and the liquidation banner under its card).
- **`EarnTable` → accordion cards** (Figma 486:22119): collapsed = token cell + Rate + chevron; expanded = Network/Risk, Rate/30D Rate, TVL/My position grid + Supply / View details. Sort headers are desktop-only (no mobile affordance in the comp).
- **`IdleStablecoinsTable`** reuses the card with a Balance field and the Supply CTA (no comp — inferred).
- **Morpho allocations** (legacy-only surface; the redesigned vault route renders `VaultStrategy` instead) keeps horizontal scroll with the always-visible thin scrollbar, documented in-code.
- Pattern-per-table documented in `docs/responsive-breakpoints.md`.

Deviations flagged for design/product (tracked on APP-387): the comp's first Earn field row is labeled "My position" but shows chain icons (shipped as "Network"); the Savings comp's From/To pair needs historical share data (APP-300) so a single Amount field stands in; Supply and View details both navigate to the product page pending a supply deep-link; stake/Idle cards are inferred. Mobile filter controls over the card lists are APP-386.

### Testing steps:

1. `pnpm dev:mock`, open http://localhost:3000/earn at a ~390px viewport: the marketplace renders accordion cards; tap a row to expand (field grid + Supply/View details), Supply/View details navigate to the product page.
2. On `/earn/savings` (and any product page) the Transactions section renders cards — action + time header, status badge, Amount field, working "View transaction" link with 8px icon separation; pagination and the action-type filter behave as on desktop.
3. `/portfolio` → Idle tab (with idle stablecoins): one card per token with Balance + Supply CTA.
4. Resize to ≥768: every table renders exactly as before (sortable Earn table, all transaction tables); no horizontal document overflow at any width down to 360.
5. `pnpm -F webapp test:unit` equivalent: `pnpm exec vitest run` in `apps/webapp` — 1970 tests green (17 new across ProductTransactionsTable, TransactionCard, EarnTable, SavingsTransactionsTable, StakePositionsTable, IdleStablecoinsTable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMwG24Q3jMMF5vvDjnHjuA
