### PR TITLE
Fix audit gate: bump axios/postcss overrides, prune expired overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,39 +285,10 @@ catalogs:
 
 overrides:
   esbuild@<0.28.1: ~0.28.1
-  '@babel/runtime@7.26.7': 7.26.10
-  axios@>=1.0.0 <1.16.0: ^1.16.0
-  '@json-rpc-tools/provider>axios@^0.21.0': ^1.16.0
-  protobufjs@<=7.6.0: ~7.6.1
-  '@protobufjs/utf8@<1.1.1': ~1.1.1
-  dompurify@<3.4.0: ~3.4.0
-  lodash@<4.18.0: ~4.18.0
-  defu@<6.1.5: ~6.1.5
-  h3@<1.15.9: ~1.15.9
-  minimatch@<3.1.4: ~3.1.4
-  minimatch@>=9.0.0 <9.0.7: ~9.0.7
-  flatted@<=3.4.1: ^3.4.2
-  glob@>=10.2.0 <10.5.0: ~10.5.0
-  glob@11.0.3: ~11.1.0
-  rollup@>=4.0.0 <4.59.0: ^4.59.0
-  picomatch@<2.3.2: ~2.3.2
-  picomatch@>=3.0.0 <3.0.2: ~3.0.2
-  picomatch@>=4.0.0 <4.0.4: ~4.0.4
-  follow-redirects@<=1.15.11: ^1.16.0
-  ajv@>=7.0.0-alpha.0 <8.18.0: ^8.18.0
-  bn.js@>=4.0.0 <4.12.3: ~4.12.3
-  bn.js@>=5.0.0 <5.2.3: ~5.2.3
-  js-yaml@<3.14.2: ~3.14.2
-  qs@<6.14.2: ^6.14.2
-  mdast-util-to-hast@>=13.0.0 <13.2.1: ^13.2.1
-  hono@<4.12.25: ^4.12.25
-  fast-uri@<3.1.2: ^3.1.2
-  uuid@>=11.0.0 <11.1.1: ~11.1.1
-  brace-expansion@>=2.0.0 <2.0.3: ~2.0.3
-  form-data@>=4.0.0 <4.0.6: ~4.0.6
-  vite@>=8.0.0 <=8.0.15: ~8.0.16
+  axios@>=1.0.0 <1.18.0: ^1.18.0
+  '@json-rpc-tools/provider>axios@^0.21.0': ^1.18.0
+  postcss@<8.5.18: ^8.5.18
   ws@>=8.0.0 <8.21.0: ~8.21.0
-  ws@>=7.0.0 <7.5.11: ~7.5.11
 
 importers:
 
