### PR TITLE
Fix: Upgrade modal silently fails to open when no wallet is connected (APP-446)

### DIFF
--- a/apps/webapp/src/hooks/upgrade/useBatchUpgrade.ts
+++ b/apps/webapp/src/hooks/upgrade/useBatchUpgrade.ts
@@ -57,31 +57,38 @@ export function useBatchUpgrade({
   });
   const hasAllowance = allowance !== undefined && allowance >= amount;
 
-  // Calls for the batch transaction
-  const approveCall = getWriteContractCall({
-    to: sourceAddress,
-    abi: erc20Abi,
-    functionName: 'approve',
-    args: [upgraderAddress, amount]
-  });
-
-  const upgradeCall = isDai
-    ? getWriteContractCall({
-        to: upgraderAddress,
-        abi: daiUsdsAbi,
-        functionName: 'daiToUsds',
-        args: [connectedAddress!, amount]
-      })
-    : getWriteContractCall({
-        to: upgraderAddress,
-        abi: mkrSkyAbi,
-        functionName: 'mkrToSky',
-        args: [connectedAddress!, amount]
-      });
-
+  // Calls for the batch transaction. Built only once an address exists: the
+  // upgrade modal opens while disconnected, and an `undefined` recipient in the
+  // args makes consumers that encode the calldata during render (e.g.
+  // useNetworkFee's calls key) throw viem's InvalidAddressError.
   const calls: Call[] = [];
-  if (!hasAllowance) calls.push(approveCall);
-  calls.push(upgradeCall);
+  if (connectedAddress) {
+    if (!hasAllowance) {
+      calls.push(
+        getWriteContractCall({
+          to: sourceAddress,
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [upgraderAddress, amount]
+        })
+      );
+    }
+    calls.push(
+      isDai
+        ? getWriteContractCall({
+            to: upgraderAddress,
+            abi: daiUsdsAbi,
+            functionName: 'daiToUsds',
+            args: [connectedAddress, amount]
+          })
+        : getWriteContractCall({
+            to: upgraderAddress,
+            abi: mkrSkyAbi,
+            functionName: 'mkrToSky',
+            args: [connectedAddress, amount]
+          })
+    );
+  }
 
   const enabled =
     isConnected && amount !== 0n && allowance !== undefined && paramEnabled && !!connectedAddress;

