### PR TITLE
APP-443: redesign QA round July 31 (items 3, 4)

### DIFF
--- a/apps/webapp/src/hooks/shared/useNetworkFee.test.tsx
+++ b/apps/webapp/src/hooks/shared/useNetworkFee.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { renderHook, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { erc20Abi, parseAbi, type Call } from 'viem';
+
+// Wallet-less scenario: no account, and no client so no query can fire.
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: undefined }),
+  useChainId: () => 1,
+  usePublicClient: () => undefined
+}));
+
+vi.mock('./useIsBatchSupported', () => ({
+  useIsBatchSupported: () => ({ data: false })
+}));
+
+vi.mock('../prices/usePrices', () => ({
+  usePrices: () => ({ data: undefined, isLoading: false })
+}));
+
+import { useNetworkFee } from './useNetworkFee';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
+
+afterEach(cleanup);
+
+describe('useNetworkFee', () => {
+  it('survives calls that cannot be encoded yet (wallet-less render, undefined recipient)', () => {
+    // The PSM engine hands over its buyGem call with `usr ?? address` while both are
+    // undefined — encoding it throws InvalidAddressError. The fee row is read-only:
+    // it must fall back to "no estimate", never take the page down (APP-443 item 3).
+    const calls: Call[] = [
+      {
+        to: '0xA188EEC8F81263234dA3622A406892F3D630f98c',
+        abi: parseAbi(['function buyGem(address usr, uint256 gemAmt)']),
+        functionName: 'buyGem',
+        args: [undefined as unknown as `0x${string}`, 100n]
+      }
+    ];
+
+    const { result } = renderHook(() => useNetworkFee({ calls }), { wrapper });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('still keys encodable calls without touching the network when disabled', () => {
+    const calls: Call[] = [
+      {
+        to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: ['0xA188EEC8F81263234dA3622A406892F3D630f98c', 1n]
+      }
+    ];
+
+    const { result } = renderHook(() => useNetworkFee({ calls, enabled: false }), { wrapper });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/webapp/src/hooks/shared/useNetworkFee.ts
+++ b/apps/webapp/src/hooks/shared/useNetworkFee.ts
@@ -97,7 +97,17 @@ export function useNetworkFee({
   // fall through to the sequential estimate — we can't model economics we can't see.
   const canBundle = batchSupported === true && calls.length > 1;
 
-  const callsKey = useMemo(() => getCallsKey(calls), [calls]);
+  // Wallet-less renders can hand over calls with an arg the engine can only fill
+  // in after connect (the Convert page mounts with no account, so the PSM call's
+  // recipient is undefined and viem's encoder throws). This row is read-only and
+  // must never take the page down — treat "can't encode" as "nothing to estimate".
+  const callsKey = useMemo(() => {
+    try {
+      return getCallsKey(calls);
+    } catch {
+      return null;
+    }
+  }, [calls]);
 
   const {
     data: gasData,
@@ -114,7 +124,7 @@ export function useNetworkFee({
         calls,
         wantsBatch: canBundle
       }),
-    enabled: enabled && !!publicClient && !!address && calls.length > 0,
+    enabled: enabled && !!publicClient && !!address && calls.length > 0 && callsKey !== null,
     staleTime: GAS_STALE_TIME,
     retry: false,
     // The key moves as the amount is typed and again when the call set settles (an

--- a/apps/webapp/src/modules/layout/components/InsideLayoutContext.ts
+++ b/apps/webapp/src/modules/layout/components/InsideLayoutContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+/**
+ * True beneath a rendered `Layout`. Chrome-owning fallbacks (the router's
+ * ErrorPage) read this to decide whether to supply their own Layout or render
+ * bare under the one already on screen: a route-level error surfaces inside the
+ * shell's Layout, while a root-level one replaces the whole tree, chrome included.
+ */
+export const InsideLayoutContext = createContext(false);

--- a/apps/webapp/src/modules/layout/components/Layout.tsx
+++ b/apps/webapp/src/modules/layout/components/Layout.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { ConfigContext } from '../../config/context/ConfigContext';
 import { ErrorBoundary } from './ErrorBoundary';
+import { InsideLayoutContext } from './InsideLayoutContext';
 import { useConnection } from 'wagmi';
 import { AuthWrapper } from './AuthWrapper';
 import { VStack } from './VStack';
@@ -35,61 +36,63 @@ export function Layout({
   const descriptionContent = metaDescription || siteConfig.description;
 
   return (
-    <div>
-      <title>{titleContent}</title>
-      <meta name="description" content={descriptionContent} />
-      <link rel="icon" href={siteConfig.favicon} />
+    <InsideLayoutContext.Provider value={true}>
+      <div>
+        <title>{titleContent}</title>
+        <meta name="description" content={descriptionContent} />
+        <link rel="icon" href={siteConfig.favicon} />
 
-      {/* Viewport-fixed page background (image + bottom fade), pinned while the
+        {/* Viewport-fixed page background (image + bottom fade), pinned while the
           document scrolls. Defined in globals.css; theme-swapped via the
           --background-image-app-background token. */}
-      <div aria-hidden className="app-background" />
+        <div aria-hidden className="app-background" />
 
-      <VStack className={shellSurfaceClasses()}>
-        <ErrorBoundary>
-          <div className={shellHeaderClasses()}>
-            <div className={shellHeaderContentClasses()}>
-              {/* justify-self-start: in the desktop header grid the logo sits
+        <VStack className={shellSurfaceClasses()}>
+          <ErrorBoundary>
+            <div className={shellHeaderClasses()}>
+              <div className={shellHeaderContentClasses()}>
+                {/* justify-self-start: in the desktop header grid the logo sits
                   in a 1fr flank; without it the anchor stretches across the
                   whole track and empty header space becomes clickable. */}
-              <AppLink to="/" title="Home page" className="desktop:justify-self-start min-w-[96px]">
-                {/* Theme-specific logo: dark is the default; light swaps in under
+                <AppLink to="/" title="Home page" className="desktop:justify-self-start min-w-[96px]">
+                  {/* Theme-specific logo: dark is the default; light swaps in under
                     [data-theme='light'] (the `light:` variant). */}
-                <img src={defaultConfig.logo} alt="logo" width={96} className="light:hidden" />
-                <img src={defaultConfig.logoLight} alt="logo" width={96} className="light:block hidden" />
-              </AppLink>
-              <TopNav />
+                  <img src={defaultConfig.logo} alt="logo" width={96} className="light:hidden" />
+                  <img src={defaultConfig.logoLight} alt="logo" width={96} className="light:block hidden" />
+                </AppLink>
+                <TopNav />
+              </div>
             </div>
-          </div>
-        </ErrorBoundary>
+          </ErrorBoundary>
 
-        <ErrorBoundary>
-          {isConnectedAndAcceptedTerms && !chain ? (
-            <UnsupportedNetworkPage>{children}</UnsupportedNetworkPage>
-          ) : (
-            <AuthWrapper>{children}</AuthWrapper>
-          )}
-        </ErrorBoundary>
+          <ErrorBoundary>
+            {isConnectedAndAcceptedTerms && !chain ? (
+              <UnsupportedNetworkPage>{children}</UnsupportedNetworkPage>
+            ) : (
+              <AuthWrapper>{children}</AuthWrapper>
+            )}
+          </ErrorBoundary>
 
-        {/* Clearance for the fixed bottom MobileNavbar (60px pill + 16px top
+          {/* Clearance for the fixed bottom MobileNavbar (60px pill + 16px top
             pad + max(16px, safe-area) bottom pad) so the end of the content can
             scroll out from under it. A spacer rather than padding utilities so
             it stays independent of the surface's own spacing. */}
-        <div
-          aria-hidden
-          className="desktop:hidden h-[calc(92px+env(safe-area-inset-bottom,0px))] w-full shrink-0"
-        />
-      </VStack>
+          <div
+            aria-hidden
+            className="desktop:hidden h-[calc(92px+env(safe-area-inset-bottom,0px))] w-full shrink-0"
+          />
+        </VStack>
 
-      <ErrorBoundary>
-        <MobileNavbar />
-      </ErrorBoundary>
-      <Banner />
-      {showEnvInfo && (
-        <div className="absolute bottom-0 left-2">
-          <Text className="text-text text-xs">{import.meta.env.VITE_CF_PAGES_COMMIT_SHA}</Text>
-        </div>
-      )}
-    </div>
+        <ErrorBoundary>
+          <MobileNavbar />
+        </ErrorBoundary>
+        <Banner />
+        {showEnvInfo && (
+          <div className="absolute bottom-0 left-2">
+            <Text className="text-text text-xs">{import.meta.env.VITE_CF_PAGES_COMMIT_SHA}</Text>
+          </div>
+        )}
+      </div>
+    </InsideLayoutContext.Provider>
   );
 }

--- a/apps/webapp/src/pages/ErrorPage.test.tsx
+++ b/apps/webapp/src/pages/ErrorPage.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The real Layout drags in the whole shell (wagmi, config, nav); the test only
+// asserts whether ErrorPage adds a Layout of its own or renders bare.
+vi.mock('../modules/layout/components/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <div data-testid="own-layout">{children}</div>
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  AppLink: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>
+}));
+
+vi.mock('@/modules/sentry/reportError', () => ({
+  reportError: vi.fn()
+}));
+
+import { InsideLayoutContext } from '../modules/layout/components/InsideLayoutContext';
+import ErrorPage from './ErrorPage';
+
+afterEach(cleanup);
+
+describe('ErrorPage', () => {
+  it('renders bare under an already-rendered Layout (no second header — APP-443 item 4)', () => {
+    render(
+      <InsideLayoutContext.Provider value={true}>
+        <ErrorPage />
+      </InsideLayoutContext.Provider>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    expect(screen.queryByTestId('own-layout')).toBeNull();
+  });
+
+  it('supplies its own Layout when no shell chrome survived the error', () => {
+    render(<ErrorPage />);
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    expect(screen.getByTestId('own-layout')).toBeTruthy();
+  });
+});

--- a/apps/webapp/src/pages/ErrorPage.tsx
+++ b/apps/webapp/src/pages/ErrorPage.tsx
@@ -1,11 +1,17 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Layout } from '../modules/layout/components/Layout';
+import { InsideLayoutContext } from '../modules/layout/components/InsideLayoutContext';
 import { AppLink } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
 import { Heading } from '@/modules/layout/components/Typography';
 import { reportError } from '@/modules/sentry/reportError';
 
 function ErrorPage({ error }: { error?: unknown }): React.ReactElement {
+  // Route-level errors surface inside the shell's Layout (header included);
+  // wrapping again there would draw the header twice. Only a boundary above the
+  // shell — where no chrome survived the error — supplies its own Layout.
+  const insideLayout = useContext(InsideLayoutContext);
+
   useEffect(() => {
     if (!error) return;
 
@@ -17,19 +23,19 @@ function ErrorPage({ error }: { error?: unknown }): React.ReactElement {
     });
   }, [error]);
 
-  return (
-    <Layout>
-      <div className="my-6 text-center">
-        <Heading variant="large">Something went wrong</Heading>
+  const content = (
+    <div className="my-6 text-center">
+      <Heading variant="large">Something went wrong</Heading>
 
-        <AppLink to="/">
-          <Button variant="secondary" className="mt-4 ml-4">
-            Back to homepage
-          </Button>
-        </AppLink>
-      </div>
-    </Layout>
+      <AppLink to="/">
+        <Button variant="secondary" className="mt-4 ml-4">
+          Back to homepage
+        </Button>
+      </AppLink>
+    </div>
   );
+
+  return insideLayout ? content : <Layout>{content}</Layout>;
 }
 
 export default ErrorPage;


### PR DESCRIPTION
Fixes items 3 and 4 of [APP-443](https://linear.app/ekliptyka/issue/APP-443/redesign-qa-round-july-31).

## Item 3 — Convert page crashes without a wallet connected

`useNetworkFee` builds its gas-estimate cache key by ABI-encoding the flow's calls at render time. With no account connected, the PSM engine's `buyGem` call carries `usr ?? address = undefined` as the recipient, so viem threw `InvalidAddressError` during render and took the page down. Every other consumer of the hook is a modal form that only mounts with a wallet connected — Convert is the first page-level consumer, which is why only it crashed.

The key computation now treats "can't encode" as "nothing to estimate yet" (the hook is documented as read-only and must never block a flow), and the gas query stays disabled until the calls are encodable.

## Item 4 — Error page renders the header twice

Route-level errors surface at the failing route's catch boundary, which sits *inside* the shell's `Layout` — and `ErrorPage` unconditionally wrapped itself in `Layout` again, drawing the header twice.

`Layout` now provides an `InsideLayoutContext`, and `ErrorPage` renders bare when a `Layout` is already on screen, supplying its own only when the error replaced the whole tree (an error in the shell itself, or in a root-level page like the legal notice that wraps itself in `Layout`).

## Testing

- Reproduced the crash live (wallet-less `/convert`), verified both fixes in the browser: the page renders cleanly, and a forced route error shows a single functional header.
- New regression tests: `useNetworkFee.test.tsx` (survives unencodable calls) and `ErrorPage.test.tsx` (bare under an existing Layout / own Layout otherwise).
- `pnpm typecheck`, eslint, prettier clean; convert-module + shared-hooks suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)