### PR TITLE
APP-432: redesign QA round — dropdowns, risk colours, charts, composition bars, convert

### DIFF
--- a/apps/webapp/src/components/InfoTooltip.tsx
+++ b/apps/webapp/src/components/InfoTooltip.tsx
@@ -31,7 +31,7 @@ export function InfoTooltip({
       <PopoverContent
         align="center"
         side="top"
-        className={`bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[100px] ${contentClassname}`}
+        className={`bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[20px] ${contentClassname}`}
       >
         {shouldShowCloseButton && (
           <PopoverClose onClick={e => e.stopPropagation()} className="absolute top-4 right-4 z-10">

--- a/apps/webapp/src/components/product/EarnTableFilters.tsx
+++ b/apps/webapp/src/components/product/EarnTableFilters.tsx
@@ -36,9 +36,10 @@ export type EarnTableFiltersProps = {
 
 /**
  * Filter bar of the Earn Opportunities section: risk pills + the three
- * dropdowns. Below md (486:22051) the dropdowns stack full-width under the
- * chips row and grow a leading glyph; from md the single-row toolbar stays as
- * C2 shipped it.
+ * dropdowns, each carrying its leading glyph at every tier (Figma 1036:201239
+ * draws them on the desktop toolbar too — they were mobile-only until APP-432
+ * item 2). Below md (486:22051) the dropdowns stack full-width under the chips
+ * row; from md the single-row toolbar stays as C2 shipped it.
  */
 export function EarnTableFilters({
   selectedRiskTiers,
@@ -96,7 +97,7 @@ export function EarnTableFilters({
           onChange={onNetworkChange}
           allLabel={
             <span className="flex items-center gap-1.5">
-              <Globe className="h-3 w-3 md:hidden" />
+              <Globe className="h-3 w-3 shrink-0" />
               <Trans>All networks</Trans>
             </span>
           }
@@ -109,7 +110,7 @@ export function EarnTableFilters({
           onChange={onStablecoinChange}
           allLabel={
             <span className="flex items-center gap-1.5">
-              <ConvertArrows boxSize={12} className="md:hidden" />
+              <ConvertArrows boxSize={12} className="shrink-0" />
               <Trans>All stablecoins</Trans>
             </span>
           }
@@ -122,7 +123,7 @@ export function EarnTableFilters({
           onChange={onProductChange}
           allLabel={
             <span className="flex items-center gap-1.5">
-              <Vaults boxSize={12} className="md:hidden" />
+              <Vaults boxSize={12} className="shrink-0" />
               <Trans>All products</Trans>
             </span>
           }

--- a/apps/webapp/src/components/product/EarnTableFilters.tsx
+++ b/apps/webapp/src/components/product/EarnTableFilters.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react';
-import { Globe } from 'lucide-react';
+import { Globe, Vault } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/cn';
 import { BP, useBreakpointIndex, type EarnRiskTier } from '@/hooks';
 import { tabsTriggerVariants } from '@/components/ui/tabs';
 import { FilterSelect, type FilterOption } from '@/components/product/FilterSelect';
-import { ConvertArrows, Vaults } from '@/modules/icons';
+import { Convert } from '@/modules/icons';
 
 export type EarnFilterOption = FilterOption;
 
@@ -40,7 +40,13 @@ export type EarnTableFiltersProps = {
  * draws them on the desktop toolbar too — they were mobile-only until APP-432
  * item 2). Below md (486:22051) the dropdowns stack full-width under the chips
  * row; from md the single-row toolbar stays as C2 shipped it.
+ *
+ * The comp tints the glyphs fg-brand-primary against the white label, and
+ * pairs each filter with the mark its domain already uses elsewhere in the
+ * app: the globe, the Convert nav mark for stablecoins, and the Vault mark the
+ * TVL detail rows carry for products.
  */
+const FILTER_ICON = 'text-fgBrand shrink-0';
 export function EarnTableFilters({
   selectedRiskTiers,
   onRiskTierToggle,
@@ -97,7 +103,7 @@ export function EarnTableFilters({
           onChange={onNetworkChange}
           allLabel={
             <span className="flex items-center gap-1.5">
-              <Globe className="h-3 w-3 shrink-0" />
+              <Globe className={cn('h-3 w-3', FILTER_ICON)} />
               <Trans>All networks</Trans>
             </span>
           }
@@ -110,7 +116,7 @@ export function EarnTableFilters({
           onChange={onStablecoinChange}
           allLabel={
             <span className="flex items-center gap-1.5">
-              <ConvertArrows boxSize={12} className="shrink-0" />
+              <Convert boxSize={12} className={FILTER_ICON} />
               <Trans>All stablecoins</Trans>
             </span>
           }
@@ -123,7 +129,7 @@ export function EarnTableFilters({
           onChange={onProductChange}
           allLabel={
             <span className="flex items-center gap-1.5">
-              <Vaults boxSize={12} className="shrink-0" />
+              <Vault className={cn('h-3 w-3', FILTER_ICON)} />
               <Trans>All products</Trans>
             </span>
           }

--- a/apps/webapp/src/components/product/FilterSelect.tsx
+++ b/apps/webapp/src/components/product/FilterSelect.tsx
@@ -48,7 +48,7 @@ export function FilterSelect({
         className={cn(
           buttonVariants({ variant: 'dropdown', size: size === 'm' ? 'dropdownM' : 'dropdownS' }),
           'h-auto w-auto bg-transparent [&>svg]:opacity-100 [&>svg]:transition-transform data-[state=open]:[&>svg]:rotate-180',
-          '[&>span]:flex [&>span]:items-center [&>span]:line-clamp-none',
+          '[&>span]:line-clamp-none [&>span]:flex [&>span]:items-center',
           size === 'm' ? '[&>svg]:size-4' : '[&>svg]:size-3',
           triggerClassName
         )}

--- a/apps/webapp/src/components/product/FilterSelect.tsx
+++ b/apps/webapp/src/components/product/FilterSelect.tsx
@@ -36,12 +36,19 @@ export function FilterSelect({
           shadcn trigger's own h-10/w-full/bg and its 16px half-opacity chevron
           are overridden here rather than editing the vendored component; the
           [&>svg] rules only reach the trigger's direct chevron child, not
-          icons inside option labels. */}
+          icons inside option labels.
+
+          The trigger's `[&>span]:line-clamp-1` also has to go: it puts
+          `-webkit-box` + overflow-hidden on the value span, which clipped the
+          chain-icon stack of the portfolio's "All networks" label to the text
+          line box (APP-432 item 1). Labels here are single-line by
+          construction, so nothing needs the clamp. */}
       <SelectTrigger
         data-testid={testId}
         className={cn(
           buttonVariants({ variant: 'dropdown', size: size === 'm' ? 'dropdownM' : 'dropdownS' }),
           'h-auto w-auto bg-transparent [&>svg]:opacity-100 [&>svg]:transition-transform data-[state=open]:[&>svg]:rotate-180',
+          '[&>span]:flex [&>span]:items-center [&>span]:line-clamp-none',
           size === 'm' ? '[&>svg]:size-4' : '[&>svg]:size-3',
           triggerClassName
         )}

--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -118,7 +118,7 @@ function DetailsSection({ title, details }: { title?: ReactNode; details: Produc
             key={row.id}
             className="border-borderPrimary flex items-center justify-between gap-4 border-b py-4"
           >
-            <span className="text-textSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-normal">
+            <span className="text-fgSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-normal">
               {row.icon}
               {row.label}
             </span>
@@ -136,14 +136,18 @@ function AboutSection({ title, about }: { title?: ReactNode; about: ProductDetai
   return (
     <section className="flex flex-col gap-4" data-testid="product-detail-about">
       <SectionHeading className={minorHeadingClasses}>{title ?? <Trans>About</Trans>}</SectionHeading>
-      <div className="text-textSecondary text-sm leading-relaxed">
+      {/* Body 5 on fg-secondary with an inline fg-brand-primary link
+          (Figma 859:35769). textSecondary is the legacy lavender
+          (rgba(198,194,255,.8)), which is what read as purple next to the
+          comp's gray — APP-432 item 10. */}
+      <div className="text-fgSecondary font-graphik text-sm leading-[22px]">
         {about.body}
         {about.learnMoreHref && (
           <a
             href={about.learnMoreHref}
             target="_blank"
             rel="noreferrer"
-            className="text-text mt-1 inline-block font-medium underline"
+            className="text-fgBrand ml-1 font-medium"
           >
             <Trans>Learn more</Trans>
           </a>

--- a/apps/webapp/src/components/product/RiskMeter.tsx
+++ b/apps/webapp/src/components/product/RiskMeter.tsx
@@ -20,7 +20,7 @@ export function RiskMeter({
   className?: string;
 }) {
   // Figma Badges/Risk (Table Cell Type=Risk): 15px bordered pill of three
-  // 8×3 segments; unlit segments are fg-quaternary at 40%.
+  // 8×3 segments; unlit segments are fg-quaternary (1036:201215).
   return (
     <div
       role={label ? 'img' : undefined}
@@ -32,7 +32,7 @@ export function RiskMeter({
       )}
     >
       {segments.map((color, index) => (
-        <span key={index} className={cn('h-[3px] w-2 rounded-[2px]', color ?? 'bg-fgQuaternary/40')} />
+        <span key={index} className={cn('h-[3px] w-2 rounded-[2px]', color ?? 'bg-fgQuaternary')} />
       ))}
     </div>
   );
@@ -159,12 +159,13 @@ export function RiskScaleMeter({
 
 const TIERS: EarnRiskTier[] = ['low', 'moderate', 'advanced'];
 
-// Figma status palette: Low = fg-success, Medium = fg-warning. A 3-lit tier
-// never appears in the Figma patterns — error red pending design confirmation.
+// Figma status palette (1036:201215, which settled the open question the H8
+// tables batch left on the 3-lit tier): Conservative = fg-success,
+// Moderate = fg-warning, Aggressive = fg-error.
 const TIER_COLOR: Record<EarnRiskTier, string> = {
   low: 'bg-statusSuccess',
   moderate: 'bg-statusWarning',
-  advanced: 'bg-error'
+  advanced: 'bg-statusError'
 };
 
 /** Compact product-risk indicator (Figma "Risk profile" cell): N segments lit in the tier color. */

--- a/apps/webapp/src/components/product/RiskTierDetails.test.tsx
+++ b/apps/webapp/src/components/product/RiskTierDetails.test.tsx
@@ -55,9 +55,9 @@ describe('RiskTierDetailsCard — tier presentation + per-profile copy (APP-396 
 
     const segments = screen.getAllByTestId('risk-details-segment');
     expect(segments).toHaveLength(3);
-    expect(segments[0].className).toContain('bg-statusSuccessSolid');
-    expect(segments[1].className).toContain('bg-bgTertiary');
-    expect(segments[2].className).toContain('bg-bgTertiary');
+    expect(segments[0].className).toContain('bg-statusSuccess');
+    expect(segments[1].className).toContain('bg-fgQuaternary');
+    expect(segments[2].className).toContain('bg-fgQuaternary');
   });
 
   it('renders the Flagship vault profile with its multi-asset exposure, with two warning segments', () => {
@@ -73,7 +73,7 @@ describe('RiskTierDetailsCard — tier presentation + per-profile copy (APP-396 
     const segments = screen.getAllByTestId('risk-details-segment');
     expect(segments[0].className).toContain('bg-statusWarning');
     expect(segments[1].className).toContain('bg-statusWarning');
-    expect(segments[2].className).toContain('bg-bgTertiary');
+    expect(segments[2].className).toContain('bg-fgQuaternary');
   });
 
   it('renders the Risk Capital vault profile as Aggressive — same provider, different assessment', () => {
@@ -113,7 +113,7 @@ describe('RiskTierDetailsCard — tier presentation + per-profile copy (APP-396 
     expect(screen.getByText('Liquidity based')).toBeTruthy();
 
     const segments = screen.getAllByTestId('risk-details-segment');
-    segments.forEach(segment => expect(segment.className).toContain('bg-error'));
+    segments.forEach(segment => expect(segment.className).toContain('bg-statusError'));
   });
 });
 

--- a/apps/webapp/src/components/product/RiskTierDetails.tsx
+++ b/apps/webapp/src/components/product/RiskTierDetails.tsx
@@ -41,9 +41,9 @@ const RISK_TIER_DETAILS: Record<
   EarnRiskTier,
   { title: ReactNode; litSegments: number; segmentClass: string }
 > = {
-  low: { title: <Trans>Conservative</Trans>, litSegments: 1, segmentClass: 'bg-statusSuccessSolid' },
+  low: { title: <Trans>Conservative</Trans>, litSegments: 1, segmentClass: 'bg-statusSuccess' },
   moderate: { title: <Trans>Moderate</Trans>, litSegments: 2, segmentClass: 'bg-statusWarning' },
-  advanced: { title: <Trans>Aggressive</Trans>, litSegments: 3, segmentClass: 'bg-error' }
+  advanced: { title: <Trans>Aggressive</Trans>, litSegments: 3, segmentClass: 'bg-statusError' }
 };
 
 /**
@@ -265,7 +265,7 @@ function RiskTierDetailsBody({ tier, profile }: { tier: EarnRiskTier; profile: E
             data-testid="risk-details-segment"
             className={cn(
               'h-1 flex-1 rounded-full',
-              index < severity.litSegments ? severity.segmentClass : 'bg-bgTertiary'
+              index < severity.litSegments ? severity.segmentClass : 'bg-fgQuaternary'
             )}
           />
         ))}

--- a/apps/webapp/src/components/product/RiskTierDetails.tsx
+++ b/apps/webapp/src/components/product/RiskTierDetails.tsx
@@ -230,7 +230,7 @@ function ExposureFactValue({ symbols }: { symbols: string[] }) {
       </PopoverTrigger>
       <PopoverContent
         side="top"
-        className="font-graphik text-fgPrimary bg-bgTertiary w-auto rounded-2xl px-3 py-2 text-[11px] leading-4 backdrop-blur-[100px]"
+        className="font-graphik text-fgPrimary bg-bgTertiary w-auto rounded-2xl px-3 py-2 text-[11px] leading-4 backdrop-blur-[20px]"
       >
         {names}
       </PopoverContent>

--- a/apps/webapp/src/components/product/TokensComposition.tsx
+++ b/apps/webapp/src/components/product/TokensComposition.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { cn } from '@/lib/cn';
 
 export type CompositionSegment = {
@@ -7,6 +7,8 @@ export type CompositionSegment = {
   label: ReactNode;
   /** Segment + legend-dot color (any CSS color / token). */
   color: string;
+  /** Hovered fill (DS Components/Charts-Hover); defaults to `color`. */
+  hoverColor?: string;
   /** Raw magnitude — drives the segment's share of the bar. */
   value: number;
   /** Pre-formatted amount for the legend, e.g. "$19.92M". */
@@ -17,37 +19,86 @@ export type CompositionSegment = {
   percent?: number;
 };
 
+// Each pill tucks this far under its predecessor so only the predecessor's
+// rounded cap + pageBackground ring shows over it — the DS "circular gap"
+// joint (Figma tokens composition 5270:15661, APP-416).
+const CAP_OVERLAP_PX = 6;
+
 /**
- * DS "Charts / Tokens Composition" (Figma 5270:15611): an optional title +
- * total over a proportional stacked bar and a token legend
- * (dot · name … icon · amount · percent). Presentational — the caller supplies
- * colors, formatted amounts, and icons.
+ * DS "Charts / Tokens Composition" (Figma 5270:15609): an optional title +
+ * total over a proportional stacked bar and a token legend, one row per token —
+ * dot · name on the left, icon · amount · percent right-aligned, hairline
+ * between rows. Presentational — the caller supplies colors, formatted amounts
+ * and icons.
+ *
+ * Hovering the bar or a legend row recolors that segment with its
+ * Charts-Hover value and dims the rest to 50%, mirroring the portfolio pie.
  */
 export function TokensComposition({
   title,
   total,
   segments,
-  className
+  valueTotal,
+  className,
+  dataTestId
 }: {
   title?: ReactNode;
   total?: ReactNode;
   segments: CompositionSegment[];
+  /** Denominator for the shares; defaults to the sum of the segment values.
+   * Pass it when the segments deliberately leave the bar short (e.g. a vault
+   * whose reported total exceeds its allocations). */
+  valueTotal?: number;
   className?: string;
+  dataTestId?: string;
 }) {
-  const sum = segments.reduce((acc, s) => acc + s.value, 0);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const sum = valueTotal ?? segments.reduce((acc, s) => acc + s.value, 0);
   const share = (value: number) => (sum > 0 ? (value / sum) * 100 : 0);
+  const fillOf = (segment: CompositionSegment) =>
+    hoveredId === segment.id ? (segment.hoverColor ?? segment.color) : segment.color;
+  const dimmed = (segment: CompositionSegment) =>
+    hoveredId !== null && hoveredId !== segment.id ? 0.5 : 1;
+
+  // Cumulative spans: pill i runs from its segment's start to its end, plus a
+  // small tuck under pill i-1; earlier pills stack on top so their caps (with
+  // the pageBackground ring) draw the joint gaps.
+  let cursor = 0;
+  const layers = segments.map(segment => {
+    const start = cursor;
+    cursor += share(segment.value) / 100;
+    return { segment, start, end: cursor };
+  });
 
   return (
-    <div className={cn('flex flex-col gap-3', className)}>
-      {title && <div className="text-textSecondary text-sm">{title}</div>}
-      {total && <div className="text-text text-2xl font-semibold">{total}</div>}
+    <div className={cn('flex flex-col gap-5', className)} data-testid={dataTestId}>
+      {title && <div className="text-fgSecondary font-graphik text-sm leading-[22px]">{title}</div>}
+      {total && (
+        <div className="text-text font-circle text-[32px] leading-[35px] font-medium tracking-[-0.64px]">
+          {total}
+        </div>
+      )}
 
-      <div className="flex h-1.5 w-full gap-0.5" aria-hidden>
-        {segments.map(segment => (
-          <span
+      {/* The tall wrapper leaves room for the joint rings. */}
+      <div
+        className="relative flex h-3.5 w-full items-center"
+        onMouseLeave={() => setHoveredId(null)}
+        aria-hidden
+      >
+        <div className="bg-bgTertiary absolute top-1/2 right-0 left-0 h-1.5 -translate-y-1/2 rounded-full" />
+        {layers.map(({ segment, start, end }, index) => (
+          <div
             key={segment.id}
-            className="h-full rounded-full"
-            style={{ width: `${share(segment.value)}%`, backgroundColor: segment.color }}
+            data-testid="composition-segment"
+            onMouseEnter={() => setHoveredId(segment.id)}
+            className="ring-pageBackground absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full ring-4 transition-[background-color,opacity] duration-150"
+            style={{
+              left: index === 0 ? 0 : `calc(${start * 100}% - ${CAP_OVERLAP_PX}px)`,
+              width: index === 0 ? `${end * 100}%` : `calc(${(end - start) * 100}% + ${CAP_OVERLAP_PX}px)`,
+              zIndex: layers.length - index,
+              backgroundColor: fillOf(segment),
+              opacity: dimmed(segment)
+            }}
           />
         ))}
       </div>
@@ -58,16 +109,23 @@ export function TokensComposition({
           return (
             <div
               key={segment.id}
-              className="border-textSecondary/10 flex items-center justify-between gap-4 border-b py-2.5 last:border-b-0"
+              data-testid="composition-row"
+              className="border-borderPrimary flex items-center justify-between gap-4 border-b py-2.5 transition-opacity duration-150 last:border-b-0"
+              style={{ opacity: dimmed(segment) }}
+              onMouseEnter={() => setHoveredId(segment.id)}
+              onMouseLeave={() => setHoveredId(null)}
             >
-              <span className="text-textSecondary flex items-center gap-2 text-sm">
-                <span className="size-1.5 shrink-0 rounded-full" style={{ backgroundColor: segment.color }} />
+              <span className="text-fgSecondary font-graphik flex items-center gap-2 text-sm leading-[22px]">
+                <span
+                  className="size-1.5 shrink-0 rounded-full transition-colors duration-150"
+                  style={{ backgroundColor: fillOf(segment) }}
+                />
                 {segment.label}
               </span>
-              <span className="text-text flex items-center gap-1.5 text-sm font-medium">
+              <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px]">
                 {segment.icon}
                 {segment.formattedValue}
-                <span className="text-textSecondary font-normal">({percent}%)</span>
+                <span className="text-fgSecondary font-graphik font-normal">({percent}%)</span>
               </span>
             </div>
           );

--- a/apps/webapp/src/components/product/TokensComposition.tsx
+++ b/apps/webapp/src/components/product/TokensComposition.tsx
@@ -57,8 +57,7 @@ export function TokensComposition({
   const share = (value: number) => (sum > 0 ? (value / sum) * 100 : 0);
   const fillOf = (segment: CompositionSegment) =>
     hoveredId === segment.id ? (segment.hoverColor ?? segment.color) : segment.color;
-  const dimmed = (segment: CompositionSegment) =>
-    hoveredId !== null && hoveredId !== segment.id ? 0.5 : 1;
+  const dimmed = (segment: CompositionSegment) => (hoveredId !== null && hoveredId !== segment.id ? 0.5 : 1);
 
   // Cumulative spans: pill i runs from its segment's start to its end, plus a
   // small tuck under pill i-1; earlier pills stack on top so their caps (with

--- a/apps/webapp/src/components/ui/progress.tsx
+++ b/apps/webapp/src/components/ui/progress.tsx
@@ -3,20 +3,25 @@ import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 import { cn } from '@/lib/cn';
 
-// DS "Charts / Progress Bar" (Figma 5246:15689): a thin rounded track with a
-// brand fill (fgBrand = #757dff). `indicatorClassName` overrides the fill for
-// callers that need a different tint.
+// DS "Charts / Progress Bar" (Figma 5246:15689, as instantiated at 859:40960):
+// a thin components/slider/bg-primary track under the brand slider gradient.
+// The track used to read `bg-surface`, a bright rgba(108,104,255,0.3) periwinkle
+// that competed with the fill (APP-432 item 14). `indicatorClassName` overrides
+// the fill for callers that need a different tint.
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & { indicatorClassName?: string }
 >(({ className, indicatorClassName, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn('bg-surface relative h-1.5 w-full overflow-hidden rounded-full', className)}
+    className={cn('bg-bgTertiary relative h-1.5 w-full overflow-hidden rounded-full', className)}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className={cn('bg-fgBrand h-full w-full flex-1 rounded-full transition-all', indicatorClassName)}
+      className={cn(
+        'from-slider-brand-start to-slider-brand-end h-full w-full flex-1 rounded-full bg-linear-to-r transition-all',
+        indicatorClassName
+      )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/apps/webapp/src/components/ui/select.tsx
+++ b/apps/webapp/src/components/ui/select.tsx
@@ -133,8 +133,10 @@ const SelectItem = React.forwardRef<
     {...props}
   >
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {/* The checkmark takes fg-brand-primary, not the row's fg-primary
+        (Figma 1036:201601 / 1036:205471 — APP-432 items 7 and 17). */}
     {!hideIndicator && (
-      <SelectPrimitive.ItemIndicator className="ml-auto flex size-4 items-center justify-center">
+      <SelectPrimitive.ItemIndicator className="text-fgBrand ml-auto flex size-4 items-center justify-center">
         <Check className="size-4" />
       </SelectPrimitive.ItemIndicator>
     )}

--- a/apps/webapp/src/components/ui/tooltip.tsx
+++ b/apps/webapp/src/components/ui/tooltip.tsx
@@ -5,7 +5,10 @@ import { cn } from '@/lib/cn';
 
 // Design-system Tooltip (Figma Components/Tooltip 5043:57748). The content
 // chrome is the shared recipe of every type — bg-tertiary glass at 16px
-// radius, 16px padding — and the base typography is the Simple type
+// radius, 16px padding, and the DS `background blur-2xl` effect, whose Figma
+// radius of 40 is CSS `blur(20px)` (Figma states background blur at twice the
+// CSS value) — the same frost the glass cards carry. The base typography is
+// the Simple type
 // (5043:58208): Body 7 on fg-primary, 260px max (228px text + padding).
 // Titled types (Default 5043:58197) compose a Label 5 heading above
 // fg-secondary body copy inside; the DS draws no arrow on any tooltip.
@@ -36,7 +39,7 @@ const TooltipContent = React.forwardRef<
       // z-101: tooltips are the topmost transient layer — they must clear the
       // app PopoverContent (z-100, e.g. the nav More menu hosting the theme
       // and batch toggles), not just the z-50 dialog/sheet/select tier.
-      'bg-bgTertiary text-fgPrimary font-graphik animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-101 max-w-[260px] rounded-2xl p-4 text-[11px] leading-4 font-normal backdrop-blur-[100px]',
+      'bg-bgTertiary text-fgPrimary font-graphik animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-101 max-w-[260px] rounded-2xl p-4 text-[11px] leading-4 font-normal backdrop-blur-[20px]',
       className
     )}
     {...props}

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -162,8 +162,18 @@
   --color-statusSuccessBorder: rgba(2, 194, 161, 0.2);
   --color-statusSuccessSolid: #02c2a1;
   --color-statusWarning: #ffc044;
+  /* components/status/fg-error (APP-432 item 6 — the risk meters' Aggressive
+     tier). Distinct from the legacy `--color-error` (--service-red #ff6d6d),
+     which the pre-redesign widgets still read for validation copy. */
+  --color-statusError: #f83c3b;
   --color-statusBrand: #9ca9ff;
   --color-statusBrandBg: rgba(156, 160, 229, 0.1);
+  /* components/charts/bg-chart1 + bg-chart2 (Figma DS Charts/Line 5041:7043):
+     the two series tints — brand indigo and teal. Consumed as `var()` from
+     recharts SVG props, not as Tailwind utilities. Theme-invariant: the DS
+     charts carry no light mode. */
+  --color-chart1: #757dff;
+  --color-chart2: #1dd9ba;
   /* Iconbox status rings + info dot (Figma Components/Iconbox 5017:7858).
      Figma types the rings by product — Pendle mint / Morpho blue — as raw
      hexes (no variable); promoted here under the system color each pairs
@@ -590,6 +600,7 @@
     --color-statusSuccess: #00a186; /* components/status/fg-success */
     --color-statusSuccessBg: #02c2a133; /* components/status/bg-success */
     --color-statusWarning: #dd6102; /* components/status/fg-warning */
+    --color-statusError: #e51f1d; /* components/status/fg-error */
     --color-statusBrand: #4836f5; /* components/status/fg-brand */
     --color-statusBrandBg: #9ca0e54d; /* components/status/bg-brand */
 

--- a/apps/webapp/src/modules/convert/components/ConvertAmountInput.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertAmountInput.tsx
@@ -17,21 +17,23 @@ const formatBalance = (balance: bigint | undefined, decimals: number) =>
     : formatNumber(parseFloat(formatUnits(balance, decimals)), { maxDecimals: 2 });
 
 /**
- * One side of the Convert card (Figma 486:31204/486:31210): a translucent
- * glass panel with the large amount top-left, USD value below it, token chip
- * top-right and balance below-right. The origin side is editable and offers
- * 25/50/100% shortcuts next to the chip; the target side is display-only (the
- * PSM rate is fixed, so the amount is always derived).
+ * One side of the Convert card (Figma 1036:205437, which supersedes the
+ * 486:31204/486:31210 frames this was built from): a translucent glass panel
+ * of two rows — the side label with the balance right-aligned beside it, then
+ * the large amount with the 25/50/100% shortcuts and the token chip to its
+ * right. The origin side is editable; the target side is display-only (the PSM
+ * rate is fixed, so the amount is always derived).
  *
- * The USD line mirrors the token amount 1:1 — both PSM tokens are USD
- * stablecoins and the swap is fee-free, the same simplification the legacy
- * widget made. The "0.00" placeholder renders in the primary text colour per
- * the Figma default frame (fg-primary, not the muted secondary).
+ * The redraw moved the balance up from the meta row and retired the USD line
+ * the meta row carried — the comp has no second figure, and with both PSM
+ * tokens being USD stablecoins on a fee-free 1:1 swap it only ever restated the
+ * amount. The "0.00" placeholder keeps the primary text colour per the comp's
+ * default frame (fg-primary, not the muted secondary).
  *
- * Phone tier (comps 1295:24298/25268, M6.9): 16px panel padding, Heading 3
- * amount, and the percent chips move from beside the token chip down to the
- * meta row, yielding to the USD value once an amount is typed — the top row
- * always keeps the input + token chip so the input can't be squeezed out.
+ * Phone tier (comps 1295:24298/25268, M6.9): 16px panel padding, a smaller
+ * amount, and — because three chips plus the token chip cannot share a 360px
+ * row with a typed figure — the percent chips still yield once an amount is
+ * entered.
  */
 export function ConvertAmountInput({
   side,
@@ -58,7 +60,6 @@ export function ConvertAmountInput({
   const { bpi } = useBreakpointIndex();
   const isMobile = bpi < BP.md;
   const isFrom = side === 'from';
-  const usdValue = `$${value === '' ? '0.00' : formatNumber(parseFloat(value) || 0, { maxDecimals: 2 })}`;
 
   const percentButtons = isFrom && isConnected && onPercentClick && (
     <span className="flex items-center gap-1.5">
@@ -79,9 +80,21 @@ export function ConvertAmountInput({
 
   return (
     <div
-      className="bg-glassSurface flex flex-col gap-1 p-4 backdrop-blur-[20px] md:px-8 md:py-6"
+      className="bg-glassSurface flex flex-col gap-2 p-4 backdrop-blur-[20px] md:gap-[9px] md:px-8 md:py-7"
       data-testid={`convert-${side}`}
     >
+      {/* Body 5 meta row: side label left, balance right (1036:205449). */}
+      <div className="flex items-center justify-between gap-2">
+        <Text className="text-fgSecondary text-xs md:text-sm md:leading-[22px]">
+          {isFrom ? <Trans>From</Trans> : <Trans>To</Trans>}
+        </Text>
+        <Text
+          className="text-fgSecondary text-xs md:text-sm md:leading-[22px]"
+          dataTestId={`convert-${side}-balance`}
+        >
+          <Trans>Balance</Trans>: {isConnected ? formatBalance(balance, decimals) : NO_VALUE}
+        </Text>
+      </div>
       <div className="flex items-center justify-between gap-3">
         <input
           inputMode="decimal"
@@ -92,22 +105,12 @@ export function ConvertAmountInput({
           readOnly={!isFrom}
           aria-label={isFrom ? t`Convert amount` : t`Amount received`}
           data-testid={`convert-${side}-amount`}
-          className="text-text placeholder:text-text w-full min-w-0 bg-transparent text-2xl leading-[26px] font-medium tracking-[-0.48px] outline-none md:text-[32px] md:leading-9 md:tracking-normal"
+          className="text-text placeholder:text-text w-full min-w-0 bg-transparent text-2xl leading-[26px] font-medium tracking-[-0.48px] outline-none md:text-[32px] md:leading-[35px] md:tracking-[-0.64px]"
         />
         <span className="flex shrink-0 items-center gap-1.5">
-          {!isMobile && percentButtons}
+          {(!isMobile || value === '') && percentButtons}
           <ConvertTokenSelect value={symbol} onChange={onTokenChange} dataTestId={`convert-${side}-token`} />
         </span>
-      </div>
-      <div className="flex h-10 items-center justify-between gap-2 md:h-auto">
-        {isMobile && value === '' && percentButtons ? (
-          percentButtons
-        ) : (
-          <Text className="text-textSecondary text-xs md:text-sm">{usdValue}</Text>
-        )}
-        <Text className="text-textSecondary text-xs md:text-sm" dataTestId={`convert-${side}-balance`}>
-          <Trans>Balance</Trans>: {isConnected ? formatBalance(balance, decimals) : NO_VALUE}
-        </Text>
       </div>
     </div>
   );

--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -52,12 +52,22 @@ export function EarnPage() {
     [chains]
   );
 
+  // Rows carry their chain icon (Figma 1036:201601, APP-432 item 7) at the
+  // dropdown's 16px icon size — the same shape the portfolio filter uses.
   const networkOptions = useMemo<EarnFilterOption[]>(() => {
     const ids = [...new Set(rows.flatMap(row => row.networks))];
     return ids
       .map(id => ({ id, chain: chains.find(chain => chain.id === id) }))
       .filter(({ chain }) => chain !== undefined)
-      .map(({ id, chain }) => ({ value: chainSlugById[id], label: chain!.name }));
+      .map(({ id, chain }) => ({
+        value: chainSlugById[id],
+        label: (
+          <span className="flex items-center gap-2">
+            {getChainIcon(id, 'h-4 w-4 shrink-0')}
+            {chain!.name}
+          </span>
+        )
+      }));
   }, [rows, chains, chainSlugById]);
 
   const stablecoinOptions = useMemo<EarnFilterOption[]>(

--- a/apps/webapp/src/modules/morpho/components/VaultStrategy.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultStrategy.tsx
@@ -1,39 +1,24 @@
-import { useState } from 'react';
 import { Trans } from '@lingui/react/macro';
 import { useMorphoVaultMarketApiData } from '@/hooks';
 import { Skeleton } from '@/components/ui/skeleton';
+import { TokensComposition } from '@/components/product/TokensComposition';
 import { buildVaultStrategy } from '../helpers/vaultStrategy';
-
-// Each pill tucks this far under its predecessor so only the predecessor's
-// rounded cap + pageBackground ring shows over it — the DS "circular gap"
-// joint (Figma tokens composition 5270:15661, APP-416).
-const CAP_OVERLAP_PX = 6;
 
 /**
  * The "Strategy" section of the vault product page (ProductDetailTemplate
  * `afterDetails` slot): the total allocated capital, a proportional stacked bar
- * of the vault's market allocations, and a per-market legend. Re-skin of the
- * existing Exposure table — same `useMorphoVaultMarketApiData` source, distilled
- * to total + shares via `buildVaultStrategy`. Hover (bar or legend) recolors the
- * segment with its DS Charts-Hover value and dims the rest to 50%, mirroring
- * the portfolio pie behavior.
+ * of the vault's market allocations, and a per-market legend. Same
+ * `useMorphoVaultMarketApiData` source as the Exposure table it replaced,
+ * distilled to total + shares via `buildVaultStrategy`, then handed to the DS
+ * Tokens Composition component — this used to carry its own wrapping column
+ * grid, which is what APP-432 item 13 flagged against the one-row-per-token
+ * layout in Figma 5270:15609.
  */
 export function VaultStrategy({ vaultAddress }: { vaultAddress: `0x${string}` }) {
   const { data, isLoading } = useMorphoVaultMarketApiData({ vaultAddress });
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
   const strategy = data?.market
     ? buildVaultStrategy(data.market.markets, data.market.idleLiquidity, data.totalAssetsUsd)
     : undefined;
-
-  // Cumulative spans: pill i runs from its segment's start to its end, plus a
-  // small tuck under pill i-1; earlier pills stack on top so their caps (with
-  // the pageBackground ring) draw the joint gaps.
-  let cursor = 0;
-  const layers = (strategy?.segments ?? []).map(segment => {
-    const start = cursor;
-    cursor += segment.share;
-    return { segment, start, end: cursor };
-  });
 
   return (
     <div data-testid="vault-strategy">
@@ -43,60 +28,26 @@ export function VaultStrategy({ vaultAddress }: { vaultAddress: `0x${string}` })
           <Skeleton className="h-2.5 w-full rounded-full" />
         </div>
       ) : !strategy || strategy.segments.length === 0 ? (
-        <span className="text-textSecondary text-sm">
+        <span className="text-fgSecondary text-sm">
           <Trans>No allocations found</Trans>
         </span>
       ) : (
-        <div className="flex flex-col gap-5">
-          <span className="text-text text-3xl font-semibold">{strategy.formattedTotal}</span>
-
-          {/* Proportional bar: absolutely stacked pills, earlier segments on
-              top; the tall wrapper leaves room for the joint rings. */}
-          <div className="relative flex h-3.5 w-full items-center" onMouseLeave={() => setHoveredId(null)}>
-            <div className="bg-surface absolute top-1/2 right-0 left-0 h-1.5 -translate-y-1/2 rounded-full" />
-            {layers.map(({ segment, start, end }, index) => (
-              <div
-                key={segment.id}
-                onMouseEnter={() => setHoveredId(segment.id)}
-                className="ring-pageBackground absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full ring-4 transition-[background-color,opacity] duration-150"
-                style={{
-                  left: index === 0 ? 0 : `calc(${start * 100}% - ${CAP_OVERLAP_PX}px)`,
-                  width:
-                    index === 0 ? `${end * 100}%` : `calc(${(end - start) * 100}% + ${CAP_OVERLAP_PX}px)`,
-                  zIndex: layers.length - index,
-                  backgroundColor: hoveredId === segment.id ? segment.hoverColor : segment.color,
-                  opacity: hoveredId !== null && hoveredId !== segment.id ? 0.5 : 1
-                }}
-              />
-            ))}
-          </div>
-
-          <div className="grid grid-cols-2 gap-x-10 gap-y-4 sm:grid-cols-3 lg:grid-cols-4">
-            {strategy.segments.map(segment => (
-              <div
-                key={segment.id}
-                className="flex flex-col gap-1 transition-opacity duration-150"
-                style={{ opacity: hoveredId !== null && hoveredId !== segment.id ? 0.5 : 1 }}
-                onMouseEnter={() => setHoveredId(segment.id)}
-                onMouseLeave={() => setHoveredId(null)}
-              >
-                <span className="text-textSecondary flex items-center gap-1.5 text-sm">
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full transition-colors duration-150"
-                    style={{
-                      backgroundColor: hoveredId === segment.id ? segment.hoverColor : segment.color
-                    }}
-                  />
-                  {segment.label}
-                </span>
-                <span className="text-text text-sm font-medium">
-                  {segment.formattedUsd}{' '}
-                  <span className="text-textSecondary">({segment.formattedShare})</span>
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
+        <TokensComposition
+          total={strategy.formattedTotal}
+          // Shares already sit on a 0..1 scale against the vault total, so the
+          // bar must not renormalize them — a vault whose reported total
+          // exceeds its allocations keeps its short tail of empty track.
+          valueTotal={1}
+          segments={strategy.segments.map(segment => ({
+            id: segment.id,
+            label: segment.label,
+            color: segment.color,
+            hoverColor: segment.hoverColor,
+            value: segment.share,
+            percent: parseFloat(segment.formattedShare),
+            formattedValue: segment.formattedUsd
+          }))}
+        />
       )}
     </div>
   );

--- a/apps/webapp/src/modules/pendle/components/PendleMaturityProgress.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleMaturityProgress.tsx
@@ -6,10 +6,14 @@ import { formatTimeLeft } from '../utils/formatTimeLeft';
 import { computeMaturityWindow } from '../utils/maturityWindow';
 
 /**
- * Elapsed-maturity body for the detail page's "Maturity" section (E1 Figma
- * 486:33863): percentage headline, progress bar, remaining label + date.
+ * Elapsed-maturity body for the detail page's "Maturity" section (Figma
+ * 859:40960): Heading 3 percentage, progress bar, remaining label + date.
  * Window precedence matches TimeToMaturityCard — real start/expiry from the
  * markets API, config expiry with a 180-day fallback window otherwise.
+ *
+ * The comp gives the meta row a fg-brand-primary dot, Body 5 fg-secondary copy
+ * and — the part APP-432 item 14 flagged — a **fg-primary** maturity date, not
+ * the secondary tint the whole row used to share.
  */
 export function PendleMaturityProgress({ market }: { market: PendleMarketConfig }) {
   const { data: marketsApi } = usePendleMarketsApiData();
@@ -26,18 +30,22 @@ export function PendleMaturityProgress({ market }: { market: PendleMarketConfig 
 
   return (
     <div className="flex flex-col gap-3" data-testid="pendle-maturity-progress">
-      <span className="text-text font-circle text-3xl">{Math.round(pct)}%</span>
+      <span className="text-text font-circle text-[32px] leading-[35px] font-medium tracking-[-0.64px]">
+        {Math.round(pct)}%
+      </span>
       <Progress value={Math.min(100, Math.max(0, pct))} />
-      <div className="flex items-center justify-between text-sm">
-        <span className="text-textSecondary flex items-center gap-2">
-          <span className="bg-bullish h-1 w-1 rounded-full" />
+      <div className="flex items-center justify-between">
+        <span className="text-fgSecondary font-graphik flex items-center gap-2 text-sm leading-[22px]">
+          <span className="bg-fgBrand size-1 rounded-full" />
           {remainingSeconds <= 0 ? (
             <Trans>Matured</Trans>
           ) : (
             <Trans>Matures in {formatTimeLeft(remainingSeconds)}</Trans>
           )}
         </span>
-        <span className="text-textSecondary">{maturityDateLabel}</span>
+        <span className="text-text font-circle text-base leading-[18px] font-medium tracking-[-0.32px]">
+          {maturityDateLabel}
+        </span>
       </div>
     </div>
   );

--- a/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.test.tsx
+++ b/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.test.tsx
@@ -62,7 +62,7 @@ describe('BorrowUtilizationBlock', () => {
 
     const dot = (label: string) => screen.getByText(label).parentElement!.querySelector('span[aria-hidden]')!;
     expect(dot('Borrowed (USDS)').className).toContain('bg-fgBrand');
-    expect(dot('Available (USDS)').className).toContain('bg-textSecondary/50');
+    expect(dot('Available (USDS)').className).toContain('bg-fgSecondary/50');
     const bar = screen.getByRole('progressbar');
     expect(bar.querySelector('.bg-fgBrand')).toBeTruthy();
   });

--- a/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.tsx
+++ b/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.tsx
@@ -77,7 +77,13 @@ export function BorrowUtilizationBlock() {
         {isLoading ? <Skeleton className="h-8 w-24" /> : error ? NO_VALUE : `${utilization.toFixed(1)}%`}
       </div>
 
-      <Progress value={isLoading ? 0 : Math.min(100, utilization)} className="mb-5 h-1.5 md:mb-4 md:h-2" />
+      {/* Flat fg-brand-primary fill per 486:31955 — the DS Progress default is
+          the slider brand gradient, which this comp does not use. */}
+      <Progress
+        value={isLoading ? 0 : Math.min(100, utilization)}
+        indicatorClassName={UTILIZED_COLOR}
+        className="mb-5 h-1.5 md:mb-4 md:h-2"
+      />
 
       <div className="flex flex-col md:gap-3">
         <LegendRow

--- a/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.tsx
+++ b/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.tsx
@@ -19,7 +19,7 @@ function LegendRow({
   label,
   isLoading,
   error,
-  dotColor = 'bg-textSecondary/50',
+  dotColor = 'bg-fgSecondary/50',
   children
 }: {
   label: ReactNode;
@@ -28,11 +28,13 @@ function LegendRow({
   dotColor?: string;
   children: ReactNode;
 }) {
-  // Phone tier (comp 1222:17089): borderPrimary hairlines under BOTH rows,
-  // 12px token icon, Label 4 values; md restores the desktop legend.
+  // Hairlines under BOTH rows at every tier — the desktop comp closes the
+  // legend under "Available (USDS)" too, which is the border APP-432 item 18
+  // spotted missing (comp 1222:17089 for the phone geometry: 12px token icon,
+  // Label 4 values).
   return (
-    <div className="border-borderPrimary md:border-textSecondary/10 flex items-center justify-between gap-4 border-b pt-4 pb-3 md:py-3 md:last:border-b-0">
-      <span className="text-textSecondary flex items-center gap-1.5 text-sm leading-[22px] md:gap-2 md:leading-normal">
+    <div className="border-borderPrimary flex items-center justify-between gap-4 border-b pt-4 pb-3 md:py-3">
+      <span className="text-fgSecondary flex items-center gap-1.5 text-sm leading-[22px] md:gap-2 md:leading-normal">
         <span className={cn('h-1 w-1 shrink-0 rounded-full', dotColor)} aria-hidden />
         {label}
       </span>
@@ -70,7 +72,7 @@ export function BorrowUtilizationBlock() {
     <div data-testid="stake-borrow-utilization" className="flex flex-col">
       <h3 className="text-text font-circle mb-4 flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:gap-1.5 md:font-sans md:text-lg md:leading-normal md:tracking-normal">
         <Trans>Borrow Utilization</Trans>
-        <Info className="text-textSecondary h-3 w-3 md:h-4 md:w-4" aria-hidden />
+        <Info className="text-fgSecondary h-3 w-3 md:h-4 md:w-4" aria-hidden />
       </h3>
 
       <div className="text-text font-circle mb-5 text-2xl leading-[26px] font-medium tracking-[-0.48px] md:mb-3 md:font-sans md:leading-normal md:font-semibold md:tracking-normal">

--- a/apps/webapp/src/modules/stake/components/StakeAboutTab.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeAboutTab.tsx
@@ -66,7 +66,7 @@ export function StakeAboutTab() {
       <div className="order-2 flex flex-col gap-10 lg:order-none lg:col-span-2 lg:gap-6">
         <Card testId="stake-about-copy">
           {banner?.title && <h3 className={sectionHeading}>{banner.title}</h3>}
-          <div className="text-textSecondary text-sm leading-[22px] md:text-base md:leading-normal">
+          <div className="text-fgSecondary text-sm leading-[22px] md:text-base md:leading-normal">
             {parseBannerContent(banner?.description)}
           </div>
         </Card>
@@ -124,7 +124,7 @@ function HowItWorksRow({
   children: React.ReactNode;
 }) {
   return (
-    <li className="border-borderPrimary md:border-textSecondary/10 flex items-center justify-between gap-3 border-b p-4 last:border-b-0 md:px-0 md:py-4">
+    <li className="border-borderPrimary flex items-center justify-between gap-3 border-b p-4 last:border-b-0 md:px-0 md:py-4">
       <span className="flex items-center gap-2 md:gap-3">
         <span className="bg-glassSurface md:bg-surface text-text font-circle flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm leading-4 font-medium tracking-[-0.28px] md:font-sans md:leading-normal md:tracking-normal">
           {n}
@@ -134,7 +134,7 @@ function HowItWorksRow({
         </span>
       </span>
       {optional && (
-        <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px] md:text-sm md:leading-normal">
+        <span className="text-fgSecondary text-xs leading-[18px] md:text-sm md:leading-normal">
           <Trans>(Optional)</Trans>
         </span>
       )}

--- a/apps/webapp/src/modules/stake/components/StakeDetailsStrip.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeDetailsStrip.tsx
@@ -14,10 +14,10 @@ const NO_VALUE = '–';
 // the desktop 2-column strip.
 function DetailRow({ icon, label, children }: { icon: ReactNode; label: ReactNode; children: ReactNode }) {
   return (
-    <div className="border-borderPrimary md:border-textSecondary/10 flex items-center justify-between gap-4 border-b pt-4 pb-3 md:py-3">
-      <span className="text-textSecondary flex items-center gap-1.5 text-sm leading-[22px] md:gap-2 md:leading-normal">
+    <div className="border-borderPrimary flex items-center justify-between gap-4 border-b pt-4 pb-3 md:py-3">
+      <span className="text-fgSecondary flex items-center gap-1.5 text-sm leading-[22px] md:gap-2 md:leading-normal">
         <span
-          className="text-textSecondary flex h-3 w-3 items-center justify-center md:h-4 md:w-4 [&>svg]:h-full [&>svg]:w-full"
+          className="text-fgSecondary flex h-3 w-3 items-center justify-center md:h-4 md:w-4 [&>svg]:h-full [&>svg]:w-full"
           aria-hidden
         >
           {icon}
@@ -108,7 +108,7 @@ export function StakeDetailsStrip() {
           label={
             <>
               <Trans>Protocol SKY Price</Trans>
-              <Info className="text-textSecondary h-3.5 w-3.5" aria-hidden />
+              <Info className="text-fgSecondary h-3.5 w-3.5" aria-hidden />
             </>
           }
         >

--- a/apps/webapp/src/modules/stake/components/StakeRateChart.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeRateChart.tsx
@@ -93,7 +93,7 @@ export function StakeRateChart() {
         variant="detail"
         dataTestId="stake-rate-chart"
         // Brand indigo (Figma Components/Charts/bg-chart1), not the shared teal.
-        color="#757dff"
+        color="var(--color-chart1)"
         data={isRate ? rateData : isBorrow ? borrowData : tvlData}
         isLoading={isRate ? rewardsLoading : isLoading}
         error={isRate ? rewardsError : error}

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -464,9 +464,14 @@ function DetailHeaderValue({
   return (
     <span
       data-testid="chart-detail-value"
+      // Desktop is Heading 2 (44/48, Circular Medium — Figma 859:35718, whose
+      // header block measures 22px of label over a 48px figure); the phone tier
+      // keeps its own Heading 5 from M6.3.
       className={cn(
-        'text-text text-2xl',
-        mobile ? 'font-circle leading-[26px] font-medium tracking-[-0.48px]' : 'font-semibold lg:text-[28px]'
+        'text-text font-circle font-medium',
+        mobile
+          ? 'text-2xl leading-[26px] tracking-[-0.48px]'
+          : 'text-[44px] leading-[48px] tracking-[-0.88px]'
       )}
     >
       {formatted}
@@ -486,7 +491,8 @@ function ChartContent({
   tooltipLabel,
   tokenSymbols,
   chartHeight,
-  color
+  color,
+  isDetail = false
 }: {
   data: Data[];
   isLarge: boolean;
@@ -500,10 +506,16 @@ function ChartContent({
   tokenSymbols?: string[];
   chartHeight?: number;
   color?: string;
+  /** detail variant: no date axis under the plot, so it runs to the card floor. */
+  isDetail?: boolean;
 }) {
   const { bpi } = useBreakpointIndex();
   const gradientId = useId();
   const dimMaskId = useId();
+
+  // components/charts/bg-chart2 unless the caller themes the series (e.g. the
+  // Stake destination chart's bg-chart1 indigo).
+  const seriesColor = color ?? 'var(--color-chart2)';
 
   // Single source of truth for the plot height so the loading skeleton
   // reserves the same space as the rendered chart (no layout shift on load).
@@ -526,21 +538,17 @@ function ChartContent({
       <ResponsiveContainer width={'100%'} height={resolvedHeight}>
         <AreaChart
           data={data}
-          margin={{ top: isLarge ? 12 : 30, right: 0, bottom: isLarge ? 22 : 0, left: 0 }}
+          margin={{ top: isLarge ? 12 : 30, right: 0, bottom: isDetail ? 0 : isLarge ? 22 : 0, left: 0 }}
         >
           <defs>
+            {/* The area wash is one hue fading to nothing at the plot floor
+                (Figma 859:35718). It used to end at 75% — and, on the default
+                teal, to fade into a *different* hue (#00A167 green) — which is
+                what read as the wrong colour and the short gradient in APP-432
+                item 9. */}
             <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="100%" gradientUnits="objectBoundingBox">
-              {color ? (
-                <>
-                  <stop offset="5%" stopColor={color} stopOpacity={0.25} />
-                  <stop offset="75%" stopColor={color} stopOpacity="0" />
-                </>
-              ) : (
-                <>
-                  <stop offset="5%" stopColor="#1DD9BA" stopOpacity={0.25} />
-                  <stop offset="75%" stopColor="#00A167" stopOpacity="0" />
-                </>
-              )}
+              <stop offset="0%" stopColor={seriesColor} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={seriesColor} stopOpacity="0" />
             </linearGradient>
           </defs>
           <HoverDimMask id={dimMaskId} />
@@ -565,7 +573,7 @@ function ChartContent({
 
           <Area
             dataKey="value"
-            stroke={color ?? '#1DD9BA'}
+            stroke={seriesColor}
             strokeWidth={2.5}
             type="monotone"
             fill={`url(#${gradientId})`}
@@ -573,9 +581,9 @@ function ChartContent({
             // and tooltip render outside the masked layer, so they stay lit.
             mask={`url(#${dimMaskId})`}
             label={<CustomizedLabel /*data={data} stroke="var(--transparent-white-40)"*/ />}
-            dot={<CustomizedDot data={data} stroke={color ?? '#1DD9BA'} />}
+            dot={<CustomizedDot data={data} stroke={seriesColor} />}
             // Ringed hover dot at the cursor point (Figma 5273:12162).
-            activeDot={{ r: 5, fill: color ?? '#1DD9BA', stroke: 'var(--color-container)', strokeWidth: 3 }}
+            activeDot={{ r: 5, fill: seriesColor, stroke: 'var(--color-container)', strokeWidth: 3 }}
           />
         </AreaChart>
       </ResponsiveContainer>
@@ -653,13 +661,20 @@ export function Chart({
     <>
       <Card
         data-testid={dataTestId}
+        // Desktop detail is the comp's 32px-padded block (859:35718: header at
+        // 32/32, a 760-wide plot, 32px under it); the phone tier and the
+        // default variant keep their own full-bleed plot inside a p-0 card.
         className={cn(
-          'relative overflow-hidden p-0',
-          isDetail ? (isMobileDetail ? 'pb-5' : 'pb-3') : 'bg-cardLight h-[288px] lg:h-[220px] lg:p-0'
+          'relative overflow-hidden',
+          isDetail
+            ? isMobileDetail
+              ? 'p-0 pb-5'
+              : 'p-8'
+            : 'bg-cardLight h-[288px] p-0 lg:h-[220px] lg:p-0'
         )}
         ref={containerRef}
       >
-        <CardHeader className="p-5 pb-0">
+        <CardHeader className={cn(isDetail && !isMobileDetail ? 'p-0' : 'p-5 pb-0')}>
           {isMobileDetail ? (
             <div className="flex w-full flex-col gap-5">
               {metrics && activeMetric !== undefined && onMetricChange && (
@@ -687,11 +702,11 @@ export function Chart({
             </div>
           ) : isDetail ? (
             <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col">
+                {/* Body 5 on fg-secondary, flush against the figure (859:35718);
+                    it was 13px on the selectActive periwinkle. */}
                 {label && (
-                  <span className="text-selectActive light:text-textSecondary text-[13px] leading-none">
-                    {label}
-                  </span>
+                  <span className="text-fgSecondary font-graphik text-sm leading-[22px]">{label}</span>
                 )}
                 <DetailHeaderValue
                   data={data}
@@ -753,7 +768,7 @@ export function Chart({
         </CardHeader>
         <div
           data-testid={dataTestId ? `${dataTestId}-plot` : undefined}
-          className={cn(isMobileDetail && 'px-5')}
+          className={cn(isMobileDetail && 'px-5', isDetail && !isMobileDetail && 'pt-2')}
         >
           <ChartContent
             data={data}
@@ -764,7 +779,8 @@ export function Chart({
             activeTimeframe={activeTimeframe}
             isLoading={isLoading}
             error={error}
-            chartHeight={isDetail ? (isMobileDetail ? 203 : 280) : undefined}
+            isDetail={isDetail}
+            chartHeight={isDetail ? (isMobileDetail ? 203 : 263) : undefined}
             tooltipLabel={resolveTooltipLabel(tooltipLabel, metrics, activeMetric)}
             tokenSymbols={tokenSymbols}
             color={color}

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -666,11 +666,7 @@ export function Chart({
         // default variant keep their own full-bleed plot inside a p-0 card.
         className={cn(
           'relative overflow-hidden',
-          isDetail
-            ? isMobileDetail
-              ? 'p-0 pb-5'
-              : 'p-8'
-            : 'bg-cardLight h-[288px] p-0 lg:h-[220px] lg:p-0'
+          isDetail ? (isMobileDetail ? 'p-0 pb-5' : 'p-8') : 'bg-cardLight h-[288px] p-0 lg:h-[220px] lg:p-0'
         )}
         ref={containerRef}
       >

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -2187,7 +2187,7 @@ function TooltipReplica({ className, children }: { className?: string; children:
   return (
     <div
       className={cn(
-        'bg-bgTertiary text-fgPrimary font-graphik max-w-[260px] rounded-2xl p-4 text-[11px] leading-4 font-normal backdrop-blur-[100px]',
+        'bg-bgTertiary text-fgPrimary font-graphik max-w-[260px] rounded-2xl p-4 text-[11px] leading-4 font-normal backdrop-blur-[20px]',
         className
       )}
     >

--- a/apps/webapp/src/widgets/shared/components/ui/tooltip/InfoTooltip.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/tooltip/InfoTooltip.tsx
@@ -34,7 +34,7 @@ export function InfoTooltip({
       <PopoverContent
         align="center"
         side="top"
-        className={`bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[100px] ${contentClassname}`}
+        className={`bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[20px] ${contentClassname}`}
       >
         {shouldShowCloseButton && (
           <PopoverClose onClick={e => e.stopPropagation()} className="absolute top-4 right-4 z-10">


### PR DESCRIPTION
Closes the design-QA findings from [APP-432](https://linear.app/ekliptyka/issue/APP-432/redesign-qa-round-july-28) items **1, 2, 4, 6, 7, 9, 10, 13, 14, 15, 17**, plus the text-colour half of **18 and 19** that fell out of the same root cause.

## Three root causes account for most of the round

| | Was | Is |
|---|---|---|
| `--color-textSecondary` (dark) | `rgba(198,194,255,.8)` — a lavender | `fg-secondary #a1a6c4` via the existing `fgSecondary` token, per surface |
| `--color-error` (dark) | `--service-red #ff6d6d` (legacy) | new `--color-statusError` = `components/status/fg-error` |
| `--color-surface` | `rgba(108,104,255,.3)` — a bright periwinkle track | `bg-tertiary` |

The `textSecondary` swap is deliberately **per surface**, not a global repoint: the token has 263 call sites across ~95 files, many in pre-redesign widgets nobody has QA'd. Flipping it wholesale is worth its own ticket.

## Per item

| # | Fix |
|---|---|
| **1** | The dropdown trigger's inherited `[&>span]:line-clamp-1` puts `-webkit-box` + `overflow:hidden` on the value span, which sliced the portfolio "All networks" chain-icon stack down to the text line box. `FilterSelect` drops the clamp its single-line labels never needed. |
| **2** | The earn toolbar's globe / stablecoins / products glyphs lose their `md:hidden` — Figma 1036:201239 draws them at the desktop tier too. |
| **4** | Tooltips frost at **20px**, not 100px. Figma 1036:201579 gives them `background blur-2xl`, whose radius of 40 is CSS `blur(20px)` (Figma states background blur at twice the CSS value) — so 100px was 5× the spec. Covers `TooltipContent`, both `InfoTooltip` touch fallbacks, the risk-details exposure popover and the DS replica. Modal/sheet **scrims** keep their deliberate 100px from APP-416. |
| **6** | Both risk meters take the Figma status palette (1036:201215): Conservative `fg-success`, Moderate `fg-warning`, Aggressive `fg-error`; unlit steps `fg-quaternary`. This settles the "High risk colour unconfirmed" question the H8 tables batch left open. |
| **7** | Earn network options grow their chain icon (the portfolio filter already had one); the selected row's checkmark takes `fg-brand-primary` on the shared `SelectItem`, which is what item 17 asked for too. |
| **9** | The area wash faded from the teal into a **different hue** (`#00A167` green) and died at 75% of the plot. Now one hue, 0% → the plot floor. Series tints move onto new `--color-chart1/2` tokens. |
| **10** | Product-page About + Details copy off the lavender, onto Body 5 / `fg-secondary` with an inline brand "Learn more" (859:35769). Every module composes `ProductDetailTemplate`, so this covers savings, vaults, fixed yield, rewards and stUSDS at once. |
| **13** | The vault Strategy section had grown a wrapping column grid while the DS Tokens Composition it was meant to be is one row per token (5270:15609). `VaultStrategy` now renders the shared component, which absorbs the hover-dim and ring-capped joints it owned privately. |
| **14** | Pendle maturity to 859:40960 — Heading 3 figure, brand dot, and the maturity **date in `fg-primary`** rather than sharing the row's secondary tint. The DS `Progress` track drops `bg-surface` for `bg-tertiary` and adopts the slider brand gradient; the stake utilization bar is pinned to its flat `fg-brand` fill per 486:31955. |
| **15** | The detail chart header takes the comp's scale — Body 5 on `fg-secondary` flush over a **Heading 2 44/48** figure (it was 13px periwinkle over a 28px semibold), inside 32px card padding with a 263px plot. Measured live: card 405px, exactly 859:35718. |
| **17** | Convert panels redrawn to **1036:205437**, which supersedes the 486:31204/31210 frames they were built from. Each side is now the comp's two rows: side label with the balance beside it, then the amount with the percent chips and token chip. The From/To labels the card never had come with it. |
| **18, 19** *(partial)* | The `fg-secondary` swap covers the text half on the /stake Details strip, Borrow Utilization legend and About tab. While in the legend: the comp closes it under "Available (USDS)" too, so the `md:last:border-b-0` that swallowed that hairline goes — the missing border item 18 called out. |