--- a/apps/webapp/src/modules/ui/components/TransactionModal.tsx
+++ b/apps/webapp/src/modules/ui/components/TransactionModal.tsx
@@ -203,7 +203,14 @@ export function TransactionModal({
   // Stable callback ref so registering the entry slot doesn't thrash on re-render.
   const slotRef = useCallback((el: HTMLDivElement | null) => registerEntrySlot?.(el), [registerEntrySlot]);
 
+  const entryConfirmAction = entry?.confirmAction;
   const handleConfirm = useCallback(() => {
+    // An entry-CTA override (e.g. "Connect wallet") runs in place: no screen
+    // advance, no onConfirm — see `TransactionEntry.confirmAction`.
+    if (isEntry && entryConfirmAction) {
+      entryConfirmAction();
+      return;
+    }
     // In the three-screen flow the entry's confirm only advances to the review —
     // nothing fires on-chain until the review's confirm.
     if (isEntry && hasReviewStage) {
@@ -215,7 +222,7 @@ export function TransactionModal({
     }
     setStep('transaction');
     onConfirm();
-  }, [isEntry, hasReviewStage, onConfirm]);
+  }, [isEntry, hasReviewStage, onConfirm, entryConfirmAction]);
 
   // The entry's secondary CTA (entry-only flows — see the contract): same
   // advance to the wallet screen, firing the secondary action's handler.

--- a/apps/webapp/src/modules/ui/context/transactionContract.ts
+++ b/apps/webapp/src/modules/ui/context/transactionContract.ts
@@ -52,6 +52,14 @@ export type TransactionEntry = {
   secondaryConfirmLabel?: string;
   /** Disables the secondary CTA independently of the primary one. */
   secondaryConfirmDisabled?: boolean;
+  /**
+   * While set, the entry's primary CTA fires this INSTEAD of starting the
+   * transaction — the modal stays on the entry screen and the config's
+   * `onConfirm` doesn't run. Lets a flow surface a prerequisite in the primary
+   * slot (e.g. a disconnected upgrade modal's "Connect wallet") while the form
+   * beneath stays visible; push `undefined` to restore the normal confirm.
+   */
+  confirmAction?: () => void;
 };
 
 /** Analytics metadata passed by consumers to attribute events correctly. */

--- a/apps/webapp/src/modules/ui/context/transactionEntryStep.test.tsx
+++ b/apps/webapp/src/modules/ui/context/transactionEntryStep.test.tsx
@@ -205,6 +205,46 @@ describe('TransactionModal — editable entry step', () => {
     expect(staleConfirm).not.toHaveBeenCalled();
   });
 
+  it('confirmAction overrides the entry CTA: fires in place, no screen advance, no onConfirm — and clearing it restores the confirm', () => {
+    const connect = vi.fn();
+    const onConfirm = vi.fn();
+    const SESSION = 'upgrade-1';
+    const get = renderModal(cb => ({
+      title: 'Upgrade DAI/MKR',
+      sessionId: SESSION,
+      entry: {
+        content: <div>fields</div>,
+        confirmLabel: 'Connect wallet',
+        confirmDisabled: false,
+        confirmAction: connect
+      },
+      // Mirror a real flow: confirm fires the engine, which calls back into the modal.
+      onConfirm: () => {
+        onConfirm();
+        cb.onMutate();
+      }
+    }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect wallet' }));
+    // The override ran in place: still on the entry screen, transaction untouched.
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.queryByText(/confirm this transaction in your wallet/i)).toBeNull();
+
+    // The wallet connects: the body pushes the normal confirm back (the
+    // upgrade form's connected state).
+    act(() => {
+      get().updateModalContent(SESSION, {
+        entry: { confirmLabel: 'Continue', confirmAction: undefined }
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/confirm this transaction in your wallet/i)).not.toBeNull();
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
   it('renders the two-CTA entry footer and routes each CTA to its own handler (Figma 1036:214001)', () => {
     const onConfirm = vi.fn();
     const onSecondaryConfirm = vi.fn();

--- a/apps/webapp/src/modules/ui/hooks/useModalEntryBody.test.tsx
+++ b/apps/webapp/src/modules/ui/hooks/useModalEntryBody.test.tsx
@@ -16,11 +16,23 @@ import { TxStatus } from '@/widgets';
 import { useModalEntryBody } from './useModalEntryBody';
 import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 
-function Host({ steps, transactionContent }: { steps?: TransactionStep[]; transactionContent?: ReactNode }) {
+function Host({
+  steps,
+  transactionContent,
+  confirmLabel,
+  confirmAction
+}: {
+  steps?: TransactionStep[];
+  transactionContent?: ReactNode;
+  confirmLabel?: string;
+  confirmAction?: () => void;
+}) {
   const renderInSlot = useModalEntryBody({
     sessionId: 's1',
     execute: () => {},
     confirmDisabled: false,
+    confirmLabel,
+    confirmAction,
     steps,
     transactionContent
   });
@@ -70,5 +82,41 @@ describe('useModalEntryBody — live-push freeze once the tx leaves IDLE', () =>
       's1',
       expect.objectContaining({ steps: [{ label: 'Supply' }] })
     );
+  });
+});
+
+describe('useModalEntryBody — entry CTA overrides', () => {
+  beforeEach(() => {
+    h.txStatus = TxStatus.IDLE;
+    h.updateModalContent.mockClear();
+  });
+
+  it('omits confirmLabel from the entry patch when not supplied, keeping the launch-time label', () => {
+    render(<Host />);
+    const entry = h.updateModalContent.mock.calls[0][1].entry;
+    expect('confirmLabel' in entry).toBe(false);
+  });
+
+  it('pushes confirmLabel and confirmAction into the entry patch when supplied', () => {
+    const connect = vi.fn();
+    render(<Host confirmLabel="Connect wallet" confirmAction={connect} />);
+    expect(h.updateModalContent).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        entry: expect.objectContaining({ confirmLabel: 'Connect wallet', confirmAction: connect })
+      })
+    );
+  });
+
+  it('always pushes confirmAction so clearing it restores the normal confirm', () => {
+    const connect = vi.fn();
+    const view = render(<Host confirmLabel="Connect wallet" confirmAction={connect} />);
+    h.updateModalContent.mockClear();
+
+    view.rerender(<Host confirmLabel="Continue" />);
+    const entry = h.updateModalContent.mock.calls[0][1].entry;
+    expect('confirmAction' in entry).toBe(true);
+    expect(entry.confirmAction).toBeUndefined();
+    expect(entry.confirmLabel).toBe('Continue');
   });
 });

--- a/apps/webapp/src/modules/ui/hooks/useModalEntryBody.ts
+++ b/apps/webapp/src/modules/ui/hooks/useModalEntryBody.ts
@@ -13,6 +13,19 @@ import type { TransactionStep } from '@/modules/ui/components/TransactionModal';
 type ModalEntryBodyLive = {
   /** Disables the shared modal's confirm button (amount zero / over balance / nothing selected). */
   confirmDisabled: boolean;
+  /**
+   * Live entry-CTA label. A body that passes it must pass it EVERY render (the
+   * entry merge keeps the last pushed value) — e.g. the upgrade form swaps
+   * "Connect wallet" ↔ "Continue" with the connection state. Omit entirely to
+   * keep the launch-time label.
+   */
+  confirmLabel?: string;
+  /**
+   * Entry-CTA override fired instead of starting the transaction (see
+   * `TransactionEntry.confirmAction`). Always pushed — `undefined` restores
+   * the normal confirm, so an override never outlives its condition.
+   */
+  confirmAction?: () => void;
   /** Read-only breakdown for a three-screen flow's review stage. */
   transactionContent?: ReactNode;
   /** Compact amount summary rendered on the wallet/status screen. */
@@ -49,6 +62,8 @@ export function useModalEntryBody({
   sessionId,
   execute,
   confirmDisabled,
+  confirmLabel,
+  confirmAction,
   transactionContent,
   transactionScreenContent,
   steps,
@@ -79,7 +94,14 @@ export function useModalEntryBody({
     updateModalContent(sessionId, {
       // `confirmDisabled` gates the entry screen via the entry descriptor and the
       // review stage via the top-level field — same value, both screens.
-      entry: { confirmDisabled },
+      // `confirmLabel` merges only when supplied (bodies that don't pass it keep
+      // their launch-time label); `confirmAction` is always pushed so clearing
+      // it (undefined) reliably restores the normal confirm.
+      entry: {
+        confirmDisabled,
+        ...(confirmLabel !== undefined ? { confirmLabel } : {}),
+        confirmAction
+      },
       confirmDisabled,
       onConfirm,
       ...(transactionContent !== undefined ? { transactionContent } : {}),
@@ -91,6 +113,8 @@ export function useModalEntryBody({
     sessionId,
     txStatus,
     confirmDisabled,
+    confirmLabel,
+    confirmAction,
     transactionContent,
     transactionScreenContent,
     steps,

--- a/apps/webapp/src/modules/upgrade/components/UpgradeModalForm.tsx
+++ b/apps/webapp/src/modules/upgrade/components/UpgradeModalForm.tsx
@@ -16,6 +16,7 @@ import { toGridCells } from '@/components/product/ModalGridCells';
 import { TokenSelectorPill } from '@/components/product/TokenSelectorPill';
 import { TokenTransferHero } from '@/components/product/TokenTransferHero';
 import { useTransaction } from '@/modules/ui/context/TransactionContext';
+import { useConnectModal } from '@/modules/ui/context/ConnectModalContext';
 import { useModalEntryBody } from '@/modules/ui/hooks/useModalEntryBody';
 import { UPGRADE_TARGET, useUpgradeLaunch } from '../hooks/useUpgradeLaunch';
 import { buildUpgradeModalRows } from './upgradeModalRows';
@@ -118,7 +119,11 @@ export function UpgradeModalForm({
       bundleState.promoVisible
     ]
   );
-  const disabled = !amountReady || !prepared;
+  // Disconnected (APP-446): the modal still opens — the CTA becomes an enabled
+  // "Connect wallet" that opens the connect modal in place (no screen advance,
+  // see `confirmAction`), and reverts to the gated "Continue" once connected.
+  const { openConnectModal } = useConnectModal();
+  const disabled = isConnected && (!amountReady || !prepared);
 
   // The wallet balance is chain state the engine's success doesn't refetch —
   // sync it so the entry screen shows the post-upgrade balance if revisited.
@@ -158,6 +163,8 @@ export function UpgradeModalForm({
     sessionId,
     execute,
     confirmDisabled: disabled,
+    confirmLabel: isConnected ? t`Continue` : t`Connect wallet`,
+    confirmAction: isConnected ? undefined : openConnectModal,
     steps,
     transactionScreenContent,
     toast


### PR DESCRIPTION
Fixes [APP-446](https://linear.app/ekliptyka/issue/APP-446/upgrade-modal-silently-fails-to-open-when-no-wallet-is-connected)

## Problem

With no wallet connected, choosing **Upgrade DAI/MKR** in the More menu closed the menu and then… nothing. `launch()` succeeded, but the hidden `backgroundContent` host rendered `UpgradeModalForm`, whose engine chain built calls with an `undefined` recipient. `useNetworkFee` encodes the calls' calldata **during render** to build its query key, so viem threw `InvalidAddressError: Address "undefined" is invalid`, and `AnalyticsErrorBoundary` silently unmounted the just-launched modal. The `?upgrade=dai|mkr` deep link failed the same way — for its primary audience, since a shared-link recipient typically arrives disconnected.

## Fix

- **`useBatchUpgrade`** builds no calls until an address exists (`enabled` already required one), removing the poisoned args at the source.
- The modal now opens disconnected in the form's designed disabled state (input disabled, balance `–`), and the entry CTA becomes an enabled **"Connect wallet"** that opens the connect drawer *in place* — the modal stays on its entry screen beneath it — reverting to the gated **"Continue"** once connected.
- Mechanism: new optional **`TransactionEntry.confirmAction`** — while set, the entry's primary CTA fires it instead of starting the transaction (no screen advance, no `onConfirm`). `useModalEntryBody` can now live-push `confirmLabel`/`confirmAction`; the action is always pushed so clearing it reliably restores the normal confirm. Other flows are untouched (label merge only applies when a body supplies one).

## Testing

- New unit coverage: `confirmAction` fires in place / clearing restores the confirm (`transactionEntryStep.test.tsx`), entry-patch push semantics (`useModalEntryBody.test.tsx`).
- Full webapp suite green (2219), typecheck + lint clean.
- Browser-verified disconnected: More-menu click and `?upgrade=dai|mkr` deep links open the modal (MKR preselects rate/penalty), "Connect wallet" raises the connect drawer over the intact modal, no `InvalidAddressError` in the console.
- Connected behavior unchanged: the CTA gating expression reduces exactly to the previous one when connected.

Note: `/convert` visited disconnected throws the same class of error from `ConvertPage` — pre-existing (reproduced without any upgrade param), left for its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)