### PR TITLE
M6.1 (APP-376): /portfolio mobile build per comps

### DIFF
--- a/apps/webapp/src/components/product/FilterSelect.tsx
+++ b/apps/webapp/src/components/product/FilterSelect.tsx
@@ -17,7 +17,8 @@ export function FilterSelect({
   onChange,
   allLabel,
   testId,
-  size = 's'
+  size = 's',
+  triggerClassName
 }: {
   options: FilterOption[];
   selected: string;
@@ -26,6 +27,8 @@ export function FilterSelect({
   testId: string;
   /** DS Button / Dropdown size: `s` for table filter bars, `m` for page headers. */
   size?: 's' | 'm';
+  /** Extra classes on the trigger button, e.g. `w-full` for the M6.1 mobile header row. */
+  triggerClassName?: string;
 }) {
   return (
     <Select value={selected} onValueChange={onChange}>
@@ -39,7 +42,8 @@ export function FilterSelect({
         className={cn(
           buttonVariants({ variant: 'dropdown', size: size === 'm' ? 'dropdownM' : 'dropdownS' }),
           'h-auto w-auto bg-transparent [&>svg]:opacity-100 [&>svg]:transition-transform data-[state=open]:[&>svg]:rotate-180',
-          size === 'm' ? '[&>svg]:size-4' : '[&>svg]:size-3'
+          size === 'm' ? '[&>svg]:size-4' : '[&>svg]:size-3',
+          triggerClassName
         )}
       >
         <SelectValue />

--- a/apps/webapp/src/modules/portfolio/components/ConnectedPortfolio.tsx
+++ b/apps/webapp/src/modules/portfolio/components/ConnectedPortfolio.tsx
@@ -108,7 +108,10 @@ export function ConnectedPortfolio() {
             <Trans>Welcome back, {displayName}</Trans>
           </p>
         )}
-        <div className="flex items-center justify-between gap-4">
+        {/* M6.1 (486:20118): below md the title and the network dropdown stack,
+            the dropdown going full-width 24px under the heading; from md the
+            comp's desktop row (heading left, dropdown right) returns. */}
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between md:gap-4">
           <PageHeading size="md">
             <Trans>Your Stablecoin Earnings</Trans>
           </PageHeading>
@@ -119,6 +122,7 @@ export function ConnectedPortfolio() {
             allLabel={allNetworksLabel}
             testId="portfolio-network-filter"
             size="m"
+            triggerClassName="w-full justify-between md:w-auto"
           />
         </div>
       </div>

--- a/apps/webapp/src/modules/portfolio/components/PortfolioDonutChart.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioDonutChart.test.tsx
@@ -8,12 +8,15 @@ import { PortfolioDonutChart } from './PortfolioDonutChart';
 i18n.load('en', {});
 i18n.activate('en');
 
-const renderChart = (segments: { id: string; color: string; value: number }[]) =>
+const renderChart = (segments: { id: string; color: string; value: number }[], size = 140) =>
   render(
     <I18nProvider i18n={i18n}>
-      <PortfolioDonutChart segments={segments} activeId={null} onActiveChange={() => {}} size={140} />
+      <PortfolioDonutChart segments={segments} activeId={null} onActiveChange={() => {}} size={size} />
     </I18nProvider>
   );
+
+/** The inner ring's radius, which every scaled radial constant feeds into. */
+const ringRadius = (container: HTMLElement) => Number(container.querySelector('circle')?.getAttribute('r'));
 
 afterEach(cleanup);
 
@@ -26,5 +29,30 @@ describe('PortfolioDonutChart', () => {
   it('does not render the empty state once a segment is present', () => {
     renderChart([{ id: 'usds', color: '#E9B44C', value: 100 }]);
     expect(screen.queryByText('No tokens')).toBeNull();
+  });
+
+  // M6.1: the radial geometry scales with `size` so the DS band stays ~5% of the
+  // diameter at every box (Figma 486:20138). Holding the constants absolute made
+  // the mobile 160 render a band twice as thick, relative, as the desktop 320.
+  describe('radial geometry scales with size', () => {
+    it('is unchanged at the 320 base size', () => {
+      const { container } = renderChart([], 320);
+      // outerRadius 160-4=156, innerRadius 156-18=138, ringRadius 138-10=128.
+      expect(ringRadius(container)).toBe(128);
+    });
+
+    it('scales the ring proportionally at the mobile 160 box', () => {
+      const { container } = renderChart([], 160);
+      // scale 0.5: outerRadius 80-2=78, innerRadius 78-9=69, ringRadius 69-5=64.
+      expect(ringRadius(container)).toBe(64);
+    });
+
+    it('keeps the ring at the same share of the box across sizes', () => {
+      const { container: big } = renderChart([], 320);
+      const bigShare = ringRadius(big) / 320;
+      cleanup();
+      const { container: small } = renderChart([], 160);
+      expect(ringRadius(small) / 160).toBeCloseTo(bigShare, 5);
+    });
   });
 });

--- a/apps/webapp/src/modules/portfolio/components/PortfolioDonutChart.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioDonutChart.tsx
@@ -22,11 +22,16 @@ type PortfolioDonutChartProps = {
   className?: string;
 };
 
+// Radial dimensions are tuned against the 320 box and scale with `size`: the DS
+// pie keeps the band at ~5% of the diameter at every size (Figma 486:20138 is
+// 160 with an ~8px band), so holding them constant would double the band's
+// relative thickness on the mobile 160.
+const BASE_SIZE = 320;
 const PAD = 4; // breathing room from the box edge
 const THICKNESS = 18; // colored band width
-const PADDING_ANGLE = 3; // gap between segments, degrees
+const PADDING_ANGLE = 3; // gap between segments, degrees — angular, so unscaled
 const RING_GAP = 10; // distance from the colored band's inner edge to the gray ring
-const RING_STROKE = 1.5;
+const RING_STROKE = 1.5; // hairline at every size
 const CORNER_RADIUS = 4; // subtle rounding on the bar ends
 const START_ANGLE = 90; // 12 o'clock
 const END_ANGLE = -270; // full sweep, clockwise
@@ -86,11 +91,12 @@ export function PortfolioDonutChart({
   const sectors = computeSectors(chartSegments);
   const isEmpty = chartSegments.length === 0;
 
+  const scale = size / BASE_SIZE;
   const cx = size / 2;
   const cy = size / 2;
-  const outerRadius = size / 2 - PAD;
-  const innerRadius = outerRadius - THICKNESS;
-  const ringRadius = innerRadius - RING_GAP;
+  const outerRadius = size / 2 - PAD * scale;
+  const innerRadius = outerRadius - THICKNESS * scale;
+  const ringRadius = innerRadius - RING_GAP * scale;
   const isSingle = chartSegments.length === 1;
   const singleFullRing =
     sectors.length === 1 && Math.abs(sectors[0].startAngle - sectors[0].endAngle) >= FULL_CIRCLE_EPS;
@@ -100,6 +106,7 @@ export function PortfolioDonutChart({
       className={className}
       style={{ position: 'relative', width: size, height: size }}
       onMouseLeave={() => onActiveChange(null)}
+      data-testid="portfolio-donut"
     >
       {chartSegments.length > 0 && (
         <div className="absolute inset-0">
@@ -115,7 +122,7 @@ export function PortfolioDonutChart({
               innerRadius={innerRadius}
               outerRadius={outerRadius}
               paddingAngle={isSingle ? 0 : PADDING_ANGLE}
-              cornerRadius={isSingle ? 0 : CORNER_RADIUS}
+              cornerRadius={isSingle ? 0 : CORNER_RADIUS * scale}
               stroke="none"
               isAnimationActive={false}
               onMouseEnter={(_, index) => onActiveChange(chartSegments[index]?.id ?? null)}

--- a/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.test.tsx
@@ -1,0 +1,174 @@
+import type { ReactNode } from 'react';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StablecoinEarningsCard } from './StablecoinEarningsCard';
+import type { SuppliedView } from '../helpers/suppliedView';
+import type { IdleView } from '../helpers/idleView';
+
+// Pin the JS breakpoint per test (happy-dom's 1024 viewport = desktop).
+const breakpoint = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@/hooks/ui/useBreakpoint', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/ui/useBreakpoint')>();
+  return {
+    ...actual,
+    useBreakpointIndex: () => ({ bpi: breakpoint.isMobile ? actual.BP.sm : actual.BP.desktop })
+  };
+});
+
+// TokenIcon reaches for wagmi's chain config, which would need a provider. This
+// suite only exercises the card's responsive wiring, so stub the icons out.
+vi.mock('@/modules/ui/components/TokenIcon', () => ({
+  TokenIcon: (props: { token: { symbol: string }; width?: number }) => (
+    <span data-testid="token-icon" data-symbol={props.token.symbol} data-width={props.width} />
+  )
+}));
+vi.mock('@/modules/ui/components/TokenIconStack', () => ({
+  IconStack: (props: { size?: number; children?: ReactNode }) => (
+    <span data-testid="icon-stack" data-size={props.size}>
+      {props.children}
+    </span>
+  )
+}));
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const SUPPLIED: SuppliedView = {
+  positions: [
+    {
+      id: 'savings',
+      name: 'Sky Savings Rate',
+      tokenSymbol: 'sUSDS',
+      kind: 'savings',
+      intent: 'SAVINGS_INTENT' as SuppliedView['positions'][number]['intent'],
+      amountUsd: 1000,
+      rate: 0.0375,
+      color: '#7C5BF5',
+      share: 1,
+      detailPath: '/earn/savings',
+      chainIds: [1]
+    }
+  ],
+  totalSupplied: 1000,
+  projected1Y: 37.5,
+  avgRate: 0.0375,
+  activePositions: 1,
+  suppliedTokens: ['sUSDS'],
+  networksWithPositions: [1]
+};
+
+const IDLE: IdleView = {
+  tokens: [{ symbol: 'USDS', name: 'USDS', amountUsd: 500, color: '#25D5C4' }],
+  walletBalance: 500,
+  idleCount: 1
+} as IdleView;
+
+const renderCard = (over: Partial<Parameters<typeof StablecoinEarningsCard>[0]> = {}) =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <StablecoinEarningsCard
+        suppliedView={SUPPLIED}
+        suppliedLoading={false}
+        idleView={IDLE}
+        idleLoading={false}
+        savingsRate={0.0375}
+        tab="supplied"
+        onTabChange={() => {}}
+        {...over}
+      />
+    </I18nProvider>
+  );
+
+/** The donut's box is inline-styled from the `size` prop, so read it back. */
+const donutBox = () => screen.getByTestId('portfolio-donut').style.width;
+
+afterEach(() => {
+  breakpoint.isMobile = false;
+  cleanup();
+});
+
+describe('StablecoinEarningsCard responsive behavior (M6.1)', () => {
+  it("renders the donut at the comp's 160 box below md", () => {
+    breakpoint.isMobile = true;
+    renderCard();
+    expect(donutBox()).toBe('160px');
+  });
+
+  it('keeps the desktop 320 donut box from md up', () => {
+    renderCard();
+    expect(donutBox()).toBe('320px');
+  });
+
+  // jsdom has no layout, so visual order can only be asserted through the
+  // classes that drive it: `contents` collapses the column below md and the
+  // three blocks order themselves against the parent flex row.
+  it('orders the chart block headline -> donut -> legend below md (486:20132)', () => {
+    breakpoint.isMobile = true;
+    renderCard();
+    expect(screen.getByTestId('portfolio-donut').className).toContain('order-2');
+    expect(screen.getByRole('list').className).toContain('order-3');
+  });
+
+  it('hands ordering back to DOM order from md up', () => {
+    renderCard();
+    expect(screen.getByTestId('portfolio-donut').className).toContain('md:order-none');
+    expect(screen.getByRole('list').className).toContain('md:order-none');
+  });
+
+  it('steps the headline down to 32px below md and back to 40 from md up', () => {
+    renderCard();
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading.className).toContain('text-[32px]');
+    expect(heading.className).toContain('md:text-[40px]');
+  });
+
+  it('drops the badge cluster to 24 below md and back to 28 from md up (486:20137)', () => {
+    breakpoint.isMobile = true;
+    const { rerender } = renderCard();
+    expect(screen.getByTestId('icon-stack').getAttribute('data-size')).toBe('24');
+
+    breakpoint.isMobile = false;
+    rerender(
+      <I18nProvider i18n={i18n}>
+        <StablecoinEarningsCard
+          suppliedView={SUPPLIED}
+          suppliedLoading={false}
+          idleView={IDLE}
+          idleLoading={false}
+          savingsRate={0.0375}
+          tab="supplied"
+          onTabChange={() => {}}
+        />
+      </I18nProvider>
+    );
+    expect(screen.getByTestId('icon-stack').getAttribute('data-size')).toBe('28');
+  });
+
+  // A bare <p> under <ul> is invalid list markup — screen readers announce
+  // "list, 0 items" and can drop the message from the accessibility tree.
+  it('wraps the supplied empty state in an li so the ul stays valid', () => {
+    renderCard({ suppliedView: { ...SUPPLIED, positions: [], suppliedTokens: [] } });
+    const li = screen.getByText('No supplied positions yet.').closest('li');
+    expect(li).toBeTruthy();
+    expect(li?.parentElement?.tagName).toBe('UL');
+  });
+
+  it('wraps the idle empty state in an li so the ul stays valid', () => {
+    renderCard({ tab: 'idle', idleView: { ...IDLE, tokens: [] } as IdleView });
+    const li = screen.getByText('No idle stablecoins.').closest('li');
+    expect(li).toBeTruthy();
+    expect(li?.parentElement?.tagName).toBe('UL');
+  });
+
+  it('keeps the skeleton donut and order in step with the loaded card', () => {
+    breakpoint.isMobile = true;
+    renderCard({ suppliedLoading: true, suppliedView: { ...SUPPLIED, positions: [] } });
+    // Skeleton donut is a plain div — 160 below md, 320 from md, via h-40/md:h-80.
+    const donut = screen.getByTestId('earnings-skeleton-donut');
+    expect(donut.className).toContain('h-40');
+    expect(donut.className).toContain('md:h-80');
+    expect(donut.className).toContain('order-2');
+  });
+});

--- a/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
+import { BP, useBreakpointIndex } from '@/hooks';
 import { formatDecimalPercentage, formatUsd, projectAnnualEarnings } from '@/utils';
 import { Card } from '@/components/ui/card';
 import { GainValue } from '@/components/ui/GainValue';
@@ -11,6 +12,33 @@ import type { SuppliedView } from '../helpers/suppliedView';
 import type { IdleView } from '../helpers/idleView';
 import { PortfolioDonutChart, type DonutSegment } from './PortfolioDonutChart';
 import { PortfolioTabs, type PortfolioTab } from './PortfolioTabs';
+
+/**
+ * M6.1 (486:20132): the mobile comp stacks the chart block headline → donut →
+ * legend, while the desktop comp pairs a headline+legend column with the donut
+ * beside it. Below md the column dissolves into the parent flow so all three
+ * blocks order themselves against it; from md it re-forms and DOM order wins,
+ * restoring the pre-M6.1 layout untouched at every tier md and up.
+ *
+ * The seam is md (768 = BP.md), matching `useDonutSize` — a mismatch would give
+ * 768–911 a hybrid (reordered blocks around a full 320 donut) matching neither
+ * comp. Callers add their own `md:gap-*` since the skeleton and the loaded card
+ * space their columns differently.
+ *
+ * Caveat: below md this makes DOM order (headline → legend → donut) diverge from
+ * visual order. Harmless today — LegendRow and the recharts sectors are
+ * hover-driven, not focusable — but giving either a keyboard affordance would
+ * create a tab-order trap, and this is the constraint to revisit first.
+ */
+const COLUMN = 'contents md:flex md:flex-col';
+const DONUT = 'order-2 md:order-none';
+const LEGEND = 'order-3 md:order-none';
+
+/** Donut box: 160 on phones per the comp (486:20138), the desktop 320 from md. */
+function useDonutSize() {
+  const { bpi } = useBreakpointIndex();
+  return bpi < BP.md ? 160 : 320;
+}
 
 export function StablecoinEarningsCard({
   suppliedView,
@@ -47,6 +75,7 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
   // Hovering a position (legend or chart) focuses the card on it: totals and
   // footer stats collapse to that single position's values.
   const [activeId, setActiveId] = useState<string | null>(null);
+  const donutSize = useDonutSize();
 
   if (isLoading && view.positions.length === 0) return <EarningsSkeleton />;
 
@@ -66,8 +95,8 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
 
   return (
     <>
-      <div className="mt-6 flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex flex-col gap-8">
+      <div className="mt-6 flex flex-col gap-10 md:gap-8 lg:flex-row lg:items-start lg:justify-between">
+        <div className={cn(COLUMN, 'md:gap-8')}>
           <EarningsHeadline
             label={<Trans>Total supplied</Trans>}
             value={displayTotal}
@@ -75,7 +104,7 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
             activeSymbol={activeSymbol}
           />
 
-          <ul className="flex flex-col gap-3" onMouseLeave={() => setActiveId(null)}>
+          <ul className={cn(LEGEND, 'flex flex-col gap-3')} onMouseLeave={() => setActiveId(null)}>
             {view.positions.map(position => {
               const pct = position.share * 100;
               const pctLabel = pct > 0 && pct < 1 ? '<1%' : `${Math.round(pct)}%`;
@@ -97,10 +126,13 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
                 </li>
               );
             })}
+            {/* `ul` only admits `li` children, so the empty state gets one too. */}
             {view.positions.length === 0 && (
-              <Text variant="medium" className="text-textSecondary">
-                <Trans>No supplied positions yet.</Trans>
-              </Text>
+              <li>
+                <Text variant="medium" className="text-textSecondary">
+                  <Trans>No supplied positions yet.</Trans>
+                </Text>
+              </li>
             )}
           </ul>
         </div>
@@ -109,11 +141,12 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
           segments={segments}
           activeId={activeId}
           onActiveChange={setActiveId}
+          size={donutSize}
           renderCenter={id => {
             const position = view.positions.find(p => p.id === id);
             return position ? <DonutCenter symbol={position.tokenSymbol} /> : null;
           }}
-          className="mx-auto shrink-0 lg:mx-0"
+          className={cn(DONUT, 'mx-auto shrink-0 lg:mx-0')}
         />
       </div>
 
@@ -153,6 +186,7 @@ function IdleContent({
 }) {
   // Hovering a token focuses the card on it (mirrors the Supplied tab).
   const [activeId, setActiveId] = useState<string | null>(null);
+  const donutSize = useDonutSize();
 
   if (isLoading && view.tokens.length === 0) return <EarningsSkeleton />;
 
@@ -169,8 +203,8 @@ function IdleContent({
 
   return (
     <>
-      <div className="mt-6 flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex flex-col gap-8">
+      <div className="mt-6 flex flex-col gap-10 md:gap-8 lg:flex-row lg:items-start lg:justify-between">
+        <div className={cn(COLUMN, 'md:gap-8')}>
           <EarningsHeadline
             label={<Trans>Wallet balance</Trans>}
             value={displayTotal}
@@ -178,7 +212,7 @@ function IdleContent({
             activeSymbol={activeSymbol}
           />
 
-          <ul className="flex flex-col gap-3" onMouseLeave={() => setActiveId(null)}>
+          <ul className={cn(LEGEND, 'flex flex-col gap-3')} onMouseLeave={() => setActiveId(null)}>
             {view.tokens.map(token => (
               <li key={token.symbol}>
                 <LegendRow
@@ -196,10 +230,13 @@ function IdleContent({
                 </LegendRow>
               </li>
             ))}
+            {/* `ul` only admits `li` children, so the empty state gets one too. */}
             {view.tokens.length === 0 && (
-              <Text variant="medium" className="text-textSecondary">
-                <Trans>No idle stablecoins.</Trans>
-              </Text>
+              <li>
+                <Text variant="medium" className="text-textSecondary">
+                  <Trans>No idle stablecoins.</Trans>
+                </Text>
+              </li>
             )}
           </ul>
         </div>
@@ -208,8 +245,9 @@ function IdleContent({
           segments={segments}
           activeId={activeId}
           onActiveChange={setActiveId}
+          size={donutSize}
           renderCenter={id => <DonutCenter symbol={id} />}
-          className="mx-auto shrink-0 lg:mx-0"
+          className={cn(DONUT, 'mx-auto shrink-0 lg:mx-0')}
         />
       </div>
 
@@ -244,21 +282,29 @@ function EarningsHeadline({
   tokenSymbols: string[];
   activeSymbol: string | null;
 }) {
+  const { bpi } = useBreakpointIndex();
+  // Badge cluster: 24 on phones per the comp (486:20137), the desktop 28 from md.
+  const iconSize = bpi < BP.md ? 24 : 28;
+
   return (
     <div className="flex flex-col gap-2">
       <Text variant="medium" className="text-textSecondary">
         {label}
       </Text>
       <div className="flex items-center gap-3">
-        <Heading tag="h2" className="text-text font-circle text-[40px] leading-none">
+        {/* 32/35 on phones per the comp (486:20136), the desktop 40 from md. */}
+        <Heading
+          tag="h2"
+          className="text-text font-circle text-[32px] leading-[35px] md:text-[40px] md:leading-none"
+        >
           {formatUsd(value)}
         </Heading>
-        <IconStack size={28}>
+        <IconStack size={iconSize}>
           {tokenSymbols.map(symbol => (
             <TokenIcon
               key={symbol}
               token={{ symbol }}
-              width={28}
+              width={iconSize}
               showChainIcon={false}
               className={cn(
                 'h-full w-full transition-opacity',
@@ -337,19 +383,32 @@ function TodoValue() {
   return <span className="text-textSecondary text-lg font-medium">TODO</span>;
 }
 
+/**
+ * Mirrors the loaded card's per-tier order so nothing jumps as data lands. Keeps
+ * its own `md:gap-6` (the loaded card uses gap-8) so spacing from md up stays as
+ * it was before the reorder. `w-72 max-w-full` likewise preserves the bar's
+ * 288px intrinsic width — which is what sizes the column on desktop, since a
+ * percentage width contributes nothing to max-content — while still fitting a
+ * 360 phone.
+ */
 function EarningsSkeleton() {
   return (
-    <div className="mt-6 flex animate-pulse flex-col gap-8 lg:flex-row lg:justify-between">
-      <div className="flex flex-col gap-6">
-        <div className="bg-surface h-4 w-28 rounded" />
-        <div className="bg-surface h-10 w-72 rounded" />
-        <div className="flex flex-col gap-3">
+    <div className="mt-6 flex animate-pulse flex-col gap-10 md:gap-8 lg:flex-row lg:justify-between">
+      <div className={cn(COLUMN, 'md:gap-6')}>
+        <div className="flex flex-col gap-6">
+          <div className="bg-surface h-4 w-28 rounded" />
+          <div className="bg-surface h-10 w-72 max-w-full rounded" />
+        </div>
+        <div className={cn(LEGEND, 'flex flex-col gap-3')}>
           <div className="bg-surface h-4 w-40 rounded" />
           <div className="bg-surface h-4 w-36 rounded" />
           <div className="bg-surface h-4 w-32 rounded" />
         </div>
       </div>
-      <div className="bg-surface mx-auto h-[320px] w-[320px] shrink-0 rounded-full lg:mx-0" />
+      <div
+        className={cn(DONUT, 'bg-surface mx-auto h-40 w-40 shrink-0 rounded-full md:h-80 md:w-80 lg:mx-0')}
+        data-testid="earnings-skeleton-donut"
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes [APP-376](https://linear.app/ekliptyka/issue/APP-376/m61-portfolio-mobile-build-per-comps). Stacked on `app-redesign` (M6.3 lineage).

Below `md` the portfolio matches the mobile comp ([486:20104](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20104)). Every tier from 768 up renders exactly as it did before this commit.

## What changed

**Header** ([486:20118](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20118)) — title stacks above a full-width network dropdown. `FilterSelect` grew a `triggerClassName` prop, mirroring M6.3's `ChainModal` change, since it hardcoded `h-auto w-auto`. It also needs `justify-between`: `w-full` alone stretches the pill but leaves the label centred by `buttonVariants` — caught by screenshot, not by reading.

**Chart block** ([486:20132](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20132)) — reorders to headline → donut → legend on mobile. The column wrapper goes `display:contents` below `md` so all three become siblings and order themselves; from `md` it re-forms and DOM order applies. **The main design call — worth a second opinion.** It avoids duplicating the JSX, but it's a trick, and it makes DOM order diverge from visual order below `md`. Harmless today (the legend rows and donut sectors are hover-driven, not focusable) but it's a tab-order trap the moment either gains a keyboard affordance; that constraint is recorded in the code. Happy to swap for a plain restructure.

**Donut** ([486:20138](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20138)) — two defects:
- The fixed `size = 320` ignored the comp's 160 and spanned the card edge-to-edge at 360, eating its `p-6` padding — the card is 360 − 40 (gutter) = 320 wide, exactly the donut's box. It overflowed the card's *padding* box while stopping short of the viewport; below ~360 it would overflow the document outright.
- The radial constants were absolute, so halving the box **doubled the band's relative thickness** (5.8% → 11.8% of diameter). The DS pie holds the band at ~5% at every size, so `PAD` / `THICKNESS` / `RING_GAP` / `CORNER_RADIUS` now scale off `BASE_SIZE = 320`. `PADDING_ANGLE` stays unscaled (angular); `RING_STROKE` stays a 1.5 hairline.

**Type** — headline 32/35 ([486:20136](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20136)), badge cluster 24 ([486:20137](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=486-20137)).

**Skeleton** — mirrors the new order so nothing jumps as data lands, keeping its own `md:gap-6` so md-and-up spacing is untouched. `w-72 max-w-full` preserves the bar's 288px intrinsic width, which is what sizes the desktop column (a percentage width contributes nothing to max-content).

**A11y** — the legend's empty state moves inside an `li`. `Text` renders a `p`, and a bare `p` under `ul` made screen readers announce "list, 0 items".

Untouched because already correct: totals grid (base `grid-cols-2` already matches the comp's 2-col rows), positions carousel, `IdleStablecoinsTable`, page gutter (M3).

## Two deliberate seam decisions

**The reorder seam is `md` (768 = `BP.md`), matching `useDonutSize`.** An earlier revision put it at `lg` (912); that left 768–911 rendering a hybrid — reordered blocks around a full 320 donut — matching neither comp. `docs/responsive-breakpoints.md` sanctions `md:` as the mobile-reflow seam (same 768 line as `ResponsiveModal` / `renderCard`), so this both closes the gap and avoids new `lg:` usages, which the doc forbids. Pre-existing `lg:` usages (`lg:flex-row` and friends) are left alone — the card already stacks below 912, so they aren't a mobile defect; DS tier conformance belongs to H16 ([APP-360](https://linear.app/ekliptyka/issue/APP-360/h16-styles-foundations-audit-ds-conformance-sweep-track-closeout)).

**The `/design-system` donut swatches change, intentionally.** They render at `size={140}`, so the scaling reaches them: their band was 12.9% of diameter against the DS pie's ~5%, and now matches. Desktop `/portfolio` is untouched (its callers are at 320, where `scale = 1`). Flagging because "desktop unchanged" is this ticket's constraint and this is the one place outside /portfolio that moves — `/design-system` is blocked in production but is exactly where design reviews DS adoption.

## Scope changes

Two of the ticket's five modules turned out to be feature gaps, not mobile adaptations — both are tier-agnostic, so doing them here would have changed desktop:

- **Module 6 (Transactions)** → [APP-391](https://linear.app/ekliptyka/issue/APP-391/d8-portfolio-transactions-section-table-filters-desktop-mobile) (D8). Specced at both tiers, built at neither.
- **Module 5 (Position cards)** → [APP-392](https://linear.app/ekliptyka/issue/APP-392/d9-positioncard-conform-to-the-ds-card-comp-labels-stat-order-iconbox) (D9). Diverges from its DS comp in seven ways. Its mobile *reflow* is fine (no overflow, no clipped text at 360), which is all M6.1 needs.

`PositionCard`'s `APY` label is a defect, not a decision — the comp says `Rate`. Tracked on D9.

## Verification

Browser-driven, mock wallet against a live vnet, measured rather than eyeballed — and checked against the pre-fix commit to confirm each defect was real.

| | 360 | 393 | 767 | 768 | 911 | 912 | 1512 |
|---|---|---|---|---|---|---|---|
| Overflow | none | none | none | none | none | none | none |
| Donut | 160 | 160 | 160 | 320 | 320 | 320 | 320 |
| Headline | 32px | 32px | 32px | 40px | 40px | 40px | 40px |
| Order | h→d→l | h→d→l | h→d→l | h→l→d | h→l→d | side | side |

768–911 (`h→l→d`, 320 donut) is identical to pre-M6.1. Dark + light both checked, plus the `/design-system` swatches and the desktop skeleton (amount bar 288px, not collapsed).

**12 new tests** pin the responsive branches per `docs/responsive-breakpoints.md` (mock `useBreakpointIndex`; happy-dom defaults to 1024): donut box, badge cluster, order classes, headline step, both empty states, skeleton, and the donut's scaled geometry at 320 vs 160. Suite **1998/1998**, typecheck + prettier clean, lint 0 errors.

## Screenshots

<!--
REVIEWER NOTE — screenshots are not yet attached.
They live on the author's machine at:
  /private/tmp/claude-501/-Users-tylersorensen-work-tarmac/4c0132c3-d073-4d62-a7a6-27360c9c96e4/scratchpad/

Drag each file into the section below (GitHub uploads on drop and rewrites the
path). Suggested mapping:
  portfolio-393-dark.png   -> Portfolio / 393 dark
  portfolio-360-dark.png   -> Portfolio / 360 dark
  portfolio-393-light.png  -> Portfolio / 393 light
  portfolio-1512-dark.png  -> Portfolio / 1512 (desktop unchanged)
  donut-both.png           -> Donut band, before/after context
  donut-160.png            -> Donut 160 after the scaling fix
-->

### Portfolio — mobile

| 393 dark | 360 dark | 393 light |
|---|---|---|
| <img width="786" height="2000" alt="portfolio-393-dark" src="https://github.com/user-attachments/assets/e8b74af9-1bee-45f6-a376-77377ab1f44d" /> | <img width="720" height="2000" alt="portfolio-360-dark" src="https://github.com/user-attachments/assets/2eb81324-1d93-4ac7-848b-a4e626288eb3" />| <img width="786" height="2000" alt="portfolio-393-light" src="https://github.com/user-attachments/assets/e2982ab3-130d-442a-b071-cd8e58907af8" /> |


### Portfolio — desktop (unchanged)
<img width="3024" height="2000" alt="portfolio-1512-dark" src="https://github.com/user-attachments/assets/5b570480-ce59-4b02-bdfc-f00e2d379a98" />


### Donut band fix

The band is the reason this PR touches `PortfolioDonutChart` at all — worth a look side by side.

| 160 after fix | 320 (reference) |
|---|---|
| <img width="480" height="480" alt="donut-160" src="https://github.com/user-attachments/assets/b0115c9e-1ca1-4406-bf7d-0e896e516172" /> | <img width="960" height="960" alt="donut-320" src="https://github.com/user-attachments/assets/8da6585a-52ac-4144-9b79-7423a1a1c7e9" />|

## Notes for the reviewer

- The `display:contents` reorder is the main call — see above.
- The mobile shots show the empty state (unfunded mock wallet), so the donut reads as an empty ring; the donut-160/320 pair above is the populated evidence for the band fix. Nothing pictured covers 768–911 — that range is measured in the table.
- Total earned / Earned this month still render `TODO` — the `TODO(D1)` cost-basis hook doesn't exist yet. Layout built per comp; the number isn't ours to invent.
- **Merge conflict incoming:** G2 ([APP-315](https://linear.app/ekliptyka/issue/APP-315/g2-light-palette-fill)) is in flight and its commit already touches `StablecoinEarningsCard.tsx`. Whichever lands second will need to reconcile — my changes there are layout/geometry, G2's are colour.
