### PR TITLE
M6.9 (APP-409): /convert mobile build per comps

### DIFF
--- a/apps/webapp/src/modules/convert/components/ConvertAmountInput.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertAmountInput.tsx
@@ -1,6 +1,7 @@
 import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
+import { BP, useBreakpointIndex } from '@/hooks';
 import { formatNumber } from '@/utils';
 import { cn } from '@/lib/cn';
 import { buttonVariants } from '@/components/ui/button';
@@ -26,6 +27,11 @@ const formatBalance = (balance: bigint | undefined, decimals: number) =>
  * stablecoins and the swap is fee-free, the same simplification the legacy
  * widget made. The "0.00" placeholder renders in the primary text colour per
  * the Figma default frame (fg-primary, not the muted secondary).
+ *
+ * Phone tier (comps 1295:24298/25268, M6.9): 16px panel padding, Heading 3
+ * amount, and the percent chips move from beside the token chip down to the
+ * meta row, yielding to the USD value once an amount is typed — the top row
+ * always keeps the input + token chip so the input can't be squeezed out.
  */
 export function ConvertAmountInput({
   side,
@@ -49,12 +55,31 @@ export function ConvertAmountInput({
   onPercentClick?: (percent: number) => void;
   isConnected: boolean;
 }) {
+  const { bpi } = useBreakpointIndex();
+  const isMobile = bpi < BP.md;
   const isFrom = side === 'from';
   const usdValue = `$${value === '' ? '0.00' : formatNumber(parseFloat(value) || 0, { maxDecimals: 2 })}`;
 
+  const percentButtons = isFrom && isConnected && onPercentClick && (
+    <span className="flex items-center gap-1.5">
+      {PERCENT_OPTIONS.map(percent => (
+        // Design-system Button / Mini (Figma 5051:168712)
+        <button
+          key={percent}
+          type="button"
+          onClick={() => onPercentClick(percent)}
+          data-testid={`convert-from-percent-${percent}`}
+          className={cn(buttonVariants({ variant: 'mini', size: 'mini' }))}
+        >
+          {percent}%
+        </button>
+      ))}
+    </span>
+  );
+
   return (
     <div
-      className="bg-glassSurface flex flex-col gap-1 px-8 py-6 backdrop-blur-[20px]"
+      className="bg-glassSurface flex flex-col gap-1 p-4 backdrop-blur-[20px] md:px-8 md:py-6"
       data-testid={`convert-${side}`}
     >
       <div className="flex items-center justify-between gap-3">
@@ -67,31 +92,20 @@ export function ConvertAmountInput({
           readOnly={!isFrom}
           aria-label={isFrom ? t`Convert amount` : t`Amount received`}
           data-testid={`convert-${side}-amount`}
-          className="text-text placeholder:text-text w-full min-w-0 bg-transparent text-[32px] leading-9 font-medium outline-none"
+          className="text-text placeholder:text-text w-full min-w-0 bg-transparent text-2xl leading-[26px] font-medium tracking-[-0.48px] outline-none md:text-[32px] md:leading-9 md:tracking-normal"
         />
         <span className="flex shrink-0 items-center gap-1.5">
-          {isFrom && isConnected && onPercentClick && (
-            <span className="flex items-center gap-1.5">
-              {PERCENT_OPTIONS.map(percent => (
-                // Design-system Button / Mini (Figma 5051:168712)
-                <button
-                  key={percent}
-                  type="button"
-                  onClick={() => onPercentClick(percent)}
-                  data-testid={`convert-from-percent-${percent}`}
-                  className={cn(buttonVariants({ variant: 'mini', size: 'mini' }))}
-                >
-                  {percent}%
-                </button>
-              ))}
-            </span>
-          )}
+          {!isMobile && percentButtons}
           <ConvertTokenSelect value={symbol} onChange={onTokenChange} dataTestId={`convert-${side}-token`} />
         </span>
       </div>
-      <div className="flex items-center justify-between gap-2">
-        <Text className="text-textSecondary text-sm">{usdValue}</Text>
-        <Text className="text-textSecondary text-sm" dataTestId={`convert-${side}-balance`}>
+      <div className="flex h-10 items-center justify-between gap-2 md:h-auto">
+        {isMobile && value === '' && percentButtons ? (
+          percentButtons
+        ) : (
+          <Text className="text-textSecondary text-xs md:text-sm">{usdValue}</Text>
+        )}
+        <Text className="text-textSecondary text-xs md:text-sm" dataTestId={`convert-${side}-balance`}>
           <Trans>Balance</Trans>: {isConnected ? formatBalance(balance, decimals) : NO_VALUE}
         </Text>
       </div>

--- a/apps/webapp/src/modules/convert/components/ConvertCard.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertCard.tsx
@@ -42,9 +42,14 @@ export function ConvertCard({ form }: { form: ConvertFormModel }) {
   const networkName = chains.find(chain => chain.id === chainId)?.name ?? 'Ethereum';
 
   return (
-    <div className="flex w-full flex-col gap-[2px] overflow-clip rounded-[28px]" data-testid="convert-card">
+    // Phone tier (comp 1295:25285, M6.9): 16px radius + 16px row padding; the
+    // desktop 28px/32px geometry returns at md.
+    <div
+      className="flex w-full flex-col gap-[2px] overflow-clip rounded-2xl md:rounded-[28px]"
+      data-testid="convert-card"
+    >
       <ChainModal variant="wrapper" chainIds={networks} dataTestId="convert-network">
-        <span className="bg-glassSurface flex w-full items-center justify-between gap-2 px-8 py-6 backdrop-blur-[20px]">
+        <span className="bg-glassSurface flex w-full items-center justify-between gap-2 p-4 backdrop-blur-[20px] md:px-8 md:py-6">
           <span className="flex items-center gap-3">
             <Text className="text-textSecondary text-sm">
               <Trans>Network</Trans>

--- a/apps/webapp/src/modules/convert/components/ConvertPage.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertPage.tsx
@@ -96,7 +96,8 @@ export function ConvertPage() {
         <Button
           variant="primary"
           size="xl"
-          className="w-full"
+          // Phone tier steps to the L button (48px, comp 1295:25314); XL at md.
+          className="h-12 w-full text-sm leading-4 tracking-[-0.28px] md:h-14 md:text-base md:leading-[18px] md:tracking-[-0.32px]"
           disabled={reviewDisabled}
           onClick={launchOrConnect}
           data-testid="convert-review-cta"


### PR DESCRIPTION
Builds the `/convert` phone tier to the new mobile comps (`1295:24298` empty / `1295:25268` filled) and fixes the input-collapse bug found in the M7 audit. [APP-409](https://linear.app/ekliptyka/issue/APP-409/m69-convert-mobile-build-per-comps)

- **`ConvertAmountInput`**: below `BP.md` the percent chips move from beside the token chip down to the meta row and yield to the USD value once an amount is typed — the top row always keeps input + token chip, so the input can no longer be squeezed to zero width. Heading 3 amount (24/26), 16px panel padding, Body 6 meta row.
- **`ConvertCard`**: 16px radius + 16px network-row padding at the phone tier.
- **`ConvertPage`**: Review CTA steps to the 48px L button below md.
- Desktop (md+) geometry unchanged; review flow already presents as a bottom sheet (M4.2), untouched.
- The "address chip over the Review CTA" from the audit turned out to be the dev-only `MockConnectButton` (`VITE_USE_MOCK_WALLET` gated) — no production change needed.

Verified at 320/360/393px (input typable, no horizontal overflow, chips↔fiat swap), both themes; convert unit suite green (47 tests).

| Before (360 — From amount squeezed out) | After: empty (360) | After: filled (360) | After: dark (360) |
| --- | --- | --- | --- |
| ![before](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/app-409/before-360.png) | ![empty](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/app-409/empty-360.png) | ![filled](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/app-409/filled-360.png) | ![dark](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/app-409/dark-360.png) |

Desktop regression check (1280, unchanged):

<img src="https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/app-409/desktop-1280.png" width="600" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
