### PR TITLE
D8 (APP-391): Portfolio Transactions section (table + filters)

### DIFF
--- a/apps/webapp/src/components/ui/table-cells.tsx
+++ b/apps/webapp/src/components/ui/table-cells.tsx
@@ -71,6 +71,14 @@ function CheckIcon() {
   );
 }
 
+function XIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+      <path d="M9 3L3 9M3 3L9 9" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 // Icons/General/move-up-right — the hash cell's external-link arrow.
 function MoveUpRightIcon() {
   return (
@@ -107,29 +115,29 @@ export function CellChevron() {
   return <ChevronRight className="text-fgTertiary size-4" aria-hidden />;
 }
 
-export type CellStatusValue = 'pending' | 'completed';
+export type CellStatusValue = 'pending' | 'completed' | 'failed';
 
-/** Type=Status: the Pending (brand) / Completed (success) pill. */
+const statusStyles: Record<CellStatusValue, { className: string; icon: ReactNode; label: ReactNode }> = {
+  pending: {
+    className: 'bg-statusBrandBg text-statusBrand',
+    icon: <DotsIcon />,
+    label: <Trans>Pending</Trans>
+  },
+  completed: {
+    className: 'bg-statusSuccessBg text-statusSuccess',
+    icon: <CheckIcon />,
+    label: <Trans>Completed</Trans>
+  },
+  failed: { className: 'bg-error/10 text-error', icon: <XIcon />, label: <Trans>Failed</Trans> }
+};
+
+/** Type=Status: the Pending (brand) / Completed (success) / Failed (error) pill. */
 export function CellStatus({ status }: { status: CellStatusValue }) {
+  const { className, icon, label } = statusStyles[status];
   return (
-    <span
-      className={cn(
-        label6,
-        'inline-flex h-6 items-center gap-1 rounded-full px-2',
-        status === 'pending' ? 'bg-statusBrandBg text-statusBrand' : 'bg-statusSuccessBg text-statusSuccess'
-      )}
-    >
-      {status === 'pending' ? (
-        <>
-          <DotsIcon />
-          <Trans>Pending</Trans>
-        </>
-      ) : (
-        <>
-          <CheckIcon />
-          <Trans>Completed</Trans>
-        </>
-      )}
+    <span className={cn(label6, 'inline-flex h-6 items-center gap-1 rounded-full px-2', className)}>
+      {icon}
+      {label}
     </span>
   );
 }

--- a/apps/webapp/src/modules/portfolio/components/ConnectedPortfolio.tsx
+++ b/apps/webapp/src/modules/portfolio/components/ConnectedPortfolio.tsx
@@ -18,6 +18,7 @@ import { useStablecoinBalances } from '../hooks/useStablecoinBalances';
 import { PendleReadyToRedeemList } from '@/modules/pendle/components/PendleReadyToRedeemList';
 import { StablecoinEarningsCard } from './StablecoinEarningsCard';
 import { PortfolioPositionsSection } from './PortfolioPositionsSection';
+import { PortfolioTransactionsSection } from './PortfolioTransactionsSection';
 import { PortfolioStatistics } from './PortfolioStatistics';
 import { SavingsTvlCallout } from './SavingsTvlCallout';
 import { AllocateStablecoinsBanner } from './AllocateStablecoinsBanner';
@@ -154,6 +155,9 @@ export function ConnectedPortfolio() {
         tab={tab}
         onTabChange={setUserTab}
       />
+
+      {/* Portfolio-wide transactions (D8), after the position cards per the comp. */}
+      <PortfolioTransactionsSection />
 
       {/* Matured PT redemption (G6): the marketplace filters matured markets out
           of the supplied view, so this self-hiding section is their only surface. */}

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
@@ -1,0 +1,95 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ModuleEnum, TransactionTypeEnum } from '@/hooks';
+import type { PortfolioTxRow } from '../helpers/transactionRow';
+import { PortfolioTransactionsView } from './PortfolioTransactionsSection';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useChains: () => [
+      { id: 1, name: 'Ethereum' },
+      { id: 8453, name: 'Base' }
+    ]
+  };
+});
+
+// Render the desktop table (not the mobile card list) and skip token images.
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return { ...actual, useBreakpointIndex: () => ({ bpi: 99 }) };
+});
+vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
+
+const row = (o: Partial<PortfolioTxRow>): PortfolioTxRow => ({
+  id: 'r',
+  txHash: '0x1234567890abcdef',
+  timestamp: new Date('2026-07-20T00:00:00Z'),
+  module: ModuleEnum.SAVINGS,
+  type: TransactionTypeEnum.SUPPLY,
+  chainId: 1,
+  action: 'Savings Supply',
+  symbol: 'USDS',
+  amount: '1,000.00',
+  usd: '$1,000.00',
+  status: 'completed',
+  positive: true,
+  ...o
+});
+
+const renderView = (rows: PortfolioTxRow[], props = {}) =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <PortfolioTransactionsView rows={rows} {...props} />
+    </I18nProvider>
+  );
+
+describe('PortfolioTransactionsView', () => {
+  afterEach(() => cleanup());
+
+  it('renders the title, three filters, and a row from the aggregated feed', () => {
+    renderView([row({ id: 'a' })]);
+    expect(screen.getByTestId('portfolio-transactions')).toBeDefined();
+    expect(screen.queryByText('Transactions')).not.toBeNull();
+    expect(screen.getByTestId('portfolio-tx-filter-network')).toBeDefined();
+    expect(screen.getByTestId('portfolio-tx-filter-stablecoin')).toBeDefined();
+    expect(screen.getByTestId('portfolio-tx-filter-product')).toBeDefined();
+
+    const table = screen.getByTestId('portfolio-transactions-table');
+    expect(within(table).queryByText('Savings Supply')).not.toBeNull();
+    expect(within(table).queryByText('Savings')).not.toBeNull(); // product cell
+    expect(within(table).queryByText('Completed')).not.toBeNull(); // status cell
+  });
+
+  it('maps a pending row to the Pending status pill', () => {
+    renderView([row({ id: 'b', status: 'pending', module: ModuleEnum.TRADE, action: 'Trade' })]);
+    const table = screen.getByTestId('portfolio-transactions-table');
+    expect(within(table).queryByText('Pending')).not.toBeNull();
+    // "Trade" is both the action label and the product name → two matches.
+    expect(within(table).getAllByText('Trade').length).toBeGreaterThan(0);
+  });
+
+  it('shows the empty state when there are no transactions', () => {
+    renderView([]);
+    expect(screen.queryByText('No transactions yet')).not.toBeNull();
+  });
+
+  it('renders across products (distinct action labels + product names)', () => {
+    renderView([
+      row({ id: 'a', module: ModuleEnum.SAVINGS, action: 'Savings Supply' }),
+      row({ id: 'b', module: ModuleEnum.MORPHO, action: 'Vault Withdraw', chainId: 8453, symbol: 'USDC' }),
+      row({ id: 'c', module: ModuleEnum.STAKE, action: 'Stake', symbol: 'SKY', usd: undefined })
+    ]);
+    const table = screen.getByTestId('portfolio-transactions-table');
+    expect(within(table).queryByText('Savings Supply')).not.toBeNull();
+    expect(within(table).queryByText('Vault Withdraw')).not.toBeNull();
+    expect(within(table).queryByText('Stake')).not.toBeNull();
+    expect(within(table).queryByText('Staking')).not.toBeNull(); // stake product label
+  });
+});

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
@@ -75,6 +75,12 @@ describe('PortfolioTransactionsView', () => {
     expect(within(table).getAllByText('Trade').length).toBeGreaterThan(0);
   });
 
