### PR TITLE
Resolve weight requests the design system doesn't define

### DIFF
--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -97,16 +97,20 @@ function ProductTitleIcon({ token }: { token: ProductDetailToken }) {
   );
 }
 
+/* font-medium is load-bearing: font-circle alone falls to `normal` (400), which
+   resolves to Circular Book 450 — the DS has no Circular Book, every Headings-family
+   style is weight 500 (font-weight/label). */
 function SectionHeading({ className, children }: { className?: string; children: ReactNode }) {
-  return <h2 className={cn('text-text font-circle text-lg', className)}>{children}</h2>;
+  return <h2 className={cn('text-text font-circle text-lg font-medium', className)}>{children}</h2>;
 }
 
 /* M6.3 section-heading scale (486:20706): Details/About step down to Label 4,
-   Transactions steps up to Heading 6; both return to the shared 18px at md. */
+   Transactions steps up to Heading 6; both return to Label 3 (18/22, -0.36px,
+   comp 859:35722) at md. */
 const minorHeadingClasses =
-  'text-base leading-[18px] tracking-[-0.32px] md:text-lg md:leading-normal md:tracking-normal';
+  'text-base leading-[18px] tracking-[-0.32px] md:text-lg md:leading-[22px] md:tracking-[-0.36px]';
 const majorHeadingClasses =
