### PR TITLE
Drop the frosted scrim behind the wallet drawer, and light its network label

### DIFF
--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -44,16 +44,19 @@ function SheetContent({
   hideCloseButton = false,
   closeButtonClassName,
   closeIconClassName,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left';
   hideCloseButton?: boolean;
   closeButtonClassName?: string;
   closeIconClassName?: string;
+  /** Extra classes on the scrim, e.g. to opt a panel out of the frosted overlay. */
+  overlayClassName?: string;
 }) {
   return (
     <SheetPortal>
-      <SheetOverlay />
+      <SheetOverlay className={overlayClassName} />
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(

--- a/apps/webapp/src/modules/app/shell/NetworkSelector.tsx
+++ b/apps/webapp/src/modules/app/shell/NetworkSelector.tsx
@@ -3,5 +3,17 @@ import { ChainModal } from '@/modules/ui/components/ChainModal';
 /** Drawer-embedded network control. Presentation wrapper only — switching logic stays in ChainModal. */
 export function NetworkSelector({ compact = false }: { compact?: boolean }) {
   // The M4.6 mobile panel pairs the 32px total with the DS Network XS pill.
-  return <ChainModal dataTestId="wallet-drawer-network" size={compact ? 'xs' : 'm'} />;
+  //
+  // The pill sits on the header's brand gradient, which is dark in both themes,
+  // so its label and chevron take fg-text-consistent-light (Figma 1030:138802)
+  // rather than the Dropdown variant's theme-following text-text — that one
+  // flips to the dark #2f2d40 in light mode and all but disappears here.
+  return (
+    <ChainModal
+      dataTestId="wallet-drawer-network"
+      size={compact ? 'xs' : 'm'}
+      triggerClassName="text-fgConsistent"
+      labelClassName="text-fgConsistent"
+    />
+  );
 }

--- a/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewDrawer.tsx
@@ -8,6 +8,16 @@ import { useConnectModal } from '@/modules/ui/context/ConnectModalContext';
 import { WalletPreviewHeader } from './WalletPreviewHeader';
 import { WalletDrawerTabs } from './WalletDrawerTabs';
 
+/**
+ * The frosted Sheet scrim is the mobile *modal* recipe (Figma 1292:63542), and
+ * the wallet preview isn't one: its comp (Figma 1030:138710) has no overlay
+ * node at all — the page reads sharp and undimmed right up to the panel edge.
+ * The panel self-frosts (backdrop-blur-sm over an opaque/glass fill), so it
+ * stays legible without a scrim. Kept as an element, transparent, so Radix
+ * still gets its pointer blocker and dismiss target.
+ */
+const NO_SCRIM = 'bg-transparent backdrop-blur-none';
+
 interface WalletPreviewDrawerProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -55,6 +65,7 @@ export function WalletPreviewDrawer({
           side="bottom"
           data-testid="wallet-drawer"
           aria-describedby={undefined}
+          overlayClassName={NO_SCRIM}
           hideCloseButton
           className="bg-containerDark border-borderPrimary inset-x-3 bottom-[max(12px,env(safe-area-inset-bottom))] h-auto max-h-[calc(100dvh-92px)] gap-0 overflow-hidden rounded-[28px] border p-0 backdrop-blur-sm"
           onOpenAutoFocus={e => e.preventDefault()}
@@ -84,6 +95,7 @@ export function WalletPreviewDrawer({
         side="right"
         data-testid="wallet-drawer"
         aria-describedby={undefined}
+        overlayClassName={NO_SCRIM}
         className="border-glassBorder bg-glassSurface inset-y-3 right-3 h-auto w-[calc(100%-24px)] flex-row gap-0 overflow-hidden rounded-[28px] border p-0 backdrop-blur-sm sm:max-w-[538px]"
         closeButtonClassName="hidden"
         onOpenAutoFocus={e => e.preventDefault()}


### PR DESCRIPTION
Two wallet-drawer fixes flagged in QA against [Figma 1030:138710](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1030-138710&m=dev).

## 1. The drawer shouldn't have a blurred background

The APP-416 pass gave `SheetOverlay` the mobile **modal** scrim recipe (`bg-modalOverlay` + `backdrop-blur-[100px]`, Figma 1292:63542). The wallet drawer only inherited it by sharing the primitive — and it isn't a modal. Its comp has **no overlay node at all**: the page reads sharp and undimmed right up to the panel edge, and the panel self-frosts (`backdrop-blur-sm` over a glass/opaque fill) so it stays legible without one.

`SheetContent` gains an `overlayClassName` escape hatch; the drawer passes `bg-transparent backdrop-blur-none` at both tiers. The overlay element stays (just invisible) so Radix keeps its pointer blocker and dismiss target.

Every other Sheet consumer — the TopNav More menu and the `ResponsiveModal` transaction sheet — keeps the frost untouched.

## 2. The network dropdown label was the wrong color

The pill is a `ChainModal` on the `dropdown` button variant, whose base color is `text-text` — a theme-following token that resolves to **#2f2d40 in light mode**. The pill sits on the header's brand gradient, which is dark in *both* themes, so the label went dark-on-dark. Figma 1030:138802 binds it to `colors/fg/fg-text-consistent-light` (#f2f3f7) — the theme-invariant token the rest of that header already hardcodes.

Now `text-fgConsistent` on the label and on the trigger, so the chevron follows via `currentColor`.

## Verification

Browser-checked on `dev:mock` in **both themes** at the desktop tier:

- overlay computes to `rgba(0, 0, 0, 0)` / `backdrop-filter: none`
- label and chevron both compute to `rgb(242, 243, 247)`
- opening the Switch-network dialog from inside the drawer still frosts correctly — modals unaffected

Gates: `typecheck` clean, `lint` 0 errors, unit suite **2087/2088**. The one failure is `EarnFeaturedCards.test.tsx`'s date-rotted `'18 Jun 2026'` assertion, which fails identically on a clean tree (pre-existing, unrelated).

⚠️ **Not yet verified:** the mobile tier is code-verified only — `resize_window` wouldn't reflow the viewport during QA. The mobile branch passes the identical prop and its panel is opaque `bg-containerDark`, so the change can only remove frost from behind it, but it hasn't been seen rendering. Draft pending Hernando's verification.