+  it('shows a Failed pill for a cancelled/expired order', () => {
+    renderView([row({ id: 'f', status: 'failed', module: ModuleEnum.TRADE, action: 'Trade' })]);
+    const table = screen.getByTestId('portfolio-transactions-table');
+    expect(within(table).queryByText('Failed')).not.toBeNull();
+  });
+
   it('shows the empty state when there are no transactions', () => {
     renderView([]);
     expect(screen.queryByText('No transactions yet')).not.toBeNull();

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
@@ -40,6 +40,7 @@ const row = (o: Partial<PortfolioTxRow>): PortfolioTxRow => ({
   usd: '$1,000.00',
   status: 'completed',
   positive: true,
+  explorerHref: 'https://etherscan.io/tx/0x1234567890abcdef',
   ...o
 });
 

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
@@ -79,11 +79,7 @@ const networkCell = (row: PortfolioTxRow) => (
   <CellNetworks>{getChainIcon(row.chainId, 'h-full w-full')}</CellNetworks>
 );
 
-// The DS CellStatus only models pending / completed; a failed CoW order (rare,
-// and generally absent from confirmed history) folds into completed for display.
-const statusCell = (row: PortfolioTxRow) => (
-  <CellStatus status={row.status === 'pending' ? 'pending' : 'completed'} />
-);
+const statusCell = (row: PortfolioTxRow) => <CellStatus status={row.status} />;
 
 const productCell = (row: PortfolioTxRow) => (
   <CellProduct icon={tokenIcon(row.symbol)} label={productName(row.module)} />

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
@@ -1,0 +1,253 @@
+import { ReactNode, useCallback, useMemo, useState } from 'react';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { Trans } from '@lingui/react/macro';
+import { t } from '@lingui/core/macro';
+import { useChains } from 'wagmi';
+import { BP, ModuleEnum, useAllNetworksCombinedHistory, useBreakpointIndex } from '@/hooks';
+import { formatAddress, getChainIcon, getEtherscanLink } from '@/utils';
+import { cn } from '@/lib/cn';
+import { Heading } from '@/modules/layout/components/Typography';
+import { TokenIcon } from '@/modules/ui/components/TokenIcon';
+import { ConvertArrows, ArrowDown, SavingsSupply } from '@/modules/icons';
+import { FilterSelect } from '@/components/product/FilterSelect';
+import {
+  ProductTransactionsTable,
+  ProductTransactionColumn
+} from '@/components/product/ProductTransactionsTable';
+import { TransactionCard } from '@/components/product/TransactionCard';
+import {
+  CellAction,
+  CellAmount,
+  CellHash,
+  CellNetworks,
+  CellProduct,
+  CellStatus
+} from '@/components/ui/table-cells';
+import { PortfolioTxRow, toPortfolioTxRow } from '../helpers/transactionRow';
+
+const ALL = 'all';
+
+// Human product name per module for the Product column.
+function productName(module: ModuleEnum): string {
+  switch (module) {
+    case ModuleEnum.SAVINGS:
+      return t`Savings`;
+    case ModuleEnum.STUSDS:
+      return t`stUSDS`;
+    case ModuleEnum.MORPHO:
+    case ModuleEnum.SUSDT:
+      return t`Vault`;
+    case ModuleEnum.REWARDS:
+      return t`Rewards`;
+    case ModuleEnum.STAKE:
+      return t`Staking`;
+    case ModuleEnum.UPGRADE:
+      return t`Upgrade`;
+    case ModuleEnum.PENDLE:
+      return t`Fixed Yield`;
+    case ModuleEnum.TRADE:
+      return t`Trade`;
+    default:
+      return '';
+  }
+}
+
+function actionIcon(row: PortfolioTxRow): ReactNode {
+  if (row.module === ModuleEnum.TRADE) return <ConvertArrows width={16} height={16} />;
+  return row.positive === false ? (
+    <ArrowDown width={12} height={16} className="light:fill-text fill-white" />
+  ) : (
+    <SavingsSupply width={16} height={15} />
+  );
+}
+
+const tokenIcon = (symbol: string, width = 12) => (
+  <TokenIcon token={{ symbol }} width={width} showChainIcon={false} className="h-3 w-3" />
+);
+
+// Header action cell (icon + verb + relative time), shared by the desktop row
+// and the mobile card header.
+const actionCell = (row: PortfolioTxRow) => (
+  <CellAction
+    icon={actionIcon(row)}
+    label={row.action}
+    sublabel={formatDistanceToNowStrict(row.timestamp, { addSuffix: true })}
+  />
+);
+
+const networkCell = (row: PortfolioTxRow) => (
+  <CellNetworks>{getChainIcon(row.chainId, 'h-full w-full')}</CellNetworks>
+);
+
+// The DS CellStatus only models pending / completed; a failed CoW order (rare,
+// and generally absent from confirmed history) folds into completed for display.
+const statusCell = (row: PortfolioTxRow) => (
+  <CellStatus status={row.status === 'pending' ? 'pending' : 'completed'} />
+);
+
+const productCell = (row: PortfolioTxRow) => (
+  <CellProduct icon={tokenIcon(row.symbol)} label={productName(row.module)} />
+);
+
+const suppliedCell = (row: PortfolioTxRow) => (
+  <CellAmount icon={tokenIcon(row.symbol)} amount={`${row.amount} ${row.symbol}`} usd={row.usd} />
+);
+
+const hashCell = (row: PortfolioTxRow) => (
+  <CellHash label={formatAddress(row.txHash, 6, 4)} href={getEtherscanLink(row.chainId, row.txHash, 'tx')} />
+);
+
+const COLUMNS: ProductTransactionColumn<PortfolioTxRow>[] = [
+  { id: 'action', header: <Trans>Action</Trans>, width: '1.6fr', cell: actionCell },
+  { id: 'network', header: <Trans>Network</Trans>, width: '0.8fr', cell: networkCell },
+  { id: 'status', header: <Trans>Status</Trans>, width: '1fr', cell: statusCell },
+  { id: 'product', header: <Trans>Product</Trans>, width: '1fr', cell: productCell },
+  { id: 'supplied', header: <Trans>Supplied</Trans>, width: '1.2fr', cell: suppliedCell },
+  { id: 'hash', header: <Trans>Tx hash</Trans>, width: '1fr', cell: hashCell }
+];
+
+// Mobile card: Action is the header, Tx hash becomes the footer button, and the
+// remaining Network / Status / Product / Supplied columns fold into the 2×2 grid.
+// (The comp mislabels the top grid row "My position" / "APY" — placeholder text
+// carried over from the PositionCard; the real fields are Network / Status.)
+const renderCard = (row: PortfolioTxRow) => (
+  <TransactionCard
+    header={actionCell(row)}
+    fields={[
+      { label: <Trans>Network</Trans>, value: networkCell(row) },
+      { label: <Trans>Status</Trans>, value: statusCell(row) },
+      { label: <Trans>Product</Trans>, value: productCell(row) },
+      { label: <Trans>Supplied</Trans>, value: suppliedCell(row) }
+    ]}
+    link={{ label: <Trans>View transaction</Trans>, href: getEtherscanLink(row.chainId, row.txHash, 'tx') }}
+  />
+);
+
+export interface PortfolioTransactionsViewProps {
+  rows: PortfolioTxRow[];
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+/**
+ * Presentational transactions section — the title, three filters, and the
+ * shared ProductTransactionsTable (card list below md) over already-normalized
+ * rows. Split from the data container so it can be unit-tested and previewed
+ * with fixture rows (the aggregate hook needs a funded wallet).
+ */
+export function PortfolioTransactionsView({ rows, isLoading, error }: PortfolioTransactionsViewProps) {
+  const { bpi } = useBreakpointIndex();
+  const isMobile = bpi < BP.md;
+  const chains = useChains();
+  const chainName = useCallback((id: number) => chains.find(c => c.id === id)?.name ?? '', [chains]);
+
+  const [network, setNetwork] = useState(ALL);
+  const [stablecoin, setStablecoin] = useState(ALL);
+  const [product, setProduct] = useState(ALL);
+
+  // Filter options derived from what's actually present, so we never offer an
+  // empty filter. Stablecoins are limited to rows that carry a USD value.
+  const { networks, stablecoins, products } = useMemo(() => {
+    const net = new Map<string, ReactNode>();
+    const stable = new Map<string, ReactNode>();
+    const prod = new Map<string, ReactNode>();
+    for (const row of rows) {
+      net.set(
+        String(row.chainId),
+        <span className="flex items-center gap-1.5">
+          <span className="flex h-4 w-4 shrink-0">{getChainIcon(row.chainId, 'h-full w-full')}</span>
+          {chainName(row.chainId)}
+        </span>
+      );
+      if (row.usd) {
+        stable.set(
+          row.symbol,
+          <span className="flex items-center gap-1.5">
+            {tokenIcon(row.symbol, 16)}
+            {row.symbol}
+          </span>
+        );
+      }
+      prod.set(row.module, productName(row.module));
+    }
+    return {
+      networks: [...net].map(([value, label]) => ({ value, label })),
+      stablecoins: [...stable].map(([value, label]) => ({ value, label })),
+      products: [...prod].map(([value, label]) => ({ value, label }))
+    };
+  }, [rows, chainName]);
+
+  const filtered = useMemo(
+    () =>
+      rows.filter(
+        row =>
+          (network === ALL || String(row.chainId) === network) &&
+          (stablecoin === ALL || row.symbol === stablecoin) &&
+          (product === ALL || row.module === product)
+      ),
+    [rows, network, stablecoin, product]
+  );
+
+  const filterKey = `${network}-${stablecoin}-${product}`;
+  const triggerClassName = isMobile ? 'w-full' : undefined;
+
+  return (
+    <section className="flex flex-col gap-5" data-testid="portfolio-transactions">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <Heading variant="small" tag="h2" className="text-fgPrimary">
+          <Trans>Transactions</Trans>
+        </Heading>
+        <div className={cn('flex gap-2 md:gap-3', isMobile ? 'flex-col' : 'flex-row')}>
+          <FilterSelect
+            testId="portfolio-tx-filter-network"
+            options={networks}
+            selected={network}
+            onChange={setNetwork}
+            allLabel={<Trans>All networks</Trans>}
+            triggerClassName={triggerClassName}
+          />
+          <FilterSelect
+            testId="portfolio-tx-filter-stablecoin"
+            options={stablecoins}
+            selected={stablecoin}
+            onChange={setStablecoin}
+            allLabel={<Trans>All stablecoins</Trans>}
+            triggerClassName={triggerClassName}
+          />
+          <FilterSelect
+            testId="portfolio-tx-filter-product"
+            options={products}
+            selected={product}
+            onChange={setProduct}
+            allLabel={<Trans>All products</Trans>}
+            triggerClassName={triggerClassName}
+          />
+        </div>
+      </div>
+
+      <ProductTransactionsTable
+        key={filterKey}
+        dataTestId="portfolio-transactions-table"
+        columns={COLUMNS}
+        rows={filtered}
+        rowKey={row => row.id}
+        isLoading={isLoading}
+        error={error}
+        emptyLabel={<Trans>No transactions yet</Trans>}
+        renderCard={renderCard}
+      />
+    </section>
+  );
+}
+
+/**
+ * Portfolio-wide Transactions section (D8/APP-391): the aggregated
+ * `useAllNetworksCombinedHistory` feed rendered as the DS Table/Transactions
+ * (486:20055 desktop / 486:20198 mobile). Read-only over the existing
+ * aggregate — no engine hooks touched.
+ */
+export function PortfolioTransactionsSection() {
+  const { data, isLoading, error } = useAllNetworksCombinedHistory();
+  const rows = useMemo(() => (data ?? []).map((item, i) => toPortfolioTxRow(item, i)), [data]);
+  return <PortfolioTransactionsView rows={rows} isLoading={isLoading} error={error} />;
+}

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { useChains } from 'wagmi';
 import { BP, ModuleEnum, useAllNetworksCombinedHistory, useBreakpointIndex } from '@/hooks';
-import { formatAddress, getChainIcon, getEtherscanLink } from '@/utils';
+import { formatAddress, getChainIcon } from '@/utils';
 import { cn } from '@/lib/cn';
 import { Heading } from '@/modules/layout/components/Typography';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
@@ -62,7 +62,12 @@ function actionIcon(row: PortfolioTxRow): ReactNode {
 }
 
 const tokenIcon = (symbol: string, width = 12) => (
-  <TokenIcon token={{ symbol }} width={width} showChainIcon={false} className="h-3 w-3" />
+  <TokenIcon
+    token={{ symbol }}
+    width={width}
+    showChainIcon={false}
+    className={width >= 16 ? 'h-4 w-4' : 'h-3 w-3'}
+  />
 );
 
 // Header action cell (icon + verb + relative time), shared by the desktop row
@@ -90,7 +95,7 @@ const suppliedCell = (row: PortfolioTxRow) => (
 );
 
 const hashCell = (row: PortfolioTxRow) => (
-  <CellHash label={formatAddress(row.txHash, 6, 4)} href={getEtherscanLink(row.chainId, row.txHash, 'tx')} />
+  <CellHash label={formatAddress(row.txHash, 6, 4)} href={row.explorerHref} />
 );
 
 const COLUMNS: ProductTransactionColumn<PortfolioTxRow>[] = [
@@ -115,7 +120,7 @@ const renderCard = (row: PortfolioTxRow) => (
       { label: <Trans>Product</Trans>, value: productCell(row) },
       { label: <Trans>Supplied</Trans>, value: suppliedCell(row) }
     ]}
-    link={{ label: <Trans>View transaction</Trans>, href: getEtherscanLink(row.chainId, row.txHash, 'tx') }}
+    link={{ label: <Trans>View transaction</Trans>, href: row.explorerHref }}
   />
 );
 

--- a/apps/webapp/src/modules/portfolio/helpers/transactionRow.test.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/transactionRow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { i18n } from '@lingui/core';
 import { ModuleEnum, TransactionTypeEnum, type CombinedHistoryItem } from '@/hooks';
+import { getCowExplorerLink, getEtherscanLink } from '@/utils';
 import { toPortfolioTxRow } from './transactionRow';
 
 i18n.load('en', {});
@@ -50,21 +51,25 @@ describe('toPortfolioTxRow', () => {
     expect(row.usd).toBeDefined();
   });
 
-  it('maps CoW trade status and defaults chainId to mainnet (no chainId on trade rows)', () => {
-    const row = toPortfolioTxRow(
+  it('reads chainId from trade rows and links CoW orders to the CoW explorer', () => {
+    const r = toPortfolioTxRow(
       asItem({
         ...base,
         module: ModuleEnum.TRADE,
         type: TransactionTypeEnum.TRADE,
+        chainId: 8453, // trade producers attach chainId at runtime (type omits it)
+        transactionHash: '0xorderuid',
         fromAmount: 10n * 10n ** 18n,
         fromToken: { symbol: 'USDS', decimals: 18 },
         cowOrderStatus: 'Open' // formatOrderStatus string, not the enum
       }),
       0
     );
-    expect(row.action).toBe('Trade');
-    expect(row.chainId).toBe(1);
-    expect(row.status).toBe('pending');
+    expect(r.action).toBe('Trade');
+    expect(r.chainId).toBe(8453);
+    expect(r.status).toBe('pending');
+    // CoW txHash is an order UID → CoW explorer, not Etherscan.
+    expect(r.explorerHref).toBe(getCowExplorerLink(8453, '0xorderuid'));
   });
 
   it('marks a fulfilled trade completed and a cancelled/expired trade failed', () => {
@@ -118,6 +123,67 @@ describe('toPortfolioTxRow', () => {
     expect(row.action).toBe('Fixed Yield Buy');
     expect(row.symbol).toBe('USDS');
     expect(row.positive).toBe(true);
+  });
+
+  it('excludes yield-bearing sUSDS from the USD column', () => {
+    const r = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.PENDLE,
+        type: TransactionTypeEnum.PENDLE_BUY,
+        chainId: 1,
+        assets: 100n * 10n ** 18n,
+        underlyingSymbol: 'sUSDS',
+        underlyingDecimals: 18
+      }),
+      0
+    );
+    expect(r.symbol).toBe('sUSDS');
+    expect(r.usd).toBeUndefined(); // sUSDS is worth >$1, not a stablecoin
+  });
+
+  it('labels a stake select-delegate row and carries no amount', () => {
+    const r = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.STAKE,
+        type: TransactionTypeEnum.STAKE_SELECT_DELEGATE,
+        chainId: 1
+      }),
+      0
+    );
+    expect(r.action).toBe('Select delegate');
+    expect(r.amount).toBe('');
+  });
+
+  it('uses SKY as the unit for a liquidation (UNSTAKE_KICK)', () => {
+    const r = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.STAKE,
+        type: TransactionTypeEnum.UNSTAKE_KICK,
+        chainId: 1,
+        amount: 5n * 10n ** 18n
+      }),
+      0
+    );
+    expect(r.action).toBe('Liquidation');
+    expect(r.symbol).toBe('SKY');
+  });
+
+  it('links non-CoW rows to the block explorer', () => {
+    const r = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.SAVINGS,
+        type: TransactionTypeEnum.SUPPLY,
+        chainId: 1,
+        assets: 1n,
+        token: { symbol: 'USDS', decimals: 18 }
+      }),
+      0
+    );
+    expect(r.explorerHref).toBe(getEtherscanLink(1, r.txHash, 'tx'));
   });
 
   it('builds a stable id from hash + module + type + index', () => {

--- a/apps/webapp/src/modules/portfolio/helpers/transactionRow.test.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/transactionRow.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { i18n } from '@lingui/core';
+import { ModuleEnum, TransactionTypeEnum, type CombinedHistoryItem } from '@/hooks';
+import { OrderStatus } from '@/hooks/trade/constants';
+import { toPortfolioTxRow } from './transactionRow';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+// Real history tokens carry `decimals`; the number form short-circuits the
+// per-chain lookup in getTokenDecimals.
+const base = { blockTimestamp: new Date(0), transactionHash: '0xabc' };
+const asItem = (o: object) => o as unknown as CombinedHistoryItem;
+
+describe('toPortfolioTxRow', () => {
+  it('normalizes a savings supply (stablecoin → USD present, positive)', () => {
+    const row = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.SAVINGS,
+        type: TransactionTypeEnum.SUPPLY,
+        chainId: 1,
+        assets: 1000000000n * 10n ** 12n, // 1,000,000 at 18dp
+        token: { symbol: 'USDS', decimals: 18 }
+      }),
+      0
+    );
+    expect(row.action).toBe('Savings Supply');
+    expect(row.symbol).toBe('USDS');
+    expect(row.chainId).toBe(1);
+    expect(row.status).toBe('completed');
+    expect(row.positive).toBe(true);
+    expect(row.usd).toBe(`$${row.amount}`); // stablecoin: USD mirrors the amount
+  });
+
+  it('normalizes a withdraw as negative and keeps USD for stables', () => {
+    const row = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.MORPHO,
+        type: TransactionTypeEnum.WITHDRAW,
+        chainId: 8453,
+        assets: -5n * 10n ** 18n,
+        token: { symbol: 'USDC', decimals: 18 }
+      }),
+      0
+    );
+    expect(row.action).toBe('Vault Withdraw');
+    expect(row.positive).toBe(false);
+    expect(row.chainId).toBe(8453);
+    expect(row.usd).toBeDefined();
+  });
+
+  it('maps CoW trade status and defaults chainId to mainnet (no chainId on trade rows)', () => {
+    const row = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.TRADE,
+        type: TransactionTypeEnum.TRADE,
+        fromAmount: 10n * 10n ** 18n,
+        fromToken: { symbol: 'USDS', decimals: 18 },
+        cowOrderStatus: OrderStatus.open
+      }),
+      0
+    );
+    expect(row.action).toBe('Trade');
+    expect(row.chainId).toBe(1);
+    expect(row.status).toBe('pending');
+  });
+
+  it('marks a fulfilled trade completed and a cancelled trade failed', () => {
+    const mk = (s: OrderStatus) =>
+      toPortfolioTxRow(
+        asItem({
+          ...base,
+          module: ModuleEnum.TRADE,
+          type: TransactionTypeEnum.TRADE,
+          fromAmount: 1n,
+          fromToken: { symbol: 'USDS', decimals: 18 },
+          cowOrderStatus: s
+        }),
+        0
+      ).status;
+    expect(mk(OrderStatus.fulfilled)).toBe('completed');
+    expect(mk(OrderStatus.cancelled)).toBe('failed');
+    expect(mk(OrderStatus.expired)).toBe('failed');
+  });
+
+  it('handles a token-less upgrade row (SKY, no USD column)', () => {
+    const row = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.UPGRADE,
+        type: TransactionTypeEnum.MKR_TO_SKY,
+        chainId: 1,
+        skyAmt: 24000n * 10n ** 18n
+      }),
+      0
+    );
+    expect(row.action).toBe('Upgrade');
+    expect(row.symbol).toBe('SKY');
+    expect(row.usd).toBeUndefined(); // SKY is not a $1-pegged stablecoin
+    expect(row.positive).toBe(true);
+  });
+
+  it('labels pendle rows and reads the underlying symbol', () => {
+    const row = toPortfolioTxRow(
+      asItem({
+        ...base,
+        module: ModuleEnum.PENDLE,
+        type: TransactionTypeEnum.PENDLE_BUY,
+        chainId: 1,
+        assets: 100n * 10n ** 18n,
+        underlyingSymbol: 'USDS',
+        underlyingDecimals: 18
+      }),
+      0
+    );
+    expect(row.action).toBe('Fixed Yield Buy');
+    expect(row.symbol).toBe('USDS');
+    expect(row.positive).toBe(true);
+  });
+
+  it('builds a stable id from hash + module + type + index', () => {
+    const item = asItem({
+      ...base,
+      module: ModuleEnum.SAVINGS,
+      type: TransactionTypeEnum.SUPPLY,
+      chainId: 1,
+      assets: 1n,
+      token: { symbol: 'USDS', decimals: 18 }
+    });
+    expect(toPortfolioTxRow(item, 3).id).toBe('0xabc-SAVINGS-SUPPLY-3');
+  });
+});

