### PR TITLE
APP-432 item 21: restyle the stake open-position takeover to the latest comps

### DIFF
--- a/apps/webapp/src/components/InfoTooltip.tsx
+++ b/apps/webapp/src/components/InfoTooltip.tsx
@@ -1,5 +1,5 @@
 import { Info, X } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from './ui/popover';
 import { useIsTouchDevice } from '@/hooks';
 
@@ -48,17 +48,23 @@ export function InfoTooltip({
       </PopoverContent>
     </Popover>
   ) : (
-    <Tooltip>
-      <TooltipTrigger aria-label="Show additional information">
-        <Info size={iconSize} className={iconClassName} />
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent className={contentClassname}>
-          <div className="max-h-[calc(var(--radix-tooltip-content-available-height)-64px)] scrollbar-thin overflow-y-auto">
-            {typeof content === 'string' ? <p>{content}</p> : content}
-          </div>
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+    // Own provider (same 300ms delay as the app root's, which nests harmlessly
+    // under it) so the trigger is self-contained on any surface — pages, cards,
+    // full-page takeovers, tests — with no host setup. Same precedent as
+    // RiskTierDetailsTrigger.
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger aria-label="Show additional information">
+          <Info size={iconSize} className={iconClassName} />
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent className={contentClassname}>
+            <div className="max-h-[calc(var(--radix-tooltip-content-available-height)-64px)] scrollbar-thin overflow-y-auto">
+              {typeof content === 'string' ? <p>{content}</p> : content}
+            </div>
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/apps/webapp/src/components/product/TakeoverShell.tsx
+++ b/apps/webapp/src/components/product/TakeoverShell.tsx
@@ -6,13 +6,13 @@ const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
- * Full-screen takeover chrome (hi-fi 486:32657): header row with title + badge
- * and a close button, a scrollable centered card column, and a sticky footer.
- * The one sanctioned ProductDetailTemplate exception (Migration Mechanics §5) —
- * layout + slots only, no data fetching. Sits at z-[46]: above the bottom-
- * anchored app overlays (cookie banner z-40, extensible Banner z-[45]) that
- * would otherwise cover the sticky footer on phones, below the transaction
- * modal (z-50).
+ * Full-screen takeover chrome (hi-fi 486:32657, restyled to 1036:209505):
+ * header row with title + badge and a close button over a scrollable centered
+ * card column that ends with the footer row. The one sanctioned
+ * ProductDetailTemplate exception (Migration Mechanics §5) — layout + slots
+ * only, no data fetching. Sits at z-[46]: above the bottom-anchored app
+ * overlays (cookie banner z-40, extensible Banner z-[45]), below the
+ * transaction modal (z-50).
  */
 export function TakeoverShell({
   title,
@@ -93,12 +93,14 @@ export function TakeoverShell({
       aria-labelledby={titleId}
       tabIndex={-1}
       data-testid={dataTestId}
-      // Same page-background recipe as the shell surface (shellLayoutClasses):
-      // `bg-background` is undefined in the dark scope (known token gap) and
-      // would leave the overlay transparent.
-      className="bg-app-background light:bg-blend-normal fixed inset-0 z-[46] flex flex-col [background-color:#040434] bg-cover bg-center bg-no-repeat bg-blend-luminosity"
+      // The comps draw the takeover as a full-page MODAL over the live page
+      // (APP-432 item 21 — 1036:209505 layers it over `bg-modal`, a render of
+      // /earn), not as a second opaque page: same scrim + blur recipe as the
+      // dialog and sheet overlays. It previously repainted the app background,
+      // which hid the page underneath entirely.
+      className="bg-modalOverlay fixed inset-0 z-[46] flex flex-col backdrop-blur-[100px]"
     >
-      <div className="border-glassBorder flex items-center justify-between gap-4 border-b px-5 py-3 md:border-b-0 md:px-8 md:py-6 lg:px-16">
+      <div className="border-glassBorder flex items-center justify-between gap-4 border-b px-5 py-3 md:px-10 md:py-5">
         <div className="flex items-center gap-2 md:gap-3">
           {onBack && (
             <Button
@@ -111,14 +113,17 @@ export function TakeoverShell({
               <ChevronLeft className="h-4 w-4" />
             </Button>
           )}
+          {/* Label 4 on phones, Label 3 from md up (1369:44362). */}
           <h2
             id={titleId}
-            className="text-text font-circle text-base leading-[18px] font-medium tracking-[-0.32px] md:font-sans md:text-lg md:leading-normal md:tracking-normal"
+            className="text-text font-circle text-base leading-[18px] font-medium tracking-[-0.32px] md:text-lg md:leading-[22px] md:tracking-[-0.36px]"
           >
             {title}
           </h2>
           {badge && (
-            <span className="bg-surfaceAlt text-text md:text-textSecondary font-circle flex h-6 items-center gap-1 rounded-full py-1 pr-2 pl-1 text-xs leading-[14px] font-medium tracking-[-0.24px] md:px-2 md:font-sans md:leading-4 md:tracking-normal">
+            // Badges / Illustration (I1369:44421): glass pill, 4px inset around
+            // a 16px logo, Label 6 on fg-primary — one recipe at every tier.
+            <span className="bg-glassBadge text-text font-circle flex items-center gap-1 rounded-[20px] py-1 pr-2 pl-1 text-xs leading-[14px] font-medium tracking-[-0.24px]">
               {badge}
             </span>
           )}
@@ -134,19 +139,19 @@ export function TakeoverShell({
         </Button>
       </div>
 
+      {/* 610px column, 12px between cards, 64px of air under the header
+          (1036:209509). The footer is the column's last row rather than a
+          sticky bar — the comps scroll it with the content. */}
       <div className="scrollbar-hidden md:scrollbar-thin-always flex-1 overflow-y-auto px-3 md:px-4">
-        <div className="mx-auto flex w-full max-w-[660px] flex-col gap-3 pt-3 pb-4 md:gap-6 md:pt-0 md:pb-8">
+        <div className="mx-auto flex w-full max-w-[610px] flex-col gap-3 pt-3 pb-[max(16px,env(safe-area-inset-bottom))] md:pt-16 md:pb-16">
           {children}
+          {footer && (
+            <div className="flex items-center justify-between gap-4 px-2 py-4 md:gap-6 md:px-6 md:py-6">
+              {footer}
+            </div>
+          )}
         </div>
       </div>
-
-      {footer && (
-        <div className="px-3 pt-2 pb-[max(12px,env(safe-area-inset-bottom))] md:px-4 md:py-6">
-          <div className="mx-auto flex w-full max-w-[660px] items-center justify-between gap-4 md:gap-6">
-            {footer}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/webapp/src/components/ui/slider.tsx
+++ b/apps/webapp/src/components/ui/slider.tsx
@@ -17,8 +17,15 @@ function Slider({
   min = 0,
   max = 100,
   variant = 'default',
+  valueText,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root> & { variant?: SliderVariant }) {
+}: React.ComponentProps<typeof SliderPrimitive.Root> & {
+  variant?: SliderVariant;
+  /** Spoken value for the thumb (aria-valuetext) — e.g. "25%" where the bare
+   *  number would be ambiguous. Radix puts role="slider" on the THUMB, so this
+   *  cannot be passed through Root's props. */
+  valueText?: string;
+}) {
   const _values = React.useMemo(
     () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
     [value, defaultValue, min, max]
@@ -83,6 +90,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
+          aria-valuetext={valueText}
           className={cn(
             'after:bg-sliderDot focus-visible:ring-focusRing relative block size-4 shrink-0 rounded-full transition-[color,box-shadow] after:absolute after:inset-1 after:rounded-full focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:outline-hidden disabled:pointer-events-none',
             isRange

--- a/apps/webapp/src/modules/stake/components/ManagePositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/ManagePositionTakeover.tsx
@@ -324,7 +324,7 @@ export function ManagePositionTakeover({
       title={<Trans>Manage a position</Trans>}
       badge={
         <>
-          <StakeSky className="h-3.5 w-3.5" />
+          <StakeSky className="h-4 w-4" />
           <Trans>SKY Staking</Trans>
         </>
       }

--- a/apps/webapp/src/modules/stake/components/OpenPositionTakeover.test.tsx
+++ b/apps/webapp/src/modules/stake/components/OpenPositionTakeover.test.tsx
@@ -294,6 +294,21 @@ describe('OpenPositionTakeover', () => {
     expect(h.launchParams?.skyToLock).toBe(500n * WAD);
   });
 
+  it('the stake slider tracks the typed share of the balance (1036:209724)', () => {
+    renderTakeover();
+
+    const slider = screen.getByTestId('stake-takeover-stake-slider').querySelector('[role="slider"]');
+    expect(slider?.getAttribute('aria-valuenow')).toBe('0');
+
+    // Balance is 1000 SKY, so a quarter of it puts the thumb at 25%.
+    fireEvent.click(screen.getByTestId('stake-takeover-stake-amount-percent-25'));
+    expect(slider?.getAttribute('aria-valuenow')).toBe('25');
+
+    // Typing past the balance pins the thumb rather than running it off-track.
+    typeStakeAmount('5000');
+    expect(slider?.getAttribute('aria-valuenow')).toBe('100');
+  });
+
   it('shows the est. annual rewards from the selected farm rate', () => {
     renderTakeover();
 

--- a/apps/webapp/src/modules/stake/components/OpenPositionTakeover.test.tsx
+++ b/apps/webapp/src/modules/stake/components/OpenPositionTakeover.test.tsx
@@ -309,6 +309,36 @@ describe('OpenPositionTakeover', () => {
     expect(slider?.getAttribute('aria-valuenow')).toBe('100');
   });
 
+  it('the stake slider still reads whole percents on a dust-bearing balance', () => {
+    // Staging floors, so a balance that is not a round multiple of 100 wei used
+    // to read back one percent LOW (25% chip → thumb at 24) when the projection
+    // floored as well. Real balances are all of this shape.
+    h.balance = 1234567891234567891234n;
+    renderTakeover();
+
+    const slider = screen.getByTestId('stake-takeover-stake-slider').querySelector('[role="slider"]');
+
+    fireEvent.click(screen.getByTestId('stake-takeover-stake-amount-percent-25'));
+    expect(slider?.getAttribute('aria-valuenow')).toBe('25');
+    expect(slider?.getAttribute('aria-valuetext')).toBe('25%');
+
+    fireEvent.click(screen.getByTestId('stake-takeover-stake-amount-percent-100'));
+    expect(slider?.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  it('dragging the stake slider stages the matching share of the balance', () => {
+    renderTakeover();
+
+    const slider = screen.getByTestId('stake-takeover-stake-slider').querySelector('[role="slider"]');
+    (slider as HTMLElement).focus();
+    // One keyboard step off zero is 1% of the 1000 SKY balance.
+    fireEvent.keyDown(slider as HTMLElement, { key: 'ArrowRight' });
+
+    expect(slider?.getAttribute('aria-valuenow')).toBe('1');
+    expect((screen.getByTestId('stake-takeover-stake-amount') as HTMLInputElement).value).toBe('10');
+    expect(h.launchParams?.skyToLock).toBe(10n * WAD);
+  });
+
   it('shows the est. annual rewards from the selected farm rate', () => {
     renderTakeover();
 

--- a/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
@@ -286,6 +286,7 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
       dataTestId="stake-takeover"
       footer={
         <>
+          {/* 237px is the comp's two-line measure for this copy (1036:209863). */}
           <p className="text-fgSecondary md:text-textSecondary flex-1 text-center text-xs leading-[18px] md:max-w-[237px] md:flex-none md:text-left">
             <Trans>Review the position details, and continue to confirm it in your wallet.</Trans>
           </p>
@@ -295,7 +296,10 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
             onClick={launch}
             disabled={confirmDisabled}
             data-testid="stake-takeover-confirm"
-            className="h-12 shrink-0 px-5 text-sm leading-4 tracking-[-0.28px] md:h-14 md:w-40 md:px-10 md:text-base md:leading-[18px] md:tracking-[-0.32px]"
+            // min-w, not w: the comp's 160px button leaves ~80px of text box
+            // inside the 40px insets, and `whitespace-nowrap` from the base
+            // recipe would clip a longer translated label rather than wrap it.
+            className="h-12 shrink-0 px-5 text-sm leading-4 tracking-[-0.28px] md:h-14 md:min-w-40 md:px-10 md:text-base md:leading-[18px] md:tracking-[-0.32px]"
           >
             <Trans>Confirm</Trans>
           </Button>

--- a/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
@@ -287,7 +287,7 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
       footer={
         <>
           {/* 237px is the comp's two-line measure for this copy (1036:209863). */}
-          <p className="text-fgSecondary md:text-textSecondary flex-1 text-center text-xs leading-[18px] md:max-w-[237px] md:flex-none md:text-left">
+          <p className="text-fgSecondary flex-1 text-center text-xs leading-[18px] md:max-w-[237px] md:flex-none md:text-left">
             <Trans>Review the position details, and continue to confirm it in your wallet.</Trans>
           </p>
           <Button

--- a/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/OpenPositionTakeover.tsx
@@ -278,7 +278,7 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
       onBack={reopen?.onBack}
       badge={
         <>
-          <StakeSky className="h-4 w-4 md:h-3.5 md:w-3.5" />
+          <StakeSky className="h-4 w-4" />
           <Trans>SKY Staking</Trans>
         </>
       }
@@ -286,7 +286,7 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
       dataTestId="stake-takeover"
       footer={
         <>
-          <p className="text-fgSecondary md:text-textSecondary flex-1 text-center text-xs leading-[18px] md:max-w-xs md:flex-none md:text-left md:text-sm md:leading-5">
+          <p className="text-fgSecondary md:text-textSecondary flex-1 text-center text-xs leading-[18px] md:max-w-[237px] md:flex-none md:text-left">
             <Trans>Review the position details, and continue to confirm it in your wallet.</Trans>
           </p>
           <Button
@@ -295,7 +295,7 @@ export function OpenPositionTakeover({ reopen }: { reopen?: ReopenContext }) {
             onClick={launch}
             disabled={confirmDisabled}
             data-testid="stake-takeover-confirm"
-            className="h-12 shrink-0 px-5 text-sm leading-4 tracking-[-0.28px] md:h-14 md:px-10 md:text-base md:leading-[18px] md:tracking-[-0.32px]"
+            className="h-12 shrink-0 px-5 text-sm leading-4 tracking-[-0.28px] md:h-14 md:w-40 md:px-10 md:text-base md:leading-[18px] md:tracking-[-0.32px]"
           >
             <Trans>Confirm</Trans>
           </Button>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverAmountField.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverAmountField.tsx
@@ -59,23 +59,16 @@ export function StakeTakeoverAmountField({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-4">
-        <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px] md:text-sm md:leading-5">
+        <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px]">
           {label ?? <Trans>Amount</Trans>}
         </span>
         {topRight && (
-          <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px] md:text-sm md:leading-5">
-            {topRight}
-          </span>
+          <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px]">{topRight}</span>
         )}
       </div>
       <div className="flex items-center justify-between gap-4">
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <TokenIcon
-            token={{ symbol: tokenSymbol }}
-            width={28}
-            className="h-6 w-6 md:h-7 md:w-7"
-            showChainIcon={false}
-          />
+          <TokenIcon token={{ symbol: tokenSymbol }} width={24} className="h-6 w-6" showChainIcon={false} />
           <input
             type="text"
             inputMode="decimal"
@@ -87,18 +80,20 @@ export function StakeTakeoverAmountField({
             aria-invalid={!!error}
             aria-describedby={error ? errorId : undefined}
             className={cn(
-              'text-text placeholder:text-textSecondary font-circle w-full min-w-0 bg-transparent text-[22px] leading-6 font-medium tracking-[-0.44px] outline-none disabled:opacity-50 md:font-sans md:text-3xl md:leading-9 md:tracking-tight',
+              // Heading 5 on phones, Heading 4 (28/30, −0.56) from md up.
+              'text-text placeholder:text-textSecondary font-circle w-full min-w-0 bg-transparent text-[22px] leading-6 font-medium tracking-[-0.44px] outline-none disabled:opacity-50 md:text-[28px] md:leading-[30px] md:tracking-[-0.56px]',
               error && 'text-error'
             )}
           />
         </div>
         {onPercentClick && (
-          <div className="flex shrink-0 items-center gap-1 md:gap-1.5">
+          <div className="flex shrink-0 items-center gap-1">
             {percentChips.map(percent => (
               // Design-system Button / Mini (Figma 5051:168712); the base
               // recipe's solid disabled fill is swapped back for the field's
-              // subtler faded look. Mobile steps down to the comp's 32px chip
-              // with a Label 6 digit (1222:19764).
+              // subtler faded look. Both tiers carry the comps' Label 6 digit
+              // (1222:19764 · 1294:37495) — mobile on a 32px chip, md+ on the
+              // 8/6 inset the takeover draws.
               <button
                 key={percent}
                 type="button"
@@ -107,7 +102,7 @@ export function StakeTakeoverAmountField({
                 data-testid={`${dataTestId}-percent-${percent}`}
                 className={cn(
                   buttonVariants({ variant: 'mini', size: 'mini' }),
-                  'h-8 px-2.5 text-xs leading-[14px] tracking-[-0.24px] md:h-auto md:px-2 md:text-sm md:leading-4 md:tracking-[-0.28px]',
+                  'h-8 px-2.5 text-xs leading-[14px] tracking-[-0.24px] md:h-auto md:px-2 md:py-1.5',
                   'disabled:text-text disabled:bg-transparent disabled:opacity-50'
                 )}
               >

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverAmountField.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverAmountField.tsx
@@ -59,12 +59,8 @@ export function StakeTakeoverAmountField({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-4">
-        <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px]">
-          {label ?? <Trans>Amount</Trans>}
-        </span>
-        {topRight && (
-          <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px]">{topRight}</span>
-        )}
+        <span className="text-fgSecondary text-xs leading-[18px]">{label ?? <Trans>Amount</Trans>}</span>
+        {topRight && <span className="text-fgSecondary text-xs leading-[18px]">{topRight}</span>}
       </div>
       <div className="flex items-center justify-between gap-4">
         <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -81,7 +77,7 @@ export function StakeTakeoverAmountField({
             aria-describedby={error ? errorId : undefined}
             className={cn(
               // Heading 5 on phones, Heading 4 (28/30, −0.56) from md up.
-              'text-text placeholder:text-textSecondary font-circle w-full min-w-0 bg-transparent text-[22px] leading-6 font-medium tracking-[-0.44px] outline-none disabled:opacity-50 md:text-[28px] md:leading-[30px] md:tracking-[-0.56px]',
+              'text-text placeholder:text-fgSecondary font-circle w-full min-w-0 bg-transparent text-[22px] leading-6 font-medium tracking-[-0.44px] outline-none disabled:opacity-50 md:text-[28px] md:leading-[30px] md:tracking-[-0.56px]',
               error && 'text-error'
             )}
           />

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
@@ -26,9 +26,7 @@ const RISK_PILL: Record<RiskLevel, string> = {
 function StatItem({ label, children }: { label: ReactNode; children: ReactNode }) {
   return (
     <div className="flex min-w-0 flex-col gap-1">
-      <span className="text-fgSecondary md:text-textSecondary flex items-center gap-1 text-xs leading-[18px]">
-        {label}
-      </span>
+      <span className="text-fgSecondary flex items-center gap-1 text-xs leading-[18px]">{label}</span>
       <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px]">
         {children}
       </span>
@@ -166,7 +164,7 @@ export function StakeTakeoverBorrowCard({
               <span className="text-text font-medium">
                 <Trans>More SKY needed to borrow</Trans>
               </span>
-              <span className="text-textSecondary">
+              <span className="text-fgSecondary">
                 <Trans>
                   The minimum borrow is {dust !== undefined ? formatBigInt(dust) : NO_VALUE} USDS, which
                   requires at least{' '}
@@ -246,7 +244,7 @@ export function StakeTakeoverBorrowCard({
             {simulatedVault?.delayedPrice
               ? `$${formatBigInt(simulatedVault.delayedPrice, { unit: WAD_PRECISION, maxDecimals: 4 })}`
               : NO_VALUE}
-            <span className="bg-glassBadge text-textSecondary font-circle flex h-[18px] items-center rounded-full px-1.5 text-[11px] leading-3 font-medium tracking-[-0.22px]">
+            <span className="bg-glassBadge text-fgSecondary font-circle flex h-[18px] items-center rounded-full px-1.5 text-[11px] leading-3 font-medium tracking-[-0.22px]">
               <Trans>Updated hourly</Trans>
             </span>
           </StatItem>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
@@ -1,45 +1,51 @@
 import { ReactNode } from 'react';
 import { Trans } from '@lingui/react/macro';
-import { Check, Info, TriangleAlert } from 'lucide-react';
+import { t } from '@lingui/core/macro';
+import { TriangleAlert } from 'lucide-react';
 import { RiskLevel, Vault, CollateralRiskParameters } from '@/hooks';
 import { capitalizeFirstLetter, formatBigInt, formatPercent, WAD_PRECISION } from '@/utils';
 import { cn } from '@/lib/cn';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { Slider, SliderTicks } from '@/components/ui/slider';
+import { InfoTooltip } from '@/components/InfoTooltip';
 import { useStakeRiskSlider } from '../hooks/useStakeRiskSlider';
 import { StakeTakeoverCard } from './StakeTakeoverCard';
 import { StakeTakeoverAmountField, BORROW_PERCENT_CHIPS } from './StakeTakeoverAmountField';
 
 const NO_VALUE = '–';
 
-// Risk-pill palette — same convention as the F3 positions-table meter.
+// Risk-pill palette on the DS components/status colours (Badge I1036:209777) —
+// the same success/warning/error trio the risk meters took in APP-432 item 6.
 const RISK_PILL: Record<RiskLevel, string> = {
-  [RiskLevel.LOW]: 'bg-bullish/20 text-bullish',
-  [RiskLevel.MEDIUM]: 'bg-orange-400/20 text-orange-400',
-  [RiskLevel.HIGH]: 'bg-error/20 text-error',
-  [RiskLevel.LIQUIDATION]: 'bg-error/20 text-error'
+  [RiskLevel.LOW]: 'bg-statusSuccess/10 text-statusSuccess',
+  [RiskLevel.MEDIUM]: 'bg-statusWarning/10 text-statusWarning',
+  [RiskLevel.HIGH]: 'bg-statusError/10 text-statusError',
+  [RiskLevel.LIQUIDATION]: 'bg-statusError/10 text-statusError'
 };
 
 function StatItem({ label, children }: { label: ReactNode; children: ReactNode }) {
   return (
     <div className="flex min-w-0 flex-col gap-1">
-      <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px] md:flex md:items-center md:gap-1 md:text-sm md:leading-5">
+      <span className="text-fgSecondary md:text-textSecondary flex items-center gap-1 text-xs leading-[18px]">
         {label}
       </span>
-      <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] md:font-sans md:leading-5 md:tracking-normal">
+      <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px]">
         {children}
       </span>
     </div>
   );
 }
 
-/** Mobile-only 32px hairline between the stat columns (comp 1222:19900). */
-function StatDivider() {
-  return <span aria-hidden className="bg-borderPrimary h-8 w-px justify-self-center md:hidden" />;
+/** 32px hairline between the stat columns (comp 1036:209771). */
+function StatDivider({ className }: { className?: string }) {
+  return (
+    <span aria-hidden className={cn('bg-borderPrimary h-8 w-px shrink-0 justify-self-center', className)} />
+  );
 }
 
 /**
- * Card 2 · Borrow USDS (Optional): enable toggle, amount + max + percent chips,
+ * Card 2 · Borrow USDS (Optional, Modal / 10 · 1036:209743): enable toggle,
+ * amount + max + percent chips,
  * the legacy risk slider (math verbatim via useStakeRiskSlider), risk/price
  * stats, and the min-collateral warning state (UX `1104:19793` — input pinned,
  * Confirm handled by the container). Risk/price rows show "–" until an amount
@@ -104,29 +110,29 @@ export function StakeTakeoverBorrowCard({
       onEnabledChange={onEnabledChange}
       dataTestId="stake-takeover-borrow-card"
     >
-      <div className="flex flex-col gap-6 md:gap-5">
-        <StakeTakeoverAmountField
-          tokenSymbol="USDS"
-          amount={usdsToBorrow}
-          onAmountChange={onAmountChange}
-          onPercentClick={onPercentClick}
-          percentChips={BORROW_PERCENT_CHIPS}
-          disabled={inputDisabled}
-          error={error}
-          dataTestId="stake-takeover-borrow-amount"
-          topRight={
-            minCollateralNotMet ? undefined : (
-              <Trans>max. {formatBigInt(maxBorrowable, { compact: true })} USDS</Trans>
-            )
-          }
-        />
-
-        {/* Mobile-only hairline below the amount block (comp 1222:19809) —
-            the comp draws it above the slider and leaves the stats undivided. */}
-        <span aria-hidden className="border-textSecondary/10 -mt-3 border-t md:hidden" />
+      <div className="flex flex-col gap-6 md:gap-8">
+        {/* Amount block over its hairline (Frame 1597879781, 1036:209752). */}
+        <div className="flex flex-col gap-2 md:gap-3">
+          <StakeTakeoverAmountField
+            tokenSymbol="USDS"
+            amount={usdsToBorrow}
+            onAmountChange={onAmountChange}
+            onPercentClick={onPercentClick}
+            percentChips={BORROW_PERCENT_CHIPS}
+            disabled={inputDisabled}
+            error={error}
+            dataTestId="stake-takeover-borrow-amount"
+            topRight={
+              minCollateralNotMet ? undefined : (
+                <Trans>max. {formatBigInt(maxBorrowable, { compact: true })} USDS</Trans>
+              )
+            }
+          />
+          <span aria-hidden className="border-borderPrimary border-t" />
+        </div>
 
         {shouldShowSlider && !minCollateralNotMet && (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1.5">
             <Slider
               variant="range"
               value={sliderValue}
@@ -136,7 +142,7 @@ export function StakeTakeoverBorrowCard({
               aria-label="Liquidation risk meter"
               data-testid="stake-takeover-borrow-slider"
             />
-            <div className="text-fgSecondary flex items-center gap-4 text-xs">
+            <div className="text-fgSecondary flex items-center gap-4 text-xs leading-[18px]">
               <span className="flex items-center gap-1">
                 <Trans>min. {dust !== undefined ? formatBigInt(dust, { compact: true }) : NO_VALUE}</Trans>
                 <TokenIcon token={{ symbol: 'USDS' }} width={12} className="h-3 w-3" showChainIcon={false} />
@@ -180,7 +186,10 @@ export function StakeTakeoverBorrowCard({
           </p>
         )}
 
-        <div className="md:border-textSecondary/10 grid grid-cols-[1fr_auto_1fr] items-center gap-4 md:flex md:flex-wrap md:items-start md:gap-6 md:border-t md:pt-4">
+        {/* 2×2 on phones (1222:19900), one 4-up row from md (1036:209767). The
+            middle divider only exists in the row: `hidden` drops it out of the
+            grid's flow entirely, so the mobile 2×2 keeps its centre rule. */}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 md:flex md:flex-wrap md:items-start md:gap-4">
           <StatItem label={<Trans>Borrow rate</Trans>}>
             {collateralData?.stabilityFee ? formatPercent(collateralData.stabilityFee) : NO_VALUE}
           </StatItem>
@@ -189,9 +198,14 @@ export function StakeTakeoverBorrowCard({
             label={
               <>
                 <Trans>Liquidation risk</Trans>
-                <Info
-                  className="ml-1 inline h-3 w-3 shrink-0 align-[-2px] md:ml-0 md:h-3.5 md:w-3.5 md:align-baseline"
-                  aria-hidden
+                <InfoTooltip
+                  iconSize={12}
+                  iconClassName="shrink-0"
+                  content={
+                    hasAmount && simulatedVault?.liquidationPrice
+                      ? t`Sky closes your position if SKY's price drops to your liquidation price ($${formatBigInt(simulatedVault.liquidationPrice, { unit: WAD_PRECISION, maxDecimals: 4 })}). Your collateral is sold to repay the debt plus a penalty.`
+                      : t`Sky closes your position if SKY's price drops to your liquidation price. Your collateral is sold to repay the debt plus a penalty.`
+                  }
                 />
               </>
             }
@@ -200,7 +214,7 @@ export function StakeTakeoverBorrowCard({
               <span
                 data-testid="stake-takeover-risk-pill"
                 className={cn(
-                  'font-circle flex h-[18px] items-center rounded-full px-1.5 text-[11px] leading-3 font-medium tracking-[-0.22px] md:h-auto md:px-2 md:py-0.5 md:font-sans md:text-xs md:leading-4 md:tracking-normal',
+                  'font-circle flex h-[18px] items-center rounded-full px-1.5 text-[11px] leading-3 font-medium tracking-[-0.22px]',
                   RISK_PILL[riskLevel]
                 )}
               >
@@ -210,6 +224,7 @@ export function StakeTakeoverBorrowCard({
               NO_VALUE
             )}
           </StatItem>
+          <StatDivider className="hidden md:block" />
           <StatItem label={<Trans>Liquidation price</Trans>}>
             {hasAmount && simulatedVault?.liquidationPrice
               ? `$${formatBigInt(simulatedVault.liquidationPrice, { unit: WAD_PRECISION, maxDecimals: 4 })}`
@@ -220,9 +235,10 @@ export function StakeTakeoverBorrowCard({
             label={
               <>
                 <Trans>Protocol SKY Price</Trans>
-                <Info
-                  className="ml-1 inline h-3 w-3 shrink-0 align-[-2px] md:ml-0 md:h-3.5 md:w-3.5 md:align-baseline"
-                  aria-hidden
+                <InfoTooltip
+                  iconSize={12}
+                  iconClassName="shrink-0"
+                  content={t`Sky uses a stale price that updates hourly to protect the system from short-term manipulation. Your liquidation level and borrow limit are based on this price, not the live market price.`}
                 />
               </>
             }
@@ -230,8 +246,7 @@ export function StakeTakeoverBorrowCard({
             {simulatedVault?.delayedPrice
               ? `$${formatBigInt(simulatedVault.delayedPrice, { unit: WAD_PRECISION, maxDecimals: 4 })}`
               : NO_VALUE}
-            <span className="bg-surfaceAlt text-textSecondary font-circle flex h-[18px] items-center gap-1 rounded-full px-1.5 text-[11px] leading-3 font-medium tracking-[-0.22px] md:h-auto md:px-2 md:py-0.5 md:font-sans md:text-xs md:leading-4 md:font-normal md:tracking-normal">
-              <Check className="hidden h-3 w-3 md:block" aria-hidden />
+            <span className="bg-glassBadge text-textSecondary font-circle flex h-[18px] items-center rounded-full px-1.5 text-[11px] leading-3 font-medium tracking-[-0.22px]">
               <Trans>Updated hourly</Trans>
             </span>
           </StatItem>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
@@ -189,7 +189,7 @@ export function StakeTakeoverBorrowCard({
         {/* 2×2 on phones (1222:19900), one 4-up row from md (1036:209767). The
             middle divider only exists in the row: `hidden` drops it out of the
             grid's flow entirely, so the mobile 2×2 keeps its centre rule. */}
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 md:flex md:flex-wrap md:items-start md:gap-4">
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 md:flex md:flex-wrap md:gap-4">
           <StatItem label={<Trans>Borrow rate</Trans>}>
             {collateralData?.stabilityFee ? formatPercent(collateralData.stabilityFee) : NO_VALUE}
           </StatItem>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverCard.tsx
@@ -3,10 +3,11 @@ import { Trans } from '@lingui/react/macro';
 import { Switch } from '@/components/ui/switch';
 
 /**
- * Numbered takeover card (hi-fi 486:32657): circled step number + title
- * (+ muted "(Optional)" and an enable toggle for cards 2/3). Optional cards
- * collapse to their header row while disabled — temporal states of one screen,
- * not wizard steps.
+ * Numbered takeover card (Modal / 10 · 12 · 17, 1036:209510+): circled step
+ * number + title (+ muted "(Optional)" and an enable toggle for cards 2/3).
+ * Optional cards collapse to their header row while disabled — temporal states
+ * of one screen, not wizard steps. 32px inset and 32px between the header and
+ * the body at md+; the collapsed card is exactly header + 2×32.
  */
 export function StakeTakeoverCard({
   step,
@@ -28,17 +29,17 @@ export function StakeTakeoverCard({
   return (
     <section
       data-testid={dataTestId}
-      className="bg-glassSurface rounded-card flex flex-col gap-6 p-5 backdrop-blur-[20px] md:p-6"
+      className="bg-glassSurface rounded-card flex flex-col gap-6 p-5 backdrop-blur-[20px] md:gap-8 md:p-8"
     >
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
-          <span className="border-glassBorder md:border-borderPrimary text-text font-circle flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm leading-4 font-medium tracking-[-0.28px] md:font-sans md:leading-5 md:tracking-normal">
+          <span className="border-glassBorder text-text font-circle flex h-8 w-8 shrink-0 items-center justify-center rounded-[20px] border text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-[18px] md:tracking-[-0.32px]">
             {step}
           </span>
-          <h3 className="text-text font-circle flex items-baseline gap-2 text-sm leading-4 font-medium tracking-[-0.28px] md:font-sans md:text-lg md:leading-normal md:tracking-normal">
+          <h3 className="text-text font-circle flex items-baseline gap-2 text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-[18px] md:tracking-[-0.32px]">
             {title}
             {optional && (
-              <span className="text-fgSecondary md:text-textSecondary font-sans text-xs leading-[18px] font-normal tracking-normal md:text-sm md:leading-5">
+              <span className="text-fgSecondary md:text-textSecondary font-sans text-xs leading-[18px] font-normal tracking-normal">
                 <Trans>(Optional)</Trans>
               </span>
             )}

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverCard.tsx
@@ -39,7 +39,7 @@ export function StakeTakeoverCard({
           <h3 className="text-text font-circle flex items-baseline gap-2 text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-[18px] md:tracking-[-0.32px]">
             {title}
             {optional && (
-              <span className="text-fgSecondary md:text-textSecondary font-sans text-xs leading-[18px] font-normal tracking-normal">
+              <span className="text-fgSecondary font-sans text-xs leading-[18px] font-normal tracking-normal">
                 <Trans>(Optional)</Trans>
               </span>
             )}

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverConfirmSummary.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverConfirmSummary.tsx
@@ -6,7 +6,7 @@ function AmountBlock({ label, amount, symbol }: { label: React.ReactNode; amount
   return (
     <div className="flex items-end justify-between gap-4">
       <div className="flex flex-col gap-1.5">
-        <span className="text-textSecondary text-sm">{label}</span>
+        <span className="text-fgSecondary text-sm">{label}</span>
         <span className="text-text flex items-center gap-2 text-3xl font-medium tracking-tight">
           <TokenIcon token={{ symbol }} width={28} className="h-7 w-7" showChainIcon={false} />
           {formatBigInt(amount)}
@@ -44,7 +44,7 @@ export function StakeTakeoverConfirmSummary({
       )}
       {rewardSymbol && (
         <div data-testid="stake-takeover-confirm-reward" className="flex items-center justify-between gap-4">
-          <span className="text-textSecondary text-sm">
+          <span className="text-fgSecondary text-sm">
             <Trans>Reward (selected automatically)</Trans>
           </span>
           <span className="bg-surfaceAlt text-text flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium">

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
@@ -3,7 +3,7 @@ import { useChainId, useConnection } from 'wagmi';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { ExternalLink, Search } from 'lucide-react';
-import { BP, useBreakpointIndex, useStakeUserDelegates, useDebounce, ZERO_ADDRESS } from '@/hooks';
+import { useStakeUserDelegates, useDebounce, ZERO_ADDRESS } from '@/hooks';
 import { formatBigInt } from '@/utils';
 import { cn } from '@/lib/cn';
 import { CustomAvatar } from '@/modules/ui/components/Avatar';
@@ -33,8 +33,6 @@ export function DelegateList({
   const chainId = useChainId();
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search);
-  const { bpi } = useBreakpointIndex();
-  const isMobile = bpi < BP.md;
 
   // Legacy SelectDelegate arguments, verbatim (pageSize 100, random, sorted).
   const { data: delegates, isLoading } = useStakeUserDelegates({
@@ -49,8 +47,9 @@ export function DelegateList({
   });
 
   return (
-    <div className="flex flex-col gap-6 md:gap-4">
-      <div className="border-textSecondary/20 flex items-center gap-2 border-b pb-3 md:pb-2">
+    <div className="flex flex-col gap-6 md:gap-8">
+      {/* Search row over its hairline (Frame 2087328600, 1036:209801). */}
+      <div className="border-borderPrimary flex items-center gap-2 border-b pb-3">
         <Search className="text-textSecondary h-4 w-4 shrink-0" aria-hidden />
         <input
           type="text"
@@ -58,7 +57,7 @@ export function DelegateList({
           placeholder={t`Search`}
           onChange={event => setSearch(event.target.value)}
           data-testid={`${dataTestIdPrefix}-search`}
-          className="text-text placeholder:text-fgTertiary md:placeholder:text-textSecondary w-full bg-transparent text-sm leading-[22px] outline-none md:leading-5"
+          className="text-text placeholder:text-fgTertiary md:placeholder:text-textSecondary w-full bg-transparent text-sm leading-[22px] outline-none"
         />
       </div>
 
@@ -87,20 +86,21 @@ export function DelegateList({
                   data-testid={`${dataTestIdPrefix}-${delegate.id.toLowerCase()}`}
                   aria-pressed={isSelected}
                   className={cn(
-                    'flex w-full items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition-colors md:rounded-xl md:p-4',
-                    // Comp 1222:19936: brand ring over the 10% brand gradient —
-                    // the brandBorder/brand3 recipe the selected wallet row in
-                    // ui/list already uses. Applied at every tier: the previous
-                    // border-primary/bg-primary pair resolves to transparent in
-                    // the dark scope, leaving desktop's selected row invisible.
+                    'flex w-full items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition-colors md:rounded-[20px] md:px-5 md:py-4',
+                    // Comp 1222:19936 / 1036:209807: brand ring over the 10%
+                    // brand gradient — the brandBorder/brand3 recipe the
+                    // selected wallet row in ui/list already uses. Applied at
+                    // every tier: the previous border-primary/bg-primary pair
+                    // resolves to transparent in the dark scope, leaving
+                    // desktop's selected row invisible.
                     isSelected
                       ? 'border-brandBorder from-brand3-start to-brand3-end bg-linear-to-b'
-                      : 'border-borderPrimary md:bg-surfaceAlt/40 bg-transparent md:border-transparent'
+                      : 'border-borderPrimary bg-transparent'
                   )}
                 >
                   <span className="flex min-w-0 items-center gap-3">
-                    <CustomAvatar address={delegate.ownerAddress ?? delegate.id} size={isMobile ? 24 : 32} />
-                    <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] md:font-sans md:leading-5 md:tracking-normal">
+                    <CustomAvatar address={delegate.ownerAddress ?? delegate.id} size={24} />
+                    <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-[18px] md:tracking-[-0.32px]">
                       {delegate.metadata?.name || shortenAddress(delegate.id)}
                       <a
                         href={delegateProfileUrl(delegate.metadata?.externalProfileURL, delegate.id)}
@@ -110,20 +110,20 @@ export function DelegateList({
                         aria-label={t`View delegate profile`}
                         className="text-textSecondary hover:text-text"
                       >
-                        <ExternalLink className="h-3 w-3 md:h-3.5 md:w-3.5" aria-hidden />
+                        <ExternalLink className="h-3 w-3" aria-hidden />
                       </a>
                     </span>
                   </span>
                   <span className="flex shrink-0 flex-col items-end gap-0.5">
-                    <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px] md:leading-4">
+                    <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px]">
                       <Trans>Total delegated</Trans>
                     </span>
-                    <span className="text-text font-circle flex items-center gap-1 text-sm leading-4 font-medium tracking-[-0.28px] md:gap-1.5 md:font-sans md:leading-5 md:tracking-normal">
+                    <span className="text-text font-circle flex items-center gap-1 text-sm leading-4 font-medium tracking-[-0.28px]">
                       {formatBigInt(delegate.totalDelegated ?? 0n, { maxDecimals: 0 })}
                       <TokenIcon
                         token={{ symbol: 'SKY' }}
-                        width={16}
-                        className="h-3 w-3 md:h-4 md:w-4"
+                        width={12}
+                        className="h-3 w-3"
                         showChainIcon={false}
                       />
                     </span>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
@@ -50,14 +50,14 @@ export function DelegateList({
     <div className="flex flex-col gap-6 md:gap-8">
       {/* Search row over its hairline (Frame 2087328600, 1036:209801). */}
       <div className="border-borderPrimary flex items-center gap-2 border-b pb-3">
-        <Search className="text-textSecondary h-4 w-4 shrink-0" aria-hidden />
+        <Search className="text-fgSecondary h-4 w-4 shrink-0" aria-hidden />
         <input
           type="text"
           value={search}
           placeholder={t`Search`}
           onChange={event => setSearch(event.target.value)}
           data-testid={`${dataTestIdPrefix}-search`}
-          className="text-text placeholder:text-fgTertiary md:placeholder:text-textSecondary w-full bg-transparent text-sm leading-[22px] outline-none"
+          className="text-text placeholder:text-fgTertiary md:placeholder:text-fgSecondary w-full bg-transparent text-sm leading-[22px] outline-none"
         />
       </div>
 
@@ -68,7 +68,7 @@ export function DelegateList({
           ))}
         </div>
       ) : !delegates || delegates.length === 0 ? (
-        <p className="text-textSecondary py-6 text-center text-sm">
+        <p className="text-fgSecondary py-6 text-center text-sm">
           <Trans>No delegates found</Trans>
         </p>
       ) : (
@@ -108,14 +108,14 @@ export function DelegateList({
                         rel="noopener noreferrer"
                         onClick={event => event.stopPropagation()}
                         aria-label={t`View delegate profile`}
-                        className="text-textSecondary hover:text-text"
+                        className="text-fgSecondary hover:text-text"
                       >
                         <ExternalLink className="h-3 w-3" aria-hidden />
                       </a>
                     </span>
                   </span>
                   <span className="flex shrink-0 flex-col items-end gap-0.5">
-                    <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px]">
+                    <span className="text-fgSecondary text-xs leading-[18px]">
                       <Trans>Total delegated</Trans>
                     </span>
                     <span className="text-text font-circle flex items-center gap-1 text-sm leading-4 font-medium tracking-[-0.28px]">

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverStakeCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverStakeCard.tsx
@@ -68,8 +68,16 @@ export function StakeTakeoverStakeCard({
   // clicking the matching chip stage the same wei. Held at whole percents (the
   // DS Standard slider's step); an amount typed past the balance pins the thumb
   // at 100 rather than running it off the track.
+  //
+  // The projection back to a percent must ROUND, not floor. Staging floors
+  // (`balance × p / 100`), so on any balance that isn't a round multiple of 100
+  // wei — i.e. essentially every real one — flooring here too reads back p − 1:
+  // the 25% chip would park the thumb at 24, and every drag step would lag the
+  // pointer by one. The extra 1e2 of scale keeps that rounding off the bigint
+  // division, which floors regardless.
   const sliderBalance = balance ?? 0n;
-  const sliderPercent = sliderBalance > 0n ? Math.min(100, Number((amount * 100n) / sliderBalance)) : 0;
+  const sliderPercent =
+    sliderBalance > 0n ? Math.min(100, Math.round(Number((amount * 10000n) / sliderBalance) / 100)) : 0;
 
   return (
     <StakeTakeoverCard step={1} title={<Trans>Stake SKY</Trans>} dataTestId="stake-takeover-stake-card">
@@ -106,6 +114,7 @@ export function StakeTakeoverStakeCard({
               onAmountChange(percent >= 100 ? sliderBalance : (sliderBalance * BigInt(percent)) / 100n);
             }}
             aria-label={t`Share of balance to stake`}
+            valueText={`${sliderPercent}%`}
             data-testid="stake-takeover-stake-slider"
           />
           <div className="text-fgSecondary flex items-center gap-4 text-xs leading-[18px]">

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverStakeCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverStakeCard.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from 'react';
 import { Trans } from '@lingui/react/macro';
-import { Info } from 'lucide-react';
+import { t } from '@lingui/core/macro';
 import { formatBigInt } from '@/utils';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Slider, SliderTicks } from '@/components/ui/slider';
+import { InfoTooltip } from '@/components/InfoTooltip';
 import { StakeTakeoverCard } from './StakeTakeoverCard';
 import { StakeTakeoverAmountField } from './StakeTakeoverAmountField';
 
@@ -11,24 +13,25 @@ const NO_VALUE = '–';
 
 function StatItem({ label, children }: { label: ReactNode; children: ReactNode }) {
   return (
-    <div className="flex min-w-0 flex-1 flex-col gap-1">
-      <span className="text-fgSecondary md:text-textSecondary text-xs leading-[18px] md:flex md:items-center md:gap-1 md:text-sm md:leading-5">
+    <div className="flex min-w-0 flex-1 flex-col gap-1 md:flex-none">
+      <span className="text-fgSecondary md:text-textSecondary flex items-center gap-1 text-xs leading-[18px]">
         {label}
       </span>
-      <span className="text-text font-circle flex items-center gap-1 text-sm leading-4 font-medium tracking-[-0.28px] md:gap-1.5 md:font-sans md:leading-5 md:tracking-normal">
+      <span className="text-text font-circle flex items-center gap-1 text-sm leading-4 font-medium tracking-[-0.28px]">
         {children}
       </span>
     </div>
   );
 }
 
-/** Mobile-only 32px hairline between the stat columns (comp 1222:19772). */
+/** 32px hairline between the stat columns (comp 1036:209729). */
 function StatDivider() {
-  return <span aria-hidden className="bg-borderPrimary h-8 w-px shrink-0 self-center md:hidden" />;
+  return <span aria-hidden className="bg-borderPrimary h-8 w-px shrink-0 self-center" />;
 }
 
 /**
- * Card 1 · Stake SKY: amount + balance/percent chips + rewards-rate stats. The
+ * Card 1 · Stake SKY (Modal / 12, 1036:209703): amount + balance/percent chips
+ * over a hairline, a 0–100%-of-balance slider, then the rewards-rate stats. The
  * `Min. stake to borrow` stat appears only while Borrow is enabled (UX §A.2).
  * Est. annual rewards shows "–" until an amount is entered.
  */
@@ -61,36 +64,70 @@ export function StakeTakeoverStakeCard({
     onAmountChange(percent === 100 ? balance : (balance * BigInt(percent)) / 100n);
   };
 
+  // Slider ↔ amount share the chips' arithmetic, so dragging to a stop and
+  // clicking the matching chip stage the same wei. Held at whole percents (the
+  // DS Standard slider's step); an amount typed past the balance pins the thumb
+  // at 100 rather than running it off the track.
+  const sliderBalance = balance ?? 0n;
+  const sliderPercent = sliderBalance > 0n ? Math.min(100, Number((amount * 100n) / sliderBalance)) : 0;
+
   return (
     <StakeTakeoverCard step={1} title={<Trans>Stake SKY</Trans>} dataTestId="stake-takeover-stake-card">
-      <StakeTakeoverAmountField
-        tokenSymbol="SKY"
-        amount={amount}
-        onAmountChange={onAmountChange}
-        onPercentClick={onPercentClick}
-        error={error}
-        dataTestId="stake-takeover-stake-amount"
-        topRight={
-          balanceLoading ? (
-            <Skeleton className="h-4 w-32" />
-          ) : (
-            <Trans>Balance: {balance !== undefined ? formatBigInt(balance) : NO_VALUE} SKY</Trans>
-          )
-        }
-      />
+      <div className="flex flex-col gap-6 md:gap-5">
+        <div className="flex flex-col gap-2 md:gap-3">
+          <StakeTakeoverAmountField
+            tokenSymbol="SKY"
+            amount={amount}
+            onAmountChange={onAmountChange}
+            onPercentClick={onPercentClick}
+            error={error}
+            dataTestId="stake-takeover-stake-amount"
+            topRight={
+              balanceLoading ? (
+                <Skeleton className="h-4 w-32" />
+              ) : (
+                <Trans>Balance: {balance !== undefined ? formatBigInt(balance) : NO_VALUE} SKY</Trans>
+              )
+            }
+          />
+          <span aria-hidden className="border-borderPrimary border-t" />
+        </div>
 
-      <div className="border-textSecondary/10 -mt-3 flex items-center gap-4 border-t pt-6 md:mt-0 md:flex-wrap md:items-start md:gap-6 md:pt-4">
+        {/* Sliders / Standard (I1036:209724): the share of the wallet balance
+            being staked. Inert with no balance to divide by. */}
+        <div className="flex flex-col gap-1.5">
+          <Slider
+            value={[sliderPercent]}
+            max={100}
+            step={1}
+            disabled={sliderBalance === 0n}
+            onValueChange={value => {
+              const percent = value[0];
+              onAmountChange(percent >= 100 ? sliderBalance : (sliderBalance * BigInt(percent)) / 100n);
+            }}
+            aria-label={t`Share of balance to stake`}
+            data-testid="stake-takeover-stake-slider"
+          />
+          <div className="text-fgSecondary flex items-center gap-4 text-xs leading-[18px]">
+            <span>0%</span>
+            <SliderTicks progress={sliderPercent} className="grow" />
+            <span>100%</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 md:gap-6">
         <StatItem label={<Trans>SKY Rewards rate</Trans>}>{rewardsRate ?? NO_VALUE}</StatItem>
         <StatDivider />
         <StatItem label={<Trans>Est. annual rewards</Trans>}>
-          <span data-testid="stake-takeover-est-rewards" className="flex items-center gap-1 md:gap-1.5">
+          <span data-testid="stake-takeover-est-rewards" className="flex items-center gap-1">
             {estAnnualRewards !== null && estAnnualRewards > 0n ? (
               <>
                 {formatBigInt(estAnnualRewards)}
                 <TokenIcon
                   token={{ symbol: rewardSymbol }}
-                  width={16}
-                  className="h-3 w-3 md:h-4 md:w-4"
+                  width={12}
+                  className="h-3 w-3"
                   showChainIcon={false}
                 />
               </>
@@ -106,21 +143,17 @@ export function StakeTakeoverStakeCard({
               label={
                 <>
                   <Trans>Min. stake to borrow</Trans>
-                  <Info
-                    className="ml-1 inline h-3 w-3 shrink-0 align-[-2px] md:ml-0 md:h-3.5 md:w-3.5 md:align-baseline"
-                    aria-hidden
+                  <InfoTooltip
+                    iconSize={12}
+                    iconClassName="shrink-0"
+                    content={t`Borrowing USDS is optional, but to use your SKY as collateral, you must stake at least ${formatBigInt(minStakeToBorrow)} SKY.`}
                   />
                 </>
               }
             >
-              <span data-testid="stake-takeover-min-stake" className="flex items-center gap-1 md:gap-1.5">
+              <span data-testid="stake-takeover-min-stake" className="flex items-center gap-1">
                 {formatBigInt(minStakeToBorrow)}
-                <TokenIcon
-                  token={{ symbol: 'SKY' }}
-                  width={16}
-                  className="h-3 w-3 md:h-4 md:w-4"
-                  showChainIcon={false}
-                />
+                <TokenIcon token={{ symbol: 'SKY' }} width={12} className="h-3 w-3" showChainIcon={false} />
               </span>
             </StatItem>
           </>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverStakeCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverStakeCard.tsx
@@ -14,9 +14,7 @@ const NO_VALUE = '–';
 function StatItem({ label, children }: { label: ReactNode; children: ReactNode }) {
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-1 md:flex-none">
-      <span className="text-fgSecondary md:text-textSecondary flex items-center gap-1 text-xs leading-[18px]">
-        {label}
-      </span>
+      <span className="text-fgSecondary flex items-center gap-1 text-xs leading-[18px]">{label}</span>
       <span className="text-text font-circle flex items-center gap-1 text-sm leading-4 font-medium tracking-[-0.28px]">
         {children}
       </span>


### PR DESCRIPTION
APP-432 item 21 — the "Open a position" stake takeover, revisited against the current comps.

Figma: [Stake SKY / 1](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1036-209505&m=dev) · [Stake SKY / 02 (Borrow & Delegation enabled)](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1036-209698&m=dev) · [Stake SKY / 03](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1036-209632&m=dev)

## What changed

**It's a modal now, not a second page.** The comps layer the takeover over a render of `/earn` — the flow keeps the page visible underneath. `TakeoverShell` drops the opaque `#040434` + app-background repaint for the DS scrim recipe the dialog and sheet overlays already use (`bg-modalOverlay` + `backdrop-blur-[100px]`).

**Chrome and metrics.** Column narrows 660 → 610px, cards sit 12px apart (was 24), 64px of air under the header, and the header takes the comp's 40/20 padding and keeps its hairline on desktop (it was being dropped above `md`). Cards take the Modal/10-12-17 recipe: 32px inset, 32px between header and body.

**Type scale.** Desktop had escalated to Graphik at 14/18px; the comps hold the compact Circular scale at every tier — Label 4 (16/18) headers and delegate names, Body 6 (12/18) labels, Label 5 (14/16) values, Heading 4 (28/30) amounts, Label 6 (12/14) percent chips. Mostly a matter of deleting `md:` overrides.

**Card 1 gains the share-of-balance slider** (Sliders/Standard) and the hairline above it — it stages the same wei as the percent chips, and an amount typed past the balance pins the thumb at 100 rather than running it off the track. The borrow card's amount block gets the same hairline (it had one on phones only).

**Stat dividers now show on desktop**, where they were `md:hidden`. The borrow card keeps its 2×2 grid on phones and becomes one 4-up row from `md` — the middle divider is `hidden md:block`, so `display:none` drops it out of the grid's flow entirely and the mobile centre rule is untouched.

**The three annotated Info icons are real tooltips now** — they were inert. Copy is verbatim from the Figma annotations, with the live liquidation price and min-collateral figures interpolated. `InfoTooltip` carries its own `TooltipProvider` so it works on any surface (same precedent as `RiskTierDetailsTrigger`).

**Risk pill** moves off `orange-400`/`bullish` onto the DS `components/status` palette, matching what APP-432 item 6 did to the risk meters. The "Updated hourly" badge loses its desktop-only check icon — the comp's badge is text-only.

## Decisions taken with Hernando

- Both optional cards stay **off** by default. Frame /1 shows Delegate expanded, but frame /3 is the true empty state and the annotation only deprioritises Borrow.
- The footer row is **inline** (scrolls with the content) as drawn, rather than pinned to the viewport.
- The annotated **micro-animation** on changing stat values is deferred to its own ticket.
- Scope is **open-position only**; item 23 (manage position) stays open. `TakeoverShell` and the amount field are shared, so the manage sheet inherits the new shell chrome and type scale — that's a step toward item 23, not a substitute for it.
- The delegate "Pre-selection?" TBD in the comp is left alone.

## Verification

- `pnpm typecheck`, `pnpm lint` (0 errors), `prettier --check` — clean.
- Unit suite: 2126 tests, 201/202 files pass. The one failure (`EarnFeaturedCards` Pendle maturity date) is a pre-existing date bomb on `app-redesign` — confirmed by running it on an untouched checkout of the base. New coverage for the slider.
- Browser-verified on a Tenderly fork with a funded mock wallet, dark mode first then light: empty state, 25% chip driving the slider, borrow card expanded with all four stats and dividers, all three tooltips, delegate list and selected-row ring, inline footer with Confirm enabled.

## Caveats

- Mobile has no comp for this item. The inline footer applies there too, so Confirm now sits below the fold on phones with a long delegate list — worth a design call.
- Light mode is interim until G2, but it was checked and holds up.
