### PR TITLE
Trim derivable content from CLAUDE.md, move Adding Features to a skill

### DIFF
--- a/.claude/skills/adding-features/SKILL.md
+++ b/.claude/skills/adding-features/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: adding-features
+description: Step-by-step conventions for adding a new smart contract, widget, or webapp feature to the tarmac webapp. Use when wiring up a new contract/ABI, creating a widget under src/widgets/, or scaffolding a new module under src/modules/.
+---
+
+# Adding Features
+
+## New Smart Contract
+
+1. Add contract address and ABI to `apps/webapp/src/hooks/contracts.ts` (mainnet contracts go in the `contracts` array; L2 contracts go in the `l2Contracts` array in the same file), re-exporting from `apps/webapp/src/hooks/index.ts` as needed.
+2. Run `pnpm -F webapp generate` to regenerate `apps/webapp/src/hooks/generated.ts`. Use `pnpm -F webapp generate:retry` to retry on flakey Etherscan responses.
+3. Create the hook in the appropriate subfolder of `apps/webapp/src/hooks/`.
+
+## New Widget
+
+1. Create the widget in `apps/webapp/src/widgets/<WidgetName>/`.
+2. Follow existing widget patterns with `WidgetProps` interface.
+3. Re-export from `apps/webapp/src/widgets/index.ts` if it needs a barrel entry.
+4. Add tests alongside the source and documentation if relevant.
+
+## New Webapp Feature
+
+1. Create module in `apps/webapp/src/modules/`.
+2. Add routes in `apps/webapp/src/pages/`.
+3. Use existing hooks and components.
+4. Add i18n messages with `<Trans>` tags.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,6 @@ Tarmac is a React-based Web3 DeFi application for interacting with the Sky/Maker
 
 ## Essential Commands
 
-### Development
-
-```bash
-pnpm install          # Install all dependencies
-pnpm dev             # Start dev server (port 3000)
-pnpm dev:mock        # Development with mock wallet
-```
-
 ### Testing
 
 ```bash
@@ -39,12 +31,6 @@ pnpm prettier:check  # Check formatting without writing. Same caveat: always che
 # pnpm exec prettier --write <path>
 ```
 
