### PR TITLE
Point dark mode's secondary text tokens at the DS fg-secondary

### DIFF
--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -137,9 +137,10 @@ function AboutSection({ title, about }: { title?: ReactNode; about: ProductDetai
     <section className="flex flex-col gap-4" data-testid="product-detail-about">
       <SectionHeading className={minorHeadingClasses}>{title ?? <Trans>About</Trans>}</SectionHeading>
       {/* Body 5 on fg-secondary with an inline fg-brand-primary link
-          (Figma 859:35769). textSecondary is the legacy lavender
-          (rgba(198,194,255,.8)), which is what read as purple next to the
-          comp's gray — APP-432 item 10. */}
+          (Figma 859:35769). Named explicitly rather than left to textSecondary:
+          that token used to be the legacy lavender (rgba(198,194,255,.8)) and
+          read as purple next to the comp's gray — APP-432 item 10. Dark has
+          since been flipped onto fg-secondary too, so the two now match. */}
       <div className="text-fgSecondary font-graphik text-sm leading-[22px]">
         {about.body}
         {about.learnMoreHref && (

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -26,10 +26,17 @@
   --font-sans: GraphikStd;
 
   --color-text: var(--primary-white);
-  --color-textSecondary: rgba(198, 194, 255, 0.8);
+  /* colors/fg/fg-secondary — the same DS variable --color-fgSecondary carries, so
+     the two secondary-text tokens now resolve alike in BOTH modes (light already
+     mapped both onto fg-secondary #3b3952). The pre-redesign value was the
+     translucent lilac rgba(198, 194, 255, 0.8), which left every
+     `text-textSecondary` surface reading a touch more purple — and, being
+     translucent, drifting with whatever sat behind it — than the redesigned
+     `text-fgSecondary` surfaces beside it. textMuted mirrors it, as in light. */
+  --color-textSecondary: #a1a6c4;
   --color-bullish: var(--service-green);
   --color-textEmphasis: var(--primary-pink);
-  --color-textMuted: rgba(198, 194, 255, 0.8);
+  --color-textMuted: #a1a6c4;
   --color-error: var(--service-red);
   --color-textDimmed: rgb(120, 116, 208);
   --color-textDesaturated: rgb(186, 182, 250);


### PR DESCRIPTION
## What

Dark mode's `--color-textSecondary` (and its mirror `--color-textMuted`) still carried the
pre-redesign translucent lilac `rgba(198, 194, 255, 0.8)`. Light mode was already caught up:
G2 mapped both onto the design system's `colors/fg/fg-secondary` (`#3b3952`), the same variable
`--color-fgSecondary` carries.

This points dark at the DS value too — `#a1a6c4`, exactly what `--color-fgSecondary` already
resolves to in dark — so the two secondary-text tokens now agree in **both** modes.

```diff
-  --color-textSecondary: rgba(198, 194, 255, 0.8);
+  --color-textSecondary: #a1a6c4;
-  --color-textMuted: rgba(198, 194, 255, 0.8);
+  --color-textMuted: #a1a6c4;
```

## Why

The redesign migrated surfaces onto `text-fgSecondary` as they were rebuilt, but ~250 call sites
still read `text-textSecondary`. In dark those two rendered *differently* — the legacy lilac
composites to roughly `rgb(164,160,214)` against a card, versus the DS `rgb(161,166,196)`: same
lightness, noticeably more purple. Side by side in one card (portfolio product cards put the
"Risk"/"Supply" labels on `textSecondary` right beside `fgSecondary` body copy) it read as a
palette inconsistency.

Being translucent, the legacy value also drifted with whatever sat behind it — modal scrims,
glass cards, hovered table rows — so "secondary text" wasn't one colour to begin with. The DS
value is opaque and stable.

`ProductDetailTemplate` carried a comment explaining that it named `fg-secondary` explicitly
because `textSecondary` "is the legacy lavender … which is what read as purple next to the comp's
gray — APP-432 item 10". Updated, since that premise no longer holds.

## Scope notes

- **`textMuted` moved with it.** Light already mirrors the two (`fg-secondary` for both), and the
  light block's comment cites dark as the precedent for that mirroring. Leaving it behind would
  have opened a fresh divergence. It has 4 call sites, all disabled-state text in legacy widgets.
- **Light mode is untouched** — its `:root[data-theme='light']` overrides already win, and both
  tokens verified unchanged at `#3b3952`.
- **Not touched:** `Button`'s legacy `link` variant still hardcodes
  `active:text-[rgba(198,194,255,0.5)]`, so its pressed state is now a lilac that no longer matches
  its resting colour. It's used only inside `widgets/` (the pre-redesign tree that dies with the
  widget migration), so it's left alone rather than churned.
- **Also left alone:** `textDesaturated` / `textDimmed` are still on legacy purples in dark
  (`rgb(186,182,250)` / `rgb(120,116,208)`) where light maps them to `fg-tertiary` / `fg-quaternary`.
  Same class of drift, one rung further down the ramp — out of scope here, happy to follow up.

## Verification

Browser-verified in dark on a Tenderly-fork dev build (portfolio, earn, stake, `/design-system`):
a DOM sweep for the legacy `rgba(198, 194, 255, 0.8)` returns **zero** elements after the change,
and the `textSecondary` / `fgSecondary` / `textMuted` swatches on the design-system page are now
identical (and opaque — no checkerboard). Light mode re-checked and unchanged.

Gates: `typecheck` clean, `prettier` clean, `2210/2211` unit tests pass. The one failure
(`EarnFeaturedCards` "18 Jun 2026" maturity) and the `lint` errors (`ProductCard.test.tsx`
`no-container`) both reproduce on `app-redesign` with this branch's changes stashed — pre-existing,
unrelated. The test failure is a date bomb: that Pendle maturity is now in the past.