@@ -1131,7 +1102,7 @@ packages:
       '@lingui/babel-plugin-lingui-macro': ^5 || ^6
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       rolldown: ^1.0.0-rc.5
-      vite: ~8.0.16
+      vite: ^6.3.0 || ^7 || ^8
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -2018,7 +1989,7 @@ packages:
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2027,7 +1998,7 @@ packages:
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2155,7 +2126,7 @@ packages:
     resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
     engines: {node: '>= 18'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: '>=3.2.0'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2777,7 +2748,7 @@ packages:
   '@tailwindcss/vite@4.3.2':
     resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
     peerDependencies:
-      vite: ~8.0.16
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tanstack/eslint-plugin-query@5.101.2':
     resolution: {integrity: sha512-cPE99s3XZwlObfn8lCezT4j4JLj2CVzpIEywx0H4hzfPsX/o9QhdwaOwcDXxrQAqx2ds7TbvTinxhB8B/ywb6w==}
@@ -3032,7 +3003,7 @@ packages:
     resolution: {integrity: sha512-PaeokKjAGraNN+s5SIApgsktnJprIyt3zgEIu7awnEdfn29QiB2crTcCzyi2XGpX9rUnTc0cKU07Wm0N0g7H2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ~8.0.16
+      vite: ^4 || ^5 || ^6 || ^7 || ^8
 
   '@vitest/coverage-v8@4.1.9':
     resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
@@ -3050,7 +3021,7 @@ packages:
     resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ~8.0.16
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -3367,13 +3338,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: ^1.16.0
+      axios: ^1.18.0
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -4105,7 +4073,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ~3.0.2
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -5032,8 +5000,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5370,20 +5338,20 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: ^8.5.18
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: ^8.5.18
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: ^8.5.18
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -5400,7 +5368,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: ^8.5.18
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -5409,8 +5377,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.21:
+    resolution: {integrity: sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.396.2:
@@ -6361,12 +6329,12 @@ packages:
   vite-plugin-node-polyfills@0.28.0:
     resolution: {integrity: sha512-NXct/ci2ef4fRyCfTb8fk2HmR80Rv7icLd+cRH41TnUugDzdKMFKqFPpZYCFUInZMMem9bkLv5pkq02+7Xu7+w==}
     peerDependencies:
-      vite: ~8.0.16
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite-plugin-simple-html@1.1.0:
     resolution: {integrity: sha512-77yBF60RKUWIkmJtKKhGTExV8eW6UvrIcrXHBWNRFfqiH4Bt8MniCeIte1Jv1ef6SkckoIsg5QFG/wafgbm6ZQ==}
     peerDependencies:
-      vite: ~8.0.16
+      vite: '>=2.3.0 <9.0.0'
 
   vite@8.1.0:
     resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
@@ -6427,7 +6395,7 @@ packages:
       '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
-      vite: ~8.0.16
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -6766,6 +6734,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - immer
       - react
+      - supports-color
       - typescript
       - use-sync-external-store
       - utf-8-validate
@@ -6790,6 +6759,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - immer
       - react
+      - supports-color
       - typescript
       - use-sync-external-store
       - utf-8-validate
@@ -6915,8 +6885,8 @@ snapshots:
       '@solana-program/token': 0.9.0(@solana/kit@5.5.1(typescript@6.0.3))
       '@solana/kit': 5.5.1(typescript@6.0.3)
       abitype: 1.0.6(typescript@6.0.3)(zod@3.25.76)
-      axios: 1.16.0
-      axios-retry: 4.5.0(axios@1.16.0)
+      axios: 1.18.1
+      axios-retry: 4.5.0(axios@1.18.1)
       bs58: 6.0.0
       jose: 6.2.2
       md5: 2.3.0
@@ -6927,6 +6897,7 @@ snapshots:
       - bufferutil
       - debug
       - fastestsmallesttextencoderdecoder
+      - supports-color
       - typescript
       - utf-8-validate
 
@@ -7181,7 +7152,7 @@ snapshots:
   '@json-rpc-tools/provider@1.7.6':
     dependencies:
       '@json-rpc-tools/utils': 1.7.6
-      axios: 1.16.1
+      axios: 1.18.1
       safe-json-utils: 1.1.1
       ws: 7.5.11
     transitivePeerDependencies:
@@ -8133,6 +8104,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -8178,6 +8150,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -8262,6 +8235,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -8322,6 +8296,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -9720,6 +9695,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -10291,20 +10267,12 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  axios-retry@4.5.0(axios@1.16.0):
+  axios-retry@4.5.0(axios@1.18.1):
     dependencies:
-      axios: 1.16.0
+      axios: 1.18.1
       is-retry-allowed: 2.2.0
 
-  axios@1.16.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.6
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.16.1:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
@@ -12230,7 +12198,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -12662,29 +12630,29 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.15):
+  postcss-import@15.1.0(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.15):
+  postcss-js@4.1.0(postcss@8.5.21):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.15
+      postcss: 8.5.21
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.21)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.15
+      postcss: 8.5.21
       yaml: 2.8.3
 
-  postcss-nested@6.2.0(postcss@8.5.15):
+  postcss-nested@6.2.0(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.21
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -12694,9 +12662,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.21:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13390,11 +13358,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-import: 15.1.0(postcss@8.5.15)
-      postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.8.3)
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.21
+      postcss-import: 15.1.0(postcss@8.5.21)
+      postcss-js: 4.1.0(postcss@8.5.21)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.21)(yaml@2.8.3)
+      postcss-nested: 6.2.0(postcss@8.5.21)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -13742,7 +13710,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.21
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -13756,7 +13724,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.21
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,39 +116,10 @@ minimumReleaseAge: 10080
 #   @noble/curves instead. Tracked in APP-201.
 overrides:
   esbuild@<0.28.1: ~0.28.1
