### PR TITLE
Fix trade price impact miscalculation for non-18-decimal tokens (USDC)

### DIFF
--- a/apps/webapp/src/hooks/trade/helpers.test.ts
+++ b/apps/webapp/src/hooks/trade/helpers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { parseUnits } from 'viem';
+import { calculateAmountUsd } from './helpers';
+
+describe('calculateAmountUsd', () => {
+  it('calculates the USD value of an 18-decimal token amount', () => {
+    expect(calculateAmountUsd(parseUnits('100', 18), '2', 18)).toBe(200);
+  });
+
+  it('calculates the USD value of a 6-decimal token amount (USDC)', () => {
+    expect(calculateAmountUsd(parseUnits('100', 6), '1', 6)).toBe(100);
+  });
+
+  it('handles fractional prices for 6-decimal tokens', () => {
+    expect(calculateAmountUsd(parseUnits('50', 6), '0.9998', 6)).toBeCloseTo(49.99, 2);
+  });
+
+  it('returns 0 for a zero amount', () => {
+    expect(calculateAmountUsd(0n, '1.5', 6)).toBe(0);
+  });
+});

--- a/apps/webapp/src/hooks/trade/helpers.ts
+++ b/apps/webapp/src/hooks/trade/helpers.ts
@@ -1,3 +1,5 @@
+import { formatUnits, parseUnits } from 'viem';
+import { WAD_PRECISION, math } from '@/utils';
 import { TOKENS } from '../tokens/tokens.constants';
 
 const STABLECOIN_SYMBOLS = new Set([
@@ -8,6 +10,15 @@ const STABLECOIN_SYMBOLS = new Set([
 ]);
 const STABLE_PAIR_AUTO_SLIPPAGE = 0.05;
 const VOLATILE_PAIR_AUTO_SLIPPAGE = 0.3;
+
+// Converts a raw token amount (in the token's native decimals) and a decimal price string
+// into a USD value as a float. The price is parsed to WAD so the result is WAD-scaled
+// regardless of the token's decimals
+export const calculateAmountUsd = (amount: bigint, price: string, tokenDecimals: number): number => {
+  return parseFloat(
+    formatUnits(math.tokenValue(amount, parseUnits(price, WAD_PRECISION), tokenDecimals), WAD_PRECISION)
+  );
+};
 
 export function getAutoSlippage(originSymbol?: string, targetSymbol?: string): number {
   if (

--- a/apps/webapp/src/hooks/trade/useTradeCosts.ts
+++ b/apps/webapp/src/hooks/trade/useTradeCosts.ts
@@ -1,6 +1,6 @@
-import { WAD_PRECISION, math } from '@/utils';
+import { WAD_PRECISION } from '@/utils';
 import { OrderQuoteSideKind, cowApiClient } from './constants';
-import { formatUnits, parseUnits } from 'viem';
+import { calculateAmountUsd } from './helpers';
 import { useChainId } from 'wagmi';
 import { mcdDaiAddress } from '../generated';
 import { useQueries } from '@tanstack/react-query';
@@ -114,30 +114,12 @@ export const useTradeCosts = ({
 
   const sellAmountBeforeFeeUsd =
     sellAmountBeforeFee && sellTokenPrice && sellToken
-      ? parseFloat(
-          formatUnits(
-            math.tokenValue(
-              sellAmountBeforeFee,
-              parseUnits(sellTokenPrice, getTokenDecimals(sellToken, chainId)),
-              getTokenDecimals(sellToken, chainId)
-            ),
-            WAD_PRECISION
-          )
-        )
+      ? calculateAmountUsd(sellAmountBeforeFee, sellTokenPrice, getTokenDecimals(sellToken, chainId))
       : undefined;
 
   const sellAmountAfterFeeUsd =
     sellAmountAfterFee && sellTokenPrice && sellToken
-      ? parseFloat(
-          formatUnits(
-            math.tokenValue(
-              sellAmountAfterFee,
-              parseUnits(sellTokenPrice, getTokenDecimals(sellToken, chainId)),
-              getTokenDecimals(sellToken, chainId)
-            ),
-            WAD_PRECISION
-          )
-        )
+      ? calculateAmountUsd(sellAmountAfterFee, sellTokenPrice, getTokenDecimals(sellToken, chainId))
       : undefined;
 
   const sellAmountUsd =
@@ -149,15 +131,10 @@ export const useTradeCosts = ({
 
   const buyAmountUsd =
     buyAmountBeforeFee && buyAmountAfterFee && buyTokenPrice && buyToken
-      ? parseFloat(
-          formatUnits(
-            math.tokenValue(
-              kind === OrderQuoteSideKind.SELL ? buyAmountAfterFee : buyAmountBeforeFee,
-              parseUnits(buyTokenPrice, getTokenDecimals(buyToken, chainId)),
-              getTokenDecimals(buyToken, chainId)
-            ),
-            WAD_PRECISION
-          )
+      ? calculateAmountUsd(
+          kind === OrderQuoteSideKind.SELL ? buyAmountAfterFee : buyAmountBeforeFee,
+          buyTokenPrice,
+          getTokenDecimals(buyToken, chainId)
         )
       : undefined;
 


### PR DESCRIPTION
USD values in useTradeCosts were computed in the token's decimal scale but formatted as WAD, making USDC amounts 1e12 times too small. This showed ~100% price impact when buying USDC and a huge negative one when selling it. Extract the conversion into calculateAmountUsd, which parses the price to WAD so the result scale is decimals-independent.

Before:
<img width="417" height="566" alt="Screenshot 2026-07-24 at 16 30 53" src="https://github.com/user-attachments/assets/310afbec-ef1c-411e-9e1a-086c71f5da10" />

<img width="409" height="506" alt="Screenshot 2026-07-24 at 16 30 30" src="https://github.com/user-attachments/assets/e0d386a1-6994-4c40-a9da-fbc5ead1eb5a" />


### What does this PR do?

Fixes the price impact miscalculation in the Trade widget for tokens with non-18 decimals (USDC). Trading any token to USDC showed a ~100% price impact, and trading USDC to any token showed a huge negative one.

Root cause: in `useTradeCosts`, USD values were computed by parsing the token price to the token's own decimal scale and then formatting the result as WAD. For 18-decimal tokens the scales happened to match, but for USDC (6 decimals) the USD value came out 1e12 times too small, skewing the price impact formula in both directions.

Changes:
- Extracted the amount-to-USD conversion into a `calculateAmountUsd` helper in `hooks/trade/helpers.ts`. The price is parsed to WAD, so the result scale is independent of the token's decimals.
- `useTradeCosts` now uses the helper for `sellAmountBeforeFeeUsd`, `sellAmountAfterFeeUsd` and `buyAmountUsd`, replacing three duplicated inline computations.
- Added unit tests covering 18-decimal and 6-decimal tokens, fractional prices and zero amounts.

`feePercentage` was not affected, since it compares two amounts of the same token and the scale error cancelled out.

### Testing steps:

1. Run the new unit tests: `pnpm test:hooks` (or `pnpm -F webapp exec vitest run -c vitest.hooks.config.ts src/hooks/trade/helpers.test.ts` against a running vnet).
2. Start the app (`pnpm dev`) and connect a wallet on mainnet.
3. Go to **Convert -> Trade** and get a quote for a token -> USDC trade (e.g. 100 USDS -> USDC). The price impact should be a small, sane value (well under 1% for a stable pair) instead of ~100%.
4. Get a quote for the reverse direction (USDC -> USDS). The price impact should again be a small value instead of a huge negative number.
5. Sanity-check an 18-decimal pair (e.g. USDS -> SKY) to confirm the price impact still looks correct there.

After:
<img width="417" height="476" alt="Screenshot 2026-07-24 at 16 29 45" src="https://github.com/user-attachments/assets/0a1f701e-88e1-46fc-9357-9095d9a6a251" />

