### PR TITLE
M4.5: More menu opens as a bottom panel on phones

### DIFF
--- a/apps/webapp/src/components/BatchTransactionsToggle.tsx
+++ b/apps/webapp/src/components/BatchTransactionsToggle.tsx
@@ -27,7 +27,9 @@ export function BatchTransactionsToggle() {
   return (
     <div className="flex w-full flex-col gap-2">
       <div className="flex items-center justify-between">
-        <span className="text-fgPrimary font-circle flex items-center gap-2 text-sm leading-4 font-medium tracking-[-0.28px]">
+        {/* Label 4 (16/18) in the M4.5 mobile panel, Label 5 (14/16) in the
+            desktop dropdown — md is also where the menu surface swaps. */}
+        <span className="text-fgPrimary font-circle flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:text-sm md:leading-4 md:tracking-[-0.28px]">
           <Zap size={16} className="text-fgBrand shrink-0" />
           <Trans>Bundle transactions</Trans>
         </span>
@@ -40,7 +42,9 @@ export function BatchTransactionsToggle() {
           data-testid="batch-transactions-switch"
         />
       </div>
-      <p className="text-fgSecondary max-w-[216px] text-[11px] leading-4">
+      {/* Width cap is the desktop dropdown's 216px explainer column; the M4.5
+          mobile panel (Figma 536:26429) lets it run the full panel width. */}
+      <p className="text-fgSecondary text-[11px] leading-4 md:max-w-[216px]">
         {batchNotSupported ? (
           <>
             <Trans>Your wallet does not currently support bundled transactions.</Trans>{' '}

--- a/apps/webapp/src/components/ThemeToggle.tsx
+++ b/apps/webapp/src/components/ThemeToggle.tsx
@@ -13,7 +13,9 @@ export function ThemeToggle() {
 
   return (
     <div className="flex w-full items-center justify-between">
-      <span className="text-fgPrimary font-circle flex items-center gap-2 text-sm leading-4 font-medium tracking-[-0.28px]">
+      {/* Label 4 (16/18) in the M4.5 mobile panel, Label 5 (14/16) in the
+          desktop dropdown — md is also where the menu surface swaps. */}
+      <span className="text-fgPrimary font-circle flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:text-sm md:leading-4 md:tracking-[-0.28px]">
         <Moon size={16} className="text-fgBrand shrink-0" />
         <Trans>Dark mode</Trans>
       </span>

--- a/apps/webapp/src/modules/app/shell/TopNav.test.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.test.tsx
@@ -27,6 +27,16 @@ const mocks = vi.hoisted(() => ({
   setIsAutoSwitching: vi.fn()
 }));
 
+// Pin the JS breakpoint per test (happy-dom's 1024 viewport = desktop popover).
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
 vi.mock('wagmi', async importOriginal => {
   const actual = await importOriginal<typeof import('wagmi')>();
   return {
@@ -223,6 +233,51 @@ describe('TopNav More menu', () => {
 
     fireEvent.click(screen.getByTestId('nav-more-cookie-settings'));
     expect(mocks.showBanner).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TopNav More menu — mobile bottom panel (M4.5)', () => {
+  beforeEach(() => {
+    breakpoint.isMobile = true;
+  });
+  afterEach(() => {
+    breakpoint.isMobile = false;
+  });
+
+  it('opens the comp bottom panel (dialog with More heading + close) instead of the popover', async () => {
+    vi.stubEnv('VITE_FOOTER_LINKS', JSON.stringify([{ url: 'https://sky.money/terms', name: 'Terms' }]));
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-more'));
+
+    const panel = await screen.findByRole('dialog');
+    expect(panel).toBeTruthy();
+    expect(screen.getByText('More')).toBeTruthy();
+    // Same rows as the desktop menu (content parity; comp omits Dark mode — kept deliberately).
+    expect(screen.getByTestId('batch-transactions-toggle-stub')).toBeTruthy();
+    expect(screen.getByTestId('theme-toggle-stub')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Terms/ })).toBeTruthy();
+    expect(screen.getByTestId('nav-more-cookie-settings')).toBeTruthy();
+  });
+
+  it('closes through the panel close button', async () => {
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-more'));
+    fireEvent.click(await screen.findByTestId('nav-more-close'));
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('still opens the cookie banner from the panel', async () => {
+    renderTopNav();
+
+    fireEvent.click(await screen.findByTestId('nav-more'));
+    fireEvent.click(await screen.findByTestId('nav-more-cookie-settings'));
+
+    expect(mocks.showBanner).toHaveBeenCalledTimes(1);
+    // The row closes the panel like the desktop menu does.
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 });
 

--- a/apps/webapp/src/modules/app/shell/TopNav.tsx
+++ b/apps/webapp/src/modules/app/shell/TopNav.tsx
@@ -2,12 +2,15 @@ import { useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { Cookie, FileText, FileWarning, Menu, Shield, X } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
+import { t } from '@lingui/core/macro';
 import { cn } from '@/lib/cn';
+import { BP, useBreakpointIndex } from '@/hooks';
 import { buttonVariants } from '@/components/ui/button';
 import { getFooterLinks, sanitizeUrl } from '@/lib/utils';
 import { BATCH_TX_ENABLED } from '@/lib/constants';
 import { useNewIntentDots } from '@/modules/app/hooks/useNewIntentDots';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { BatchTransactionsToggle } from '@/components/BatchTransactionsToggle';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { WalletChip } from './WalletChip';
@@ -21,10 +24,12 @@ import { DESTINATIONS, navTestId, useActiveDestinationPath, useDestinationLinkPr
 // styling keys off the link's aria-current="page".
 const navItemClasses = cn(buttonVariants({ variant: 'navbar', size: 'navbar' }), 'relative');
 
-// Menu dropdown row (Figma 5069:27509): 16px glyph + Label 5 on fg-primary,
-// 8px apart; rows sit bare on the panel (no pill/tint), 20px between them.
+// Menu dropdown row (Figma 5069:27509): 16px glyph + label on fg-primary,
+// 8px apart; rows sit bare on the panel (no pill/tint). The M4.5 mobile panel
+// (536:26429) steps the label up to 16/18 (Label 4); the desktop popover
+// keeps 14/16 (Label 5) from md up — the same cutoff that swaps the surface.
 const moreItemClasses =
-  'text-fgPrimary hover:text-fgSecondary font-circle flex items-center gap-2 text-left text-sm leading-4 font-medium tracking-[-0.28px] transition-colors';
+  'text-fgPrimary hover:text-fgSecondary font-circle flex items-center gap-2 text-left text-base leading-[18px] font-medium tracking-[-0.32px] transition-colors md:text-sm md:leading-4 md:tracking-[-0.28px]';
 
 // Env-driven legal links pick their DS glyph by name (User Risk Documentation /
 // Terms of Use / Privacy Policy in the comp); anything else gets the document glyph.
@@ -35,23 +40,115 @@ function linkIcon(name: string) {
   return FileText;
 }
 
+/**
+ * Shared body of the More menu: bundling toggle + hairline, then the theme
+ * toggle, legal links and cookie row. `mobile` swaps the desktop row rhythm
+ * (20px gaps) for the comp's 40px touch rows with 2px gaps (Figma 536:26429).
+ */
+function MoreMenuContent({ mobile, closeMenu }: { mobile?: boolean; closeMenu: () => void }) {
+  const { showBanner } = useCookieConsent();
+  const footerLinks = getFooterLinks();
+
+  return (
+    <>
+      {BATCH_TX_ENABLED && (
+        <>
+          <BatchTransactionsToggle />
+          <div className="bg-glassBorder h-px w-full" />
+        </>
+      )}
+      <div className={cn('flex flex-col', mobile ? 'gap-0.5 *:min-h-10' : 'gap-5')}>
+        <ThemeToggle />
+        {footerLinks.map(link => {
+          const url = sanitizeUrl(link.url);
+          if (!url) return null;
+          const Icon = linkIcon(link.name);
+          return (
+            <ExternalLink key={url} href={url} showIcon={false} className={moreItemClasses}>
+              {/* Single child: ExternalLink HStack-wraps element children, which
+                  would swallow the anchor's gap and leave the glyph flush. */}
+              <span className="flex items-center gap-2">
+                <Icon size={16} className="text-fgBrand shrink-0" />
+                {link.name}
+              </span>
+            </ExternalLink>
+          );
+        })}
+        {POSTHOG_ENABLED && (
+          <button
+            data-testid="nav-more-cookie-settings"
+            onClick={() => {
+              closeMenu();
+              showBanner();
+            }}
+            className={moreItemClasses}
+          >
+            <Cookie size={16} className="text-fgBrand shrink-0" />
+            <Trans>Cookie settings</Trans>
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
 /** Secondary actions that don't earn a destination: toggles, legal links. */
 function MoreMenu() {
   const [isOpen, setIsOpen] = useState(false);
-  const { showBanner } = useCookieConsent();
-  const footerLinks = getFooterLinks();
   const closeMenu = () => setIsOpen(false);
+  const { bpi } = useBreakpointIndex();
+
+  // Menu type of Button / Navbar: Radix supplies data-state=open for the
+  // active recipe, and the glyph flips hamburger → X while open.
+  const trigger = isOpen ? (
+    <X size={16} className="nav-menu-icon" />
+  ) : (
+    <Menu size={16} className="nav-menu-icon" />
+  );
+  const triggerClasses = cn(buttonVariants({ variant: 'navbar', size: 'navbar' }), 'w-10 px-0');
+
+  // M4.5 (Figma 536:26429): below md the popover becomes a bottom-anchored
+  // floating panel — 12px viewport insets (the DS in-situ inset), 24px radius,
+  // its own More heading + 32px circular close. Same rows as the desktop
+  // menu; the comp's Upgrade DAI/MKR row stays omitted (E2 parked) and the
+  // Dark mode row stays included (content parity — flagged on APP-388).
+  if (bpi < BP.md) {
+    return (
+      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+        <SheetTrigger data-testid="nav-more" aria-label="More" className={triggerClasses}>
+          {trigger}
+        </SheetTrigger>
+        {/* light:bg-container — the 5% lavender surface disappears over the
+            overlay-dimmed page, so the panel takes the opaque light container
+            token (the "popovers read on the light page" elevation). */}
+        <SheetContent
+          side="bottom"
+          hideCloseButton
+          aria-describedby={undefined}
+          className="bg-bgSecondary light:bg-container inset-x-3 bottom-[max(12px,env(safe-area-inset-bottom))] flex flex-col gap-6 rounded-[24px] border-0 px-5 py-6 shadow-none backdrop-blur-[100px]"
+        >
+          <div className="flex items-center justify-between">
+            <SheetTitle className="text-fgPrimary font-circle text-sm leading-4 font-medium tracking-[-0.28px]">
+              <Trans>More</Trans>
+            </SheetTitle>
+            <SheetClose
+              data-testid="nav-more-close"
+              aria-label={t`Close menu`}
+              className={cn(buttonVariants({ variant: 'secondary', size: 'iconS' }))}
+            >
+              <X aria-hidden />
+            </SheetClose>
+          </div>
+          <MoreMenuContent mobile closeMenu={closeMenu} />
+        </SheetContent>
+      </Sheet>
+    );
+  }
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      {/* Menu type of Button / Navbar: Radix supplies data-state=open for the
-          active recipe, and the glyph flips hamburger → X while open. */}
-      <PopoverTrigger
-        data-testid="nav-more"
-        aria-label="More"
-        className={cn(buttonVariants({ variant: 'navbar', size: 'navbar' }), 'w-10 px-0')}
-      >
-        {isOpen ? <X size={16} className="nav-menu-icon" /> : <Menu size={16} className="nav-menu-icon" />}
+      <PopoverTrigger data-testid="nav-more" aria-label="More" className={triggerClasses}>
+        {trigger}
       </PopoverTrigger>
       {/* Menu dropdown panel (Figma 5069:27495): 274px glass panel — bg-secondary
           over a 100px backdrop blur, 24px radius, 20px padding, 24px between
@@ -61,43 +158,7 @@ function MoreMenu() {
         align="end"
         className="bg-bgSecondary flex w-[274px] flex-col gap-6 rounded-3xl p-5 shadow-none backdrop-blur-[100px]"
       >
-        {BATCH_TX_ENABLED && (
-          <>
-            <BatchTransactionsToggle />
-            <div className="bg-glassBorder h-px w-full" />
-          </>
-        )}
-        <div className="flex flex-col gap-5">
-          <ThemeToggle />
-          {footerLinks.map(link => {
-            const url = sanitizeUrl(link.url);
-            if (!url) return null;
-            const Icon = linkIcon(link.name);
-            return (
-              <ExternalLink key={url} href={url} showIcon={false} className={moreItemClasses}>
-                {/* Single child: ExternalLink HStack-wraps element children, which
-                    would swallow the anchor's gap and leave the glyph flush. */}
-                <span className="flex items-center gap-2">
-                  <Icon size={16} className="text-fgBrand shrink-0" />
-                  {link.name}
-                </span>
-              </ExternalLink>
-            );
-          })}
-          {POSTHOG_ENABLED && (
-            <button
-              data-testid="nav-more-cookie-settings"
-              onClick={() => {
-                closeMenu();
-                showBanner();
-              }}
-              className={moreItemClasses}
-            >
-              <Cookie size={16} className="text-fgBrand shrink-0" />
-              <Trans>Cookie settings</Trans>
-            </button>
-          )}
-        </div>
+        <MoreMenuContent closeMenu={closeMenu} />
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
### What does this PR do?
<img width="435" height="939" alt="image" src="https://github.com/user-attachments/assets/b63ac968-36a9-4aba-af70-579a88fdaaec" />

M4.5 (APP-388): below 768px the hamburger "More" menu opens as the mobile comp's bottom panel (Figma 536:26429) instead of the floating desktop popover.

- **Presentation switch at `BP.md`** (the M4/M5 cutoff): the menu body is extracted into a shared `MoreMenuContent`; below md it renders in a bottom-anchored Sheet — 12px viewport insets (+ safe-area), 24px radius, `px-5 py-6`, "More" heading with a 32px circular ✕ (DS secondary icon button). Desktop popover at 768px+ is unchanged.
- **Comp-verified type scale:** mobile row labels step up to Label 4 (16/18, −0.32px) from the desktop dropdown's Label 5 (14/16) — confirmed by measuring identical text-run widths against the comp render at the same scale ("Bundle transactions": comp 137px vs app 135.4px after the fix). Heading stays 14px; explainer stays 11px. Rows become 40px touch targets (42px pitch, from the comp's pixels).
- **Batch explainer** loses its 216px cap below md (full panel width per comp); CSS-only.
- **Light theme fix:** the translucent `bgSecondary` surface disappeared over the overlay-dimmed page, so the panel takes `light:bg-container` — the opaque light elevation token documented for popovers/banners reading on the light page. Dark keeps the comp's frosted look.
- Deviations (pre-flagged on APP-388): Upgrade DAI/MKR row stays omitted (E2 parked); Dark mode row stays included for content parity with the desktop menu.

### Testing steps:

1. `pnpm dev:mock`, open any page at a ~393px viewport, tap the hamburger: the bottom panel opens with the More heading, Bundle transactions switch + explainer, divider, Dark mode + legal links + Cookie settings rows; ✕ closes it; Cookie settings opens the banner and closes the panel.
2. Toggle Dark mode from the panel and check both themes — the panel surface stays legible in light.
3. At ≥768px the hamburger opens the existing 274px dropdown, byte-identical.
4. `pnpm exec vitest run src/modules/app/shell/TopNav.test.tsx` — 21 tests (3 new mobile-panel tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMwG24Q3jMMF5vvDjnHjuA