-  '@babel/runtime@7.26.7': 7.26.10
-  axios@>=1.0.0 <1.16.0: ^1.16.0
-  '@json-rpc-tools/provider>axios@^0.21.0': ^1.16.0
-  protobufjs@<=7.6.0: ~7.6.1
-  '@protobufjs/utf8@<1.1.1': ~1.1.1
-  dompurify@<3.4.0: ~3.4.0
-  lodash@<4.18.0: ~4.18.0
-  defu@<6.1.5: ~6.1.5
-  h3@<1.15.9: ~1.15.9
-  minimatch@<3.1.4: ~3.1.4
-  minimatch@>=9.0.0 <9.0.7: ~9.0.7
-  flatted@<=3.4.1: ^3.4.2
-  glob@>=10.2.0 <10.5.0: ~10.5.0
-  glob@11.0.3: ~11.1.0
-  rollup@>=4.0.0 <4.59.0: ^4.59.0
-  picomatch@<2.3.2: ~2.3.2
-  picomatch@>=3.0.0 <3.0.2: ~3.0.2
-  picomatch@>=4.0.0 <4.0.4: ~4.0.4
-  follow-redirects@<=1.15.11: ^1.16.0
-  ajv@>=7.0.0-alpha.0 <8.18.0: ^8.18.0
-  bn.js@>=4.0.0 <4.12.3: ~4.12.3
-  bn.js@>=5.0.0 <5.2.3: ~5.2.3
-  js-yaml@<3.14.2: ~3.14.2
-  qs@<6.14.2: ^6.14.2
-  mdast-util-to-hast@>=13.0.0 <13.2.1: ^13.2.1
-  hono@<4.12.25: ^4.12.25
-  fast-uri@<3.1.2: ^3.1.2
-  uuid@>=11.0.0 <11.1.1: ~11.1.1
-  brace-expansion@>=2.0.0 <2.0.3: ~2.0.3
-  form-data@>=4.0.0 <4.0.6: ~4.0.6
-  vite@>=8.0.0 <=8.0.15: ~8.0.16
+  axios@>=1.0.0 <1.18.0: ^1.18.0
+  '@json-rpc-tools/provider>axios@^0.21.0': ^1.18.0
+  postcss@<8.5.18: ^8.5.18
   ws@>=8.0.0 <8.21.0: ~8.21.0
-  ws@>=7.0.0 <7.5.11: ~7.5.11
 
 allowBuilds:
   '@reown/appkit': false


### PR DESCRIPTION
Unblocks the failing \`pnpm audit --prod --audit-level high\` gate (and the dev→staging promotion PR). Two new high advisories published against transitive deps:

- **axios** [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9) (`>=1.15.2 <1.18.0`) — our own override was pinning into the vulnerable range; bumped `^1.16.0` → `^1.18.0`
- **postcss** [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (`<=8.5.17`) — new override → `^8.5.21` resolved

Both are Node-only/build-time code paths, so no runtime exposure for the shipped webapp — this is CI hygiene.

Also pruned 30 self-expired overrides: regenerated the lockfile with `overrides: {}` and checked every selector against natural resolutions — only `esbuild@<0.28.1`, `@json-rpc-tools/provider>axios@^0.21.0`, and `ws@>=8.0.0 <8.21.0` still match anything, so only those remain. Audit after: **0 high** (moderates also dropped 23 → 14 from fresher transitive resolutions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)