### PR TITLE
M6.3 (APP-378): /earn/savings mobile build per comps

### DIFF
--- a/apps/webapp/src/components/product/PositionHero.tsx
+++ b/apps/webapp/src/components/product/PositionHero.tsx
@@ -21,10 +21,17 @@ export function PositionHero({
 }) {
   const { whole, fraction } = splitAmount(amount);
 
+  // M6.3 mobile (486:20976): 16px inset, 40px pill→balance gap, Heading 3
+  // figure (32/35) with an 18/20 fraction; desktop keeps the C3 scale.
   return (
-    <div className="flex flex-col gap-6 rounded-2xl bg-[linear-gradient(180deg,_rgba(182,179,252,0)_50.24%,_rgba(117,111,236,0.1)_100%)] p-5">
-      <span className="bg-surface text-textSecondary flex w-fit items-center gap-1.5 rounded-full px-3 py-1 text-sm">
-        <TokenIcon token={{ symbol: pillSymbol }} width={16} showChainIcon={false} className="h-4 w-4" />
+    <div className="flex flex-col gap-10 rounded-2xl bg-[linear-gradient(180deg,_rgba(182,179,252,0)_50.24%,_rgba(117,111,236,0.1)_100%)] p-4 md:gap-6 md:p-5">
+      <span className="bg-surface text-textSecondary font-circle md:font-graphik flex w-fit items-center gap-1 rounded-full py-[5px] pr-2 pl-1 text-xs leading-[14px] font-medium tracking-[-0.24px] md:gap-1.5 md:px-3 md:py-1 md:text-sm md:leading-normal md:font-normal md:tracking-normal">
+        <TokenIcon
+          token={{ symbol: pillSymbol }}
+          width={16}
+          showChainIcon={false}
+          className="h-3 w-3 md:h-4 md:w-4"
+        />
         <Trans>My position</Trans>
       </span>
       <span className="text-text flex items-end gap-2 font-semibold">
@@ -34,8 +41,14 @@ export function PositionHero({
           showChainIcon={false}
           className="mb-1 h-8 w-8"
         />
-        <span className="text-4xl leading-none">{whole}</span>
-        {fraction && <span className="text-textSecondary text-2xl leading-tight">.{fraction}</span>}
+        <span className="font-circle md:font-graphik text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:text-4xl md:leading-none md:font-semibold md:tracking-normal">
+          {whole}
+        </span>
+        {fraction && (
+          <span className="text-textSecondary font-circle md:font-graphik text-lg leading-5 font-medium tracking-[-0.36px] md:text-2xl md:leading-tight md:font-semibold md:tracking-normal">
+            .{fraction}
+          </span>
+        )}
       </span>
     </div>
   );

--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
+import { cn } from '@/lib/cn';
 import { AppLink } from '@/lib/navigation';
 import { IconboxStatus } from '@/components/ui/iconbox';
 import { PageHeading } from '@/components/ui/page-header';
@@ -82,30 +83,42 @@ export interface ProductDetailTemplateProps {
 function ProductTitleIcon({ token }: { token: ProductDetailToken }) {
   return (
     <div className="shrink-0" data-testid="product-detail-token-icon">
-      <IconboxStatus size="l">{token.icon}</IconboxStatus>
+      {/* M6.3 mobile header ring is 56px (486:20720); 64 from md. */}
+      <IconboxStatus size="l" className="size-14 md:size-16">
+        {token.icon}
+      </IconboxStatus>
     </div>
   );
 }
 
-function SectionHeading({ children }: { children: ReactNode }) {
-  return <h2 className="text-text font-circle text-lg">{children}</h2>;
+function SectionHeading({ className, children }: { className?: string; children: ReactNode }) {
+  return <h2 className={cn('text-text font-circle text-lg', className)}>{children}</h2>;
 }
+
+/* M6.3 section-heading scale (486:20706): Details/About step down to Label 4,
+   Transactions steps up to Heading 6; both return to the shared 18px at md. */
+const minorHeadingClasses =
+  'text-base leading-[18px] tracking-[-0.32px] md:text-lg md:leading-normal md:tracking-normal';
+const majorHeadingClasses =
+  'text-xl leading-[22px] tracking-[-0.4px] md:text-lg md:leading-normal md:tracking-normal';
 
 function DetailsSection({ title, details }: { title?: ReactNode; details: ProductDetailRow[] }) {
   return (
     <section className="flex flex-col gap-4" data-testid="product-detail-details">
-      <SectionHeading>{title ?? <Trans>Details</Trans>}</SectionHeading>
+      <SectionHeading className={minorHeadingClasses}>{title ?? <Trans>Details</Trans>}</SectionHeading>
       <div className="grid grid-cols-1 gap-x-12 sm:grid-cols-2">
         {details.map(row => (
           <div
             key={row.id}
             className="border-borderPrimary flex items-center justify-between gap-4 border-b py-4"
           >
-            <span className="text-textSecondary flex items-center gap-2 text-sm">
+            <span className="text-textSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-normal">
               {row.icon}
               {row.label}
             </span>
-            <span className="text-text text-right font-medium">{row.value}</span>
+            <span className="text-text font-circle md:font-graphik text-right text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-normal md:tracking-normal">
+              {row.value}
+            </span>
           </div>
         ))}
       </div>
@@ -116,7 +129,7 @@ function DetailsSection({ title, details }: { title?: ReactNode; details: Produc
 function AboutSection({ title, about }: { title?: ReactNode; about: ProductDetailAbout }) {
   return (
     <section className="flex flex-col gap-4" data-testid="product-detail-about">
-      <SectionHeading>{title ?? <Trans>About</Trans>}</SectionHeading>
+      <SectionHeading className={minorHeadingClasses}>{title ?? <Trans>About</Trans>}</SectionHeading>
       <div className="text-textSecondary text-sm leading-relaxed">
         {about.body}
         {about.learnMoreHref && (
@@ -144,9 +157,13 @@ function TransactionsSection({
   children: ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-4" data-testid="product-detail-transactions">
-      <div className="flex items-center justify-between">
-        <SectionHeading>{title ?? <Trans>Transactions</Trans>}</SectionHeading>
+    // M6.3 (486:20827): on mobile the action drops under the heading as its
+    // own full-width row (24px below the heading, 32px above the cards).
+    <section className="flex flex-col gap-8 md:gap-4" data-testid="product-detail-transactions">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <SectionHeading className={majorHeadingClasses}>
+          {title ?? <Trans>Transactions</Trans>}
+        </SectionHeading>
         {action}
       </div>
       {children}
@@ -173,23 +190,30 @@ export function ProductDetailTemplate({
   dataTestId = 'product-detail'
 }: ProductDetailTemplateProps) {
   return (
-    <div className="flex w-full flex-col gap-8 py-4 md:py-10" data-testid={dataTestId}>
+    <div className="flex w-full flex-col gap-8 py-6 md:py-10" data-testid={dataTestId}>
       {/* Header (Patterns/Headers, Savings type 5039:35173): Label 5 back-link
           over the ringed-icon + Heading 3 title row, network pill right. The
-          DS 17px icon-title gap is normalized to 16. */}
-      <div className="flex flex-col gap-8">
+          DS 17px icon-title gap is normalized to 16. M6.3 mobile (486:20720):
+          Label 6 back-link, 56px ring + Heading 5 title, and the network
+          selector drops to its own full-width row 32px under the title. */}
+      <div className="flex flex-col gap-4 md:gap-8">
         <AppLink
           to={backHref}
-          className="text-fgSecondary hover:text-fgPrimary font-circle flex w-fit items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] transition-colors"
+          className="text-fgSecondary hover:text-fgPrimary font-circle flex w-fit items-center gap-1.5 text-xs leading-[14px] font-medium tracking-[-0.24px] transition-colors md:text-sm md:leading-4 md:tracking-[-0.28px]"
           data-testid="product-detail-back"
         >
           <ChevronLeft className="size-4" />
           {backLabel ?? <Trans>Back to products</Trans>}
         </AppLink>
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-4">
+        <div className="flex flex-col items-stretch gap-8 md:flex-row md:items-center md:justify-between md:gap-4">
+          <div className="flex items-center gap-3 md:gap-4">
             <ProductTitleIcon token={token} />
-            <PageHeading size="md">{title}</PageHeading>
+            <PageHeading
+              size="md"
+              className="text-2xl leading-[26px] tracking-[-0.48px] md:text-[32px] md:leading-[35px] md:tracking-[-0.64px]"
+            >
+              {title}
+            </PageHeading>
           </div>
           {networkSelector}
         </div>
@@ -201,22 +225,23 @@ export function ProductDetailTemplate({
           chart → details → about → transactions; the right pane (4 cols,
           self-start) holds the position card at its own height. Below desktop
           the left pane dissolves (`contents`) and every block spans the full
-          row, so all four stack, with `order` slotting the card between chart
-          and details: chart → position → details → …. */}
+          row, so all four stack, with `order` slotting the card first (M6.3,
+          486:20706 — the position/hero card leads on phones): position →
+          chart → details → …. Stacked rows sit 40px apart per the comp. */}
       <div
-        className="desktop:grid-cols-12 desktop:gap-8 grid grid-cols-4 gap-5 sm:grid-cols-8"
+        className="desktop:grid-cols-12 desktop:gap-8 grid grid-cols-4 gap-x-5 gap-y-10 sm:grid-cols-8"
         data-testid="product-detail-body"
       >
         <div
           className="desktop:col-span-8 desktop:flex desktop:flex-col desktop:gap-8 contents"
           data-testid="product-detail-left-pane"
         >
-          <div className="order-1 col-span-full">{chart}</div>
-          <div className="order-3 col-span-full flex flex-col gap-10">
+          <div className="order-2 col-span-full">{chart}</div>
+          <div className="order-3 col-span-full flex flex-col gap-12 md:gap-10">
             <DetailsSection title={detailsTitle} details={details} />
             {afterDetails && (
               <section className="flex flex-col gap-4" data-testid="product-detail-after-details">
-                <SectionHeading>{afterDetails.title}</SectionHeading>
+                <SectionHeading className={minorHeadingClasses}>{afterDetails.title}</SectionHeading>
                 {afterDetails.body}
               </section>
             )}
@@ -227,7 +252,7 @@ export function ProductDetailTemplate({
           </div>
         </div>
         <div
-          className="desktop:col-span-4 desktop:col-start-9 desktop:row-start-1 desktop:self-start order-2 col-span-full"
+          className="desktop:col-span-4 desktop:col-start-9 desktop:row-start-1 desktop:self-start order-1 col-span-full"
           data-testid="product-detail-right-pane"
         >
           {position}

--- a/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
@@ -18,11 +18,15 @@ const NO_VALUE = '–';
 const formatToken = (value?: bigint) =>
   value === undefined ? NO_VALUE : formatNumber(parseFloat(formatUnits(value, 18)), { maxDecimals: 2 });
 
+// M6.3 mobile (486:20984): Body 6 labels over Label 6 values with 12px icons;
+// desktop keeps the C3 scale.
 function Stat({ label, className, children }: { label: ReactNode; className?: string; children: ReactNode }) {
   return (
-    <div className={cn('flex flex-col gap-1.5', className)}>
-      <span className="text-textSecondary text-sm">{label}</span>
-      <span className="text-text flex items-center gap-1.5 font-medium">{children}</span>
+    <div className={cn('flex flex-col gap-1 md:gap-1.5', className)}>
+      <span className="text-textSecondary text-xs leading-4 md:text-sm md:leading-normal">{label}</span>
+      <span className="text-text font-circle md:font-graphik flex items-center gap-1 text-xs leading-[14px] font-medium tracking-[-0.24px] md:gap-1.5 md:text-base md:leading-normal md:tracking-normal">
+        {children}
+      </span>
     </div>
   );
 }
@@ -96,9 +100,14 @@ export function SavingsPositionCard() {
             </Stat>
             <StatDivider />
             <Stat className="flex-1" label={<Trans>1Y projected earnings</Trans>}>
-              <TrendingUp className="text-bullish h-4 w-4" />
+              <TrendingUp className="text-bullish h-3 w-3 md:h-4 md:w-4" />
               {formatUsd(projectedEarnings)}
-              <TokenIcon token={{ symbol: 'USDS' }} width={16} showChainIcon={false} className="h-4 w-4" />
+              <TokenIcon
+                token={{ symbol: 'USDS' }}
+                width={16}
+                showChainIcon={false}
+                className="h-3 w-3 md:h-4 md:w-4"
+              />
             </Stat>
           </div>
           <div className="flex">
@@ -107,7 +116,7 @@ export function SavingsPositionCard() {
                 token={{ symbol: 'sUSDS' }}
                 width={18}
                 showChainIcon={false}
-                className="h-4.5 w-4.5"
+                className="h-3 w-3 md:h-4.5 md:w-4.5"
               />
               {susds}
             </Stat>
@@ -118,8 +127,9 @@ export function SavingsPositionCard() {
           </div>
         </div>
 
-        {/* Supply / Withdraw each open the editable modal for their flow. */}
-        <div className="flex gap-3">
+        {/* Supply / Withdraw each open the editable modal for their flow.
+            8px apart on mobile (486:21010), 12 from md. */}
+        <div className="flex gap-2 md:gap-3">
           <Button
             variant="primary"
             size="l"

--- a/apps/webapp/src/modules/savings/components/SavingsProductDetail.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsProductDetail.test.tsx
@@ -6,8 +6,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 i18n.load('en', {});
 i18n.activate('en');
 
-// Mutable savings balance — drives the position-aware branch.
-const h = vi.hoisted(() => ({ savingsBalance: 0n as bigint }));
+// Mutable savings balance — drives the position-aware branch. isMobile drives
+// the M6.3 breakpoint branch (happy-dom's 1024px default always lands desktop).
+const h = vi.hoisted(() => ({ savingsBalance: 0n as bigint, isMobile: false }));
+
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: h.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
 
 vi.mock('wagmi', async importOriginal => {
   const actual = await importOriginal<typeof import('wagmi')>();
@@ -42,7 +51,11 @@ vi.mock('./SavingsTransactionsTable', () => ({
 vi.mock('./SavingsTransactionsFilter', () => ({
   SavingsTransactionsFilter: () => <div data-testid="savings-transactions-filter" />
 }));
-vi.mock('@/modules/ui/components/ChainModal', () => ({ ChainModal: () => <div /> }));
+vi.mock('@/modules/ui/components/ChainModal', () => ({
+  ChainModal: ({ triggerClassName }: { triggerClassName?: string }) => (
+    <div data-testid="mock-chain-modal" data-trigger-class={triggerClassName ?? ''} />
+  )
+}));
 vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
 
 import { SavingsProductDetail } from './SavingsProductDetail';
@@ -55,7 +68,11 @@ const renderDetail = () =>
   );
 
 describe('SavingsProductDetail — position-aware transactions filter', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    h.savingsBalance = 0n;
+    h.isMobile = false;
+  });
 
   it('omits the transactions filter when the user has no position', () => {
     h.savingsBalance = 0n;
@@ -72,6 +89,35 @@ describe('SavingsProductDetail — position-aware transactions filter', () => {
 
     expect(screen.getByTestId('savings-transactions-filter')).toBeTruthy();
     // Defaults to the full list until a filter is picked.
+    expect(screen.getByTestId('mock-tx-table').getAttribute('data-filter')).toBe('all');
+  });
+
+  // M6.3 (486:20732): on mobile the network selector is a single full-width
+  // labelled row under the title instead of the right-aligned icon-only pill.
+  it('renders one full-width network selector on mobile', () => {
+    h.isMobile = true;
+    renderDetail();
+
+    const chainModal = screen.getByTestId('mock-chain-modal');
+    expect(chainModal.getAttribute('data-trigger-class')).toContain('w-full');
+  });
+
+  it('keeps the compact header network pill on desktop', () => {
+    h.isMobile = false;
+    renderDetail();
+
+    const chainModal = screen.getByTestId('mock-chain-modal');
+    expect(chainModal.getAttribute('data-trigger-class') || '').not.toContain('w-full');
+  });
+
+  // M6.3: the mobile comp (486:20706) shows the "All transactions" select even
+  // on the no-position page; only desktop keeps the has-position gating.
+  it('shows the transactions filter on mobile even without a position', () => {
+    h.savingsBalance = 0n;
+    h.isMobile = true;
+    renderDetail();
+
+    expect(screen.getByTestId('savings-transactions-filter')).toBeTruthy();
     expect(screen.getByTestId('mock-tx-table').getAttribute('data-filter')).toBe('all');
   });
 });

--- a/apps/webapp/src/modules/savings/components/SavingsProductDetail.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsProductDetail.tsx
@@ -4,7 +4,14 @@ import { Trans } from '@lingui/react/macro';
 import { AudioLines, Asterisk, Vault, Droplet, UsersRound } from 'lucide-react';
 import { ROUTES } from '@/lib/routes';
 import { Intent } from '@/lib/enums';
-import { productNetworks, useOverallSkyData, useSavingsData, useSkySavingsRateHistoricData } from '@/hooks';
+import {
+  BP,
+  productNetworks,
+  useBreakpointIndex,
+  useOverallSkyData,
+  useSavingsData,
+  useSkySavingsRateHistoricData
+} from '@/hooks';
 import { formatDecimalPercentage, formatNumber } from '@/utils';
 import { parseBannerContent } from '@/utils/bannerContentParser';
 import { getBannerById } from '@/data/banners/banners';
@@ -41,6 +48,12 @@ export function SavingsProductDetail() {
   const { data: savingsData } = useSavingsData();
   const hasPosition = (savingsData?.userSavingsBalance ?? 0n) > 0n;
   const [txFilter, setTxFilter] = useState<SavingsTxFilter>('all');
+
+  // M6.3: the mobile comp (486:20706) keeps the transactions filter visible
+  // even without a position; desktop retains the C3 has-position gating.
+  const { bpi } = useBreakpointIndex();
+  const isMobile = bpi < BP.md;
+  const showTxFilter = hasPosition || isMobile;
 
   const { data: overall } = useOverallSkyData();
   // "6M Rate" = trailing 6-month average APY. 🔶 confirm semantics with design
@@ -106,15 +119,33 @@ export function SavingsProductDetail() {
     <ProductDetailTemplate
       backHref={ROUTES.EARN}
       token={{
-        icon: <TokenIcon token={{ symbol: 'sUSDS' }} width={48} className="h-12 w-12" showChainIcon={false} />
+        icon: (
+          <TokenIcon
+            token={{ symbol: 'sUSDS' }}
+            width={48}
+            className="h-11 w-11 md:h-12 md:w-12"
+            showChainIcon={false}
+          />
+        )
       }}
       title={<Trans>Sky Savings</Trans>}
       networkSelector={
-        <ChainModal
-          chainIds={networks}
-          labelClassName="hidden sm:block"
-          dataTestId="product-detail-network"
-        />
+        isMobile ? (
+          // M6.3 (486:20732): full-width labelled row under the title — 24px
+          // chain icon + Label 6 name left, chevron flush right.
+          <ChainModal
+            chainIds={networks}
+            dataTestId="product-detail-network"
+            triggerClassName="w-full [&>svg:last-child]:ml-auto"
+            labelClassName="font-circle text-xs leading-[14px] font-medium tracking-[-0.24px]"
+          />
+        ) : (
+          <ChainModal
+            chainIds={networks}
+            labelClassName="hidden sm:block"
+            dataTestId="product-detail-network"
+          />
+        )
       }
       chart={<SavingsDetailChart />}
       position={<SavingsPositionCard />}
@@ -123,9 +154,9 @@ export function SavingsProductDetail() {
         body: aboutBanner ? parseBannerContent(aboutBanner) : NO_VALUE,
         learnMoreHref: 'https://docs.sky.money'
       }}
-      transactions={<SavingsTransactionsTable filter={hasPosition ? txFilter : 'all'} />}
+      transactions={<SavingsTransactionsTable filter={showTxFilter ? txFilter : 'all'} />}
       transactionsAction={
-        hasPosition ? <SavingsTransactionsFilter value={txFilter} onChange={setTxFilter} /> : undefined
+        showTxFilter ? <SavingsTransactionsFilter value={txFilter} onChange={setTxFilter} /> : undefined
       }
     />
   );

--- a/apps/webapp/src/modules/savings/components/SavingsSupplyCard.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsSupplyCard.test.tsx
@@ -90,6 +90,15 @@ describe('SavingsSupplyCard — no-position entry card', () => {
     expect(screen.queryByTestId('savings-amount-input')).toBeNull();
   });
 
+  // M6.3: both comps carry a product badge above the headline (desktop
+  // 486:20522 reads "Sky Savings"; the mobile comp's "Sky Staking Engine"
+  // wording looks like a design copy error — that engine belongs to Stake).
+  it('renders the product badge above the headline', () => {
+    renderCard();
+
+    expect(screen.getByTestId('savings-supply-badge').textContent).toContain('Sky Savings');
+  });
+
   it('opens the supply modal via onSupply when the CTA is clicked', () => {
     const onSupply = renderCard();
 

--- a/apps/webapp/src/modules/savings/components/SavingsSupplyCard.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsSupplyCard.tsx
@@ -78,7 +78,7 @@ export function SavingsSupplyCard({ onSupply }: { onSupply: () => void }) {
             showChainIcon={false}
             // align-middle centers to the line's x-height; nudge up ~2px so the icon
             // centers on the uppercase symbol's cap-height instead of sitting low.
-            className="mr-1 inline-block h-6 w-6 -translate-y-0.5 align-middle"
+            className="mr-1 inline-block h-5 w-5 -translate-y-0.5 align-middle md:h-6 md:w-6"
           />
           {symbol}
         </span>
@@ -87,35 +87,55 @@ export function SavingsSupplyCard({ onSupply }: { onSupply: () => void }) {
   );
 
   return (
-    <Card className="flex flex-col gap-6 p-6" data-testid="savings-supply-card">
-      <h3 className="text-text text-2xl leading-snug font-medium">
+    <Card className="flex flex-col gap-5 p-5 md:gap-6 md:p-6" data-testid="savings-supply-card">
+      {/* Product badge (Figma 486:20741 / desktop 486:20522). The desktop comp
+          reads "Sky Savings"; the mobile comp's "Sky Staking Engine" wording is
+          treated as a copy error (that engine belongs to Stake) — flagged on
+          APP-378. */}
+      <span
+        data-testid="savings-supply-badge"
+        className="bg-glassBadge text-textSecondary font-circle flex w-fit items-center gap-1 rounded-full py-[5px] pr-2 pl-1 text-xs leading-[14px] font-medium tracking-[-0.24px]"
+      >
+        <TokenIcon token={{ symbol: 'sUSDS' }} width={12} showChainIcon={false} className="h-3 w-3" />
+        <Trans>Sky Savings</Trans>
+      </span>
+
+      <h3 className="text-text font-circle md:font-graphik text-[22px] leading-6 font-medium tracking-[-0.44px] md:text-2xl md:leading-snug md:tracking-normal">
         <Trans>
           Supply {supplyTokens} and earn {rate} APY
         </Trans>
       </h3>
 
-      <p className="text-textSecondary text-sm leading-relaxed">
+      <p className="text-textSecondary text-xs leading-[19px] md:text-sm md:leading-relaxed">
         <Trans>
           Governed by Sky Ecosystem to deliver the best risk-adjusted yield, sUSDS allows you to grow your
           holdings with instant liquidity and zero fees.
         </Trans>
       </p>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="flex flex-col gap-1.5">
-          <span className="text-textSecondary text-sm">
+      {/* Mobile (486:20747): the two stats sit content-width around a 28px
+          hairline; from md the C3 two-column grid returns. */}
+      <div className="flex items-center gap-6 md:grid md:grid-cols-2 md:gap-4">
+        <div className="flex flex-col gap-1 md:gap-1.5">
+          <span className="text-textSecondary text-xs leading-4 md:text-sm md:leading-normal">
             <Trans>Current Rate</Trans>
           </span>
-          <span className="text-text flex items-center gap-1.5 font-medium">
+          <span className="text-text font-circle md:font-graphik flex items-center gap-1.5 leading-[18px] font-medium tracking-[-0.32px] md:leading-normal md:tracking-normal">
             {rate}
-            <TokenIcon token={{ symbol: 'sUSDS' }} width={18} showChainIcon={false} className="h-4.5 w-4.5" />
+            <TokenIcon
+              token={{ symbol: 'sUSDS' }}
+              width={18}
+              showChainIcon={false}
+              className="h-4 w-4 md:h-4.5 md:w-4.5"
+            />
           </span>
         </div>
-        <div className="flex flex-col gap-1.5">
-          <span className="text-textSecondary text-sm">
+        <div className="bg-border h-7 w-px shrink-0 md:hidden" />
+        <div className="flex flex-col gap-1 md:gap-1.5">
+          <span className="text-textSecondary text-xs leading-4 md:text-sm md:leading-normal">
             <Trans>Idle balance</Trans>
           </span>
-          <span className="text-text flex items-center gap-1.5 font-medium">
+          <span className="text-text font-circle md:font-graphik flex items-center gap-1.5 leading-[18px] font-medium tracking-[-0.32px] md:leading-normal md:tracking-normal">
             {idleBalance}
             <TokenIconStack symbols={origins} size={18} />
           </span>

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.test.tsx
@@ -2,6 +2,19 @@ import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { render, screen, cleanup } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// happy-dom's 1024px default always lands desktop; isMobile drives the M6.3
+// mobile trigger variant.
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
 import { SavingsTransactionsFilter, SavingsTxFilter } from './SavingsTransactionsFilter';
 
 i18n.load('en', {});
@@ -20,7 +33,10 @@ const renderFilter = (value: SavingsTxFilter, onChange = vi.fn()) =>
 // here; the value -> visible-rows narrowing is covered in
 // SavingsTransactionsTable.test.tsx.
 describe('SavingsTransactionsFilter', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    breakpoint.isMobile = false;
+  });
 
   it('renders the trigger labelled with the active filter', () => {
     renderFilter('all');
@@ -40,5 +56,21 @@ describe('SavingsTransactionsFilter', () => {
     renderFilter('all');
 
     expect(screen.getByLabelText('Filter transactions')).toBeTruthy();
+  });
+
+  // M6.3 (Figma 486:20830): the mobile trigger is a full-width bordered pill
+  // whose resting label reads "All transactions" instead of the desktop "All".
+  it('labels the default filter "All transactions" on mobile', () => {
+    breakpoint.isMobile = true;
+    renderFilter('all');
+
+    expect(screen.getByTestId('savings-transactions-filter').textContent).toContain('All transactions');
+  });
+
+  it('keeps the specific action labels on mobile', () => {
+    breakpoint.isMobile = true;
+    renderFilter('supply');
+
+    expect(screen.getByTestId('savings-transactions-filter').textContent).toContain('Supply');
   });
 });

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from 'react';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
+import { BP, useBreakpointIndex } from '@/hooks';
+import { cn } from '@/lib/cn';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 /**
@@ -13,16 +15,21 @@ export type SavingsTxFilter = 'all' | 'supply' | 'withdraw';
 
 export const SAVINGS_TX_FILTERS: SavingsTxFilter[] = ['all', 'supply', 'withdraw'];
 
-function FilterLabel({ value }: { value: SavingsTxFilter }) {
+function FilterLabel({ value, mobileTrigger = false }: { value: SavingsTxFilter; mobileTrigger?: boolean }) {
   if (value === 'supply') return <Trans>Supply</Trans>;
   if (value === 'withdraw') return <Trans>Withdraw</Trans>;
+  // The mobile pill spells out its resting state (Figma 486:20830); the
+  // desktop chip and the dropdown rows keep the short "All".
+  if (mobileTrigger) return <Trans>All transactions</Trans>;
   return <Trans>All</Trans>;
 }
 
 /**
- * The Figma `All ▾` filter shown beside the has-position "Transactions" heading
- * (node 527:7204), mounted through the `ProductDetailTemplate` `transactionsAction`
- * slot. The no-position page omits it (it always shows the full list).
+ * The transactions filter beside (desktop) or below (mobile) the has-position
+ * "Transactions" heading, mounted through the `ProductDetailTemplate`
+ * `transactionsAction` slot. Desktop is the Figma `All ▾` text chip (527:7204);
+ * below `BP.md` it becomes the comp's full-width bordered pill labelled
+ * "All transactions" (M6.3, Figma 486:20830).
  *
  * Purely presentational — it owns no state. The parent (`SavingsProductDetail`)
  * holds the active filter and feeds the same value to `SavingsTransactionsTable`.
@@ -34,15 +41,24 @@ export function SavingsTransactionsFilter({
   value: SavingsTxFilter;
   onChange: (next: SavingsTxFilter) => void;
 }): ReactNode {
+  const { bpi } = useBreakpointIndex();
+  const isMobile = bpi < BP.md;
+
   return (
     <Select value={value} onValueChange={next => onChange(next as SavingsTxFilter)}>
       <SelectTrigger
         data-testid="savings-transactions-filter"
         aria-label={t`Filter transactions`}
-        className="text-textSecondary hover:text-text h-auto w-auto shrink-0 gap-1.5 rounded-full border-none bg-transparent p-0 text-sm font-medium transition-colors focus-visible:ring-0"
+        className={cn(
+          'shrink-0 bg-transparent transition-colors focus-visible:ring-0',
+          isMobile
+            ? // Label 6 pill, 12px chevron ([&_svg] outranks the built-in h-4).
+              'border-glassBorder text-text font-circle h-[30px] w-full justify-between rounded-full border py-2 pr-2 pl-3 text-xs leading-[14px] font-medium tracking-[-0.24px] [&_svg]:h-3 [&_svg]:w-3'
+            : 'text-textSecondary hover:text-text h-auto w-auto gap-1.5 rounded-full border-none p-0 text-sm font-medium'
+        )}
       >
         <SelectValue>
-          <FilterLabel value={value} />
+          <FilterLabel value={value} mobileTrigger={isMobile} />
         </SelectValue>
       </SelectTrigger>
       {/* Panel and rows are the DS Dropdown recipe (SelectContent/SelectItem defaults). */}

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -40,6 +40,7 @@ const getChainIcon = (chainId: number, className?: string) =>
 export function ChainModal({
   showLabel = true,
   labelClassName,
+  triggerClassName,
   showDropdownIcon = true,
   variant = 'default',
   dataTestId = 'chain-modal-trigger',
@@ -51,6 +52,8 @@ export function ChainModal({
   showLabel?: boolean;
   /** Extra classes on the chain-name label, e.g. to hide it per tier. */
   labelClassName?: string;
+  /** Extra classes on the trigger button, e.g. `w-full justify-between` for the M6.3 full-width row. */
+  triggerClassName?: string;
   showDropdownIcon?: boolean;
   variant?: 'default' | 'widget' | 'wrapper';
   dataTestId?: string;
@@ -90,7 +93,8 @@ export function ChainModal({
             className={cn(
               variant === ChainModalVariant.widget
                 ? 'from-primary-start/100 to-primary-end/100 hover:from-primary-start/100 hover:to-primary-end/100 focus:from-primary-start/100 focus:to-primary-end/100 flex items-center gap-1.5 border-transparent bg-radial-(--gradient-position) px-[9px] py-2 bg-blend-overlay hover:border-transparent hover:bg-white/10 focus:border-transparent focus:bg-white/15'
-                : 'group'
+                : 'group',
+              triggerClassName
             )}
             data-testid={dataTestId}
           >

--- a/apps/webapp/src/modules/ui/components/Chart.test.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.test.tsx
@@ -1,12 +1,23 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { HoverDimMask, resolveTooltipLabel } from './Chart';
+import { Chart, HoverDimMask, resolveTooltipLabel } from './Chart';
 
 const h = vi.hoisted(() => ({
   isActive: false,
-  coordinate: undefined as { x: number; y: number } | undefined
+  coordinate: undefined as { x: number; y: number } | undefined,
+  isMobile: false
 }));
+
+// happy-dom's 1024px default always lands desktop; isMobile drives the M6.3
+// detail-header branch.
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: h.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
 
 // The mask reads the hover state through recharts' chart-context hooks; feed
 // it directly so the test doesn't need a live chart interaction.
@@ -73,5 +84,60 @@ describe('HoverDimMask', () => {
 
     expect(screen.getByTestId('chart-dim-mask-lit').getAttribute('width')).toBe('800');
     expect(screen.queryByTestId('chart-dim-mask-dimmed')).toBeNull();
+  });
+});
+
+// M6.3 (Figma 486:20761): below BP.md the detail header re-stacks — the
+// Rate|TVL toggle becomes a full-width bar ABOVE the label/value block and the
+// timeframe toggle moves to a full-width bar at the card's bottom, under the
+// plot. Desktop keeps label/value left with both toggles clustered right.
+describe('Chart — detail variant header order', () => {
+  afterEach(() => {
+    cleanup();
+    h.isMobile = false;
+  });
+
+  const renderDetail = () =>
+    render(
+      <Chart
+        variant="detail"
+        dataTestId="detail-chart"
+        data={[
+          { value: 3.7, date: new Date('2026-01-01') },
+          { value: 3.75, date: new Date('2026-01-02') }
+        ]}
+        isPercentage
+        displayValue={3.75}
+        label="Current Rate"
+        metrics={METRICS}
+        activeMetric="rate"
+        onMetricChange={() => {}}
+      />
+    );
+
+  const isBefore = (a: Element, b: Element) =>
+    Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+  it('desktop: value block precedes the metric and timeframe toggles', () => {
+    renderDetail();
+
+    const value = screen.getByTestId('chart-detail-value');
+    const metric = screen.getByTestId('chart-metric-toggle');
+    const timeframe = screen.getByTestId('chart-timeframe-toggle');
+    expect(isBefore(value, metric)).toBe(true);
+    expect(isBefore(metric, timeframe)).toBe(true);
+  });
+
+  it('mobile: metric toggle leads, timeframe toggle trails the plot', () => {
+    h.isMobile = true;
+    renderDetail();
+
+    const value = screen.getByTestId('chart-detail-value');
+    const metric = screen.getByTestId('chart-metric-toggle');
+    const timeframe = screen.getByTestId('chart-timeframe-toggle');
+    const plot = screen.getByTestId('detail-chart-plot');
+    expect(isBefore(metric, value)).toBe(true);
+    expect(isBefore(value, plot)).toBe(true);
+    expect(isBefore(plot, timeframe)).toBe(true);
   });
 });

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -263,22 +263,28 @@ function SegmentedPills<T extends string>({
   options,
   value,
   onChange,
-  dataTestId
+  dataTestId,
+  className,
+  itemClassName
 }: {
   options: { value: T; label: React.ReactNode }[];
   value: T;
   onChange: (value: T) => void;
   dataTestId?: string;
+  /** Extra classes on the pill group (e.g. `w-full` for the M6.3 mobile bars). */
+  className?: string;
+  /** Extra classes on each pill (e.g. `flex-1` to split the width evenly). */
+  itemClassName?: string;
 }) {
   return (
-    <div className={cn(tabsListVariants({ variant: 'segmented' }))} data-testid={dataTestId}>
+    <div className={cn(tabsListVariants({ variant: 'segmented' }), className)} data-testid={dataTestId}>
       {options.map(option => (
         <button
           key={option.value}
           type="button"
           onClick={() => onChange(option.value)}
           data-state={value === option.value ? 'active' : 'inactive'}
-          className={cn(tabsTriggerVariants({ variant: 'segmented' }))}
+          className={cn(tabsTriggerVariants({ variant: 'segmented' }), itemClassName)}
         >
           {option.label}
         </button>
@@ -436,7 +442,8 @@ function DetailHeaderValue({
   isPercentage,
   symbol,
   prefix,
-  isLoading
+  isLoading,
+  mobile = false
 }: {
   data: Data[];
   displayValue?: number;
@@ -444,6 +451,8 @@ function DetailHeaderValue({
   symbol?: string;
   prefix?: string;
   isLoading: boolean;
+  /** M6.3 mobile figure: Heading 5 (24/26, Circular Medium). */
+  mobile?: boolean;
 }) {
   if (isLoading) {
     return <Skeleton className="h-9 w-32" />;
@@ -452,7 +461,17 @@ function DetailHeaderValue({
   const formatted = `${prefix || ''}${formatNumber(value, { maxDecimals: 2, compact: true })}${
     isPercentage ? '%' : symbol ? ` ${symbol}` : ''
   }`;
-  return <span className="text-text text-2xl font-semibold lg:text-[28px]">{formatted}</span>;
+  return (
+    <span
+      data-testid="chart-detail-value"
+      className={cn(
+        'text-text text-2xl',
+        mobile ? 'font-circle leading-[26px] font-medium tracking-[-0.48px]' : 'font-semibold lg:text-[28px]'
+      )}
+    >
+      {formatted}
+    </span>
+  );
 }
 
 function ChartContent({
@@ -589,6 +608,10 @@ export function Chart({
   const containerRef = useRef<HTMLDivElement>(null);
   const { bpi } = useBreakpointIndex();
   const isLarge = bpi >= BP.lg;
+  // M6.3 (Figma 486:20761): below md the detail card re-stacks — full-width
+  // metric bar on top, label/value under it, inset 203px plot, full-width
+  // timeframe bar at the bottom.
+  const isMobileDetail = isDetail && bpi < BP.md;
   const percentage = useMemo(() => {
     if (data[0]?.value === undefined || data[data.length - 1]?.value === undefined) {
       return 0;
@@ -632,12 +655,37 @@ export function Chart({
         data-testid={dataTestId}
         className={cn(
           'relative overflow-hidden p-0',
-          isDetail ? 'pb-3' : 'bg-cardLight h-[288px] lg:h-[220px] lg:p-0'
+          isDetail ? (isMobileDetail ? 'pb-5' : 'pb-3') : 'bg-cardLight h-[288px] lg:h-[220px] lg:p-0'
         )}
         ref={containerRef}
       >
         <CardHeader className="p-5 pb-0">
-          {isDetail ? (
+          {isMobileDetail ? (
+            <div className="flex w-full flex-col gap-5">
+              {metrics && activeMetric !== undefined && onMetricChange && (
+                <SegmentedPills
+                  options={metrics}
+                  value={activeMetric}
+                  onChange={onMetricChange}
+                  dataTestId="chart-metric-toggle"
+                  className="w-full"
+                  itemClassName="flex-1"
+                />
+              )}
+              <div className="flex flex-col gap-0.5">
+                {label && <span className="text-textSecondary text-xs leading-[18px]">{label}</span>}
+                <DetailHeaderValue
+                  mobile
+                  data={data}
+                  displayValue={displayValue}
+                  isPercentage={isPercentage}
+                  symbol={symbol}
+                  prefix={prefix}
+                  isLoading={isLoading}
+                />
+              </div>
+            </div>
+          ) : isDetail ? (
             <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex flex-col gap-1">
                 {label && (
@@ -703,20 +751,40 @@ export function Chart({
             </HStack>
           )}
         </CardHeader>
-        <ChartContent
-          data={data}
-          isLarge={isLarge}
-          symbol={symbol}
-          prefix={prefix}
-          isPercentage={isPercentage}
-          activeTimeframe={activeTimeframe}
-          isLoading={isLoading}
-          error={error}
-          chartHeight={isDetail ? 280 : undefined}
-          tooltipLabel={resolveTooltipLabel(tooltipLabel, metrics, activeMetric)}
-          tokenSymbols={tokenSymbols}
-          color={color}
-        />
+        <div
+          data-testid={dataTestId ? `${dataTestId}-plot` : undefined}
+          className={cn(isMobileDetail && 'px-5')}
+        >
+          <ChartContent
+            data={data}
+            isLarge={isLarge}
+            symbol={symbol}
+            prefix={prefix}
+            isPercentage={isPercentage}
+            activeTimeframe={activeTimeframe}
+            isLoading={isLoading}
+            error={error}
+            chartHeight={isDetail ? (isMobileDetail ? 203 : 280) : undefined}
+            tooltipLabel={resolveTooltipLabel(tooltipLabel, metrics, activeMetric)}
+            tokenSymbols={tokenSymbols}
+            color={color}
+          />
+        </div>
+        {isMobileDetail && (
+          <div className="px-5 pt-5">
+            <SegmentedPills
+              options={TIMEFRAME_OPTIONS}
+              value={activeTimeframe}
+              onChange={tf => {
+                setActiveTimeframe(tf);
+                onTimeFrameChange?.(tf);
+              }}
+              dataTestId="chart-timeframe-toggle"
+              className="w-full"
+              itemClassName="flex-1"
+            />
+          </div>
+        )}
       </Card>
       {/* Detail variant drops the x-axis date labels (Figma). */}
       {!isDetail && (


### PR DESCRIPTION
Closes APP-378 (M6.3, Track M — per-page slice of M6 / APP-373).
<img width="438" height="941" alt="image" src="https://github.com/user-attachments/assets/1b098e1e-0f3e-409d-888b-587d8abf0ed5" />

<img width="438" height="941" alt="image" src="https://github.com/user-attachments/assets/fe118d34-e370-4f52-bfb0-36c4cd5e83ea" />


## What

Below the `md` tier (768px), /earn/savings matches the mobile comps ([empty 486:20706](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20706&m=dev) / [deposited 486:20942](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20942&m=dev)): the position/hero card leads the stack, the header restacks with a full-width network selector row, the chart card grows full-width metric/timeframe bars, the Details/About/Transactions sections take the comp type scale, and the transactions filter becomes a full-width "All transactions" pill that also shows on the no-position page. Desktop is unchanged, with one deliberate exception (hero badge, below).

## How

- **`ProductDetailTemplate`** (shared by all product pages): stacked order below `desktop:` is position → chart → details (`order` swap; the desktop grid placement is untouched). Mobile header per 486:20720 — Label 6 back-link, 56px icon ring, Heading 5 (24/26) title, network slot on its own full-width row 32px under the title. Stacked cards sit 40px apart (`gap-y-10`), sections 48px. Details/About headings step down to Label 4 (16/18) while Transactions steps up to Heading 6 (20/22); details rows pair Body 6 labels with Label 5 Circular values. `TransactionsSection` stacks its action full-width under the heading (24px below it, 32px above the cards).
- **`Chart` (detail variant)** re-stacks below `BP.md` (486:20761): full-width Rate|TVL bar on top, Body 6 label + Heading 5 (24/26) figure, 203px plot inset 20px, full-width timeframe bar at the card bottom. `SegmentedPills` grew `className`/`itemClassName`; desktop keeps the clustered-right layout byte-for-byte. DOM-order tests pin both arrangements.
- **`SavingsSupplyCard`**: the comps' product badge, 22/24 headline with 20px inline token icons, 12px description, and the comp's stat pair around a 28px hairline (grid returns at `md`). **The badge shows at all tiers deliberately** — the desktop comp (486:20522) carries it too and the app had missed it; trivially scoped to mobile if preferred.
- **`SavingsPositionCard` / `PositionHero`**: 32/35 balance with 18/20 fraction, compact Label 6 pill, 12/14 stat values with 12px icons, 8px button gap — all `md:`-reverted.
- **`SavingsTransactionsFilter` + `SavingsProductDetail`**: below `BP.md` the filter renders as the comp's full-width bordered pill labelled "All transactions" and shows even without a position (the mobile comp includes it on the empty page); its selection now filters the list in that state too. Desktop keeps the C3 has-position gating and the "All ▾" chip. `ChainModal` gained `triggerClassName` (used for the `w-full` network row; all other triggers unchanged).

## Design fidelity

The generated-code type sizes for these frames ran **one step large**; sizes were pinned by metadata text-box heights and cap-height pixel measurement on the 1:1 comp render (headline 22/24 — a non-DS size, measured twice — title 24/26, balance 32/35 + 18/20, deposited stat values 12/14, filter/network labels 12/14). Inverse of the M4.5 `get_variable_defs` bug; pixels remain ground truth.

Deliberate deviations, flagged for design/product:
- Badge copy: the mobile comp says "Sky Staking Engine" — treated as a copy error (that engine belongs to Stake); shipped as the desktop comp's "Sky Savings".
- Page gutter stays at M3's 20px (the comp header block sits at 24px).
- Desktop empty state keeps its transactions filter hidden per the C3 comps, though the newer desktop comp shows it — follow-up if wanted.
- M5's transaction-card list keeps its shipped 2px gaps (the deposited comp hints at 8px; the empty comp agrees with 2px).

## Testing

- 9 new tests (red-first): mobile filter visibility without a position, mobile "All transactions" label, single full-width network selector on mobile vs compact pill on desktop, hero badge, and chart detail-header DOM order on both tiers.
- Full unit suite **1981/1981**; typecheck, ESLint, Prettier clean; zero i18n catalog churn (both strings already existed).
- Browser-verified against the 1:1 comp renders at 393px (dark, side-by-side), plus 360px both themes, the 800px tablet band, and 1512px desktop connected + disconnected. No horizontal overflow at 360 (`scrollWidth` == viewport). The supply flow was completed end-to-end at 360px through the M4 bottom sheet (approve + supply on a private Tenderly fork), flipping the page to the deposited state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMwG24Q3jMMF5vvDjnHjuA
