### PR TITLE
APP-442: quote the claimable Merkl amount the claim actually pays

### DIFF
--- a/apps/webapp/src/hooks/morpho/useMorphoVaultRewards.ts
+++ b/apps/webapp/src/hooks/morpho/useMorphoVaultRewards.ts
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useChainId, useConnection } from 'wagmi';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { TRUST_LEVELS, TrustLevelEnum } from '../constants';
 import { ReadHook } from '../hooks';
 import { isTestnetId, formatBigInt } from '@/utils';
@@ -228,7 +228,13 @@ export function useMorphoVaultRewards({
   const chainId = isTestnetId(connectedChainId) ? mainnet.id : connectedChainId;
 
   const queryClient = useQueryClient();
-  const queryKey = ['morpho-vault-rewards', userAddress, vaultAddress, chainId];
+  // Memoized for the same reason useMerklRewards memoizes its key: `mutate`
+  // closes over it, so a fresh array literal per render gives `mutate` a new
+  // identity every render and churns every consumer that depends on it.
+  const queryKey = useMemo(
+    () => ['morpho-vault-rewards', userAddress, vaultAddress, chainId],
+    [userAddress, vaultAddress, chainId]
+  );
 
   const { data, error, isLoading } = useQuery({
     queryKey,

--- a/apps/webapp/src/hooks/morpho/useMorphoVaultRewards.ts
+++ b/apps/webapp/src/hooks/morpho/useMorphoVaultRewards.ts
@@ -76,11 +76,18 @@ export type MorphoVaultReward = {
   tokenDecimals: number;
   /** Token price in USD */
   tokenPrice: number;
-  /** Total accumulated reward amount (raw bigint) */
+  /**
+   * Gross lifetime reward amount for this vault (raw bigint) — everything the
+   * campaign ever accrued, INCLUDING what has already been claimed. Never render
+   * this as a claimable/available balance (APP-442): what a claim actually pays
+   * out is `amount - claimed`, which is what the claim modal quotes. Anything
+   * user-facing should read through the Merkl claim adapter instead, so the
+   * figure and the transaction come from one source.
+   */
   amount: bigint;
   /** Amount already claimed (raw bigint) */
   claimed: bigint;
-  /** Formatted total amount (e.g., "2.65") */
+  /** Formatted gross amount (e.g., "2.65") — see `amount` */
   formattedAmount: string;
   /** Formatted claimed amount */
   formattedClaimed: string;
@@ -193,7 +200,9 @@ async function fetchMorphoVaultRewards(
     });
   }
 
-  const hasClaimableRewards = morphoRewards.some(r => r.amount > 0n);
+  // Claimable means there is an unclaimed remainder, not that the campaign ever
+  // paid out — a fully claimed reward keeps a non-zero gross `amount` forever.
+  const hasClaimableRewards = morphoRewards.some(r => r.amount > r.claimed);
 
   return {
     rewards: morphoRewards,

--- a/apps/webapp/src/modules/morpho/components/VaultPositionCard.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultPositionCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useChainId, useConnection } from 'wagmi';
 import { formatUnits } from 'viem';
 import { TrendingUp } from 'lucide-react';
@@ -6,7 +6,6 @@ import { Trans } from '@lingui/react/macro';
 import {
   useVaultMarketData,
   useErc4626VaultData,
-  useMorphoVaultRewards,
   getTokenDecimals,
   type Token,
   type VaultProvider
@@ -21,7 +20,7 @@ import {
   ProductStatPair
 } from '@/components/product/ProductCard';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
-import { useClaimRewardsModal } from '@/modules/claim';
+import { merklAdapter, useClaimRewardsModal } from '@/modules/claim';
 import { useVaultModal } from '../hooks/useVaultModal';
 import { VaultSupplyCard } from './VaultSupplyCard';
 
@@ -56,14 +55,23 @@ export function VaultPositionCard({
   const netRate = marketData?.rate?.netRate;
 
   const { data: vaultData, mutate: mutateVault } = useErc4626VaultData({ vaultAddress });
-  const { data: rewardsData, mutate: mutateRewards } = useMorphoVaultRewards({ vaultAddress });
+
+  // Rewards read through the same claim adapter the "Claim rewards" modal uses,
+  // so the amount on this card is by construction the amount the modal quotes
+  // and the distributor pays out (APP-442). Reading Merkl directly here instead
+  // showed the gross cumulative campaign total — everything ever earned,
+  // including what was already claimed — which is not what a claim sends you.
+  // The scope object is memoized: the adapter memoizes its read on scope
+  // identity, so a fresh literal per render would churn every consumer.
+  const claimScope = useMemo(() => ({ kind: 'vault' as const, vaultAddress }), [vaultAddress]);
+  const { rewards, refresh: refreshRewards } = merklAdapter.useClaimable(claimScope);
 
   // Refresh the position + rewards after a supply/withdraw/claim. A no-position
   // supply also flips this card to "My position" once userAssets refetches > 0.
   const refresh = useCallback(() => {
     mutateVault();
-    mutateRewards();
-  }, [mutateVault, mutateRewards]);
+    refreshRewards();
+  }, [mutateVault, refreshRewards]);
 
   const { openSupply, openWithdraw } = useVaultModal({ onSuccess: refresh });
   const { openClaim } = useClaimRewardsModal({ onSuccess: refresh });
@@ -89,7 +97,9 @@ export function VaultPositionCard({
   // value used for the projection).
   const positionValue = parseFloat(formatUnits(userAssets, decimals));
   const projectedEarnings = projectAnnualEarnings(positionValue, netRate);
-  const reward = rewardsData?.rewards[0];
+  // A vault campaign pays one token today; the stat cell is a single line, so a
+  // second token would only ever surface in the modal (which lists them all).
+  const reward = rewards[0];
 
   const assetIcon = (
     <TokenIcon
@@ -165,7 +175,9 @@ export function VaultPositionCard({
             </Button>
           </ProductActions>
           <ProductActions>
-            {rewardsData?.hasClaimableRewards && (
+            {/* Nothing left to claim → no button. The adapter has already
+                dropped tokens whose campaign total is fully claimed. */}
+            {reward && (
               <Button
                 variant="secondary"
                 size="l"

--- a/apps/webapp/src/modules/morpho/components/vaultPositionCard.rewards.test.tsx
+++ b/apps/webapp/src/modules/morpho/components/vaultPositionCard.rewards.test.tsx
@@ -1,0 +1,183 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Token } from '@/hooks';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const USER = '0xc12f7C1F2DCE119e2d0b77D65eC479Bfc32b0327' as const;
+// A real registry vault: useMerklRewards only keeps tokens whose breakdown
+// reason names a known Morpho vault, so a placeholder address wouldn't parse.
+const VAULT = '0xE15fcC81118895b67b6647BBd393182dF44E11E0' as const;
+const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F' as const;
+
+/**
+ * The campaign accrued 0.04 USDS lifetime and 0.02 of it has already been
+ * claimed, so 0.02 is what another `claim` would pay out. This is the shape
+ * that produced APP-442: the card read the 0.04 while the claim modal quoted
+ * the 0.02 the distributor actually sends.
+ */
+const GROSS = '40000000000000000';
+const CLAIMED = '20000000000000000';
+
+const merklPayload = (claimed = CLAIMED) => [
+  {
+    chain: { id: 1, name: 'Ethereum', icon: '', endOfDisputePeriod: 0, liveCampaigns: 1 },
+    rewards: [
+      {
+        root: '0xroot',
+        distributionChainId: 1,
+        recipient: USER,
+        amount: GROSS,
+        claimed,
+        pending: '0',
+        proofs: ['0xproof'],
+        token: { address: USDS, chainId: 1, symbol: 'USDS', decimals: 18, price: 1 },
+        breakdowns: [
+          {
+            root: '0xroot',
+            distributionChainId: 1,
+            reason: `MorphoSupply_${VAULT}`,
+            amount: GROSS,
+            claimed,
+            pending: '0',
+            campaignId: '0xcampaign',
+            subCampaignId: ''
+          }
+        ]
+      }
+    ]
+  }
+];
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useChainId: () => 1,
+    useConnection: () => ({ address: USER, isConnected: true, isConnecting: false }),
+    // The claim adapter's recently-claimed filter; an empty result leaves the
+    // reward in place.
+    useReadContracts: () => ({ data: undefined, isLoading: false, error: null, refetch: () => {} })
+  };
+});
+
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    getTokenDecimals: () => 18,
+    // 8.24 USDS supplied — enough of a position to render the "My position" card.
+    useErc4626VaultData: () => ({ data: { userAssets: 8_240_000_000_000_000_000n }, mutate: () => {} }),
+    useVaultMarketData: () => ({ data: { rate: { netRate: 0.05 } } })
+  };
+});
+
+vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
+vi.mock('../hooks/useVaultModal', () => ({
+  useVaultModal: () => ({ openSupply: () => {}, openWithdraw: () => {} })
+}));
+vi.mock('@/modules/claim', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/modules/claim')>();
+  return { ...actual, useClaimRewardsModal: () => ({ openClaim: () => {} }) };
+});
+
+import { merklAdapter } from '@/modules/claim';
+import { VaultPositionCard } from './VaultPositionCard';
+
+const usds = { symbol: 'USDS', name: 'USDS', address: { 1: USDS } } as unknown as Token;
+
+const renderCard = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <I18nProvider i18n={i18n}>
+        <VaultPositionCard
+          vaultAddress={VAULT}
+          assetToken={usds}
+          vaultName="USDS Flagship"
+          provider="morpho"
+        />
+      </I18nProvider>
+    </QueryClientProvider>
+  );
+
+  /**
+   * Resolves once the Merkl read has actually landed. Asserting the ABSENCE of
+   * a claim button is otherwise indistinguishable from asserting it before the
+   * fetch resolved, which would pass against the bug as happily as against the
+   * fix.
+   */
+  const settled = () =>
+    vi.waitFor(() =>
+      expect(
+        client
+          .getQueryCache()
+          .getAll()
+          .some(q => String(q.queryKey[0]).includes('reward') && q.state.status === 'success')
+      ).toBe(true)
+    );
+
+  return { settled };
+};
+
+const stubMerkl = (claimed?: string) =>
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify(merklPayload(claimed)), { status: 200 }))
+  );
+
+describe('VaultPositionCard claimable rewards (APP-442)', () => {
+  beforeEach(() => stubMerkl());
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  it('shows the unclaimed remainder, not the gross campaign total', async () => {
+    renderCard();
+
+    expect(await screen.findByText('0.02')).toBeTruthy();
+    expect(screen.queryByText('0.04')).toBeNull();
+  });
+
+  it('matches the amount the claim modal quotes for the same vault', async () => {
+    renderCard();
+    await screen.findByText('0.02');
+
+    // Same source of truth as the modal body: whatever the adapter yields for
+    // this vault scope is what the card must be rendering.
+    const { result } = await import('@testing-library/react').then(({ renderHook }) =>
+      renderHook(() => merklAdapter.useClaimable({ kind: 'vault', vaultAddress: VAULT }), {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+            {children}
+          </QueryClientProvider>
+        )
+      })
+    );
+
+    await vi.waitFor(() => expect(result.current.rewards.length).toBe(1));
+    expect(screen.getByText(result.current.rewards[0].formattedAmount)).toBeTruthy();
+  });
+
+  it('offers Claim rewards while something is unclaimed', async () => {
+    renderCard();
+
+    expect(await screen.findByTestId('vault-position-claim')).toBeTruthy();
+  });
+
+  it('dashes the stat and drops the Claim button once the campaign is fully claimed', async () => {
+    stubMerkl(GROSS);
+    const { settled } = renderCard();
+    await settled();
+
+    expect(screen.getByTestId('vault-position-withdraw')).toBeTruthy();
+    expect(screen.queryByTestId('vault-position-claim')).toBeNull();
+    expect(screen.queryByText('0.04')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes APP-442.

## What was wrong

The vault product page's "My position" card showed a bigger "Claimable rewards" figure than the Claim rewards modal (reported: 0.04 vs 0.02).

The modal is the correct one. The two surfaces were parsing the same Merkl API response through two different hooks:

| | hook | number |
|---|---|---|
| position card | `useMorphoVaultRewards` | Σ `breakdown.amount` — **gross lifetime accrual, `claimed` never subtracted** |
| claim modal / Portfolio "Merkl Rewards" | `useMerklRewards` via `merklAdapter` | `amount - claimed` |

The distributor settles the argument. `claim(users, tokens, amounts, proofs)` takes the *cumulative* amount and the contract transfers `amount - claimed[user][token]` — that's why it also exposes `claimed(user, token)` as a running total. So `amount - claimed` is what actually lands in the wallet, and the gross figure was promising rewards a claim cannot pay a second time.

## Other places checked

I swept every surface that renders a Merkl amount. Only the vault position card was wrong on a reachable screen:

- **Portfolio → "Merkl Rewards" table** ("Available to claim") — already reads through `merklAdapter`, correct.
- **Claim rewards modal** (all scopes) — correct.
- **`MorphoVaultRewardsDetails`** ("Accumulated Rewards" card) — also gross, but unreachable: it only renders from the legacy `VaultDetails` path, which `VaultDetailPage` hands only to non-Morpho vaults, and it is itself gated on `provider === 'morpho'`. Left as-is since "Accumulated" is at least an honest label for a gross number, but the type now says so out loud.
- **`VaultsBalanceCard`** (BalancesWidget) — shows a third variant (vault-sourced pending only, excluding "Other campaigns"), but `BalancesWidgetPane` has no importer left, so nothing mounts it. Untouched.
- The other "Claimable rewards" labels in the app are the stake module and the Sky `getReward` farms — different engines, not affected.

## The fix

The card reads through `merklAdapter.useClaimable({ kind: 'vault', vaultAddress })` — the same adapter that fills the modal body. The number is now the modal's number by construction, not because two parsers happen to agree.

Three things fall out of sharing the adapter:

1. **The Claim button follows the scope.** It no longer appears on a fully-claimed campaign. The old gate was `hasClaimableRewards = amount > 0n`, which stays true forever once a campaign has ever paid out.
2. **The post-claim refresh now hits the right query.** The card used to refetch `['morpho-vault-rewards', …]`, which a claim through the modal never invalidates; it now refreshes the `['merkl-rewards-all', …]` query the modal reads, including its on-chain recently-claimed filter.
3. **The figure covers the whole reward token, the way the claim does.** A vault-scoped claim sends the token's full cumulative amount (Merkl has no partial claim), so if a token also carries an "Other campaigns" portion, the card now counts it — because claiming will.

`useMorphoVaultRewards` keeps its gross semantics for the legacy card, but the type now documents that `amount` is gross and must not be rendered as a balance, and `hasClaimableRewards` means "something is unclaimed".

## Tests

New `vaultPositionCard.rewards.test.tsx` drives the card from a raw Merkl payload (0.04 accrued / 0.02 already claimed) through the real parser and the real adapter, and asserts: the card shows 0.02 and never 0.04; the string it renders is the one `merklAdapter.useClaimable` yields for the same scope; the Claim button appears while something is unclaimed and disappears when the campaign is fully claimed.

3 of the 4 assertions fail against the pre-fix component (verified by reverting it), so it is a real regression guard rather than a restatement of the new code.

## Gates

- `pnpm typecheck` — clean
- `pnpm -F webapp test` — 2214 passed, 1 failed: `EarnFeaturedCards` "renders the Pendle fixed-yield card with maturity stat". **Pre-existing and unrelated** — it fails identically on the base branch with my changes stashed (a date-dependent Pendle maturity assertion).
- `pnpm lint` — 3 errors, all in `ProductCard.test.tsx`, identical count on the base branch with my changes stashed.
- Prettier — clean on the touched files.

## Not done

No fork/browser QA: this is a data-source swap into the same rendering slot with no layout change, and the regression test exercises the real Merkl parse end-to-end at the component level. Happy to run a fork pass with a stubbed partially-claimed payload if you want eyes on it.