--- a/apps/webapp/src/modules/portfolio/helpers/transactionRow.test.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/transactionRow.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { i18n } from '@lingui/core';
 import { ModuleEnum, TransactionTypeEnum, type CombinedHistoryItem } from '@/hooks';
-import { OrderStatus } from '@/hooks/trade/constants';
 import { toPortfolioTxRow } from './transactionRow';
 
 i18n.load('en', {});
@@ -59,7 +58,7 @@ describe('toPortfolioTxRow', () => {
         type: TransactionTypeEnum.TRADE,
         fromAmount: 10n * 10n ** 18n,
         fromToken: { symbol: 'USDS', decimals: 18 },
-        cowOrderStatus: OrderStatus.open
+        cowOrderStatus: 'Open' // formatOrderStatus string, not the enum
       }),
       0
     );
@@ -68,8 +67,8 @@ describe('toPortfolioTxRow', () => {
     expect(row.status).toBe('pending');
   });
 
-  it('marks a fulfilled trade completed and a cancelled trade failed', () => {
-    const mk = (s: OrderStatus) =>
+  it('marks a fulfilled trade completed and a cancelled/expired trade failed', () => {
+    const mk = (s: string) =>
       toPortfolioTxRow(
         asItem({
           ...base,
@@ -81,9 +80,9 @@ describe('toPortfolioTxRow', () => {
         }),
         0
       ).status;
-    expect(mk(OrderStatus.fulfilled)).toBe('completed');
-    expect(mk(OrderStatus.cancelled)).toBe('failed');
-    expect(mk(OrderStatus.expired)).toBe('failed');
+    expect(mk('Fulfilled')).toBe('completed');
+    expect(mk('Cancelled')).toBe('failed');
+    expect(mk('Expired')).toBe('failed');
   });
 
   it('handles a token-less upgrade row (SKY, no USD column)', () => {

--- a/apps/webapp/src/modules/portfolio/helpers/transactionRow.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/transactionRow.ts
@@ -1,20 +1,16 @@
 import { t } from '@lingui/core/macro';
 import { CombinedHistoryItem, ModuleEnum, TransactionTypeEnum, getTokenDecimals } from '@/hooks';
-import { formatBigInt } from '@/utils';
-
-// The history items carry a `Token` shaped slightly differently from the one
-// `getTokenDecimals` expects (a second Token type in the codebase); bridge them
-// the same way the widget helpers do.
-type TokenArg = Parameters<typeof getTokenDecimals>[0];
+import { capitalizeFirstLetter, formatBigInt, getCowExplorerLink, getEtherscanLink } from '@/utils';
 
 /**
  * Flat, display-ready row for the Portfolio Transactions table (D8/APP-391),
  * normalized from the `CombinedHistoryItem` discriminated union returned by
- * `useAllNetworksCombinedHistory`. The union-narrowing here mirrors the wallet
- * activity modal's `getTitle`/`getAmount`/`getToken`/`getPositive`
- * (`widgets/BalancesWidget/lib`); it is re-implemented in the module layer on
- * purpose so this feature doesn't couple to the widget tree that is being
- * retired. Keep the two in sync until the widget history is removed.
+ * `useAllNetworksCombinedHistory`. The union-narrowing here is a faithful port
+ * of the wallet activity modal's `getTitle` / `getAmount` / `getToken` and its
+ * CoW-vs-Etherscan link branch (`widgets/BalancesWidget/lib` +
+ * `BalancesHistoryItem`); it is re-implemented in the module layer on purpose
+ * so this feature doesn't couple to the widget tree that is being retired.
+ * Keep the two in sync until the widget history is removed.
  */
 export type PortfolioTxStatus = 'pending' | 'completed' | 'failed';
 
@@ -30,23 +26,43 @@ export interface PortfolioTxRow {
   action: string;
   /** Token symbol for the amount/product cells. */
   symbol: string;
-  /** Formatted token amount (compact, absolute). */
+  /** Formatted token amount (compact, absolute); empty for admin/no-value events. */
   amount: string;
   /** `$`-prefixed USD, present only for $1-pegged tokens. */
   usd?: string;
   status: PortfolioTxStatus;
-  /** Amount sign for the bullish/bearish treatment; undefined = no sign. */
+  /** Deposit-style (true) vs withdraw-style (false) — drives the action icon only. */
   positive?: boolean;
+  /** Explorer link: the CoW explorer for CoW orders (whose `txHash` is an order UID), Etherscan otherwise. */
+  explorerHref: string;
 }
 
-// $1-pegged tokens whose formatted amount doubles as its USD value, matching
-// the per-product tables (e.g. VaultTransactionsTable: `usd: '$' + amount`).
-const STABLES = new Set(['USDS', 'SUSDS', 'USDC', 'USDT', 'SUSDT', 'DAI', 'USDL']);
+// The history items carry a `Token` shaped slightly differently from the one
+// `getTokenDecimals` expects (a second Token type in the codebase); bridge them
+// the same way the widget helpers do.
+type TokenArg = Parameters<typeof getTokenDecimals>[0];
+
+// True $1-pegged tokens whose formatted amount doubles as its USD value. sUSDS /
+// sUSDT are yield-bearing shares worth more than $1, so they are excluded (a
+// Pendle row carries `underlyingSymbol: 'sUSDS'`, which must not read as $1).
+const STABLES = new Set(['USDS', 'USDC', 'USDT', 'DAI', 'USDL']);
+
+// Administrative events (open position, pick a delegate/reward) record no value
+// movement, so they carry no amount — mirrors getAmount's select-guard.
+const NO_VALUE_TYPES = new Set<TransactionTypeEnum>([
+  TransactionTypeEnum.OPEN,
+  TransactionTypeEnum.STAKE_OPEN,
+  TransactionTypeEnum.SELECT_DELEGATE,
+  TransactionTypeEnum.SELECT_REWARD,
+  TransactionTypeEnum.STAKE_SELECT_DELEGATE,
+  TransactionTypeEnum.STAKE_SELECT_REWARD
+]);
 
 const absBigInt = (v: bigint): bigint => (v < 0n ? -v : v);
 
 function actionLabel(item: CombinedHistoryItem): string {
-  switch (item.type) {
+  const { type, module } = item;
+  switch (type) {
     case TransactionTypeEnum.DAI_TO_USDS:
     case TransactionTypeEnum.MKR_TO_SKY:
       return t`Upgrade`;
@@ -56,16 +72,16 @@ function actionLabel(item: CombinedHistoryItem): string {
     case TransactionTypeEnum.TRADE:
       return t`Trade`;
     case TransactionTypeEnum.SUPPLY:
-      if (item.module === ModuleEnum.REWARDS) return t`Rewards Supply`;
-      if (item.module === ModuleEnum.SAVINGS) return t`Savings Supply`;
-      if (item.module === ModuleEnum.STUSDS) return t`stUSDS Supply`;
-      if (item.module === ModuleEnum.MORPHO || item.module === ModuleEnum.SUSDT) return t`Vault Supply`;
+      if (module === ModuleEnum.REWARDS) return t`Rewards Supply`;
+      if (module === ModuleEnum.SAVINGS) return t`Savings Supply`;
+      if (module === ModuleEnum.STUSDS) return t`stUSDS Supply`;
+      if (module === ModuleEnum.MORPHO || module === ModuleEnum.SUSDT) return t`Vault Supply`;
       return t`Supply`;
     case TransactionTypeEnum.WITHDRAW:
-      if (item.module === ModuleEnum.REWARDS) return t`Rewards Withdraw`;
-      if (item.module === ModuleEnum.SAVINGS) return t`Savings Withdraw`;
-      if (item.module === ModuleEnum.STUSDS) return t`stUSDS Withdraw`;
-      if (item.module === ModuleEnum.MORPHO || item.module === ModuleEnum.SUSDT) return t`Vault Withdraw`;
+      if (module === ModuleEnum.REWARDS) return t`Rewards Withdraw`;
+      if (module === ModuleEnum.SAVINGS) return t`Savings Withdraw`;
+      if (module === ModuleEnum.STUSDS) return t`stUSDS Withdraw`;
+      if (module === ModuleEnum.MORPHO || module === ModuleEnum.SUSDT) return t`Vault Withdraw`;
       return t`Withdraw`;
     case TransactionTypeEnum.REWARD:
     case TransactionTypeEnum.STAKE_REWARD:
@@ -80,6 +96,10 @@ function actionLabel(item: CombinedHistoryItem): string {
       return t`Borrow`;
     case TransactionTypeEnum.STAKE_REPAY:
       return t`Repay`;
+    case TransactionTypeEnum.STAKE_SELECT_DELEGATE:
+      return t`Select delegate`;
+    case TransactionTypeEnum.STAKE_SELECT_REWARD:
+      return t`Select reward`;
     case TransactionTypeEnum.UNSTAKE_KICK:
       return t`Liquidation`;
     case TransactionTypeEnum.PENDLE_BUY:
@@ -89,7 +109,8 @@ function actionLabel(item: CombinedHistoryItem): string {
     case TransactionTypeEnum.PENDLE_REDEEM:
       return t`Fixed Yield Redeem`;
     default:
-      return t`Transaction`;
+      // Same fallback as getTitle: humanize the enum value.
+      return capitalizeFirstLetter((type || module).toLowerCase().replace('_', ' '));
   }
 }
 
@@ -102,6 +123,7 @@ function tokenSymbol(item: CombinedHistoryItem): string {
     case TransactionTypeEnum.SKY_TO_MKR:
     case TransactionTypeEnum.STAKE:
     case TransactionTypeEnum.UNSTAKE:
+    case TransactionTypeEnum.UNSTAKE_KICK:
       return 'SKY';
     default:
       return 'USDS';
@@ -109,6 +131,7 @@ function tokenSymbol(item: CombinedHistoryItem): string {
 }
 
 function amountString(item: CombinedHistoryItem, chainId: number): string {
+  if (NO_VALUE_TYPES.has(item.type)) return '';
   switch (item.module) {
     case ModuleEnum.TRADE:
       return formatBigInt(absBigInt('fromAmount' in item ? item.fromAmount : 0n), {
@@ -141,12 +164,17 @@ function amountString(item: CombinedHistoryItem, chainId: number): string {
   }
 }
 
-// Sign for the amount's bullish (+) / bearish (−) treatment; undefined = no sign
-// (e.g. open-position / select-delegate rows that carry no value).
+// Deposit-style (true) vs withdraw-style (false); undefined = no direction. Drives
+// only the action icon (in/out), not the amount color.
 function isPositive(type: TransactionTypeEnum): boolean | undefined {
   switch (type) {
     case TransactionTypeEnum.STAKE_OPEN:
     case TransactionTypeEnum.UNSTAKE_KICK:
+    case TransactionTypeEnum.OPEN:
+    case TransactionTypeEnum.SELECT_DELEGATE:
+    case TransactionTypeEnum.SELECT_REWARD:
+    case TransactionTypeEnum.STAKE_SELECT_DELEGATE:
+    case TransactionTypeEnum.STAKE_SELECT_REWARD:
       return undefined;
     case TransactionTypeEnum.SUPPLY:
     case TransactionTypeEnum.STAKE:
@@ -182,10 +210,18 @@ function txStatus(item: CombinedHistoryItem): PortfolioTxStatus {
 }
 
 export function toPortfolioTxRow(item: CombinedHistoryItem, index: number): PortfolioTxRow {
-  // Trade rows (ParsedTradeRecord) don't carry chainId; CoW trades are mainnet.
+  // ParsedTradeRecord omits chainId in its *type*, but every runtime producer
+  // (cowswap / psm / hybrid) attaches it, so `'chainId' in item` reads it; the
+  // `: 1` is only a defensive default.
   const chainId = 'chainId' in item ? item.chainId : 1;
   const symbol = tokenSymbol(item);
   const amount = amountString(item, chainId);
+  // CoW orders store an order UID in `transactionHash`, which resolves on the
+  // CoW explorer, not Etherscan (mirrors BalancesHistoryItem).
+  const explorerHref =
+    'cowOrderStatus' in item
+      ? getCowExplorerLink(chainId, item.transactionHash)
+      : getEtherscanLink(chainId, item.transactionHash, 'tx');
   return {
     id: `${item.transactionHash}-${item.module}-${item.type}-${index}`,
     txHash: item.transactionHash,
@@ -198,6 +234,7 @@ export function toPortfolioTxRow(item: CombinedHistoryItem, index: number): Port
     amount,
     usd: amount && STABLES.has(symbol.toUpperCase()) ? `$${amount}` : undefined,
     status: txStatus(item),
-    positive: isPositive(item.type)
+    positive: isPositive(item.type),
+    explorerHref
   };
 }

--- a/apps/webapp/src/modules/portfolio/helpers/transactionRow.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/transactionRow.ts
@@ -1,6 +1,5 @@
 import { t } from '@lingui/core/macro';
 import { CombinedHistoryItem, ModuleEnum, TransactionTypeEnum, getTokenDecimals } from '@/hooks';
-import { OrderStatus } from '@/hooks/trade/constants';
 import { formatBigInt } from '@/utils';
 
 // The history items carry a `Token` shaped slightly differently from the one
@@ -163,20 +162,21 @@ function isPositive(type: TransactionTypeEnum): boolean | undefined {
   }
 }
 
-// Only CoW trades carry a real lifecycle status; every other row comes from the
-// subgraph and is therefore an indexed, confirmed transaction.
+// Only CoW trades carry a lifecycle status; every other row is an indexed,
+// confirmed subgraph transaction. `cowOrderStatus` holds the *formatted* string
+// from `formatOrderStatus` (Fulfilled / Open / Signature Pending / Cancelled /
+// Expired) — not the OrderStatus enum, despite the field's declared type.
 function txStatus(item: CombinedHistoryItem): PortfolioTxStatus {
   if (!('cowOrderStatus' in item)) return 'completed';
-  switch (item.cowOrderStatus) {
-    case OrderStatus.fulfilled:
-      return 'completed';
-    case OrderStatus.open:
-    case OrderStatus.presignaturePending:
-      return 'pending';
-    case OrderStatus.cancelled:
-    case OrderStatus.expired:
+  switch (String(item.cowOrderStatus)) {
+    case 'Cancelled':
+    case 'Expired':
       return 'failed';
+    case 'Open':
+    case 'Signature Pending':
+      return 'pending';
     default:
+      // 'Fulfilled' + any settled/unknown historical order.
       return 'completed';
   }
 }

--- a/apps/webapp/src/modules/portfolio/helpers/transactionRow.ts
+++ b/apps/webapp/src/modules/portfolio/helpers/transactionRow.ts
@@ -1,0 +1,203 @@
+import { t } from '@lingui/core/macro';
+import { CombinedHistoryItem, ModuleEnum, TransactionTypeEnum, getTokenDecimals } from '@/hooks';
+import { OrderStatus } from '@/hooks/trade/constants';
+import { formatBigInt } from '@/utils';
+
+// The history items carry a `Token` shaped slightly differently from the one
+// `getTokenDecimals` expects (a second Token type in the codebase); bridge them
+// the same way the widget helpers do.
+type TokenArg = Parameters<typeof getTokenDecimals>[0];
+
+/**
+ * Flat, display-ready row for the Portfolio Transactions table (D8/APP-391),
+ * normalized from the `CombinedHistoryItem` discriminated union returned by
+ * `useAllNetworksCombinedHistory`. The union-narrowing here mirrors the wallet
+ * activity modal's `getTitle`/`getAmount`/`getToken`/`getPositive`
+ * (`widgets/BalancesWidget/lib`); it is re-implemented in the module layer on
+ * purpose so this feature doesn't couple to the widget tree that is being
+ * retired. Keep the two in sync until the widget history is removed.
+ */
+export type PortfolioTxStatus = 'pending' | 'completed' | 'failed';
+
+export interface PortfolioTxRow {
+  /** Stable key — a tx hash can carry several events, so compose it. */
+  id: string;
+  txHash: string;
+  timestamp: Date;
+  module: ModuleEnum;
+  type: TransactionTypeEnum;
+  chainId: number;
+  /** Translated action label, e.g. "Savings Supply". */
+  action: string;
+  /** Token symbol for the amount/product cells. */
+  symbol: string;
+  /** Formatted token amount (compact, absolute). */
+  amount: string;
+  /** `$`-prefixed USD, present only for $1-pegged tokens. */
+  usd?: string;
+  status: PortfolioTxStatus;
+  /** Amount sign for the bullish/bearish treatment; undefined = no sign. */
+  positive?: boolean;
+}
+
+// $1-pegged tokens whose formatted amount doubles as its USD value, matching
+// the per-product tables (e.g. VaultTransactionsTable: `usd: '$' + amount`).
+const STABLES = new Set(['USDS', 'SUSDS', 'USDC', 'USDT', 'SUSDT', 'DAI', 'USDL']);
+
+const absBigInt = (v: bigint): bigint => (v < 0n ? -v : v);
+
+function actionLabel(item: CombinedHistoryItem): string {
+  switch (item.type) {
+    case TransactionTypeEnum.DAI_TO_USDS:
+    case TransactionTypeEnum.MKR_TO_SKY:
+      return t`Upgrade`;
+    case TransactionTypeEnum.SKY_TO_MKR:
+    case TransactionTypeEnum.USDS_TO_DAI:
+      return t`Revert`;
+    case TransactionTypeEnum.TRADE:
+      return t`Trade`;
+    case TransactionTypeEnum.SUPPLY:
+      if (item.module === ModuleEnum.REWARDS) return t`Rewards Supply`;
+      if (item.module === ModuleEnum.SAVINGS) return t`Savings Supply`;
+      if (item.module === ModuleEnum.STUSDS) return t`stUSDS Supply`;
+      if (item.module === ModuleEnum.MORPHO || item.module === ModuleEnum.SUSDT) return t`Vault Supply`;
+      return t`Supply`;
+    case TransactionTypeEnum.WITHDRAW:
+      if (item.module === ModuleEnum.REWARDS) return t`Rewards Withdraw`;
+      if (item.module === ModuleEnum.SAVINGS) return t`Savings Withdraw`;
+      if (item.module === ModuleEnum.STUSDS) return t`stUSDS Withdraw`;
+      if (item.module === ModuleEnum.MORPHO || item.module === ModuleEnum.SUSDT) return t`Vault Withdraw`;
+      return t`Withdraw`;
+    case TransactionTypeEnum.REWARD:
+    case TransactionTypeEnum.STAKE_REWARD:
+      return t`Claim rewards`;
+    case TransactionTypeEnum.STAKE:
+      return t`Stake`;
+    case TransactionTypeEnum.UNSTAKE:
+      return t`Unstake`;
+    case TransactionTypeEnum.STAKE_OPEN:
+      return t`Open position`;
+    case TransactionTypeEnum.STAKE_BORROW:
+      return t`Borrow`;
+    case TransactionTypeEnum.STAKE_REPAY:
+      return t`Repay`;
+    case TransactionTypeEnum.UNSTAKE_KICK:
+      return t`Liquidation`;
+    case TransactionTypeEnum.PENDLE_BUY:
+      return t`Fixed Yield Buy`;
+    case TransactionTypeEnum.PENDLE_SELL:
+      return t`Fixed Yield Sell`;
+    case TransactionTypeEnum.PENDLE_REDEEM:
+      return t`Fixed Yield Redeem`;
+    default:
+      return t`Transaction`;
+  }
+}
+
+function tokenSymbol(item: CombinedHistoryItem): string {
+  if ('token' in item && item.token) return item.token.symbol;
+  if ('fromToken' in item && item.fromToken) return item.fromToken.symbol;
+  if ('underlyingSymbol' in item && item.underlyingSymbol) return item.underlyingSymbol;
+  switch (item.type) {
+    case TransactionTypeEnum.MKR_TO_SKY:
+    case TransactionTypeEnum.SKY_TO_MKR:
+    case TransactionTypeEnum.STAKE:
+    case TransactionTypeEnum.UNSTAKE:
+      return 'SKY';
+    default:
+      return 'USDS';
+  }
+}
+
+function amountString(item: CombinedHistoryItem, chainId: number): string {
+  switch (item.module) {
+    case ModuleEnum.TRADE:
+      return formatBigInt(absBigInt('fromAmount' in item ? item.fromAmount : 0n), {
+        compact: true,
+        unit: getTokenDecimals(('fromToken' in item ? item.fromToken : undefined) as TokenArg, chainId)
+      });
+    case ModuleEnum.UPGRADE:
+      if (item.type === TransactionTypeEnum.MKR_TO_SKY || item.type === TransactionTypeEnum.SKY_TO_MKR) {
+        return formatBigInt(absBigInt('skyAmt' in item ? item.skyAmt : 0n), { compact: true });
+      }
+      return formatBigInt(absBigInt('wad' in item ? item.wad : 0n), { compact: true });
+    case ModuleEnum.REWARDS:
+    case ModuleEnum.STAKE:
+      return formatBigInt(absBigInt('amount' in item ? item.amount : 0n), { compact: true });
+    case ModuleEnum.SAVINGS:
+    case ModuleEnum.STUSDS:
+    case ModuleEnum.MORPHO:
+    case ModuleEnum.SUSDT:
+      return formatBigInt(absBigInt('assets' in item ? item.assets : 0n), {
+        compact: true,
+        unit: getTokenDecimals(('token' in item ? item.token : undefined) as TokenArg, chainId)
+      });
+    case ModuleEnum.PENDLE:
+      return formatBigInt(absBigInt('assets' in item ? item.assets : 0n), {
+        compact: true,
+        unit: 'underlyingDecimals' in item ? item.underlyingDecimals : 18
+      });
+    default:
+      return '';
+  }
+}
+
+// Sign for the amount's bullish (+) / bearish (−) treatment; undefined = no sign
+// (e.g. open-position / select-delegate rows that carry no value).
+function isPositive(type: TransactionTypeEnum): boolean | undefined {
+  switch (type) {
+    case TransactionTypeEnum.STAKE_OPEN:
+    case TransactionTypeEnum.UNSTAKE_KICK:
+      return undefined;
+    case TransactionTypeEnum.SUPPLY:
+    case TransactionTypeEnum.STAKE:
+    case TransactionTypeEnum.REWARD:
+    case TransactionTypeEnum.STAKE_REWARD:
+    case TransactionTypeEnum.MKR_TO_SKY:
+    case TransactionTypeEnum.DAI_TO_USDS:
+    case TransactionTypeEnum.STAKE_REPAY:
+    case TransactionTypeEnum.PENDLE_BUY:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Only CoW trades carry a real lifecycle status; every other row comes from the
+// subgraph and is therefore an indexed, confirmed transaction.
+function txStatus(item: CombinedHistoryItem): PortfolioTxStatus {
+  if (!('cowOrderStatus' in item)) return 'completed';
+  switch (item.cowOrderStatus) {
+    case OrderStatus.fulfilled:
+      return 'completed';
+    case OrderStatus.open:
+    case OrderStatus.presignaturePending:
+      return 'pending';
+    case OrderStatus.cancelled:
+    case OrderStatus.expired:
+      return 'failed';
+    default:
+      return 'completed';
+  }
+}
+
+export function toPortfolioTxRow(item: CombinedHistoryItem, index: number): PortfolioTxRow {
+  // Trade rows (ParsedTradeRecord) don't carry chainId; CoW trades are mainnet.
+  const chainId = 'chainId' in item ? item.chainId : 1;
+  const symbol = tokenSymbol(item);
+  const amount = amountString(item, chainId);
+  return {
+    id: `${item.transactionHash}-${item.module}-${item.type}-${index}`,
+    txHash: item.transactionHash,
+    timestamp: item.blockTimestamp,
+    module: item.module,
+    type: item.type,
+    chainId,
+    action: actionLabel(item),
+    symbol,
+    amount,
+    usd: amount && STABLES.has(symbol.toUpperCase()) ? `$${amount}` : undefined,
+    status: txStatus(item),
+    positive: isPositive(item.type)
+  };
+}


### PR DESCRIPTION
## D8 · Portfolio Transactions section

Linear: [APP-391](https://linear.app/ekliptyka/issue/APP-391)

Adds the portfolio-wide Transactions section to `/portfolio` (Figma `486:20055` desktop / `486:20198` mobile) — a D1 gap: the comps specify it at both tiers but it was never built.

### Screenshots
| Desktop | Mobile |
| --- | --- |
| ![desktop](https://raw.githubusercontent.com/jetstreamgg/tarmac/497def7563357d8ce2e843d5a9437eb6da842360/pr-assets/app-391/transactions-desktop.png) | ![mobile](https://raw.githubusercontent.com/jetstreamgg/tarmac/497def7563357d8ce2e843d5a9437eb6da842360/pr-assets/app-391/transactions-mobile.png) |

### What it does
- **No new data layer** — reuses the existing `useAllNetworksCombinedHistory` aggregate; a normalizer maps its `CombinedHistoryItem` union to display rows (ported from the wallet-modal helpers, kept in the module layer to avoid coupling to the retiring widget tree).
- Desktop DS table / mobile `TransactionCard` list via the shared `ProductTransactionsTable`; network / stablecoin / product filters. Container/view split so the view is unit-testable with fixtures. Mounted in `ConnectedPortfolio` after the position cards.

### Notes for review
- Adds a **`failed`** state to the DS `CellStatus` (cancelled/expired CoW orders) — previously pending/completed only.
- Mobile comp mislabels the card's top grid row "My position"/"APY" (placeholder from the PositionCard); built with the correct **Network / Status** labels — flagging for design.
- Data source confirmed on the ticket (AC #5).

### Tests
Normalizer + view unit tests (incl. CoW-link, status, stablecoin, and admin-event edge cases); suites green, typecheck / eslint / prettier clean.

<sub>Screenshots hotlinked from the throwaway `d8-screenshots` branch (not in this diff).</sub>