-  'text-xl leading-[22px] tracking-[-0.4px] md:text-lg md:leading-normal md:tracking-normal';
+  'text-xl leading-[22px] tracking-[-0.4px] md:text-lg md:leading-[22px] md:tracking-[-0.36px]';
 
 function DetailsSection({ title, details }: { title?: ReactNode; details: ProductDetailRow[] }) {
   return (

--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -143,12 +143,7 @@ function AboutSection({ title, about }: { title?: ReactNode; about: ProductDetai
       <div className="text-fgSecondary font-graphik text-sm leading-[22px]">
         {about.body}
         {about.learnMoreHref && (
-          <a
-            href={about.learnMoreHref}
-            target="_blank"
-            rel="noreferrer"
-            className="text-fgBrand ml-1 font-medium"
-          >
+          <a href={about.learnMoreHref} target="_blank" rel="noreferrer" className="text-fgBrand ml-1">
             <Trans>Learn more</Trans>
           </a>
         )}

--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -118,11 +118,14 @@ function DetailsSection({ title, details }: { title?: ReactNode; details: Produc
             key={row.id}
             className="border-borderPrimary flex items-center justify-between gap-4 border-b py-4"
           >
-            <span className="text-fgSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-normal">
+            {/* Desktop comp (859:35723): label Body 5 (Graphik 14/22), value
+                Label 4 (Circular Medium 16/18, -0.32px). Mobile keeps the M6.3
+                step-down — Body 6 labels and Label 5 values (486:20706). */}
+            <span className="text-fgSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-[22px]">
               {row.icon}
               {row.label}
             </span>
-            <span className="text-text font-circle md:font-graphik text-right text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-normal md:tracking-normal">
+            <span className="text-text font-circle text-right text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-[18px] md:tracking-[-0.32px]">
               {row.value}
             </span>
           </div>

--- a/apps/webapp/src/components/toast/ToastCloseAll.tsx
+++ b/apps/webapp/src/components/toast/ToastCloseAll.tsx
@@ -60,7 +60,7 @@ export const ToastCloseAll = () => {
         className={cn(
           'text-text/70 hover:text-text bg-transparent',
           'flex items-center gap-1 rounded-md',
-          'text-xs font-medium',
+          'font-circle text-xs font-medium',
           'hover:bg-container/30 transition-all',
           // No border or padding on any screen size
           'p-0'

--- a/apps/webapp/src/components/ui/SlippageMenu.tsx
+++ b/apps/webapp/src/components/ui/SlippageMenu.tsx
@@ -123,7 +123,7 @@ export function SlippageMenu({
       >
         <div className="flex w-full flex-col gap-5">
           <div className="space-y-3">
-            <h3 className="text-text font-medium">
+            <h3 className="text-text font-circle font-medium">
               <Trans>Slippage</Trans>
             </h3>
             <p className="text-textSecondary text-sm leading-relaxed">

--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -11,7 +11,10 @@ const buttonVariants = cva(
   // --tw-gradient-from/to are @property-registered colors, so listing them
   // here lets gradient-stop changes (the primary/secondary state fills)
   // cross-fade; background-image itself never interpolates.
-  'inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition-[background-color,background-image,--tw-gradient-from,--tw-gradient-to,opacity,border-color,color,box-shadow] duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primaryDisabled disabled:text-surfaceAlt light:disabled:text-textDimmed',
+  // font-circle on the base (not only the xl/l/m/s size recipes): defaultVariants
+  // sets size='default', so a <Button> with no size prop would otherwise fall
+  // through to Graphik. Every button in the comps is Circular.
+  'inline-flex items-center justify-center whitespace-nowrap rounded-xl font-circle text-sm font-medium ring-offset-background transition-[background-color,background-image,--tw-gradient-from,--tw-gradient-to,opacity,border-color,color,box-shadow] duration-250 ease-out-expo focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primaryDisabled disabled:text-surfaceAlt light:disabled:text-textDimmed',
   {
     variants: {
       variant: {

--- a/apps/webapp/src/components/ui/dialog.tsx
+++ b/apps/webapp/src/components/ui/dialog.tsx
@@ -79,7 +79,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn('text-lg leading-none font-semibold tracking-tight', className)}
+    className={cn('font-circle text-lg leading-none font-medium tracking-tight', className)}
     {...props}
   />
 ));

--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -104,7 +104,7 @@ function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPr
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('text-foreground font-circle font-medium', className)}
       {...props}
     />
   );

--- a/apps/webapp/src/components/ui/sonner.tsx
+++ b/apps/webapp/src/components/ui/sonner.tsx
@@ -31,9 +31,9 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
     description: 'font-graphik text-[11px] leading-4! font-normal text-fgSecondary! mt-1',
     icon: 'size-auto! shrink-0',
     actionButton:
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 font-circle text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
     cancelButton:
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 font-circle text-sm font-medium transition-colors hover:bg-secondary disabled:pointer-events-none disabled:opacity-50',
     // transform-none (not translate-none): sonner hangs its close button off
     // the corner via `transform: translate(-35%,-35%)`, which the translate
     // property doesn't reset. 24px box at 12px insets = a 16px visual gap on

--- a/apps/webapp/src/components/ui/toggle.tsx
+++ b/apps/webapp/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/cn';
 
 const toggleVariants = cva(
-  'inline-flex flex-col items-center rounded-xl justify-center text-sm text-textSecondary font-medium ring-offset-background transition-[background-color,color] after:bg-muted disabled:pointer-events-none disabled:opacity-50 overflow-hidden',
+  'inline-flex flex-col items-center rounded-xl justify-center font-circle text-sm text-textSecondary font-medium ring-offset-background transition-[background-color,color] after:bg-muted disabled:pointer-events-none disabled:opacity-50 overflow-hidden',
   {
     variants: {
       variant: {

--- a/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
+++ b/apps/webapp/src/modules/balances/components/BalancesSuggestedActions.tsx
@@ -510,7 +510,7 @@ export function BalancesSuggestedActions({
                     <Text className="text-text truncate">{resolved.label}</Text>
                     {action.badge && (
                       <span
-                        className={`flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${
+                        className={`font-circle flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase ${
                           action.showMorphoIcon
                             ? 'bg-[#2973FF]/15 text-[#2973FF]'
                             : 'bg-textEmphasis/15 text-textEmphasis'
@@ -600,7 +600,7 @@ export function BalancesSuggestedActions({
                   <div className="flex shrink-0 items-center gap-2">
                     {action.badge && (
                       <span
-                        className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${
+                        className={`font-circle flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase ${
                           action.showMorphoIcon
                             ? 'bg-[#2973FF]/15 text-[#2973FF]'
                             : 'bg-textEmphasis/15 text-textEmphasis'
@@ -640,7 +640,7 @@ export function BalancesSuggestedActions({
               </Text>
               {action.badge && (
                 <span
-                  className={`ml-auto flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${
+                  className={`font-circle ml-auto flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase ${
                     action.showMorphoIcon
                       ? 'bg-[#2973FF]/15 text-[#2973FF]'
                       : 'bg-textEmphasis/15 text-textEmphasis'

--- a/apps/webapp/src/modules/claim/components/ClaimRewardsPanel.tsx
+++ b/apps/webapp/src/modules/claim/components/ClaimRewardsPanel.tsx
@@ -181,7 +181,7 @@ export function ClaimRewardsPanel({ sessionId, scope }: { sessionId: string; sco
 
       {skyStakeReward && (
         <label className="flex items-center justify-between" data-testid="claim-restake-toggle">
-          <Text className="text-fgPrimary text-sm font-medium">
+          <Text className="text-fgPrimary font-circle text-sm font-medium">
             <Trans>Restake SKY rewards</Trans>
           </Text>
           <Switch checked={effectiveRestake} onCheckedChange={setRestake} aria-label="Restake SKY rewards" />

--- a/apps/webapp/src/modules/convert/components/ConvertAmountInput.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertAmountInput.tsx
@@ -105,7 +105,7 @@ export function ConvertAmountInput({
           readOnly={!isFrom}
           aria-label={isFrom ? t`Convert amount` : t`Amount received`}
           data-testid={`convert-${side}-amount`}
-          className="text-text placeholder:text-text w-full min-w-0 bg-transparent text-2xl leading-[26px] font-medium tracking-[-0.48px] outline-none md:text-[32px] md:leading-[35px] md:tracking-[-0.64px]"
+          className="text-text placeholder:text-text font-circle w-full min-w-0 bg-transparent text-2xl leading-[26px] font-medium tracking-[-0.48px] outline-none md:text-[32px] md:leading-[35px] md:tracking-[-0.64px]"
         />
         <span className="flex shrink-0 items-center gap-1.5">
           {(!isMobile || value === '') && percentButtons}

--- a/apps/webapp/src/modules/convert/components/ConvertCard.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertCard.tsx
@@ -56,7 +56,7 @@ export function ConvertCard({ form }: { form: ConvertFormModel }) {
             </Text>
             <span className="bg-glassBadge flex items-center gap-1 rounded-full py-1 pr-2 pl-1">
               {getChainIcon(chainId, 'h-4 w-4')}
-              <Text className="text-text text-xs font-medium">{networkName}</Text>
+              <Text className="text-text font-circle text-xs font-medium">{networkName}</Text>
             </span>
           </span>
           <ChevronDown width={16} height={16} className="text-textSecondary" />

--- a/apps/webapp/src/modules/convert/components/ConvertTokenSelect.tsx
+++ b/apps/webapp/src/modules/convert/components/ConvertTokenSelect.tsx
@@ -13,7 +13,7 @@ function TokenOption({ symbol }: { symbol: ConvertTokenSymbol }) {
   return (
     <span className="flex items-center gap-1">
       <TokenIcon token={{ symbol }} width={16} showChainIcon={false} className="h-4 w-4" />
-      <Text className="text-sm font-medium">{symbol}</Text>
+      <Text className="font-circle text-sm font-medium">{symbol}</Text>
     </span>
   );
 }

--- a/apps/webapp/src/modules/portfolio/components/AllocateStablecoinsBanner.tsx
+++ b/apps/webapp/src/modules/portfolio/components/AllocateStablecoinsBanner.tsx
@@ -36,10 +36,7 @@ export function AllocateStablecoinsBanner({
         <p className="text-fgSecondary max-w-[248px] text-xs leading-[18px]">
           <Trans>
             That&apos;s what your idle stablecoins can earn at today&apos;s{' '}
-            <span className="text-fgPrimary font-medium">
-              {formatDecimalPercentage(savingsRate)} Sky Savings Rate
-            </span>
-            .
+            <span className="text-fgPrimary">{formatDecimalPercentage(savingsRate)} Sky Savings Rate</span>.
           </Trans>
         </p>
       }

--- a/apps/webapp/src/modules/portfolio/components/EarnMarketplaceCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/EarnMarketplaceCard.tsx
@@ -44,7 +44,7 @@ export function EarnMarketplaceCard({ row, onStart }: { row: EarnProductRow; onS
 
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
-          <Text variant="large" tag="span" className="text-text text-2xl font-medium">
+          <Text variant="large" tag="span" className="text-text font-circle text-2xl font-medium">
             {row.name}
           </Text>
           <ProductGlyph id={row.id} kind={row.kind} />
@@ -60,7 +60,7 @@ export function EarnMarketplaceCard({ row, onStart }: { row: EarnProductRow; onS
         <Stat label={<Trans>Risk</Trans>}>
           <div className="flex items-center gap-2">
             <RiskTierDetailsTrigger profile={row.riskProfile} />
-            <span className="text-text text-sm font-medium">{RISK_LABEL[row.risk]}</span>
+            <span className="text-text font-circle text-sm font-medium">{RISK_LABEL[row.risk]}</span>
           </div>
         </Stat>
         <Stat label={<Trans>Supply</Trans>}>
@@ -94,6 +94,8 @@ function Stat({ label, children }: { label: ReactNode; children: ReactNode }) {
 
 function Badge({ children }: { children: ReactNode }) {
   return (
-    <span className="bg-surface text-text rounded-full px-2 py-0.5 text-xs font-medium">{children}</span>
+    <span className="bg-surface text-text font-circle rounded-full px-2 py-0.5 text-xs font-medium">
+      {children}
+    </span>
   );
 }

--- a/apps/webapp/src/modules/portfolio/components/PortfolioStatistics.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioStatistics.tsx
@@ -70,7 +70,7 @@ function Stat({ label, value }: { label: ReactNode; value: string | undefined })
         {label}
       </Text>
       {value ? (
-        <span className="text-text font-medium">{value}</span>
+        <span className="text-text font-circle font-medium">{value}</span>
       ) : (
         <span className="bg-surface h-5 w-24 animate-pulse rounded" />
       )}

--- a/apps/webapp/src/modules/portfolio/components/SavingsTvlCallout.tsx
+++ b/apps/webapp/src/modules/portfolio/components/SavingsTvlCallout.tsx
@@ -20,7 +20,7 @@ export function SavingsTvlCallout({ tvlUsd, savingsRate }: { tvlUsd: number; sav
       data-testid="savings-tvl-callout"
     >
       <div className="flex flex-col gap-2">
-        <Heading tag="h2" className="text-text text-xl font-medium">
+        <Heading tag="h2" className="text-text font-circle text-xl font-medium">
           <Trans>
             {`$${formatNumber(tvlUsd, { compact: true }).toLowerCase()}`} in stablecoins already earning the
             Sky Savings Rate

--- a/apps/webapp/src/modules/portfolio/components/SimulateEarningsModal.tsx
+++ b/apps/webapp/src/modules/portfolio/components/SimulateEarningsModal.tsx
@@ -45,7 +45,7 @@ export function SimulateEarningsModal({
 
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2 pr-8">
-            <DialogTitle className="text-text text-lg font-medium">
+            <DialogTitle className="text-text font-circle text-lg font-medium">
               <Trans>Simulate earnings with Sky Savings</Trans>
             </DialogTitle>
             <Pill>{formatDecimalPercentage(savingsRate)}</Pill>
@@ -105,13 +105,15 @@ function Stat({ label, value, divided }: { label: ReactNode; value: string; divi
       <Text variant="medium" tag="span" className="text-textSecondary">
         {label}
       </Text>
-      <span className="text-text text-lg font-medium">{value}</span>
+      <span className="text-text font-circle text-lg font-medium">{value}</span>
     </div>
   );
 }
 
 function Pill({ children }: { children: ReactNode }) {
   return (
-    <span className="bg-surface text-text rounded-full px-2 py-0.5 text-xs font-medium">{children}</span>
+    <span className="bg-surface text-text font-circle rounded-full px-2 py-0.5 text-xs font-medium">
+      {children}
+    </span>
   );
 }

--- a/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.tsx
@@ -120,7 +120,7 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
                     onActivate={() => setActiveId(position.id)}
                     onDeactivate={() => setActiveId(null)}
                   >
-                    <Text variant="medium" tag="span" className="text-text font-medium">
+                    <Text variant="medium" tag="span" className="text-text font-circle font-medium">
                       {position.name}
                     </Text>
                     <Text variant="medium" tag="span" className="text-textSecondary">
@@ -227,7 +227,7 @@ function IdleContent({
                   onActivate={() => setActiveId(token.symbol)}
                   onDeactivate={() => setActiveId(null)}
                 >
-                  <Text variant="medium" tag="span" className="text-text font-medium">
+                  <Text variant="medium" tag="span" className="text-text font-circle font-medium">
                     {token.symbol}
                   </Text>
                   <Text variant="medium" tag="span" className="text-textSecondary">

--- a/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsTransactionsFilter.tsx
@@ -54,7 +54,7 @@ export function SavingsTransactionsFilter({
           isMobile
             ? // Label 6 pill, 12px chevron ([&_svg] outranks the built-in h-4).
               'border-glassBorder text-text font-circle h-[30px] w-full justify-between rounded-full border py-2 pr-2 pl-3 text-xs leading-[14px] font-medium tracking-[-0.24px] [&_svg]:h-3 [&_svg]:w-3'
-            : 'text-textSecondary hover:text-text h-auto w-auto gap-1.5 rounded-full border-none p-0 text-sm font-medium'
+            : 'text-textSecondary hover:text-text font-circle h-auto w-auto gap-1.5 rounded-full border-none p-0 text-sm font-medium'
         )}
       >
         <SelectValue>

--- a/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.tsx
+++ b/apps/webapp/src/modules/stake/components/BorrowUtilizationBlock.tsx
@@ -70,12 +70,12 @@ export function BorrowUtilizationBlock() {
 
   return (
     <div data-testid="stake-borrow-utilization" className="flex flex-col">
-      <h3 className="text-fgPrimary font-circle mb-4 flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:gap-1.5 md:font-sans md:text-lg md:leading-normal md:tracking-normal">
+      <h3 className="text-fgPrimary font-circle mb-4 flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:gap-1.5 md:text-lg md:leading-normal md:tracking-normal">
         <Trans>Borrow Utilization</Trans>
         <Info className="text-fgSecondary h-3 w-3 md:h-4 md:w-4" aria-hidden />
       </h3>
 
-      <div className="text-fgPrimary font-circle mb-5 text-2xl leading-[26px] font-medium tracking-[-0.48px] md:mb-3 md:font-sans md:leading-normal md:font-semibold md:tracking-normal">
+      <div className="text-fgPrimary font-circle mb-5 text-2xl leading-[26px] font-medium tracking-[-0.48px] md:mb-3 md:leading-normal md:tracking-normal">
         {isLoading ? <Skeleton className="h-8 w-24" /> : error ? NO_VALUE : `${utilization.toFixed(1)}%`}
       </div>
 

--- a/apps/webapp/src/modules/stake/components/LiquidationPostMortemModal.tsx
+++ b/apps/webapp/src/modules/stake/components/LiquidationPostMortemModal.tsx
@@ -33,7 +33,7 @@ function StatCell({ label, children }: { label: ReactNode; children: ReactNode }
   return (
     <div className="flex flex-col gap-1">
       <span className="text-textSecondary text-sm">{label}</span>
-      <span className="text-text flex items-center gap-1.5 text-sm font-medium">{children}</span>
+      <span className="text-text font-circle flex items-center gap-1.5 text-sm font-medium">{children}</span>
     </div>
   );
 }
@@ -83,7 +83,7 @@ function LiquidationRecoveryConfirmSummary({
           <span className="text-textSecondary text-sm">
             <Trans>Withdraw amount</Trans>
           </span>
-          <span className="text-text flex items-center gap-2 text-2xl font-medium tracking-tight">
+          <span className="text-text font-circle flex items-center gap-2 text-2xl font-medium tracking-tight">
             <TokenIcon token={{ symbol: 'SKY' }} width={28} className="h-7 w-7" showChainIcon={false} />
             {formatStakeAmount(skyToFree)} SKY
           </span>
@@ -101,7 +101,7 @@ function LiquidationRecoveryConfirmSummary({
           <span className="text-textSecondary text-sm">
             <Trans>Rewards amount ({claim.symbol})</Trans>
           </span>
-          <span className="text-text flex items-center gap-2 text-2xl font-medium tracking-tight">
+          <span className="text-text font-circle flex items-center gap-2 text-2xl font-medium tracking-tight">
             <TokenIcon
               token={{ symbol: claim.symbol }}
               width={28}
@@ -220,11 +220,11 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
         {/* Left panel — refunded/claimable heroes + the historical stat grid. */}
         <div className="flex flex-1 flex-col gap-6 p-8">
           <div className="flex items-center justify-between">
-            <DialogTitle className="text-text flex items-center gap-2 text-lg font-medium">
+            <DialogTitle className="text-text font-circle flex items-center gap-2 text-lg font-medium">
               <Trans>Position {urnIndex + 1}</Trans>
               <span
                 data-testid="stake-postmortem-liquidated-chip"
-                className="bg-error/15 text-error rounded-full px-2 py-0.5 text-xs font-medium"
+                className="bg-error/15 text-error font-circle rounded-full px-2 py-0.5 text-xs font-medium"
               >
                 <Trans>Liquidated</Trans>
               </span>
@@ -248,7 +248,7 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
               {vaultLoading ? (
                 <Skeleton className="h-9 w-32" />
               ) : (
-                <span className="text-text flex items-baseline gap-2 text-3xl font-medium tracking-tight">
+                <span className="text-text font-circle flex items-baseline gap-2 text-3xl font-medium tracking-tight">
                   <TokenIcon
                     token={{ symbol: 'SKY' }}
                     width={28}
@@ -272,10 +272,10 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
               {claimableLoading ? (
                 <Skeleton className="h-9 w-32" />
               ) : claims.length === 0 ? (
-                <span className="text-text text-3xl font-medium tracking-tight">{NO_VALUE}</span>
+                <span className="text-text font-circle text-3xl font-medium tracking-tight">{NO_VALUE}</span>
               ) : claims.length === 1 ? (
                 <>
-                  <span className="text-text flex items-baseline gap-2 text-3xl font-medium tracking-tight">
+                  <span className="text-text font-circle flex items-baseline gap-2 text-3xl font-medium tracking-tight">
                     <TokenIcon
                       token={{ symbol: claims[0].symbol }}
                       width={28}
@@ -288,7 +288,7 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
                 </>
               ) : (
                 <>
-                  <span className="text-text flex items-center gap-2 text-3xl font-medium tracking-tight">
+                  <span className="text-text font-circle flex items-center gap-2 text-3xl font-medium tracking-tight">
                     {formatUsd(claimableUsd)}
                     <IconStack size={20}>
                       {claims.map(claim => (
@@ -328,7 +328,10 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
         {/* Right rail — historical context + the bundled recovery CTA. */}
         <div className="bg-surfaceAlt/30 flex w-full flex-col justify-between gap-6 p-8 lg:w-[340px]">
           <div className="flex flex-col gap-4">
-            <h3 className="text-text text-lg font-medium" data-testid="stake-postmortem-liquidated-on">
+            <h3
+              className="text-text font-circle text-lg font-medium"
+              data-testid="stake-postmortem-liquidated-on"
+            >
               {!lastBark ? (
                 <Skeleton className="h-6 w-40" />
               ) : (

--- a/apps/webapp/src/modules/stake/components/ManagePositionTakeover.tsx
+++ b/apps/webapp/src/modules/stake/components/ManagePositionTakeover.tsx
@@ -355,7 +355,7 @@ export function ManagePositionTakeover({
         className="flex flex-col gap-5 px-2"
         aria-label="Position summary"
       >
-        <h3 className="text-text text-lg font-medium">
+        <h3 className="text-text font-circle text-lg font-medium">
           <Trans>Position summary</Trans>
         </h3>
         <div className="flex flex-wrap items-start gap-10">
@@ -363,7 +363,7 @@ export function ManagePositionTakeover({
             <span className="text-textSecondary text-sm">
               <Trans>Staked amount</Trans>
             </span>
-            <span className="text-text flex items-center gap-2 text-3xl font-medium tracking-tight">
+            <span className="text-text font-circle flex items-center gap-2 text-3xl font-medium tracking-tight">
               <TokenIcon token={{ symbol: 'SKY' }} width={28} className="h-7 w-7" showChainIcon={false} />
               {formatBigInt(existingCollateral)}
             </span>
@@ -372,7 +372,7 @@ export function ManagePositionTakeover({
             <span className="text-textSecondary text-sm">
               <Trans>Borrowed amount</Trans>
             </span>
-            <span className="text-text flex items-center gap-2 text-3xl font-medium tracking-tight">
+            <span className="text-text font-circle flex items-center gap-2 text-3xl font-medium tracking-tight">
               <TokenIcon token={{ symbol: 'USDS' }} width={28} className="h-7 w-7" showChainIcon={false} />
               {formatBigInt(existingDebt)}
             </span>
@@ -383,7 +383,7 @@ export function ManagePositionTakeover({
             <span className="text-textSecondary text-sm">
               <Trans>Rewards earned</Trans>
             </span>
-            <span className="text-bullish flex items-center gap-1 text-sm font-medium">
+            <span className="text-bullish font-circle flex items-center gap-1 text-sm font-medium">
               <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
               {`+${formatUsd(detail.rewardsEarnedUsd)}`}
             </span>
@@ -392,7 +392,7 @@ export function ManagePositionTakeover({
             <span className="text-textSecondary text-sm">
               <Trans>Liquidation risk</Trans>
             </span>
-            <span className="text-text text-sm font-medium">
+            <span className="text-text font-circle text-sm font-medium">
               {existingDebt > 0n && existingVault?.riskLevel ? (
                 <RiskValue riskLevel={existingVault.riskLevel} />
               ) : (
@@ -404,7 +404,7 @@ export function ManagePositionTakeover({
             <span className="text-textSecondary text-sm">
               <Trans>Liquidation price</Trans>
             </span>
-            <span className="text-text text-sm font-medium">
+            <span className="text-text font-circle text-sm font-medium">
               {existingDebt > 0n && existingVault?.liquidationPrice !== undefined
                 ? `$${formatBigInt(existingVault.liquidationPrice, { unit: WAD_PRECISION, maxDecimals: 4 })}`
                 : NO_VALUE}
@@ -415,7 +415,7 @@ export function ManagePositionTakeover({
               <Trans>Protocol SKY Price</Trans>
               <Info className="h-3.5 w-3.5" aria-hidden />
             </span>
-            <span className="text-text text-sm font-medium">
+            <span className="text-text font-circle text-sm font-medium">
               {existingVault?.delayedPrice !== undefined
                 ? `$${formatBigInt(existingVault.delayedPrice, { unit: WAD_PRECISION, maxDecimals: 4 })}`
                 : NO_VALUE}

--- a/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
@@ -102,7 +102,7 @@ function MenuRow({
     >
       <span
         className={cn(
-          'text-text flex items-center gap-3 text-sm font-medium',
+          'text-text font-circle flex items-center gap-3 text-sm font-medium',
           variant === 'sheet' && 'font-circle leading-4 tracking-[-0.28px]'
         )}
       >
@@ -435,7 +435,7 @@ export function PositionDetailsModal({
   const claimDisabled = detail.claimableLoading || detail.claimableTokenAmount === 0n;
   const claimChip =
     detail.claimableTokenAmount > 0n ? (
-      <span className="bg-surfaceAlt text-text flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium">
+      <span className="bg-surfaceAlt text-text font-circle flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium">
         {formatBigInt(detail.claimableTokenAmount)} {detail.claimableSymbols[0]}
         <TokenIcon
           token={{ symbol: detail.claimableSymbols[0] }}
@@ -498,7 +498,7 @@ export function PositionDetailsModal({
                 {isInactive && (
                   <span
                     data-testid="stake-position-inactive-chip"
-                    className="bg-surfaceAlt text-textSecondary rounded-full px-2 py-0.5 text-xs font-medium"
+                    className="bg-surfaceAlt text-textSecondary font-circle rounded-full px-2 py-0.5 text-xs font-medium"
                   >
                     <Trans>Inactive</Trans>
                   </span>
@@ -655,7 +655,7 @@ export function PositionDetailsModal({
                   </span>
                   <span
                     data-testid="stake-position-risk-pill"
-                    className="bg-surfaceAlt text-textSecondary w-fit rounded-full px-2 py-0.5 text-xs font-medium"
+                    className="bg-surfaceAlt text-textSecondary font-circle w-fit rounded-full px-2 py-0.5 text-xs font-medium"
                   >
                     <Trans>No position</Trans>
                   </span>
@@ -737,7 +737,7 @@ export function PositionDetailsModal({
                 >
                   <Trans>
                     If the price of the collateral will go down{' '}
-                    <span className="text-text font-medium">
+                    <span className="text-text font-circle font-medium">
                       {dropPercent !== null ? `${dropPercent}%` : NO_VALUE} ({formattedLiqPrice})
                     </span>
                     , you&apos;ll get liquidated. If you want to reduce these risks, add collateral or repay
@@ -763,7 +763,7 @@ export function PositionDetailsModal({
                         <span
                           data-testid="stake-position-risk-pill"
                           className={cn(
-                            'rounded-full px-2 py-0.5 text-xs font-medium capitalize',
+                            'font-circle rounded-full px-2 py-0.5 text-xs font-medium capitalize',
                             RISK_PILL_COLOR[vault.riskLevel]
                           )}
                         >
@@ -799,7 +799,7 @@ export function PositionDetailsModal({
               reaches the same rows through the manage sheet below). */}
           <div className="bg-surfaceAlt/30 hidden w-full flex-col justify-between gap-6 p-8 md:flex lg:w-[340px]">
             <div className="flex flex-col">
-              <h3 className="text-text mb-2 text-lg font-medium">
+              <h3 className="text-text font-circle mb-2 text-lg font-medium">
                 <Trans>Manage position</Trans>
               </h3>
               <ManageMenuRows {...menuRowsProps} variant="panel" />

--- a/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
@@ -52,7 +52,7 @@ function StatCell({ label, children }: { label: ReactNode; children: ReactNode }
       <span className="text-textSecondary flex items-center gap-1 text-xs leading-[18px] md:text-sm md:leading-normal">
         {label}
       </span>
-      <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] md:font-sans md:leading-normal md:tracking-normal">
+      <span className="text-text font-circle flex items-center gap-1.5 text-sm leading-4 font-medium tracking-[-0.28px] md:leading-normal md:tracking-normal">
         {children}
       </span>
     </div>
@@ -493,7 +493,7 @@ export function PositionDetailsModal({
           {/* Left panel — read-only position detail */}
           <div className="flex flex-1 flex-col gap-6 p-5 md:p-8">
             <div className="flex items-center justify-between">
-              <DialogTitle className="text-text font-circle flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:font-sans md:text-lg md:leading-normal md:tracking-normal">
+              <DialogTitle className="text-text font-circle flex items-center gap-2 text-base leading-[18px] font-medium tracking-[-0.32px] md:text-lg md:leading-normal md:tracking-normal">
                 <Trans>Position {urnIndex + 1}</Trans>
                 {isInactive && (
                   <span
@@ -519,7 +519,7 @@ export function PositionDetailsModal({
               <span className="text-textSecondary text-xs leading-[18px] md:text-sm md:leading-normal">
                 <Trans>Staked amount</Trans>
               </span>
-              <span className="text-text font-circle flex items-baseline gap-3 text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:gap-2 md:font-sans md:text-4xl md:leading-normal md:tracking-tight">
+              <span className="text-text font-circle flex items-baseline gap-3 text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:gap-2 md:text-4xl md:leading-normal md:tracking-tight">
                 <TokenIcon
                   token={{ symbol: 'SKY' }}
                   width={32}
@@ -638,7 +638,7 @@ export function PositionDetailsModal({
                   <span className="text-textSecondary text-xs leading-[18px] md:text-sm md:leading-normal">
                     <Trans>Borrowed amount</Trans>
                   </span>
-                  <span className="text-text font-circle flex items-baseline gap-3 text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:gap-2 md:font-sans md:text-4xl md:leading-normal md:tracking-tight">
+                  <span className="text-text font-circle flex items-baseline gap-3 text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:gap-2 md:text-4xl md:leading-normal md:tracking-tight">
                     <TokenIcon
                       token={{ symbol: 'USDS' }}
                       width={32}
@@ -708,7 +708,7 @@ export function PositionDetailsModal({
                   <span className="text-textSecondary text-xs leading-[18px] md:text-sm md:leading-normal">
                     <Trans>Borrowed amount</Trans>
                   </span>
-                  <span className="text-text font-circle flex items-baseline gap-3 text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:gap-2 md:font-sans md:text-4xl md:leading-normal md:tracking-tight">
+                  <span className="text-text font-circle flex items-baseline gap-3 text-[32px] leading-[35px] font-medium tracking-[-0.64px] md:gap-2 md:text-4xl md:leading-normal md:tracking-tight">
                     <TokenIcon
                       token={{ symbol: 'USDS' }}
                       width={32}

--- a/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeActivityTable.tsx
@@ -342,7 +342,7 @@ export function StakeActivityTable({ positions }: { positions?: StakeUserPositio
       {/* Phone tier (comp 1222:16962): heading above a full-width pill filter;
           md restores the heading row with the inline borderless trigger. */}
       <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-4">
-        <h3 className="text-text font-circle text-lg leading-[22px] font-medium tracking-[-0.36px] md:font-sans md:leading-normal md:tracking-normal">
+        <h3 className="text-text font-circle text-lg leading-[22px] font-medium tracking-[-0.36px]">
           <Trans>My activity</Trans>
         </h3>
         {(positions?.length ?? 0) > 0 && (
@@ -353,7 +353,7 @@ export function StakeActivityTable({ positions }: { positions?: StakeUserPositio
             <SelectTrigger
               data-testid="stake-activity-filter"
               aria-label={t`Filter activity by position`}
-              className="border-glassBorder text-text font-circle md:text-textSecondary md:hover:text-text h-11 w-full justify-between rounded-full border bg-transparent py-0 pr-3 pl-4 text-sm leading-4 font-medium tracking-[-0.28px] transition-colors focus-visible:ring-0 md:h-auto md:w-auto md:shrink-0 md:justify-normal md:gap-1.5 md:border-none md:p-0 md:font-sans md:leading-normal md:tracking-normal"
+              className="border-glassBorder text-text font-circle md:text-textSecondary md:hover:text-text h-11 w-full justify-between rounded-full border bg-transparent py-0 pr-3 pl-4 text-sm leading-4 font-medium tracking-[-0.28px] transition-colors focus-visible:ring-0 md:h-auto md:w-auto md:shrink-0 md:justify-normal md:gap-1.5 md:border-none md:p-0 md:leading-normal md:tracking-normal"
             >
               <SelectValue>
                 {filter === 'all' ? <Trans>All positions</Trans> : <Trans>Position {filter + 1}</Trans>}

--- a/apps/webapp/src/modules/stake/components/StakeDetailsStrip.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeDetailsStrip.tsx
@@ -68,7 +68,7 @@ export function StakeDetailsStrip() {
 
   return (
     <div data-testid="stake-details-strip" className="flex flex-col">
-      <h3 className="text-fgPrimary font-circle mb-4 text-base leading-[18px] font-medium tracking-[-0.32px] md:mb-2 md:font-sans md:text-lg md:leading-normal md:tracking-normal">
+      <h3 className="text-fgPrimary font-circle mb-4 text-base leading-[18px] font-medium tracking-[-0.32px] md:mb-2 md:text-lg md:leading-normal md:tracking-normal">
         <Trans>Details</Trans>
       </h3>
 

--- a/apps/webapp/src/modules/stake/components/StakeManageBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeManageBorrowCard.tsx
@@ -171,7 +171,7 @@ export function StakeManageBorrowCard({
           <span className="text-textSecondary">
             <Trans>Borrowed:</Trans>
           </span>
-          <span className="text-text font-medium" data-testid="stake-manage-borrowed-line">
+          <span className="text-text font-circle font-medium" data-testid="stake-manage-borrowed-line">
             {showDeltas && newDebt !== undefined && newDebt !== existingDebt
               ? `${formatBigInt(existingDebt)} → ${formatBigInt(newDebt)}`
               : formatBigInt(existingDebt)}
@@ -224,7 +224,7 @@ export function StakeManageBorrowCard({
           >
             <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-orange-400" aria-hidden />
             <div className="flex flex-col gap-1 text-sm">
-              <span className="text-text font-medium">
+              <span className="text-text font-circle font-medium">
                 <Trans>More SKY needed to borrow</Trans>
               </span>
               <span className="text-textSecondary">

--- a/apps/webapp/src/modules/stake/components/StakeManageCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeManageCard.tsx
@@ -40,7 +40,7 @@ export function StakeManageCard<Mode extends string>({
               aria-pressed={mode.value === activeMode}
               data-testid={`${dataTestId}-mode-${mode.value}`}
               className={cn(
-                'rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
+                'font-circle rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
                 mode.value === activeMode ? 'bg-surfaceAlt text-text' : 'text-textSecondary hover:text-text'
               )}
             >
@@ -81,7 +81,7 @@ export function StakeManageDeltaRow({
       className="border-textSecondary/10 flex items-center justify-between gap-4 border-b py-2.5 text-sm last:border-b-0"
     >
       <span className="text-textSecondary flex items-center gap-1">{label}</span>
-      <span className="text-text flex items-center gap-2 font-medium">
+      <span className="text-text font-circle flex items-center gap-2 font-medium">
         <span className={cn(hasDelta && 'text-textSecondary')}>{current}</span>
         {hasDelta && (
           <>

--- a/apps/webapp/src/modules/stake/components/StakeManageConfirmSummary.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeManageConfirmSummary.tsx
@@ -23,7 +23,7 @@ function AmountHero({
   return (
     <div className="flex flex-col gap-1" data-testid={dataTestId}>
       <span className="text-textSecondary text-sm">{label}</span>
-      <span className="text-text flex items-center gap-2 text-2xl font-medium tracking-tight">
+      <span className="text-text font-circle flex items-center gap-2 text-2xl font-medium tracking-tight">
         <TokenIcon token={{ symbol }} width={28} className="h-7 w-7" showChainIcon={false} />
         {formatBigInt(amount)} {symbol}
       </span>
@@ -106,7 +106,7 @@ export function StakeManageConfirmSummary({
             <span className="text-textSecondary text-sm">
               <Trans>From</Trans>
             </span>
-            <span className="text-text flex items-center gap-2 text-lg font-medium">
+            <span className="text-text font-circle flex items-center gap-2 text-lg font-medium">
               {delegateFrom ? (
                 <>
                   <CustomAvatar address={delegateFrom} size={28} />
@@ -122,7 +122,7 @@ export function StakeManageConfirmSummary({
             <span className="text-textSecondary text-sm">
               <Trans>To</Trans>
             </span>
-            <span className="text-text flex items-center gap-2 text-lg font-medium">
+            <span className="text-text font-circle flex items-center gap-2 text-lg font-medium">
               <CustomAvatar address={delegateTo!} size={28} />
               {shortenAddress(delegateTo!)}
             </span>

--- a/apps/webapp/src/modules/stake/components/StakeManageDelegateCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeManageDelegateCard.tsx
@@ -27,7 +27,7 @@ export function StakeManageDelegateCard({
       className="bg-glassSurface rounded-card flex flex-col gap-6 p-6 backdrop-blur-[20px]"
     >
       <div className="flex items-center justify-between gap-4">
-        <h3 className="text-text text-lg font-medium">
+        <h3 className="text-text font-circle text-lg font-medium">
           <Trans>Change delegate</Trans>
         </h3>
         <Switch

--- a/apps/webapp/src/modules/stake/components/StakeManageStakeCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeManageStakeCard.tsx
@@ -92,7 +92,7 @@ export function StakeManageStakeCard({
 
         <div className="border-textSecondary/10 flex items-center justify-between border-b pb-3 text-sm">
           <span className="text-textSecondary">{isStake ? t`Balance:` : t`Staked:`}</span>
-          <span className="text-text font-medium" data-testid="stake-manage-stake-base">
+          <span className="text-text font-circle font-medium" data-testid="stake-manage-stake-base">
             {isStake && walletBalanceLoading ? <Skeleton className="h-4 w-24" /> : formatBigInt(base)}
           </span>
         </div>

--- a/apps/webapp/src/modules/stake/components/StakePositionRowBanner.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionRowBanner.tsx
@@ -85,7 +85,7 @@ export function StakePositionRowBanner({
       >
         <TriangleAlert className="text-error mt-0.5 h-4 w-4 shrink-0" />
         <div className="flex flex-1 flex-col gap-1">
-          <p className="text-text text-sm font-medium">
+          <p className="text-text font-circle text-sm font-medium">
             <Trans>This position was liquidated</Trans>
           </p>
           <p className="text-textSecondary text-sm">
@@ -120,7 +120,7 @@ export function StakePositionRowBanner({
     >
       <TriangleAlert className="text-error mt-0.5 h-4 w-4 shrink-0" />
       <div className="flex flex-1 flex-col gap-1">
-        <p className="text-text text-sm font-medium">
+        <p className="text-text font-circle text-sm font-medium">
           <Trans>Your liquidation buffer dropped to {dropPercent}%</Trans>
         </p>
         <p className="text-textSecondary text-sm">

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
@@ -66,7 +66,7 @@ function LiquidatedBadge() {
   return (
     <span
       data-testid="stake-position-liquidated-badge"
-      className="bg-error/15 text-error inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
+      className="bg-error/15 text-error font-circle inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
     >
       <Liquidated width={16} height={16} />
       <Trans>Liquidation</Trans>

--- a/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
+++ b/apps/webapp/src/modules/stake/components/StakePositionsTable.tsx
@@ -328,11 +328,13 @@ export function StakePositionsTable({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-4">
-        <h3 className="text-text font-circle text-lg leading-[22px] font-medium tracking-[-0.36px] md:font-sans md:leading-normal md:tracking-normal">
+        <h3 className="text-text font-circle text-lg leading-[22px] font-medium tracking-[-0.36px]">
           <Trans>Active positions</Trans>
         </h3>
+        {/* Label 5 per comp 1036:214062 (Circular Medium 14/16, -0.28px). The comp
+            also puts this on fg-primary; the fgSecondary tint is left as-is. */}
         {allPositions.length > 0 && (
-          <label className="text-textSecondary flex cursor-pointer items-center gap-2 text-sm">
+          <label className="text-textSecondary font-circle flex cursor-pointer items-center gap-2 text-sm leading-4 font-medium tracking-[-0.28px]">
             {/* Comp 1222:16843 shortens the label at the phone tier. */}
             <span className="md:hidden">
               <Trans>Hide inactive</Trans>

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
@@ -161,7 +161,7 @@ export function StakeTakeoverBorrowCard({
           >
             <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-orange-400" aria-hidden />
             <div className="flex flex-col gap-1 text-sm">
-              <span className="text-text font-medium">
+              <span className="text-text font-circle font-medium">
                 <Trans>More SKY needed to borrow</Trans>
               </span>
               <span className="text-fgSecondary">

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverConfirmSummary.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverConfirmSummary.tsx
@@ -7,12 +7,12 @@ function AmountBlock({ label, amount, symbol }: { label: React.ReactNode; amount
     <div className="flex items-end justify-between gap-4">
       <div className="flex flex-col gap-1.5">
         <span className="text-fgSecondary text-sm">{label}</span>
-        <span className="text-text flex items-center gap-2 text-3xl font-medium tracking-tight">
+        <span className="text-text font-circle flex items-center gap-2 text-3xl font-medium tracking-tight">
           <TokenIcon token={{ symbol }} width={28} className="h-7 w-7" showChainIcon={false} />
           {formatBigInt(amount)}
         </span>
       </div>
-      <span className="bg-surfaceAlt text-text flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium">
+      <span className="bg-surfaceAlt text-text font-circle flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium">
         <TokenIcon token={{ symbol }} width={14} className="h-3.5 w-3.5" showChainIcon={false} />
         {symbol}
       </span>
@@ -47,7 +47,7 @@ export function StakeTakeoverConfirmSummary({
           <span className="text-fgSecondary text-sm">
             <Trans>Reward (selected automatically)</Trans>
           </span>
-          <span className="bg-surfaceAlt text-text flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium">
+          <span className="bg-surfaceAlt text-text font-circle flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium">
             <TokenIcon
               token={{ symbol: rewardSymbol }}
               width={14}

--- a/apps/webapp/src/modules/ui/components/ChartTooltip.tsx
+++ b/apps/webapp/src/modules/ui/components/ChartTooltip.tsx
@@ -64,7 +64,7 @@ export function ChartTooltip({
             </span>
           )}
           <span className="ml-auto flex items-center gap-2">
-            <span className="text-text text-sm font-medium">
+            <span className="text-text font-circle text-sm font-medium">
               {prefix || ''}
               {`${formatNumber(entry.value)}${symbol && !isPercentage && !hasTokenIcon ? ` ${symbol}` : ''}${isPercentage ? '%' : ''}`}
             </span>

--- a/apps/webapp/src/modules/ui/components/MinimizedTransactionToast.tsx
+++ b/apps/webapp/src/modules/ui/components/MinimizedTransactionToast.tsx
@@ -36,7 +36,7 @@ export function MinimizedTransactionToast({
     >
       <span className="shrink-0">{statusIcon[status]}</span>
       <span className="flex flex-col">
-        <Text className="text-text font-medium">{title}</Text>
+        <Text className="text-text font-circle font-medium">{title}</Text>
         {hash && <Text className="text-textSecondary text-sm">{formatAddress(hash, 6, 4)}</Text>}
       </span>
     </button>

--- a/apps/webapp/src/modules/ui/components/TransactionNoticeToast.tsx
+++ b/apps/webapp/src/modules/ui/components/TransactionNoticeToast.tsx
@@ -20,7 +20,7 @@ export function TransactionNoticeToast({
     <div className="flex w-full items-center gap-4 pr-6" data-testid="transaction-notice-toast">
       <span className="shrink-0">{icon}</span>
       <span className="flex flex-col gap-0.5">
-        <Text className="text-text font-medium">{title}</Text>
+        <Text className="text-text font-circle font-medium">{title}</Text>
         <Text className="text-textSecondary text-sm">{description}</Text>
       </span>
     </div>

--- a/apps/webapp/src/modules/ui/components/WalletIcon.tsx
+++ b/apps/webapp/src/modules/ui/components/WalletIcon.tsx
@@ -58,7 +58,7 @@ export const WalletIcon = ({ connector, iconUrl, className }: WalletIconProps) =
         // className must merge here too — callers size this badge (h-3/h-6) and
         // the fixed 40px fallback used to swallow small avatars for icon-less
         // connectors (e.g. the mock wallet).
-        'flex h-10 w-10 items-center justify-center overflow-hidden rounded-lg font-semibold text-white',
+        'font-circle flex h-10 w-10 items-center justify-center overflow-hidden rounded-lg font-medium text-white',
         getBackgroundColor(),
         className
       )}

--- a/apps/webapp/src/pages/DesignSystem.tsx
+++ b/apps/webapp/src/pages/DesignSystem.tsx
@@ -1864,12 +1864,12 @@ function ChartsSection() {
               <span className="text-fgSecondary text-sm">Maturity</span>
               <span className="text-fgSecondary text-sm">18 Jun 2026</span>
             </div>
-            <span className="text-fgPrimary text-2xl font-medium">85%</span>
+            <span className="text-fgPrimary font-circle text-2xl font-medium">85%</span>
             <Progress value={85} />
           </div>
           <div className="flex flex-col gap-2">
             <span className="text-fgSecondary text-sm">Borrow Utilization</span>
-            <span className="text-fgPrimary text-2xl font-medium">83.5%</span>
+            <span className="text-fgPrimary font-circle text-2xl font-medium">83.5%</span>
             <Progress value={83.5} className="h-2" />
           </div>
         </div>
@@ -1943,7 +1943,7 @@ function ChartsSection() {
               activeId="susds"
               onActiveChange={() => {}}
               size={140}
-              renderCenter={id => <span className="text-text text-sm font-medium">{id}</span>}
+              renderCenter={id => <span className="text-text font-circle text-sm font-medium">{id}</span>}
             />
             <span className="text-fgSecondary text-xs">active (hover)</span>
           </div>
@@ -2013,7 +2013,7 @@ function BannersSection() {
           subtitle={
             <p className="text-fgSecondary max-w-[248px] text-xs leading-[18px]">
               That&apos;s what your idle stablecoins can earn at today&apos;s{' '}
-              <span className="text-fgPrimary font-medium">3.75%</span> Sky Savings Rate.
+              <span className="text-fgPrimary">3.75%</span> Sky Savings Rate.
             </p>
           }
           action={

--- a/apps/webapp/src/widgets/VaultWidget/components/MorphoRateBreakdownPopover.tsx
+++ b/apps/webapp/src/widgets/VaultWidget/components/MorphoRateBreakdownPopover.tsx
@@ -106,7 +106,9 @@ export function MorphoRateBreakdownPopover({
                 {hasExtraIncentive && <Sparkles className="h-4 w-4" />}
                 <Text
                   className={
-                    hasExtraIncentive ? 'text-bullish text-sm font-medium' : 'text-text text-sm font-medium'
+                    hasExtraIncentive
+                      ? 'text-bullish font-circle text-sm font-medium'
+                      : 'text-text font-circle text-sm font-medium'
                   }
                 >
                   <Trans>Net Rate</Trans>
@@ -114,7 +116,9 @@ export function MorphoRateBreakdownPopover({
               </div>
               <Text
                 className={
-                  hasExtraIncentive ? 'text-bullish text-sm font-medium' : 'text-text text-sm font-medium'
+                  hasExtraIncentive
+                    ? 'text-bullish font-circle text-sm font-medium'
+                    : 'text-text font-circle text-sm font-medium'
                 }
               >
                 ={rateData.formattedNetRate}

--- a/apps/webapp/src/widgets/shared/components/ui/RiskSlider.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/RiskSlider.tsx
@@ -232,7 +232,9 @@ const RiskSlider = React.forwardRef<React.ComponentRef<typeof SliderPrimitive.Ro
               </TooltipTrigger>
               <TooltipPortal>
                 <TooltipContent side="right" className="max-w-xs">
-                  <p className="text-text text-sm font-medium">{maxPermittedRiskTooltip?.title}</p>
+                  <p className="text-text font-circle text-sm font-medium">
+                    {maxPermittedRiskTooltip?.title}
+                  </p>
                   <p className="light:text-textSecondary mt-2 text-xs text-gray-400">
                     {maxPermittedRiskTooltip?.tooltip}
                   </p>
@@ -259,7 +261,7 @@ const RiskSlider = React.forwardRef<React.ComponentRef<typeof SliderPrimitive.Ro
                   </TooltipTrigger>
                   <TooltipPortal>
                     <TooltipContent side="right" className="max-w-xs">
-                      <p className="text-text text-sm font-medium">{riskFloorTooltip?.title}</p>
+                      <p className="text-text font-circle text-sm font-medium">{riskFloorTooltip?.title}</p>
                       <p className="light:text-textSecondary mt-2 text-xs text-gray-400">
                         {riskFloorTooltip?.tooltip}
                       </p>
@@ -287,7 +289,7 @@ const RiskSlider = React.forwardRef<React.ComponentRef<typeof SliderPrimitive.Ro
                   </TooltipTrigger>
                   <TooltipPortal>
                     <TooltipContent side="right" className="max-w-xs">
-                      <p className="text-text text-sm font-medium">{riskCeilingTooltip?.title}</p>
+                      <p className="text-text font-circle text-sm font-medium">{riskCeilingTooltip?.title}</p>
                       <p className="light:text-textSecondary mt-2 text-xs text-gray-400">
                         {riskCeilingTooltip?.tooltip}
                       </p>

--- a/apps/webapp/src/widgets/shared/components/ui/Typography.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/Typography.tsx
@@ -14,7 +14,7 @@ interface TypographyProps {
 
 const ELEMENTS: Record<TypographyElement, string> = {
   h1: 'scroll-m-20 font-normal tracking-tight',
-  h2: 'scroll-m-20 font-medium tracking-tight leading-normal transition-colors',
+  h2: 'scroll-m-20 font-circle font-medium tracking-tight leading-normal transition-colors',
   h3: 'scroll-m-20 font-normal tracking-tight',
   h4: 'scroll-m-20 font-normal tracking-tight',
   p: 'leading-normal text-base',

--- a/apps/webapp/src/widgets/shared/components/ui/card/StatsAccordionCard.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/card/StatsAccordionCard.tsx
@@ -45,7 +45,7 @@ export const StatsAccordionCard = ({
               ) : (
                 <Skeleton className="bg-textSecondary h-5" />
               )}
-              <Text variant="medium" className="font-medium">
+              <Text variant="medium" className="font-circle font-medium">
                 <Trans>{accordionTitle}</Trans>
               </Text>
             </HStack>

--- a/apps/webapp/src/widgets/shared/components/ui/spinner/FetchingSpinner.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/spinner/FetchingSpinner.tsx
@@ -17,7 +17,7 @@ export function FetchingSpinner({
   return (
     <HStack gap={2} className={classes}>
       <LoadingSpinner className={spinnerClassName} />
-      <Text variant="medium" className="text-text font-medium">
+      <Text variant="medium" className="text-text font-circle font-medium">
         {message}
       </Text>
     </HStack>

--- a/apps/webapp/src/widgets/shared/components/ui/token/TokenDropdown.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/token/TokenDropdown.tsx
@@ -46,7 +46,7 @@ export function TokenDropdown({
       >
         <VStack className="w-full space-y-2">
           <motion.div variants={positionAnimations}>
-            <Text className="text-selectActive light:text-textSecondary ml-5 text-sm leading-none font-medium">
+            <Text className="text-selectActive light:text-textSecondary font-circle ml-5 text-sm leading-none font-medium">
               <Trans>Select token</Trans>
             </Text>
           </motion.div>

--- a/apps/webapp/src/widgets/shared/components/ui/token/TokenInput.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/token/TokenInput.tsx
@@ -450,7 +450,7 @@ export function TokenInput({
         >
           <VStack className="w-full space-y-2">
             <motion.div variants={positionAnimations}>
-              <Text className="text-selectActive light:text-textSecondary ml-5 text-sm leading-none font-medium">
+              <Text className="text-selectActive light:text-textSecondary font-circle ml-5 text-sm leading-none font-medium">
                 <Trans>Select token</Trans>
               </Text>
             </motion.div>

--- a/apps/webapp/src/widgets/shared/components/ui/transaction/TransactionOverview.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/transaction/TransactionOverview.tsx
@@ -149,7 +149,7 @@ export function TransactionOverview({
             <Accordion type="single" collapsible defaultValue="overview" className="mb-2">
               <AccordionItem value="overview">
                 <AccordionTrigger className="py-1">
-                  <Text variant="medium" className="font-medium">
+                  <Text variant="medium" className="font-circle font-medium">
                     {title}
                   </Text>
                 </AccordionTrigger>
@@ -168,7 +168,7 @@ export function TransactionOverview({
             <Accordion type="single" collapsible>
               <AccordionItem value="details">
                 <AccordionTrigger className="py-1">
-                  <Text variant="medium" className="font-medium">
+                  <Text variant="medium" className="font-circle font-medium">
                     {detailsTitle}
                   </Text>
                 </AccordionTrigger>
@@ -197,7 +197,7 @@ export function TransactionOverview({
           <Accordion type="single" collapsible className="p-4" defaultValue="item-1">
             <AccordionItem value="item-1">
               <AccordionTrigger className="py-1">
-                <Text variant="medium" className="font-medium">
+                <Text variant="medium" className="font-circle font-medium">
                   {title}
                 </Text>
               </AccordionTrigger>


### PR DESCRIPTION
**Stacked on #1785** (`redesign/circular-medium-weight`) — review that one first; this PR's diff is only the two commits on top.

## Why

#1785 shipped Circular Medium 500 and made `font-medium` real. This is the follow-up it named: the ~121 sites asking for a weight the design system doesn't define.

The DS has exactly two weights — `font-weight/body` 400 on Graphik, `font-weight/label` 500 on Circular. These sites requested 500 or 600 on **Graphik**, which has neither cut. They silently rendered at 400, or (for `font-semibold`) as Chrome's synthetic bold. Shipping Medium didn't touch any of them, because none of them said `font-circle`.

Each site is resolved to whichever the comp actually wants:

- **Label / value / badge / title / tooltip heading / amount input → `font-circle`**, so it lands on the real Medium cut. Covers stake (largest group), portfolio, convert, savings, claim, balances, toasts, chart tooltips, and the shared widget primitives.
- **Inline emphasis inside Graphik prose → drop the weight.** The `ProductDetailTemplate` "Learn more" link and the `AllocateStablecoinsBanner` rate span already carry emphasis in colour, and there is no Graphik 500 to promote them to. Removing the class is a **visual no-op today** — it was never rendering — and stops the code claiming a weight that doesn't exist.

**Family and weight only.** No sizes, tracking or line-heights changed; that would have ballooned the diff into a re-spec.

## One real bug found

`components/ui/button.tsx` — the DS size recipes (`xl/l/m/s/mini`) each add `font-circle`, but `defaultVariants` sets `size: 'default'`, which doesn't. So any `<Button>` with no explicit `size` prop rendered in Graphik. `font-circle` now lives on the base.

## Deliberately untouched

| Site | Reason |
|---|---|
| `CardWidgetTitle`, `AccordionWidgetTrigger`, `TableFooter`, `SelectLabel` | Exported, **zero consumers**. Dead. |
| `buttonWidgetVariants` | One consumer (`pagination.tsx`), itself legacy. |
| `widgets/components/ui/input.tsx` | Its `font-medium` is `file:font-medium` — shadcn file-input boilerplate, not the field's text. Rewriting it would have produced broken output. |
| `widgets/TradeWidget`, `modules/analytics`, `pages/SealEngine` | Out of the agreed scope: no route mounts Trade/Upgrade, and the others are uncomped internal pages. |

The four dead exports are a good candidate for a separate deletion PR — they're carrying stale styling nothing renders.

## Verification

- typecheck clean, prettier clean, lint at the pre-existing baseline (3 errors in `ProductCard.test.tsx`, untouched here)
- **2210/2211** unit tests — the one failure is the `EarnFeaturedCards` Pendle date-bomb, which reproduces on a clean `app-redesign`
- Checked the bulk transform for damage: no variant-prefixed classes (`hover:font-circle` etc.) and no doubled classes in the final diff. One `font-circle font-circle` did appear mid-pass on a `font-semibold` line and was fixed before commit.
- JSDoc comments were guarded so prose mentioning `font-medium` wasn't rewritten.

Not browser-verified: most of these surfaces are wallet-gated and the vnet in `.env` is expired. The changes are family swaps on classes whose weight was previously inert, so the risk is a surface reading heavier than intended rather than breaking — worth a pass on the Vercel preview, particularly stake, which owns the largest share of the diff.

## Still open from #1785

The `Font Family/Headings` variable should be relabelled `Circular Std` → `Circular XX`, and the `Graphik Trial` / "Maker Growth" licence questions are unaffected by this PR.
