### PR TITLE
Put product Details values on Label 4 at desktop

### DIFF
--- a/apps/webapp/src/components/product/ProductDetailTemplate.tsx
+++ b/apps/webapp/src/components/product/ProductDetailTemplate.tsx
@@ -118,11 +118,14 @@ function DetailsSection({ title, details }: { title?: ReactNode; details: Produc
             key={row.id}
             className="border-borderPrimary flex items-center justify-between gap-4 border-b py-4"
           >
-            <span className="text-fgSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-normal">
+            {/* Desktop comp (859:35723): label Body 5 (Graphik 14/22), value
+                Label 4 (Circular Medium 16/18, -0.32px). Mobile keeps the M6.3
+                step-down — Body 6 labels and Label 5 values (486:20706). */}
+            <span className="text-fgSecondary flex items-center gap-1.5 text-xs leading-[18px] md:gap-2 md:text-sm md:leading-[22px]">
               {row.icon}
               {row.label}
             </span>
-            <span className="text-text font-circle md:font-graphik text-right text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-normal md:tracking-normal">
+            <span className="text-text font-circle text-right text-sm leading-4 font-medium tracking-[-0.28px] md:text-base md:leading-[18px] md:tracking-[-0.32px]">
               {row.value}
             </span>
           </div>


### PR DESCRIPTION
**Stacked on #1786** (which is stacked on #1785). Review those first — this PR is one commit, one file.

## The bug

Desktop comp [859:35723](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=859-35723&m=dev) specs every Details row as:

| | Family | Style | Metrics |
|---|---|---|---|
| Label | Graphik Regular | Body 5 | 14 / 22, tracking 0, `fg-secondary` |
| Value | **Circular Medium** | **Label 4** | **16 / 18, −0.32px**, `fg-primary` |

The value span was doing this:

```
text-text font-circle md:font-graphik ... md:text-base md:leading-normal md:tracking-normal
```

Circular on mobile, then **switching to Graphik at `md`** — precisely where the comp calls for Circular Medium — with `normal` leading and tracking instead of 18px / −0.32px. So from `md` up, every data point on every product page rendered in the body face at the wrong metrics.

## Why it was there

Not a design decision. The `md:` overrides arrived with the M6.3 mobile build (`b0e03b569`, APP-378), which added the mobile Label 5 treatment and pinned the *pre-existing* desktop styling behind `md:` rather than checking it against the desktop comp. The mobile side was comp-verified; the desktop side was inherited.

Worth noting this was invisible until #1785 — with only the Book cut shipped, Circular and its `font-medium` rendered nearly the same weight anyway, so a family switch didn't read as wrong.

## Scope

Fixed in the shared `ProductDetailTemplate`, so **all six product pages** inherit it: savings, vaults, fixed/Pendle, rewards, stUSDS and stake. I checked every consumer — none styles its own row values, so the template is the single point of control.

**Mobile is untouched.** `font-circle text-sm leading-4 tracking-[-0.28px]` is the M6.3 Label 5 step-down against its own comp (486:20706), which was pixel-verified at the time.

Labels also take the comp's 22px line height at `md` — `leading-normal` on 14px resolves to 21px. One pixel, same rows, same comp; easy to drop if you'd rather keep the diff to the values only.

## Verification

typecheck clean, prettier clean, **2210/2211** tests — the one failure is the `EarnFeaturedCards` Pendle date-bomb that reproduces on a clean `app-redesign`.

Not browser-verified: the product pages are wallet-gated and the vnet in `.env` is expired. This is a class-level change to one span, but the Details rows on the preview are the obvious place to confirm — at ≥768px the values should now be Circular Medium, matching the section heading's face.
