### PR TITLE
fix(auth): attach denial reason and wallet context to terms-signature Sentry events

### DIFF
--- a/apps/webapp/src/modules/ui/components/TermsModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TermsModal.tsx
@@ -28,7 +28,7 @@ export function TermsModal() {
   const [isChecked, setIsChecked] = useState(false);
   const [signStatus, setSignStatus] = useState<'idle' | 'loading' | 'signing' | 'error'>('idle');
   const [hasScrolledToEnd, setHasScrolledToEnd] = useState(false);
-  const { address, chainId } = useConnection();
+  const { address, chainId, connector } = useConnection();
   const { disconnect } = useDisconnect();
   const [termsMarkdown] = useState<string>(getTermsContent());
 
@@ -53,12 +53,19 @@ export function TermsModal() {
         setHasAcceptedTerms(true);
         closeModal();
       } else {
+        // A 403 body names which gate refused — location/network vs address screening —
+        // and both are fixed server strings. Other statuses can echo the address back,
+        // so their bodies stay out of Sentry.
+        const deniedReason =
+          response.status === 403 ? await response.text().catch(() => '<unreadable>') : undefined;
+
         reportError(new Error(`Failed to send signature: ${response.status}`), {
           module: 'auth',
           flow: 'terms-signature',
           action: 'submit',
           type: 'http_error',
-          statusCode: response.status
+          statusCode: response.status,
+          extra: { deniedReason, chainId, connector: connector?.name }
         });
         setSignStatus('error');
         // TODO show error message to user
@@ -68,7 +75,8 @@ export function TermsModal() {
         module: 'auth',
         flow: 'terms-signature',
         action: 'submit',
-        type: 'request_error'
+        type: 'request_error',
+        extra: { chainId, connector: connector?.name }
       });
       setSignStatus('error');
       // TODO show error message to user
@@ -89,7 +97,8 @@ export function TermsModal() {
           module: 'auth',
           flow: 'terms-signature',
           action: 'sign',
-          type: 'wallet_signature_error'
+          type: 'wallet_signature_error',
+          extra: { chainId, connector: connector?.name }
         });
       }
     }


### PR DESCRIPTION
## Problem

Terms-signature failures report to Sentry with only classification tags — no per-event detail. [`WEBAPP-5P`](https://jetstream-gg.sentry.io/issues/WEBAPP-5P) (`Failed to send signature: 403`) has fired **110 times since May 20**, 6 in the last 24h, and is still firing while marked resolved.

`/terms-acceptance/add` returns 403 from exactly two gates, each with a distinct body:

- `isIpAllowed` → `"Access denied based on your location or network."`
- `isAddressAllowed` → `"The address is invalid or not allowed to be used on this app"`

We build the error from `response.status` alone and never read the body — so the server names the gate and we discard it.

## Change

- Read the response body on **403 only** → `extra.deniedReason`
- Add `chainId` + `connector.name` to all three `reportError` sites

`reportError` already forwards `extra` to `scope.setExtras`.

## Why 403-only

The 403 bodies are fixed strings, safe to capture.

400 is overloaded across seven causes and the status code can't separate them. Six are safe; one — `` `Address ${normalizedAddress} has already accepted the terms` `` — embeds a real address. Gating on 403 keeps addresses out of Sentry with no scrubbing.

## Not included

- **Wallet address / `setUser`** — would make these attributable (`Users Impacted` reads `0` today), needs privacy sign-off
- **403 UX** — denied users still hit `// TODO show error message to user`, see nothing, and retry while `termsAccepted` stays false. The actual user-facing bug; this only makes it diagnosable.
- **400 bodies** — dropping the address from that one server message makes all seven safe and retires the gate above. Pairs with the `api-workers` PR.
- **Backend instrumentation** — address-screening path has zero `captureException`, and `AddressStatusSource.API` doesn't distinguish TRM from Chainalysis. Separate `api-workers` PR.

## Testing

`typecheck` / `eslint` / `prettier` / existing `TermsModal.test.tsx` (4 tests) all pass.