-### Build
-
-```bash
-pnpm build           # Build the webapp (runs `pnpm messages` first)
-```
-
 ### Security audit
 
 ```bash
@@ -53,101 +39,25 @@ pnpm audit --prod --audit-level high   # Audit runtime deps; fails on high/criti
 
 `pnpm audit`'s `dev` flag is unreliable in workspaces. CI uses `pnpm audit --prod --audit-level high` to audit only the runtime dependency trees.
 
-### i18n
-
-```bash
-pnpm messages        # Extract and compile translations
-```
-
-## Architecture
-
-### Repo Layout
-
-- `/apps/webapp/` - The React application (the only product of this repo).
-  - `src/hooks/` - React hooks for Web3 interactions (Wagmi-based). Includes wagmi-generated `generated.ts`.
-  - `src/widgets/` - Self-contained UI components for protocol features.
-  - `src/utils/` - Shared utilities and helpers.
-  - `src/modules/` - Webapp modules (see below).
-  - `wagmi.config.ts` + `generate-with-retry.js` - Wagmi codegen config and retry wrapper.
-- `/apps/webapp/test/hooks/` - Test helpers + global setup for the vnet-backed hooks suite.
-
-### Key Webapp Modules (`/apps/webapp/src/modules/`)
-
-- `trade/` - Trading interface with Sky Protocol
-- `savings/` - USDS savings functionality
-- `rewards/` - Token rewards claiming
-- `stake/` - MKR/SKY staking features
-- `seal/` - Seal protocol integration
-- `upgrade/` - MKR to SKY token migration
-- `balances/` - Wallet balance management
-- `auth/` - Authentication and wallet connection
-
-### Tech Stack
-
-- **Frontend**: React 19, TypeScript 5.8
-- **Web3**: Wagmi, Viem, RainbowKit
-- **State**: TanStack Query, React Context
-- **Styling**: Tailwind CSS v4, Radix UI
-- **Build**: Vite 6.3
-- **Testing**: Vitest (unit), Playwright (E2E)
-- **i18n**: Lingui
-
 ## Development Patterns
 
 ### React Components
 
-- Use functional components with TypeScript
 - Component files: PascalCase (e.g., `Button.tsx`)
 - Props type: `ComponentNameProps`
 - Hooks: camelCase (e.g., `useWallet.ts`)
-- Tests: kebab-case (e.g., `button-test.tsx`)
 
 ### TypeScript
 
 - Hand-authored type files use `.ts`, not `.d.ts`. `skipLibCheck` makes TypeScript skip type-checking `.d.ts` contents, so exported types defined there go unchecked. Reserve `.d.ts` for genuine ambient declarations like `vite-env.d.ts`.
 
-### Web3 Integration
-
-- Use Wagmi hooks for contract interactions
-- Handle transaction lifecycle (pending, success, error)
-- Provide user-friendly error messages
-- Use generated contract types from ABIs
-
-### Styling
-
-- Use Tailwind CSS classes
-- Radix UI for accessible primitives
-- class-variance-authority for component variants
-- CSS variables for theming
-
 ### Testing
 
-- Unit tests alongside source files (`.test.ts(x)`)
-- Mock blockchain calls appropriately
 - Use Tenderly forks for consistent test environments
-- E2E tests in `/apps/webapp/src/test/e2e/tests`
 
 ## Adding Features
 
-### New Smart Contract
-
-1. Add contract address and ABI to `apps/webapp/src/hooks/contracts.ts` (mainnet contracts go in the `contracts` array; L2 contracts go in the `l2Contracts` array in the same file), re-exporting from `apps/webapp/src/hooks/index.ts` as needed.
-2. Run `pnpm -F webapp generate` to regenerate `apps/webapp/src/hooks/generated.ts`. Use `pnpm -F webapp generate:retry` to retry on flakey Etherscan responses.
-3. Create the hook in the appropriate subfolder of `apps/webapp/src/hooks/`.
-
-### New Widget
-
-1. Create the widget in `apps/webapp/src/widgets/<WidgetName>/`.
-2. Follow existing widget patterns with `WidgetProps` interface.
-3. Re-export from `apps/webapp/src/widgets/index.ts` if it needs a barrel entry.
-4. Add tests alongside the source and documentation if relevant.
-
-### New Webapp Feature
-
-1. Create module in `apps/webapp/src/modules/`.
-2. Add routes in `apps/webapp/src/pages/`.
-3. Use existing hooks and components.
-4. Add i18n messages with `<Trans>` tags.
+See the `adding-features` skill (`.claude/skills/adding-features/SKILL.md`) for the steps to add a new smart contract, widget, or webapp module.
 
 ## Environment Setup
 


### PR DESCRIPTION
## What

Cuts the parts of `CLAUDE.md` that a session can reconstruct from the repo itself, and moves the three "Adding Features" workflows into an on-demand skill. The file goes from 5,769 to 2,743 chars — roughly 750 fewer tokens loaded into every session.

## Why

Beyond the token cost, several of the derivable sections had quietly gone stale and were actively misleading:

- The module list named `seal/`, which no longer exists, and omitted 16 real modules (`convert`, `earn`, `portfolio`, `claim`, `morpho`, `pendle`, `stusds`, `vaults`, …).
- `pnpm dev:mock` was listed as a root command; there is no such root script (it lives at the webapp level).
- `- Tests: kebab-case (e.g., button-test.tsx)` contradicted both the Testing section two headings below it and the repo, which has 264 `*.test.ts(x)` files and zero `*-test.tsx`.

Content the codebase can't explain stays put.

## Removed

- `### Development`, `### Build`, `### i18n` command blocks — plain `package.json` scripts with no caveat attached
- `## Architecture` — repo layout, module list, tech stack
- `### Web3 Integration`, `### Styling` — generic guidance plus what the configs already show
- The `button-test.tsx` line and four generic bullets

## Kept

The Testing / Code Quality / Security-audit command blocks, because their annotations are the actual value — the vnet-backed Tenderly fork lifecycle, `pnpm prettier` always targeting `.` regardless of path args, and why CI uses `pnpm audit --prod`. Also kept: the `.ts`-not-`.d.ts` rationale, component naming, Environment Setup env vars, and the Git Commit Guidelines.

## Moved

`## Adding Features` (new smart contract / widget / webapp feature) → `.claude/skills/adding-features/SKILL.md`, verbatim. Only its one-line description stays resident; the body loads when the task calls for it. `CLAUDE.md` keeps a pointer.