### PR TITLE
M4.4 (APP-384): give popovers a safe edge margin + viewport width cap at 360px

### DIFF
--- a/apps/webapp/src/components/ui/popover.test.tsx
+++ b/apps/webapp/src/components/ui/popover.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Popover, PopoverContent, PopoverTrigger, PopoverWidgetContent } from './popover';
+
+const CLAMP = 'max-w-[min(var(--radix-popover-content-available-width),calc(100vw_-_2rem))]';
+
+afterEach(cleanup);
+
+describe('PopoverContent', () => {
+  it('clamps its width to the viewport so it never renders off-screen at 360px', () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>open</PopoverTrigger>
+        <PopoverContent data-testid="pc">content</PopoverContent>
+      </Popover>
+    );
+    expect(screen.getByTestId('pc').className).toContain(CLAMP);
+  });
+
+  it('keeps the clamp when a consumer overrides the fixed width', () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>open</PopoverTrigger>
+        <PopoverContent data-testid="pc" className="w-[330px]">
+          content
+        </PopoverContent>
+      </Popover>
+    );
+    const cls = screen.getByTestId('pc').className;
+    expect(cls).toContain('w-[330px]');
+    expect(cls).toContain(CLAMP);
+  });
+});
+
+describe('PopoverWidgetContent', () => {
+  it('clamps its width to the viewport', () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>open</PopoverTrigger>
+        <PopoverWidgetContent data-testid="pw">content</PopoverWidgetContent>
+      </Popover>
+    );
+    expect(screen.getByTestId('pw').className).toContain(CLAMP);
+  });
+});

--- a/apps/webapp/src/components/ui/popover.tsx
+++ b/apps/webapp/src/components/ui/popover.tsx
@@ -19,14 +19,15 @@ const PopoverArrow = PopoverPrimitive.Arrow;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 4, collisionPadding = 8, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
       className={cn(
-        'bg-container text-text data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-100 max-h-(--radix-popover-content-available-height) w-80 rounded-xl p-4 shadow-md outline-hidden',
+        'bg-container text-text data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-100 max-h-(--radix-popover-content-available-height) w-80 max-w-[min(var(--radix-popover-content-available-width),calc(100vw_-_2rem))] rounded-xl p-4 shadow-md outline-hidden',
         className
       )}
       {...props}
@@ -40,14 +41,15 @@ PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 const PopoverWidgetContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, children, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 4, collisionPadding = 8, children, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
       className={cn(
-        'bg-container text-text data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-hidden',
+        'bg-container text-text data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 max-w-[min(var(--radix-popover-content-available-width),calc(100vw_-_2rem))] rounded-md border p-4 shadow-md outline-hidden',
         className
       )}
       asChild


### PR DESCRIPTION
## M4.4 (APP-384) · Popover — mobile width + collision at 360px

At 360px, fixed-width popovers sit **flush against the viewport edge** — their rounded corner butts the screen with a 0px margin. Radix's `avoidCollisions` keeps them on-screen (so nothing currently renders *off*-screen), but nothing reserves an edge margin or caps content width against the viewport.

### Change
Both shared popover contents in `src/components/ui/popover.tsx` (`PopoverContent` and the widget-look `PopoverWidgetContent`) gain:

- **`collisionPadding={8}`** (default, overridable) — Radix keeps an 8px buffer from the screen edge, so popovers no longer touch the boundary.
- a **viewport-relative width cap** — `max-w-[min(var(--radix-popover-content-available-width),calc(100vw_-_2rem))]` — a popover can never be wider than the space it has.

The widest consumers are the three `w-[330px]` config menus (`SlippageMenu`, `TradeWidget/TradeConfigMenu`, `PendleWidget/PendleConfigMenu`). They set no `max-w` of their own, so the primitive covers them — no per-consumer edits. The More menu (the ticket's `w-60` note) already became a bottom Sheet below `md` in M4.5, so its popover only renders on desktop.

### Scope of the win — read this
This is **edge-margin polish + width hardening**, not an off-screen-clipping fix:

- **Today:** `avoidCollisions` already prevents any current popover from rendering off-screen at 360px. The observable change is that popovers gain an **8px margin** from the edge (was 0px) and the `w-[330px]` menus are trimmed to the ~328px available width.
- **Hardening:** the width cap is the guardrail Radix doesn't provide — it protects sub-360px viewports, anchor positions where available space is less than a popover's fixed width, and any future popover wider than a phone.

### Before / after at 360px
Worst case — a **330px** popover injected onto the live rendered `PopoverContent` to mirror the config menus. Both frames are captured the same way; only the popover primitive differs (pre-fix vs this PR):

| Before (flush at edge, 0px margin) | After (8px margin, capped 328px) |
|---|---|
| ![before](https://raw.githubusercontent.com/jetstreamgg/tarmac/assets/app-384-screenshots/before-360-dark.png) | ![after](https://raw.githubusercontent.com/jetstreamgg/tarmac/assets/app-384-screenshots/after-360-dark.png) |

The difference is deliberately modest: the left rounded corner butts the screen edge before, and gains an 8px inset after. Desktop is unchanged — at 1512px the same popover keeps its full 330px:

![1512 desktop](https://raw.githubusercontent.com/jetstreamgg/tarmac/assets/app-384-screenshots/popover-1512-desktop.png)

> Screenshots are from the `/design-system` popover sandbox; the 330px width is injected to reproduce the real config menus (which live behind the trade ACTION screen).

### Verification
Browser-driven (Playwright) against `dev:mock`, computed `max-width` + on-screen bounding box:

| Viewport | computed `max-width` | 330px popover | edge margin |
|---|---|---|---|
| 360px (dark & light) | `328px` | capped to 328px | left 8px (was 0px) |
| 1512px | `1480px` | full 330px (uncapped) | desktop unchanged |

- Confirms the Tailwind arbitrary value compiles to valid CSS (the `calc()` spacing case).
- New unit test pins the cap on both contents and its survival when a consumer overrides the width (`w-[330px]` + cap coexist via tailwind-merge).
- `prettier`, `eslint`, `typecheck`, unit suite green.

### AC
- [x] No popover renders off-screen at 360px — and now keeps an 8px edge margin
- [x] Desktop unchanged

Closes APP-384.
