### PR TITLE
Don't report MetaMask 'getActiveSession' noise to Sentry

### DIFF
--- a/apps/webapp/src/modules/sentry/init.ts
+++ b/apps/webapp/src/modules/sentry/init.ts
@@ -80,7 +80,14 @@ export function initSentry(): void {
       // handled, 0 affected users, the message is itself user guidance and the
       // pending request still resolves. Global match because the auto-reconnect
       // path fires with no `flow` tag, like WEBAPP-5N above (WEBAPP-5H).
-      /Existing connection is pending/
+      /Existing connection is pending/,
+      // MetaMask multichain SDK probes transport.getActiveSession() and the
+      // DefaultTransport stub intentionally throws to signal "no session support";
+      // it escapes as an unhandled rejection from a setTimeout inside the SDK.
+      // thirdPartyErrorFilterIntegration misses it because Sentry's own setTimeout
+      // instrumentation wrapper puts a first-party frame on top of the stack.
+      // Purely SDK-internal, 0 affected users (WEBAPP-9R).
+      /getActiveSession is purposely not implemented for the DefaultTransport/
     ],
     integrations: [
       Sentry.thirdPartyErrorFilterIntegration({


### PR DESCRIPTION
## Summary

Adds the MetaMask connect-multichain error `getActiveSession is purposely not implemented for the DefaultTransport` to the Sentry `ignoreErrors` list, alongside the two existing mutes for the same SDK (WEBAPP-5N, WEBAPP-5H).

## Why muting is safe

- The throw is intentional SDK-internal control flow: the SDK probes `transport.getActiveSession()` and the `DefaultTransport` stub throws by design; the rejection escapes a `setTimeout` inside the SDK.
- It slips past `thirdPartyErrorFilterIntegration` because Sentry's own `setTimeout` instrumentation wrapper puts a first-party bundle frame on top of the stack.
- 52 events since 2026-07-09, 0 impacted users; every real stack frame is inside `@metamask/connect-multichain@0.15.0`.
- Manual QA (2026-07-29, iOS Mobile Safari) confirmed the MetaMask connect flow works end-to-end: deep-link connect, auto-reconnect, in-app browser connect, rejection handling.
- The regex matches only this exact, distinctive message, so real wallet-connect regressions remain reportable.

Linear: [APP-434](https://linear.app/ekliptyka/issue/APP-434/mute-metamask-sdk-getactivesession-error-webapp-9r-in-sentry) · Sentry: [WEBAPP-9R](https://jetstream-gg.sentry.io/issues/WEBAPP-9R) (auto-resolves via `Fixes WEBAPP-9R` in the commit)

## Testing

- `pnpm typecheck` ✅
- ESLint + Prettier on the touched file ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)