### PR TITLE
Ignore Firefox wording of non-actionable chunk load failures (WEBAPP-17)

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -55,11 +55,15 @@ export function initSentry(): void {
       // deep-link to wallets from those WebViews anyway (WEBAPP-1Z).
       /Can't find variable: indexedDB/,
       /indexedDB is not defined/,
-      // Stale-chunk after deploy: a long-lived tab has the previous build's
-      // hashed chunk URLs baked into its module graph; the next __vitePreload
-      // 404s. User just needs to refresh — not actionable.
+      // Chunk load failures: either a stale tab after deploy (previous build's
+      // hashed chunk URLs baked into its module graph, next __vitePreload 404s)
+      // or a transient client-side fetch failure (network flap, extension
+      // interference) on a chunk that's still live. User just needs to
+      // refresh/retry — not actionable. One regex per browser wording:
+      // Chromium / Safari / Firefox respectively (WEBAPP-17).
       /Failed to fetch dynamically imported module.*\/assets\/.+\.js/,
       /Importing a module script failed.*\/assets\/.+\.js/,
+      /error loading dynamically imported module.*\/assets\/.+\.js/,
       // MetaMask multichain SDK transport handshake timeout during wallet
       // connect (@metamask/connect-multichain throws TransportTimeoutError).
       // A client-side network timeout — common on high-latency / filtered


### PR DESCRIPTION
## Summary

Sentry issue [WEBAPP-17](https://jetstream-gg.sentry.io/issues/WEBAPP-17) kept regressing because our `ignoreErrors` filters for dynamic-import chunk failures only covered the Chromium ("Failed to fetch dynamically imported module") and Safari ("Importing a module script failed") wordings. Every event on the issue is Firefox, whose wording is "error loading dynamically imported module" — it slipped past both regexes. This adds the Firefox variant to the same filter block.

## Investigation notes

- All 9 events (over ~3.5 months) are Firefox-only; the recent ones (Jul 17–18) reference `dist-KI8SkFRt.js`, which still returns HTTP 200 in the current production deploy — so these are transient client-side fetch failures (network flap / extension interference), not just the stale-deploy case. Either way, non-actionable server-side: the user retries or refreshes. The filter comment is updated to cover both causes.
- `Fixes WEBAPP-17` in the commit resolves the Sentry issue on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)