### PR TITLE
M4.6: Wallet preview opens as a full-screen bottom panel on phones

### DIFF
--- a/apps/webapp/src/modules/app/shell/NetworkSelector.tsx
+++ b/apps/webapp/src/modules/app/shell/NetworkSelector.tsx
@@ -1,6 +1,7 @@
 import { ChainModal } from '@/modules/ui/components/ChainModal';
 
 /** Drawer-embedded network control. Presentation wrapper only — switching logic stays in ChainModal. */
-export function NetworkSelector() {
-  return <ChainModal dataTestId="wallet-drawer-network" />;
+export function NetworkSelector({ compact = false }: { compact?: boolean }) {
+  // The M4.6 mobile panel pairs the 32px total with the DS Network XS pill.
+  return <ChainModal dataTestId="wallet-drawer-network" size={compact ? 'xs' : 'm'} />;
 }

--- a/apps/webapp/src/modules/app/shell/WalletDrawerAssets.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletDrawerAssets.tsx
@@ -39,7 +39,7 @@ export function WalletDrawerAssets() {
 
   if (isLoading && assets.every(asset => asset.amountUsd === 0)) {
     return (
-      <div className="flex flex-col gap-2 p-4" data-testid="wallet-drawer-assets">
+      <div className="flex flex-col gap-2 px-2 py-3 md:p-4" data-testid="wallet-drawer-assets">
         {Array.from({ length: 4 }).map((_, index) => (
           <Skeleton key={index} className="h-16 rounded-2xl" />
         ))}
@@ -72,7 +72,7 @@ function AssetRow({
 }) {
   return (
     <div
-      className="group light:focus-within:bg-[#1a1855]/5 light:hover:bg-[#1a1855]/5 rounded-2xl p-4 transition-colors focus-within:bg-[#bcb6ef]/5 hover:bg-[#bcb6ef]/5"
+      className="group light:focus-within:bg-[#1a1855]/5 light:hover:bg-[#1a1855]/5 rounded-2xl px-2 py-3 transition-colors focus-within:bg-[#bcb6ef]/5 hover:bg-[#bcb6ef]/5 md:p-4"
       data-testid={`wallet-drawer-asset-${asset.symbol.toLowerCase()}`}
     >
       <div className="flex items-center justify-between">
@@ -82,7 +82,10 @@ function AssetRow({
           </span>
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
-              <Text tag="span" className="font-circle text-text text-lg leading-[22px] tracking-tight">
+              <Text
+                tag="span"
+                className="font-circle text-text text-base leading-[18px] tracking-tight md:text-lg md:leading-[22px]"
+              >
                 {asset.symbol}
               </Text>
               {showEarnActions && asset.bestRate !== undefined && asset.bestRate > 0 && (
@@ -95,16 +98,27 @@ function AssetRow({
                 </RateBadge>
               )}
             </div>
-            <Text tag="span" variant="captionSm" className="text-textSecondary">
+            <Text
+              tag="span"
+              variant="captionSm"
+              className="text-textSecondary text-[11px] leading-4 md:text-xs"
+            >
               {asset.name}
             </Text>
           </div>
         </div>
         <div className="flex flex-col items-end gap-0.5">
-          <Text tag="span" className="font-circle text-text text-lg leading-[22px] tracking-tight">
+          <Text
+            tag="span"
+            className="font-circle text-text text-base leading-[18px] tracking-tight md:text-lg md:leading-[22px]"
+          >
             {formatNumber(asset.amount)}
           </Text>
-          <Text tag="span" variant="captionSm" className="text-textSecondary">
+          <Text
+            tag="span"
+            variant="captionSm"
+            className="text-textSecondary text-[11px] leading-4 md:text-xs"
+          >
             {formatUsd(asset.amountUsd)}
           </Text>
         </div>
@@ -131,7 +145,7 @@ function AssetRow({
 function RateBadge({ children }: { children: ReactNode }) {
   return (
     <span className="inline-flex items-center rounded-full border-[0.5px] border-[#02c2a1] bg-gradient-to-b from-[#02c2a1]/10 to-[#9fde88]/10 px-1.5 py-[3px]">
-      <span className="font-circle bg-gradient-to-b from-[#02c2a1] to-[#9fde88] bg-clip-text text-xs leading-[14px] font-medium text-transparent">
+      <span className="font-circle bg-gradient-to-b from-[#02c2a1] to-[#9fde88] bg-clip-text text-[11px] leading-3 font-medium text-transparent md:text-xs md:leading-[14px]">
         {children}
       </span>
     </span>

--- a/apps/webapp/src/modules/app/shell/WalletDrawerTabs.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletDrawerTabs.tsx
@@ -15,7 +15,9 @@ export function WalletDrawerTabs() {
 
   return (
     <Tabs defaultValue={WalletDrawerTab.ASSETS} className="flex min-h-0 flex-1 flex-col">
-      <TabsList variant="pills" className="mb-6 px-4">
+      {/* Base = the M4.6 mobile panel (20px content inset via the body's pl-3
+          + px-2 here); md: restores the desktop drawer's 28px inset. */}
+      <TabsList variant="pills" className="mb-4 px-2 md:mb-6 md:px-4">
         <TabsTrigger value={WalletDrawerTab.ASSETS} variant="pill" data-testid="wallet-drawer-tab-assets">
           <Trans>Assets</Trans>
         </TabsTrigger>
@@ -31,7 +33,7 @@ export function WalletDrawerTabs() {
       </TabsContent>
       <TabsContent
         value={WalletDrawerTab.ACTIVITY}
-        className="scrollbar-thin-always min-h-0 flex-1 overflow-auto px-4"
+        className="scrollbar-thin-always min-h-0 flex-1 overflow-auto px-2 md:px-4"
       >
         <BalancesHistory
           onExternalLinkClicked={onExternalLinkClicked}

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.test.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     connector: undefined
   },
   chainId: 1,
+  isMobile: false,
   isSafeWallet: false,
   isRegionRestricted: false,
   walletAssets: {
@@ -71,7 +72,13 @@ vi.mock('wagmi', async importOriginal => {
 
 vi.mock('@/hooks', async importOriginal => {
   const actual = await importOriginal<typeof import('@/hooks')>();
-  return { ...actual, useIsSafeWallet: () => mocks.isSafeWallet };
+  return {
+    ...actual,
+    useIsSafeWallet: () => mocks.isSafeWallet,
+    // happy-dom evaluates matchMedia at its 1024px default, so the real hook
+    // always lands on the desktop drawer; the flag drives the M4.6 mobile panel.
+    useBreakpointIndex: () => ({ bpi: mocks.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
 });
 
 vi.mock('@/modules/ui/context/ConnectModalContext', async importOriginal => {
@@ -110,6 +117,7 @@ vi.mock('@/modules/geo-config', async importOriginal => {
 beforeEach(() => {
   mocks.connection = { isConnected: true, address: ADDRESS, connector: undefined };
   mocks.chainId = 1;
+  mocks.isMobile = false;
   mocks.isSafeWallet = false;
   mocks.isRegionRestricted = false;
   mocks.disconnect.mockClear();
@@ -287,5 +295,62 @@ describe('WalletPreviewDrawer', () => {
     });
 
     expect(screen.queryByTestId('wallet-drawer')).toBeNull();
+  });
+
+  it('keeps the desktop collapse rail and no header close button at md+', async () => {
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    expect(drawer.querySelector('[data-testid="wallet-drawer-collapse"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="wallet-drawer-close"]')).toBeNull();
+  });
+});
+
+describe('WalletPreviewDrawer — mobile panel (M4.6)', () => {
+  beforeEach(() => {
+    mocks.isMobile = true;
+  });
+
+  it('presents the full panel with a header close button instead of the collapse rail', async () => {
+    renderDrawer({ ensName: 'bartoo.eth' });
+    const drawer = await openDrawer();
+
+    expect(drawer.querySelector('[data-testid="wallet-drawer-close"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="wallet-drawer-collapse"]')).toBeNull();
+    // Same content contract as the desktop drawer.
+    expect(drawer.textContent).toContain('bartoo.eth');
+    expect(drawer.querySelector('[data-testid="wallet-drawer-total"]')?.textContent).toContain('2,000');
+    expect(drawer.querySelector('[data-testid="wallet-drawer-network"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="wallet-drawer-assets"]')).toBeTruthy();
+  });
+
+  it('dismisses via the header close button', async () => {
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    fireEvent.click(drawer.querySelector('[data-testid="wallet-drawer-close"]')!);
+    expect(screen.queryByTestId('wallet-drawer')).toBeNull();
+  });
+
+  it('keeps switch-account and disconnect working in the mobile header', async () => {
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    fireEvent.click(drawer.querySelector('[data-testid="wallet-drawer-disconnect"]')!);
+    expect(mocks.disconnect).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(drawer.querySelector('[data-testid="wallet-drawer-switch-account"]')!);
+    expect(mocks.openConnectModal).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('wallet-drawer')).toBeNull();
+  });
+
+  it('still shows the close button for Safe wallets while hiding the account actions', async () => {
+    mocks.isSafeWallet = true;
+    renderDrawer();
+    const drawer = await openDrawer();
+
+    expect(drawer.querySelector('[data-testid="wallet-drawer-close"]')).toBeTruthy();
+    expect(drawer.querySelector('[data-testid="wallet-drawer-switch-account"]')).toBeNull();
+    expect(drawer.querySelector('[data-testid="wallet-drawer-disconnect"]')).toBeNull();
   });
 });

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
@@ -3,6 +3,7 @@ import { useRouterState } from '@tanstack/react-router';
 import { ChevronsRight } from 'lucide-react';
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { t } from '@lingui/core/macro';
+import { BP, useBreakpointIndex } from '@/hooks';
 import { useConnectModal } from '@/modules/ui/context/ConnectModalContext';
 import { WalletPreviewHeader } from './WalletPreviewHeader';
 import { WalletDrawerTabs } from './WalletDrawerTabs';
@@ -16,9 +17,11 @@ interface WalletPreviewDrawerProps {
 }
 
 /**
- * V2 right slide-out wallet preview opened from the wallet chip: a floating
- * rounded panel with a collapse rail, gradient identity header and
- * Assets/Activity tabs.
+ * V2 wallet preview opened from the wallet chip. At md+ it's the right
+ * slide-out drawer: a floating rounded panel with a collapse rail, gradient
+ * identity header and Assets/Activity tabs. Below md (Figma 536:26681, M4.6)
+ * the same content presents as a bottom-anchored panel with 12px viewport
+ * insets and a close button in the header instead of the rail.
  */
 export function WalletPreviewDrawer({
   isOpen,
@@ -29,6 +32,8 @@ export function WalletPreviewDrawer({
 }: WalletPreviewDrawerProps) {
   const locationHref = useRouterState({ select: s => s.location.href });
   const { openConnectModal } = useConnectModal();
+  const { bpi } = useBreakpointIndex();
+  const isMobile = bpi < BP.md;
 
   useEffect(() => {
     // Any navigation closes the preview.
@@ -39,6 +44,39 @@ export function WalletPreviewDrawer({
     onOpenChange(false);
     openConnectModal();
   };
+
+  if (isMobile) {
+    return (
+      <Sheet open={isOpen} onOpenChange={onOpenChange}>
+        {/* The comp's panel hugs its content above a 12px bottom inset; the
+            max-height (68px topbar + 12px inset each side) only bites when the
+            Activity tab grows past the viewport and the tab panel scrolls. */}
+        <SheetContent
+          side="bottom"
+          data-testid="wallet-drawer"
+          aria-describedby={undefined}
+          hideCloseButton
+          className="light:border-[#1a1855]/10 bg-containerDark inset-x-3 bottom-[max(12px,env(safe-area-inset-bottom))] h-auto max-h-[calc(100dvh-92px)] gap-0 overflow-hidden rounded-[28px] border border-[#bcb6ef]/10 p-0 backdrop-blur-sm"
+          onOpenAutoFocus={e => e.preventDefault()}
+          onCloseAutoFocus={e => e.preventDefault()}
+        >
+          <SheetTitle className="sr-only">{t`Account`}</SheetTitle>
+          <WalletPreviewHeader
+            mobile
+            ensName={ensName}
+            ensAvatar={ensAvatar}
+            onSwitchAccountClick={onSwitchAccountClick}
+            onDisconnect={onDisconnect}
+          />
+          {/* pr compensates the 10px scrollbar gutter reserved inside the tab
+              panels; pl-3 + the panels' px-2 lands the comp's 20px inset. */}
+          <div className="flex min-h-0 flex-1 flex-col pt-6 pr-0.5 pb-3 pl-3">
+            <WalletDrawerTabs />
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
 
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>

--- a/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from 'react';
 import { useConnection } from 'wagmi';
 import { t } from '@lingui/core/macro';
-import { ArrowLeftRight, Unlink } from 'lucide-react';
+import { ArrowLeftRight, Unlink, X } from 'lucide-react';
+import { cn } from '@/lib/cn';
 import { useIsSafeWallet } from '@/hooks';
 import { WALLET_ICONS } from '@/lib/constants';
 import { formatUsd } from '@/utils';
@@ -10,16 +11,23 @@ import { CustomAvatar } from '@/modules/ui/components/Avatar';
 import { WalletIcon } from '@/modules/ui/components/WalletIcon';
 import { CopyToClipboard } from '@/widgets/shared/components/ui/CopyToClipboard';
 import { Skeleton } from '@/components/ui/skeleton';
+import { SheetClose } from '@/components/ui/sheet';
 import { NetworkSelector } from './NetworkSelector';
 import { useWalletDrawerAssets } from './useWalletDrawerAssets';
 
 const formatAddress = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+
+const iconButtonClasses =
+  'flex size-8 items-center justify-center rounded-full border border-[#bcb6ef]/10 bg-gradient-to-b from-white/0 to-white/8 bg-origin-border text-[#f2f3f7] transition-colors hover:bg-white/10';
 
 interface WalletPreviewHeaderProps {
   ensName?: string | null;
   ensAvatar?: string | null;
   onSwitchAccountClick: () => void;
   onDisconnect: () => void;
+  /** M4.6 mobile panel: tighter type scale, 24px avatar and a close button
+   *  in the action row (the drawer's collapse rail doesn't exist below md). */
+  mobile?: boolean;
 }
 
 /**
@@ -31,7 +39,8 @@ export function WalletPreviewHeader({
   ensName,
   ensAvatar,
   onSwitchAccountClick,
-  onDisconnect
+  onDisconnect,
+  mobile = false
 }: WalletPreviewHeaderProps) {
   const { address, connector } = useConnection();
   const isSafeWallet = useIsSafeWallet();
@@ -41,14 +50,25 @@ export function WalletPreviewHeader({
   const walletIconUrl = connector?.icon || WALLET_ICONS[connector?.id as keyof typeof WALLET_ICONS];
 
   return (
-    <div className="flex min-h-[280px] shrink-0 flex-col justify-between border-b border-[#bcb6ef]/10 bg-gradient-to-b from-[#2a197d] to-[#504dff] p-7">
+    <div
+      className={cn(
+        'flex shrink-0 flex-col justify-between border-b border-[#bcb6ef]/10 bg-gradient-to-b from-[#2a197d] to-[#504dff]',
+        // The comp's mobile header is content-sized: 72px between the identity
+        // and total rows instead of the desktop's 280px justify-between spread.
+        mobile ? 'gap-[72px] px-5 py-6' : 'min-h-[280px] p-7'
+      )}
+    >
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <div className={cn('flex items-center', mobile ? 'gap-2' : 'gap-3')}>
           <div className="relative flex items-center">
             {ensAvatar ? (
-              <img alt="ENS Avatar" className="size-8 rounded-full" src={ensAvatar} />
+              <img
+                alt="ENS Avatar"
+                className={cn('rounded-full', mobile ? 'size-6' : 'size-8')}
+                src={ensAvatar}
+              />
             ) : (
-              address && <CustomAvatar address={address} size={32} />
+              address && <CustomAvatar address={address} size={mobile ? 24 : 32} />
             )}
             {connector && (
               <div className="absolute -right-0.5 -bottom-0.5 rounded-full bg-white p-0.5">
@@ -57,49 +77,75 @@ export function WalletPreviewHeader({
             )}
           </div>
           <div className="flex flex-col gap-0.5">
-            <Text tag="span" className="font-circle text-base leading-[18px] tracking-tight text-[#f2f3f7]">
+            <Text
+              tag="span"
+              className={cn(
+                'font-circle tracking-tight text-[#f2f3f7]',
+                mobile ? 'text-sm leading-4' : 'text-base leading-[18px]'
+              )}
+            >
               {`${isSafeWallet ? 'safe:' : ''}${ensName || truncatedAddress}`}
             </Text>
             <div className="flex items-center gap-1 text-[#f2f3f7] opacity-60">
-              <Text tag="span" variant="captionSm" className="leading-[18px] text-[#f2f3f7]">
+              <Text
+                tag="span"
+                variant="captionSm"
+                className={cn('text-[#f2f3f7]', mobile ? 'text-[11px] leading-4' : 'leading-[18px]')}
+              >
                 {truncatedAddress}
               </Text>
               <CopyToClipboard text={address || ''} />
             </div>
           </div>
         </div>
-        {!isSafeWallet && (
+        {(!isSafeWallet || mobile) && (
           <div className="flex items-center gap-2">
-            <HeaderIconButton
-              label={t`Switch account`}
-              testId="wallet-drawer-switch-account"
-              onClick={onSwitchAccountClick}
-            >
-              <ArrowLeftRight className="size-3.5" />
-            </HeaderIconButton>
-            <HeaderIconButton
-              label={t`Disconnect wallet`}
-              testId="wallet-drawer-disconnect"
-              onClick={onDisconnect}
-            >
-              <Unlink className="size-3.5" />
-            </HeaderIconButton>
+            {!isSafeWallet && (
+              <>
+                <HeaderIconButton
+                  label={t`Switch account`}
+                  testId="wallet-drawer-switch-account"
+                  onClick={onSwitchAccountClick}
+                >
+                  <ArrowLeftRight className={mobile ? 'size-3' : 'size-3.5'} />
+                </HeaderIconButton>
+                <HeaderIconButton
+                  label={t`Disconnect wallet`}
+                  testId="wallet-drawer-disconnect"
+                  onClick={onDisconnect}
+                >
+                  <Unlink className={mobile ? 'size-3' : 'size-3.5'} />
+                </HeaderIconButton>
+              </>
+            )}
+            {mobile && (
+              <SheetClose
+                data-testid="wallet-drawer-close"
+                aria-label={t`Close`}
+                className={iconButtonClasses}
+              >
+                <X className="size-3" />
+              </SheetClose>
+            )}
           </div>
         )}
       </div>
       <div className="flex items-center justify-between gap-2">
         {totalLoading && totalUsd === 0 ? (
-          <Skeleton className="h-12 w-40" />
+          <Skeleton className={cn(mobile ? 'h-9 w-32' : 'h-12 w-40')} />
         ) : (
           <Text
             tag="span"
             dataTestId="wallet-drawer-total"
-            className="font-circle text-[44px] leading-[48px] tracking-[-0.02em] text-[#f2f3f7]"
+            className={cn(
+              'font-circle tracking-[-0.02em] text-[#f2f3f7]',
+              mobile ? 'text-[32px] leading-[35px]' : 'text-[44px] leading-[48px]'
+            )}
           >
             {formatUsd(totalUsd)}
           </Text>
         )}
-        <NetworkSelector />
+        <NetworkSelector compact={mobile} />
       </div>
     </div>
   );
@@ -123,7 +169,7 @@ function HeaderIconButton({
       title={label}
       data-testid={testId}
       onClick={onClick}
-      className="flex size-8 items-center justify-center rounded-full border border-[#bcb6ef]/10 bg-gradient-to-b from-white/0 to-white/8 bg-origin-border text-[#f2f3f7] transition-colors hover:bg-white/10"
+      className={iconButtonClasses}
     >
       {children}
     </button>

--- a/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
@@ -130,7 +130,10 @@ export function WalletPreviewHeader({
           </div>
         )}
       </div>
-      <div className="flex items-center justify-between gap-2">
+      {/* flex-wrap: a hundreds-of-millions total (formatUsd never compacts)
+          otherwise shoves the network pill past the panel's overflow-hidden
+          edge; wrapped, the pill drops under the figure instead. */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
         {totalLoading && totalUsd === 0 ? (
           <Skeleton className={cn(mobile ? 'h-9 w-32' : 'h-12 w-40')} />
         ) : (

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -42,6 +42,7 @@ export function ChainModal({
   labelClassName,
   showDropdownIcon = true,
   variant = 'default',
+  size = 'm',
   dataTestId = 'chain-modal-trigger',
   children,
   nextIntent,
@@ -53,6 +54,8 @@ export function ChainModal({
   labelClassName?: string;
   showDropdownIcon?: boolean;
   variant?: 'default' | 'widget' | 'wrapper';
+  /** DS Button / Dropdown recipe: Network M (24px icon) or Network XS (16px icon). */
+  size?: 'm' | 'xs';
   dataTestId?: string;
   children?: React.ReactNode;
   nextIntent?: Intent;
@@ -86,7 +89,9 @@ export function ChainModal({
         ) : (
           <Button
             variant={variant === ChainModalVariant.widget ? 'connectPrimary' : 'dropdown'}
-            size={variant === ChainModalVariant.widget ? 'default' : 'dropdownM'}
+            size={
+              variant === ChainModalVariant.widget ? 'default' : size === 'xs' ? 'dropdownXs' : 'dropdownM'
+            }
             className={cn(
               variant === ChainModalVariant.widget
                 ? 'from-primary-start/100 to-primary-end/100 hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 flex items-center gap-1.5 border-transparent bg-radial-(--gradient-position) px-[9px] py-2 bg-blend-overlay hover:border-transparent hover:bg-white/10 focus:border-transparent focus:bg-white/15'
@@ -94,15 +99,31 @@ export function ChainModal({
             )}
             data-testid={dataTestId}
           >
-            {getChainIcon(chainId, variant === ChainModalVariant.widget ? 'h-5 w-5' : 'h-6 w-6')}
+            {getChainIcon(
+              chainId,
+              variant === ChainModalVariant.widget ? 'h-5 w-5' : size === 'xs' ? 'h-4 w-4' : 'h-6 w-6'
+            )}
             {showLabel && (
-              <Text className={cn('text-text', labelClassName)}>{client?.chain.name || 'Ethereum'}</Text>
+              <Text
+                className={cn(
+                  'text-text',
+                  size === 'xs' && 'font-circle text-xs leading-[14px] font-medium tracking-[-0.24px]',
+                  labelClassName
+                )}
+              >
+                {client?.chain.name || 'Ethereum'}
+              </Text>
             )}
             {showDropdownIcon &&
               (variant === ChainModalVariant.widget ? (
                 <ChevronDown width={14} height={14} />
               ) : (
-                <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                <ChevronDown
+                  className={cn(
+                    'transition-transform group-data-[state=open]:rotate-180',
+                    size === 'xs' ? 'size-3' : 'size-4'
+                  )}
+                />
               ))}
           </Button>
         )}

--- a/apps/webapp/src/modules/ui/components/WalletIcon.tsx
+++ b/apps/webapp/src/modules/ui/components/WalletIcon.tsx
@@ -55,8 +55,12 @@ export const WalletIcon = ({ connector, iconUrl, className }: WalletIconProps) =
   return (
     <div
       className={cn(
-        'flex h-10 w-10 items-center justify-center rounded-lg font-semibold text-white',
-        getBackgroundColor()
+        // className must merge here too — callers size this badge (h-3/h-6) and
+        // the fixed 40px fallback used to swallow small avatars for icon-less
+        // connectors (e.g. the mock wallet).
+        'flex h-10 w-10 items-center justify-center overflow-hidden rounded-lg font-semibold text-white',
+        getBackgroundColor(),
+        className
       )}
     >
       {getInitials()}

--- a/docs/responsive-breakpoints.md
+++ b/docs/responsive-breakpoints.md
@@ -59,6 +59,13 @@ ordinal mirrors the legacy Tailwind scale (`sm 0 … 2xl 5`); for new code
 compare against `BP.md` (mobile cutoff) or `BP.desktop` only, matching the
 three-tier strategy above.
 
+Overlays follow the same seam. `ResponsiveModal` (M4.2) and the wallet
+preview drawer (M4.6, `WalletPreviewDrawer`) branch presentation at
+`bpi < BP.md` — bottom/full panel on phones, dialog or side drawer at md+ —
+while their shared children reflow with plain `md:` variants, which sit on
+the same 768px line. Unit tests exercise the mobile branch by mocking
+`useBreakpointIndex` (happy-dom's 1024px default always lands on desktop).
+
 ## Viewport height units (`dvh` / `svh`)
 
 On mobile browsers the URL bar and toolbars collapse as you scroll, so the


### PR DESCRIPTION
Closes APP-389 (M4.6, Track M — sub-issue of M4 / APP-370).

<img width="399" height="851" alt="image" src="https://github.com/user-attachments/assets/e333d5ca-8762-40d6-b8c1-9095bf08e063" />


## What

Below the `md` tier (768px), tapping the wallet chip now opens the mobile comp's panel ([Nav / Wallet preview, 536:26681](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=536-26681&m=dev)) instead of the desktop right-side drawer: a bottom-anchored sheet with 12px viewport insets (+ safe-area), 28px radius, the brand-gradient identity header, total + network selector, and the existing Assets/Activity tabs. The desktop drawer is unchanged at md+.

## How

- **`WalletPreviewDrawer`** branches presentation at `bpi < BP.md` (same seam as M4.2's ResponsiveModal and M4.5's More panel). The mobile `SheetContent` sits on `bg-containerDark` (near-opaque in both themes — no light-theme workaround needed), is content-sized like the comp, and caps at `max-h: calc(100dvh − 92px)` (68px topbar + 12px insets); the tab panels already scroll internally (`overflow-auto`), verified at a 500px-tall viewport.
- **`WalletPreviewHeader`** takes a `mobile` prop: `px-5 py-6` with the comp's 72px identity→total gap (instead of `min-h-[280px]` justify-between), 24px avatar, name Label 4 (14/16), address Body 6 (11px), total Heading 2 (32/35), 12px button glyphs, and a **close button** (`wallet-drawer-close`, `SheetClose`) appended to the action row — the desktop collapse rail doesn't exist below md. Safe wallets keep hiding switch/disconnect but still get the close button.
- **Tabs + asset rows** reflow with plain `md:` variants (Tailwind `md:` and `BP.md` are both 768px, so CSS and the JS switch agree): 20px content insets, symbol/amount Label 3 (16/18 vs desktop 18/22), secondary text 11px, 60px rows, smaller rate badges.
- **`ChainModal`** gains an opt-in `size="xs"` — the DS *Button / Dropdown, Network XS* recipe (`dropdownXs`: 16px chain icon, Label 5 label, 12px chevron, ~28px pill). Only the mobile panel's `NetworkSelector` opts in; every other trigger keeps Network M (consumer tests for stake/pendle/savings/convert pass).
- **`WalletIcon`** initials fallback now merges `className` (pre-existing bug: icon-less connectors, e.g. the mock wallet, rendered a fixed 40px badge that swallowed the 24/32px avatars in the drawer header and ConnectModal).

## Design fidelity

Comp type scale and geometry pixel-verified against the 393px comp render before implementation (insets 12, radius 28, header ≈188px, 32px icon buttons at 8px gaps, avatar 24, rows 60, total 32px, tabs 12px) — the generated-code fallback values checked out this time; the M4.5 one-step-small bug is specific to frame-level `get_variable_defs`.

Deliberate deviations:
- Standard `black/50` overlay instead of the comp's `blur(100px)` scrim — consistency with the M4.2/M4.5 bottom sheets.
- Panel body on `containerDark` (desktop-drawer parity, theme-safe) rather than the comp's translucent `bgSecondary`.
- The wallet-connector badge stays on the avatar (functional parity; the comp omits it).

## Testing

- `WalletPreviewDrawer.test.tsx`: +5 cases (16 total) — mobile panel presents with header close and no collapse rail, close dismisses, switch/disconnect work on mobile, Safe wallets keep close while hiding account actions, desktop keeps the rail and no close. Mobile branch driven through the existing `@/hooks` mock (happy-dom's 1024px default always lands on desktop).
- Full unit suite: **1954/1954**. Typecheck, ESLint, Prettier clean; no i18n catalog churn.
- Browser-audited at 393px (dark + light), 700px (tablet band — bottom panel, no `sm:` misfires), 1512px (desktop regression: rail, 44px total, Network M pill untouched); close/switch/disconnect exercised with real input; internal scroll verified with the max-height cap engaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMwG24Q3jMMF5vvDjnHjuA
