### PR TITLE
APP-443: redesign QA round July 31 (items 19-21)

### DIFF
--- a/apps/webapp/src/hooks/shared/useFilteredPortfolioHistory.test.tsx
+++ b/apps/webapp/src/hooks/shared/useFilteredPortfolioHistory.test.tsx
@@ -87,7 +87,7 @@ describe('useFilteredPortfolioHistory — source selection', () => {
 
   it('serves the family document for an Envio-backed product filter', () => {
     const { result } = renderHook(() =>
-      useFilteredPortfolioHistory({ product: ModuleEnum.STAKE, network: chainIdMap.mainnet })
+      useFilteredPortfolioHistory({ products: [ModuleEnum.STAKE], network: chainIdMap.mainnet })
     );
 
     expect(result.current.data[0].transactionHash).toBe('0xfamily');
@@ -96,12 +96,42 @@ describe('useFilteredPortfolioHistory — source selection', () => {
   });
 
   it('serves the REST hooks for Morpho and Pendle products', () => {
-    const morpho = renderHook(() => useFilteredPortfolioHistory({ product: ModuleEnum.MORPHO }));
+    const morpho = renderHook(() => useFilteredPortfolioHistory({ products: [ModuleEnum.MORPHO] }));
     expect(morpho.result.current.data[0].transactionHash).toBe('0xmorpho');
     expect(morpho.result.current.hasNextPage).toBe(false);
 
-    const pendle = renderHook(() => useFilteredPortfolioHistory({ product: ModuleEnum.PENDLE }));
+    const pendle = renderHook(() => useFilteredPortfolioHistory({ products: [ModuleEnum.PENDLE] }));
     expect(pendle.result.current.data[0].transactionHash).toBe('0xpendle');
+  });
+
+  // APP-443 item 21: the "Vault" filter is one dropdown row over two modules,
+  // so it has to merge the REST Morpho feed with the Envio sUSDT document.
+  it('merges both vault sources behind the grouped Vault filter', () => {
+    const { result } = renderHook(() =>
+      useFilteredPortfolioHistory({ products: [ModuleEnum.MORPHO, ModuleEnum.SUSDT] })
+    );
+
+    expect(result.current.data.map(i => i.transactionHash).sort()).toEqual(['0xfamily', '0xmorpho']);
+    expect(vi.mocked(useHistoryFamilyQuery).mock.calls[0][0]).toMatchObject({
+      family: 'susdt',
+      enabled: true
+    });
+  });
+
+  it('withholds vault REST rows below the sUSDT document floor', () => {
+    vi.mocked(useHistoryFamilyQuery).mockReturnValue(
+      source({ data: [item(500, '0xsusdt')], nextCursor: 400, hasNextPage: true }) as any
+    );
+    vi.mocked(useMorphoVaultHistory).mockReturnValue(
+      source({ data: [item(450, '0xmorpho-above'), item(350, '0xmorpho-below-floor')] }) as any
+    );
+
+    const { result } = renderHook(() =>
+      useFilteredPortfolioHistory({ products: [ModuleEnum.MORPHO, ModuleEnum.SUSDT] })
+    );
+
+    expect(result.current.data.map(i => i.transactionHash)).toEqual(['0xsusdt', '0xmorpho-above']);
+    expect(result.current.hasNextPage).toBe(true);
   });
 
   it('merges PSM and CoW trades under the PSM floor with per-chain cutoffs', () => {
@@ -127,7 +157,7 @@ describe('useFilteredPortfolioHistory — source selection', () => {
           })
         : source()) as any);
 
-    const { result } = renderHook(() => useFilteredPortfolioHistory({ product: ModuleEnum.TRADE }));
+    const { result } = renderHook(() => useFilteredPortfolioHistory({ products: [ModuleEnum.TRADE] }));
 
     // Pre-cutoff CoW trades are PSM swaps (already in the family doc), and
     // post-cutoff ones older than the PSM floor wait for the next page.
@@ -144,7 +174,7 @@ describe('useFilteredPortfolioHistory — source selection', () => {
 
   it('narrows the CoW feeds when the trade filter is network-scoped', () => {
     renderHook(() =>
-      useFilteredPortfolioHistory({ product: ModuleEnum.TRADE, network: chainIdMap.arbitrum })
+      useFilteredPortfolioHistory({ products: [ModuleEnum.TRADE], network: chainIdMap.arbitrum })
     );
 
     const enabledByChain = Object.fromEntries(

--- a/apps/webapp/src/hooks/shared/useFilteredPortfolioHistory.ts
+++ b/apps/webapp/src/hooks/shared/useFilteredPortfolioHistory.ts
@@ -48,24 +48,32 @@ const INERT_PAGINATION = {
  * Filter-scoped queries only fire when their filter is selected, and the
  * always-on sources (aggregate, CoW/Morpho/Pendle) are shared with the
  * aggregate's own instances through the react-query cache.
+ *
+ * `products` is a list because one product in the UI can span several modules:
+ * Morpho and sUSDT are both "Vault" (APP-443 item 21), and their history comes
+ * from two different sources that have to be merged behind the one filter.
  */
 export function useFilteredPortfolioHistory({
-  product,
+  products,
   network
 }: {
-  product?: ModuleEnum;
+  products?: ModuleEnum[];
   network?: number;
 }): FilteredPortfolioHistory {
   const currentChainId = useChainId();
   const mainnetChainId = isTestnetId(currentChainId) ? chainIdMap.tenderly : chainIdMap.mainnet;
   const isMainnetNetwork = network === mainnetChainId;
   const isL2Network = network !== undefined && L2_HISTORY_CHAIN_IDS.includes(network);
-  const family = product !== undefined ? FAMILY_BY_MODULE[product] : undefined;
+  const isFiltered = products !== undefined && products.length > 0;
+  const wants = (module: ModuleEnum) => isFiltered && products.includes(module);
+  // At most one selected module is Envio-backed — the REST-backed ones (Morpho,
+  // Pendle) have no family — so a group needs a single family document.
+  const family = isFiltered ? products.map(module => FAMILY_BY_MODULE[module]).find(Boolean) : undefined;
 
   const aggregate = useAllNetworksCombinedHistory();
   const ethereumCombined = useEthereumCombinedHistory();
   const l2Combined = useL2CombinedHistory(isL2Network ? network : chainIdMap.base, {
-    enabled: product === undefined && isL2Network
+    enabled: !isFiltered && isL2Network
   });
   const familyQuery = useHistoryFamilyQuery({
     family: family ?? 'savings',
@@ -74,7 +82,7 @@ export function useFilteredPortfolioHistory({
   });
 
   // The CoW side of the trade family (mainnet + post-cutoff hybrid chains).
-  const tradeSelected = product === ModuleEnum.TRADE;
+  const tradeSelected = wants(ModuleEnum.TRADE);
   const mainnetCow = useCowswapTradeHistory({
     chainId: 1,
     enabled: tradeSelected && (network === undefined || isMainnetNetwork)
@@ -91,68 +99,71 @@ export function useFilteredPortfolioHistory({
   const morphoHistory = useMorphoVaultHistory();
   const pendleHistory = usePendleCombinedHistory();
 
-  const tradeData = useMemo(() => {
-    const cowItems: CombinedHistoryItem[] = [
-      ...(mainnetCow.data || []),
-      ...(baseCow.data || []).filter(trade => trade.blockTimestamp >= TRADE_CUTOFF_DATES[chainIdMap.base]),
-      ...(arbitrumCow.data || []).filter(
-        trade => trade.blockTimestamp >= TRADE_CUTOFF_DATES[chainIdMap.arbitrum]
-      )
-    ];
-    return [...(familyQuery.data || []), ...clampHistoryPage(cowItems, familyQuery.nextCursor)].sort(
-      (a, b) => b.blockTimestamp.getTime() - a.blockTimestamp.getTime()
-    );
-  }, [familyQuery.data, familyQuery.nextCursor, mainnetCow.data, baseCow.data, arbitrumCow.data]);
+  // Every REST-backed source the selection asks for, held back to the family
+  // document's completeness floor so rows never insert mid-list on the next
+  // page. With no family document there is no floor and nothing is withheld.
+  const morphoSelected = wants(ModuleEnum.MORPHO);
+  const pendleSelected = wants(ModuleEnum.PENDLE);
+  const restData = useMemo(() => {
+    const items: CombinedHistoryItem[] = [];
+    if (tradeSelected) {
+      items.push(
+        ...(mainnetCow.data || []),
+        ...(baseCow.data || []).filter(trade => trade.blockTimestamp >= TRADE_CUTOFF_DATES[chainIdMap.base]),
+        ...(arbitrumCow.data || []).filter(
+          trade => trade.blockTimestamp >= TRADE_CUTOFF_DATES[chainIdMap.arbitrum]
+        )
+      );
+    }
+    if (morphoSelected) items.push(...(morphoHistory.data || []));
+    if (pendleSelected) items.push(...(pendleHistory.data || []));
+    return items;
+  }, [
+    tradeSelected,
+    morphoSelected,
+    pendleSelected,
+    mainnetCow.data,
+    baseCow.data,
+    arbitrumCow.data,
+    morphoHistory.data,
+    pendleHistory.data
+  ]);
+
+  const filteredData = useMemo(
+    () =>
+      [
+        ...(family !== undefined ? familyQuery.data || [] : []),
+        ...clampHistoryPage(restData, family !== undefined ? familyQuery.nextCursor : undefined)
+      ].sort((a, b) => b.blockTimestamp.getTime() - a.blockTimestamp.getTime()),
+    [family, familyQuery.data, familyQuery.nextCursor, restData]
+  );
 
   // No product filter → the network-scoped (or full) aggregates.
-  if (product === undefined) {
+  if (!isFiltered) {
     if (isMainnetNetwork) return ethereumCombined;
     if (isL2Network) return l2Combined;
     return aggregate;
   }
 
-  switch (product) {
-    case ModuleEnum.MORPHO:
-      return {
-        data: morphoHistory.data || [],
-        isLoading: morphoHistory.isLoading,
-        error: morphoHistory.error,
-        mutate: morphoHistory.mutate,
-        ...INERT_PAGINATION
-      };
-    case ModuleEnum.PENDLE:
-      return {
-        data: pendleHistory.data || [],
-        isLoading: pendleHistory.isLoading,
-        error: pendleHistory.error,
-        mutate: pendleHistory.mutate,
-        ...INERT_PAGINATION
-      };
-    case ModuleEnum.TRADE:
-      return {
-        data: tradeData,
-        isLoading:
-          familyQuery.isLoading || mainnetCow.isLoading || baseCow.isLoading || arbitrumCow.isLoading,
-        error: familyQuery.error || mainnetCow.error || baseCow.error || arbitrumCow.error,
-        mutate: () => {
-          familyQuery.mutate();
-          mainnetCow.mutate();
-          baseCow.mutate();
-          arbitrumCow.mutate();
-        },
-        hasNextPage: Boolean(familyQuery.hasNextPage),
-        isFetchingNextPage: familyQuery.isFetchingNextPage,
-        fetchNextPage: familyQuery.fetchNextPage
-      };
-    default:
-      return {
-        data: familyQuery.data || [],
-        isLoading: familyQuery.isLoading,
-        error: familyQuery.error,
-        mutate: familyQuery.mutate,
-        hasNextPage: Boolean(familyQuery.hasNextPage),
-        isFetchingNextPage: familyQuery.isFetchingNextPage,
-        fetchNextPage: familyQuery.fetchNextPage
-      };
-  }
+  type SelectedSource = { isLoading: boolean; error: Error | null; mutate: () => void };
+  const sources: SelectedSource[] = [];
+  if (family !== undefined) sources.push(familyQuery);
+  if (tradeSelected) sources.push(mainnetCow, baseCow, arbitrumCow);
+  if (morphoSelected) sources.push(morphoHistory);
+  if (pendleSelected) sources.push(pendleHistory);
+
+  return {
+    data: filteredData,
+    isLoading: sources.some(source => source.isLoading),
+    error: sources.map(source => source.error).find(Boolean) ?? null,
+    mutate: () => sources.forEach(source => source.mutate()),
+    // Only the family document paginates; the REST feeds arrive whole.
+    ...(family !== undefined
+      ? {
+          hasNextPage: Boolean(familyQuery.hasNextPage),
+          isFetchingNextPage: familyQuery.isFetchingNextPage,
+          fetchNextPage: familyQuery.fetchNextPage
+        }
+      : INERT_PAGINATION)
+  };
 }

--- a/apps/webapp/src/modules/portfolio/components/EarnMarketplaceCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/EarnMarketplaceCard.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Trans } from '@lingui/react/macro';
-import type { EarnProductRow, EarnRiskTier } from '@/hooks';
+import type { EarnProductRow } from '@/hooks';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Text } from '@/modules/layout/components/Typography';
@@ -11,12 +11,6 @@ import { RateBadge } from '@/components/ui/RateBadge';
 import { RiskTierDetailsTrigger } from '@/components/product/RiskTierDetails';
 import { productIconSymbol, productStatusType } from '@/components/product/productVisuals';
 import { ProductGlyph } from './ProductGlyph';
-
-const RISK_LABEL: Record<EarnRiskTier, ReactNode> = {
-  low: <Trans>Low</Trans>,
-  moderate: <Trans>Moderate</Trans>,
-  advanced: <Trans>Advanced</Trans>
-};
 
 /**
  * Card version of an Earn marketplace row, shown in the Portfolio "Earn with
@@ -60,15 +54,14 @@ export function EarnMarketplaceCard({ row, onStart }: { row: EarnProductRow; onS
         </Text>
       </div>
 
+      {/* Supply leads, Risk follows, and Risk is the bare meter — no tier word
+          beside it (1036:189284 dark / 1030:58560 light, APP-443 item 20). */}
       <div className="mt-auto grid grid-cols-2 gap-4">
-        <Stat label={<Trans>Risk</Trans>}>
-          <div className="flex items-center gap-2">
-            <RiskTierDetailsTrigger profile={row.riskProfile} />
-            <span className="text-text font-circle text-sm font-medium">{RISK_LABEL[row.risk]}</span>
-          </div>
-        </Stat>
         <Stat label={<Trans>Supply</Trans>}>
           <TokenIconStack symbols={row.supplyTokens} size={20} />
+        </Stat>
+        <Stat label={<Trans>Risk</Trans>}>
+          <RiskTierDetailsTrigger profile={row.riskProfile} />
         </Stat>
       </div>
 

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.test.tsx
@@ -1,6 +1,6 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
-import { render, screen, within, cleanup } from '@testing-library/react';
+import { render, screen, within, cleanup, fireEvent } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ModuleEnum, TransactionTypeEnum } from '@/hooks';
 import type { PortfolioTxRow } from '../helpers/transactionRow';
@@ -26,6 +26,36 @@ vi.mock('@/hooks', async importOriginal => {
   return { ...actual, useBreakpointIndex: () => ({ bpi: 99 }) };
 });
 vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
+
+// Radix Select renders its items in a portal only once opened, which happy-dom
+// can't drive; swap in a native select carrying the same options and testid so
+// the derived filter lists are inspectable.
+vi.mock('@/components/product/FilterSelect', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/components/product/FilterSelect')>();
+  return {
+    ...actual,
+    FilterSelect: ({
+      testId,
+      options,
+      selected,
+      onChange
+    }: {
+      testId?: string;
+      options: { value: string; label: React.ReactNode }[];
+      selected: string;
+      onChange: (value: string) => void;
+    }) => (
+      <select data-testid={testId} value={selected} onChange={event => onChange(event.target.value)}>
+        <option value="all">All</option>
+        {options.map(option => (
+          <option key={option.value} value={option.value}>
+            {typeof option.label === 'string' ? option.label : option.value}
+          </option>
+        ))}
+      </select>
+    )
+  };
+});
 
 const row = (o: Partial<PortfolioTxRow>): PortfolioTxRow => ({
   id: 'r',
@@ -108,5 +138,27 @@ describe('PortfolioTransactionsView', () => {
     expect(within(table).queryByText('Vault Withdraw')).not.toBeNull();
     expect(within(table).queryByText('Stake')).not.toBeNull();
     expect(within(table).queryByText('Staking')).not.toBeNull(); // stake product label
+  });
+
+  // APP-443 item 21: Morpho and sUSDT are both "Vault", and keying the filter
+  // by module listed that name twice.
+  it('offers one Vault row for the two vault modules, and filters on both', () => {
+    renderView([
+      row({ id: 'a', module: ModuleEnum.SAVINGS, action: 'Savings Supply' }),
+      row({ id: 'b', module: ModuleEnum.MORPHO, action: 'Morpho Withdraw' }),
+      row({ id: 'c', module: ModuleEnum.SUSDT, action: 'Susdt Supply' })
+    ]);
+
+    const productFilter = screen.getByTestId('portfolio-tx-filter-product');
+    const labels = within(productFilter)
+      .getAllByRole('option')
+      .map(option => option.textContent);
+    expect(labels).toEqual(['All', 'Savings', 'Vault']);
+
+    fireEvent.change(productFilter, { target: { value: 'vault' } });
+    const table = screen.getByTestId('portfolio-transactions-table');
+    expect(within(table).queryByText('Morpho Withdraw')).not.toBeNull();
+    expect(within(table).queryByText('Susdt Supply')).not.toBeNull();
+    expect(within(table).queryByText('Savings Supply')).toBeNull();
   });
 });

--- a/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
+++ b/apps/webapp/src/modules/portfolio/components/PortfolioTransactionsSection.tsx
@@ -39,29 +39,30 @@ import { PortfolioTxRow, RewardTokenLookup, toPortfolioTxRow } from '../helpers/
 
 const ALL = 'all';
 
+/**
+ * The products the history is grouped by, in dropdown order.
+ *
+ * A product is not always one module: Morpho and sUSDT are both "Vault", and
+ * keying the filter by module put two identical "Vault" rows in the dropdown
+ * (APP-443 item 21). One entry per product, each owning its module(s), is also
+ * the single source of truth for the Product column's label.
+ */
+export const PRODUCT_GROUPS: { id: string; modules: ModuleEnum[]; label: () => string }[] = [
+  { id: 'savings', modules: [ModuleEnum.SAVINGS], label: () => t`Savings` },
+  { id: 'stusds', modules: [ModuleEnum.STUSDS], label: () => t`stUSDS` },
+  { id: 'vault', modules: [ModuleEnum.MORPHO, ModuleEnum.SUSDT], label: () => t`Vault` },
+  { id: 'fixed', modules: [ModuleEnum.PENDLE], label: () => t`Fixed Yield` },
+  { id: 'rewards', modules: [ModuleEnum.REWARDS], label: () => t`Rewards` },
+  { id: 'stake', modules: [ModuleEnum.STAKE], label: () => t`Staking` },
+  { id: 'upgrade', modules: [ModuleEnum.UPGRADE], label: () => t`Upgrade` },
+  { id: 'trade', modules: [ModuleEnum.TRADE], label: () => t`Trade` }
+];
+
+const groupForModule = (module: ModuleEnum) => PRODUCT_GROUPS.find(g => g.modules.includes(module));
+
 // Human product name per module for the Product column.
 function productName(module: ModuleEnum): string {
-  switch (module) {
-    case ModuleEnum.SAVINGS:
-      return t`Savings`;
-    case ModuleEnum.STUSDS:
-      return t`stUSDS`;
-    case ModuleEnum.MORPHO:
-    case ModuleEnum.SUSDT:
-      return t`Vault`;
-    case ModuleEnum.REWARDS:
-      return t`Rewards`;
-    case ModuleEnum.STAKE:
-      return t`Staking`;
-    case ModuleEnum.UPGRADE:
-      return t`Upgrade`;
-    case ModuleEnum.PENDLE:
-      return t`Fixed Yield`;
-    case ModuleEnum.TRADE:
-      return t`Trade`;
-    default:
-      return '';
-  }
+  return groupForModule(module)?.label() ?? '';
 }
 
 function actionIcon(row: PortfolioTxRow): ReactNode {
@@ -188,10 +189,12 @@ export function PortfolioTransactionsView({
 
   // Filter options derived from what's actually present, so we never offer an
   // empty filter. Stablecoins are limited to rows that carry a USD value.
+  // Products are grouped, so two modules that share a name (Morpho / sUSDT →
+  // "Vault") offer one row that selects both.
   const { networks, stablecoins, products } = useMemo(() => {
     const net = new Map<string, ReactNode>();
     const stable = new Map<string, ReactNode>();
-    const prod = new Map<string, ReactNode>();
+    const groupIds = new Set<string>();
     for (const row of optionRows ?? rows) {
       net.set(
         String(row.chainId),
@@ -209,12 +212,16 @@ export function PortfolioTransactionsView({
           </span>
         );
       }
-      prod.set(row.module, productName(row.module));
+      const group = groupForModule(row.module);
+      if (group) groupIds.add(group.id);
     }
     return {
       networks: [...net].map(([value, label]) => ({ value, label })),
       stablecoins: [...stable].map(([value, label]) => ({ value, label })),
-      products: [...prod].map(([value, label]) => ({ value, label }))
+      products: PRODUCT_GROUPS.filter(group => groupIds.has(group.id)).map(group => ({
+        value: group.id,
+        label: group.label()
+      }))
     };
   }, [optionRows, rows, chainName]);
 
@@ -224,7 +231,7 @@ export function PortfolioTransactionsView({
         row =>
           (network === ALL || String(row.chainId) === network) &&
           (stablecoin === ALL || row.symbol === stablecoin) &&
-          (product === ALL || row.module === product)
+          (product === ALL || groupForModule(row.module)?.id === product)
       ),
     [rows, network, stablecoin, product]
   );
@@ -301,7 +308,7 @@ export function PortfolioTransactionsSection() {
   const aggregate = useAllNetworksCombinedHistory();
   const { data, isLoading, error, hasNextPage, fetchNextPage } = useFilteredPortfolioHistory({
     network: network === ALL ? undefined : Number(network),
-    product: product === ALL ? undefined : (product as ModuleEnum)
+    products: product === ALL ? undefined : PRODUCT_GROUPS.find(g => g.id === product)?.modules
   });
 
   // Reward claims only carry the reward contract address; resolve it to the

--- a/apps/webapp/src/modules/ui/components/Chart.test.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.test.tsx
@@ -53,55 +53,43 @@ describe('resolveTooltipLabel', () => {
   });
 });
 
-// APP-443 item 19.4: hovering dims the whole series and relights only the span
-// between the neighbouring data points, never narrower than the DS mock's 44px.
+// APP-443 item 19.4: hovering dims the whole series and relights only the DS
+// mock's 44px window around the hover point.
 describe('HoverDimMask', () => {
-  const renderMask = (pointCount: number) =>
+  const renderMask = () =>
     render(
       <svg>
-        <HoverDimMask id="dim" pointCount={pointCount} />
+        <HoverDimMask id="dim" />
       </svg>
     );
 
-  it('lights the span from the previous data point to the next one', () => {
+  it('dims the plot and lights a 44px window around the hover point', () => {
     h.isActive = true;
     h.coordinate = { x: 300, y: 100 };
-    // 9 points across 800px → a 100px step either side of the cursor.
-    renderMask(9);
+    renderMask();
 
     expect(Number(screen.getByTestId('chart-dim-mask-base').getAttribute('opacity'))).toBeLessThan(1);
 
     const lit = screen.getByTestId('chart-dim-mask-lit');
-    expect(lit.getAttribute('x')).toBe('200');
-    expect(lit.getAttribute('width')).toBe('200');
-    expect(lit.getAttribute('fill')).toBe('white');
-  });
-
-  it('widens a dense series to the minimum window instead of lighting a sliver', () => {
-    h.isActive = true;
-    h.coordinate = { x: 300, y: 100 };
-    // 401 points across 800px → a 2px step, well under the 22px floor.
-    renderMask(401);
-
-    const lit = screen.getByTestId('chart-dim-mask-lit');
     expect(lit.getAttribute('x')).toBe('278');
     expect(lit.getAttribute('width')).toBe('44');
+    expect(lit.getAttribute('fill')).toBe('white');
   });
 
   it('clamps the window to the plot at the edges', () => {
     h.isActive = true;
     h.coordinate = { x: 0, y: 100 };
-    renderMask(9);
+    renderMask();
 
     const lit = screen.getByTestId('chart-dim-mask-lit');
     expect(lit.getAttribute('x')).toBe('0');
-    expect(lit.getAttribute('width')).toBe('100');
+    expect(lit.getAttribute('width')).toBe('22');
   });
 
   it('shows the whole plot at full strength when nothing is hovered', () => {
     h.isActive = false;
     h.coordinate = undefined;
-    renderMask(9);
+    renderMask();
 
     const base = screen.getByTestId('chart-dim-mask-base');
     expect(base.getAttribute('width')).toBe('800');

--- a/apps/webapp/src/modules/ui/components/Chart.test.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.test.tsx
@@ -53,37 +53,60 @@ describe('resolveTooltipLabel', () => {
   });
 });
 
+// APP-443 item 19.4: hovering dims the whole series and relights only the span
+// between the neighbouring data points, never narrower than the DS mock's 44px.
 describe('HoverDimMask', () => {
-  it('dims the plot past the hover cursor, full strength before it', () => {
-    h.isActive = true;
-    h.coordinate = { x: 300, y: 100 };
+  const renderMask = (pointCount: number) =>
     render(
       <svg>
-        <HoverDimMask id="dim" />
+        <HoverDimMask id="dim" pointCount={pointCount} />
       </svg>
     );
 
-    const lit = screen.getByTestId('chart-dim-mask-lit');
-    expect(lit.getAttribute('width')).toBe('300');
-    expect(lit.getAttribute('fill')).toBe('white');
+  it('lights the span from the previous data point to the next one', () => {
+    h.isActive = true;
+    h.coordinate = { x: 300, y: 100 };
+    // 9 points across 800px → a 100px step either side of the cursor.
+    renderMask(9);
 
-    const dimmed = screen.getByTestId('chart-dim-mask-dimmed');
-    expect(dimmed.getAttribute('x')).toBe('300');
-    expect(dimmed.getAttribute('width')).toBe('500');
-    expect(Number(dimmed.getAttribute('opacity'))).toBeLessThan(1);
+    expect(Number(screen.getByTestId('chart-dim-mask-base').getAttribute('opacity'))).toBeLessThan(1);
+
+    const lit = screen.getByTestId('chart-dim-mask-lit');
+    expect(lit.getAttribute('x')).toBe('200');
+    expect(lit.getAttribute('width')).toBe('200');
+    expect(lit.getAttribute('fill')).toBe('white');
+  });
+
+  it('widens a dense series to the minimum window instead of lighting a sliver', () => {
+    h.isActive = true;
+    h.coordinate = { x: 300, y: 100 };
+    // 401 points across 800px → a 2px step, well under the 22px floor.
+    renderMask(401);
+
+    const lit = screen.getByTestId('chart-dim-mask-lit');
+    expect(lit.getAttribute('x')).toBe('278');
+    expect(lit.getAttribute('width')).toBe('44');
+  });
+
+  it('clamps the window to the plot at the edges', () => {
+    h.isActive = true;
+    h.coordinate = { x: 0, y: 100 };
+    renderMask(9);
+
+    const lit = screen.getByTestId('chart-dim-mask-lit');
+    expect(lit.getAttribute('x')).toBe('0');
+    expect(lit.getAttribute('width')).toBe('100');
   });
 
   it('shows the whole plot at full strength when nothing is hovered', () => {
     h.isActive = false;
     h.coordinate = undefined;
-    render(
-      <svg>
-        <HoverDimMask id="dim" />
-      </svg>
-    );
+    renderMask(9);
 
-    expect(screen.getByTestId('chart-dim-mask-lit').getAttribute('width')).toBe('800');
-    expect(screen.queryByTestId('chart-dim-mask-dimmed')).toBeNull();
+    const base = screen.getByTestId('chart-dim-mask-base');
+    expect(base.getAttribute('width')).toBe('800');
+    expect(Number(base.getAttribute('opacity'))).toBe(1);
+    expect(screen.queryByTestId('chart-dim-mask-lit')).toBeNull();
   });
 });
 

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -153,11 +153,32 @@ const CustomizedLabel = (
  */
 const SERIES_STROKE_WIDTH = 1.5;
 /** Hover dot: 12px overall — r 5.25 under a 1.5 ring in the series colour. */
-const ACTIVE_DOT = {
-  r: 5.25,
-  strokeWidth: SERIES_STROKE_WIDTH,
-  fill: 'var(--color-statusBrandBg)'
-} as const;
+const ACTIVE_DOT_RADIUS = 5.25;
+
+/**
+ * The ringed dot under the hover cursor (Figma 5273:12162).
+ *
+ * Its core is drawn twice: an opaque page-background disc under the
+ * `statusBrandBg` tint. The tint alone is 10% alpha, so the series and the
+ * dashed hover cursor both read straight through the dot — the comp draws it
+ * solid.
+ */
+function ActiveDot({ cx, cy, color }: { cx?: number; cy?: number; color?: string }) {
+  if (cx == null || cy == null) return null;
+  return (
+    <g data-testid="chart-active-dot">
+      <circle cx={cx} cy={cy} r={ACTIVE_DOT_RADIUS} fill="var(--color-pageBackground)" />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={ACTIVE_DOT_RADIUS}
+        fill="var(--color-statusBrandBg)"
+        stroke={color}
+        strokeWidth={SERIES_STROKE_WIDTH}
+      />
+    </g>
+  );
+}
 
 /** How much of the series' alpha survives outside the hover window (DS Line hover). */
 const POST_CURSOR_ALPHA = 0.4;
@@ -672,7 +693,7 @@ function ChartContent({
               // No resting points — the DS plots the bare line.
               dot={false}
               // Ringed hover dot at the cursor point (Figma 5273:12162).
-              activeDot={{ ...ACTIVE_DOT, stroke: seriesColor }}
+              activeDot={<ActiveDot color={seriesColor} />}
             />
           </AreaChart>
         </ResponsiveContainer>

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -159,17 +159,26 @@ const ACTIVE_DOT = {
   fill: 'var(--color-statusBrandBg)'
 } as const;
 
-/** How much of the series' alpha survives past the hover cursor (DS Line hover). */
+/** How much of the series' alpha survives outside the hover window (DS Line hover). */
 const POST_CURSOR_ALPHA = 0.4;
 
 /**
- * DS Line hover (Figma 5273:12162): the plotted series keeps full strength up
- * to the hover cursor and dims past it. Implemented as a luminance mask on the
- * Area — white keeps the series, gray fades stroke+fill together — so the
- * dimming can't veil the glass card background the way an overlay rect would.
- * Rendered inside the AreaChart, where recharts' chart-context hooks resolve.
+ * Narrowest half-width of the lit window, in px. The DS mock's mask measures
+ * 45px across (Figma 5391:44830), which on its dense series spans well past
+ * the neighbouring points; keeping that as a floor stops a year of daily data
+ * — ~2px apart — from collapsing the highlight into the hover dot.
  */
-export function HoverDimMask({ id }: { id: string }) {
+const MIN_HALF_WINDOW = 22;
+
+/**
+ * DS Line hover (Figma 5273:12162): the plotted series dims and only the range
+ * from the previous data point to the next one stays at full strength.
+ * Implemented as a luminance mask on the Area — white keeps the series, gray
+ * fades stroke+fill together — so the dimming can't veil the glass card
+ * background the way an overlay rect would. Rendered inside the AreaChart,
+ * where recharts' chart-context hooks resolve.
+ */
+export function HoverDimMask({ id, pointCount }: { id: string; pointCount: number }) {
   const isActive = useIsTooltipActive();
   const coordinate = useActiveTooltipCoordinate();
   const width = useChartWidth();
@@ -178,31 +187,69 @@ export function HoverDimMask({ id }: { id: string }) {
   // full-coverage white mask so the series never flashes hidden.
   const cursorX = isActive && coordinate && width != null ? coordinate.x : null;
 
+  // Points sit on an evenly-spaced band across the plot (category axis, zero
+  // left/right margins), so one step is the distance to either neighbour.
+  const step = pointCount > 1 && width != null ? width / (pointCount - 1) : 0;
+  const halfWindow = Math.max(step, MIN_HALF_WINDOW);
+  const litStart = cursorX != null ? Math.max(cursorX - halfWindow, 0) : 0;
+  const litEnd = cursorX != null && width != null ? Math.min(cursorX + halfWindow, width) : 0;
+
   return (
     <defs>
       <mask id={id} maskUnits="userSpaceOnUse" x={0} y={0} width={width ?? '100%'} height={height ?? '100%'}>
         <rect
-          data-testid="chart-dim-mask-lit"
+          data-testid="chart-dim-mask-base"
           x={0}
           y={0}
-          width={cursorX ?? width ?? '100%'}
+          width={width ?? '100%'}
           height={height ?? '100%'}
           fill="white"
+          opacity={cursorX != null ? POST_CURSOR_ALPHA : 1}
         />
-        {cursorX != null && width != null && (
+        {cursorX != null && (
           <rect
-            data-testid="chart-dim-mask-dimmed"
-            x={cursorX}
+            data-testid="chart-dim-mask-lit"
+            x={litStart}
             y={0}
-            width={Math.max(width - cursorX, 0)}
+            width={Math.max(litEnd - litStart, 0)}
             height={height ?? '100%'}
             fill="white"
-            opacity={POST_CURSOR_ALPHA}
           />
         )}
       </mask>
     </defs>
   );
+}
+
+/** Id of the body-level layer every chart tooltip renders into. */
+const TOOLTIP_PORTAL_ID = 'chart-tooltip-portal';
+
+/**
+ * The layer the chart tooltip is portalled into (APP-443 item 19.1).
+ *
+ * Rendered inside the chart card, the tooltip's `backdrop-filter` has nothing
+ * to work with: the card carries its own `backdrop-blur`, which makes it a
+ * backdrop root, and a nested backdrop-filter then samples an empty backdrop —
+ * so the plot showed straight through the panel unblurred. Hoisting it to the
+ * body puts it in the same position as every other app tooltip, which is
+ * portalled by Radix, and the frost resolves against the page.
+ */
+function useChartTooltipPortal(): HTMLElement | null {
+  const [portal, setPortal] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    let element = document.getElementById(TOOLTIP_PORTAL_ID);
+    if (!element) {
+      element = document.createElement('div');
+      element.id = TOOLTIP_PORTAL_ID;
+      // z-101 matches the app tooltip tier — above the z-100 popovers.
+      element.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:101';
+      document.body.appendChild(element);
+    }
+    setPortal(element);
+  }, []);
+
+  return portal;
 }
 
 const formatedXAxis = (data: Data[], tf: TimeFrame, bpi: BP) => {
@@ -524,6 +571,10 @@ function ChartContent({
   const { bpi } = useBreakpointIndex();
   const gradientId = useId();
   const dimMaskId = useId();
+  const tooltipPortal = useChartTooltipPortal();
+  // The plot box, so the portalled tooltip can turn recharts' chart-space
+  // coordinate into viewport pixels.
+  const plotRef = useRef<HTMLDivElement>(null);
 
   // components/charts/bg-chart2 unless the caller themes the series (e.g. the
   // Stake destination chart's bg-chart1 indigo).
@@ -547,66 +598,83 @@ function ChartContent({
         </VStack>
       }
     >
-      <ResponsiveContainer width={'100%'} height={resolvedHeight}>
-        <AreaChart
-          data={data}
-          margin={{ top: isLarge ? 12 : 30, right: 0, bottom: isDetail ? 0 : isLarge ? 22 : 0, left: 0 }}
-        >
-          <defs>
-            {/* The area wash is one hue fading to nothing at the plot floor
-                (Figma 859:35718). It used to end at 75% — and, on the default
-                teal, to fade into a *different* hue (#00A167 green) — which is
-                what read as the wrong colour and the short gradient in APP-432
-                item 9. */}
-            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="100%" gradientUnits="objectBoundingBox">
-              <stop offset="0%" stopColor={seriesColor} stopOpacity={0.3} />
-              <stop offset="100%" stopColor={seriesColor} stopOpacity="0" />
-            </linearGradient>
-          </defs>
-          <HoverDimMask id={dimMaskId} />
-          <YAxis domain={['dataMin', 'dataMax']} padding={{ top: 20, bottom: bpi > BP.md ? 20 : 40 }} hide />
-          {/* We can't extract the XAxis component outside of the chart as in the designs */}
-          <XAxis dataKey="date" axisLine={false} tickLine={false} tick={false} />
-          {/* Uncomment tooltip if we want to track day by day with the mouse cursor */}
-          <Tooltip
-            // DS hover cursor: a faint dashed vertical rule (Figma 5273:12162 —
-            // border-quaternary, 3/3 dashes with round caps).
-            cursor={{
-              stroke: 'var(--color-borderQuarternary)',
-              strokeWidth: 1,
-              strokeDasharray: '3 3',
-              strokeLinecap: 'round'
-            }}
-            content={
-              <ChartTooltip
-                symbol={symbol}
-                isPercentage={isPercentage}
-                labelFormatter={date => formatDate(date, activeTimeframe)}
-                prefix={prefix}
-                tooltipLabel={tooltipLabel}
-                tokenSymbols={tokenSymbols}
-              />
-            }
-          />
+      <div ref={plotRef}>
+        <ResponsiveContainer width={'100%'} height={resolvedHeight}>
+          <AreaChart
+            data={data}
+            margin={{ top: isLarge ? 12 : 30, right: 0, bottom: isDetail ? 0 : isLarge ? 22 : 0, left: 0 }}
+          >
+            <defs>
+              {/* The area wash is one hue fading to nothing at the plot floor
+                  (Figma 859:35718). It used to end at 75% — and, on the default
+                  teal, to fade into a *different* hue (#00A167 green) — which is
+                  what read as the wrong colour and the short gradient in APP-432
+                  item 9. */}
+              <linearGradient
+                id={gradientId}
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="100%"
+                gradientUnits="objectBoundingBox"
+              >
+                <stop offset="0%" stopColor={seriesColor} stopOpacity={0.3} />
+                <stop offset="100%" stopColor={seriesColor} stopOpacity="0" />
+              </linearGradient>
+            </defs>
+            <HoverDimMask id={dimMaskId} pointCount={data.length} />
+            <YAxis
+              domain={['dataMin', 'dataMax']}
+              padding={{ top: 20, bottom: bpi > BP.md ? 20 : 40 }}
+              hide
+            />
+            {/* We can't extract the XAxis component outside of the chart as in the designs */}
+            <XAxis dataKey="date" axisLine={false} tickLine={false} tick={false} />
+            {/* Uncomment tooltip if we want to track day by day with the mouse cursor */}
+            <Tooltip
+              // Out of the card so the panel's frost has a backdrop to sample
+              // (see useChartTooltipPortal); the tooltip places itself.
+              portal={tooltipPortal}
+              // DS hover cursor: a faint dashed vertical rule (Figma 5273:12162 —
+              // border-quaternary, 3/3 dashes with round caps).
+              cursor={{
+                stroke: 'var(--color-borderQuarternary)',
+                strokeWidth: 1,
+                strokeDasharray: '3 3',
+                strokeLinecap: 'round'
+              }}
+              content={
+                <ChartTooltip
+                  symbol={symbol}
+                  isPercentage={isPercentage}
+                  labelFormatter={date => formatDate(date, activeTimeframe)}
+                  prefix={prefix}
+                  tooltipLabel={tooltipLabel}
+                  tokenSymbols={tokenSymbols}
+                  anchorRef={plotRef}
+                />
+              }
+            />
 
-          <Area
-            dataKey="value"
-            stroke={seriesColor}
-            strokeWidth={SERIES_STROKE_WIDTH}
-            strokeLinecap="round"
-            type="monotone"
-            fill={`url(#${gradientId})`}
-            // Dim the series past the hover cursor (mask above); the active dot
-            // and tooltip render outside the masked layer, so they stay lit.
-            mask={`url(#${dimMaskId})`}
-            label={<CustomizedLabel /*data={data} stroke="var(--transparent-white-40)"*/ />}
-            // No resting points — the DS plots the bare line.
-            dot={false}
-            // Ringed hover dot at the cursor point (Figma 5273:12162).
-            activeDot={{ ...ACTIVE_DOT, stroke: seriesColor }}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+            <Area
+              dataKey="value"
+              stroke={seriesColor}
+              strokeWidth={SERIES_STROKE_WIDTH}
+              strokeLinecap="round"
+              type="monotone"
+              fill={`url(#${gradientId})`}
+              // Dim everything outside the hover window (mask above); the active
+              // dot renders outside the masked layer, so it stays lit.
+              mask={`url(#${dimMaskId})`}
+              label={<CustomizedLabel /*data={data} stroke="var(--transparent-white-40)"*/ />}
+              // No resting points — the DS plots the bare line.
+              dot={false}
+              // Ringed hover dot at the cursor point (Figma 5273:12162).
+              activeDot={{ ...ACTIVE_DOT, stroke: seriesColor }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
     </LoadingErrorWrapper>
   );
 }

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -163,22 +163,28 @@ const ACTIVE_DOT = {
 const POST_CURSOR_ALPHA = 0.4;
 
 /**
- * Narrowest half-width of the lit window, in px. The DS mock's mask measures
- * 45px across (Figma 5391:44830), which on its dense series spans well past
- * the neighbouring points; keeping that as a floor stops a year of daily data
- * — ~2px apart — from collapsing the highlight into the hover dot.
+ * Half-width of the lit window, in px — the DS mock's mask measures 45px across
+ * (Figma 5391:44830).
+ *
+ * It is a flat number rather than the distance to the neighbouring data points
+ * the ticket describes, because the series are far denser than they look: the
+ * Morpho rate chart plots 170 hourly points over 779px at 1W and 722 at 1M, so
+ * neighbours sit 1–5px apart and a point-relative window would light little
+ * more than the hover dot. Charts sparse enough for it to matter (the portfolio
+ * protocol statistics, 7–8 points) would swing the other way and light a third
+ * of the plot. One width keeps every chart reading alike.
  */
-const MIN_HALF_WINDOW = 22;
+const HALF_WINDOW = 22;
 
 /**
- * DS Line hover (Figma 5273:12162): the plotted series dims and only the range
- * from the previous data point to the next one stays at full strength.
- * Implemented as a luminance mask on the Area — white keeps the series, gray
- * fades stroke+fill together — so the dimming can't veil the glass card
- * background the way an overlay rect would. Rendered inside the AreaChart,
- * where recharts' chart-context hooks resolve.
+ * DS Line hover (Figma 5273:12162): the plotted series dims and only a window
+ * around the hover point stays at full strength. Implemented as a luminance
+ * mask on the Area — white keeps the series, gray fades stroke+fill together —
+ * so the dimming can't veil the glass card background the way an overlay rect
+ * would. Rendered inside the AreaChart, where recharts' chart-context hooks
+ * resolve.
  */
-export function HoverDimMask({ id, pointCount }: { id: string; pointCount: number }) {
+export function HoverDimMask({ id }: { id: string }) {
   const isActive = useIsTooltipActive();
   const coordinate = useActiveTooltipCoordinate();
   const width = useChartWidth();
@@ -187,12 +193,8 @@ export function HoverDimMask({ id, pointCount }: { id: string; pointCount: numbe
   // full-coverage white mask so the series never flashes hidden.
   const cursorX = isActive && coordinate && width != null ? coordinate.x : null;
 
-  // Points sit on an evenly-spaced band across the plot (category axis, zero
-  // left/right margins), so one step is the distance to either neighbour.
-  const step = pointCount > 1 && width != null ? width / (pointCount - 1) : 0;
-  const halfWindow = Math.max(step, MIN_HALF_WINDOW);
-  const litStart = cursorX != null ? Math.max(cursorX - halfWindow, 0) : 0;
-  const litEnd = cursorX != null && width != null ? Math.min(cursorX + halfWindow, width) : 0;
+  const litStart = cursorX != null ? Math.max(cursorX - HALF_WINDOW, 0) : 0;
+  const litEnd = cursorX != null && width != null ? Math.min(cursorX + HALF_WINDOW, width) : 0;
 
   return (
     <defs>
@@ -622,7 +624,7 @@ function ChartContent({
                 <stop offset="100%" stopColor={seriesColor} stopOpacity="0" />
               </linearGradient>
             </defs>
-            <HoverDimMask id={dimMaskId} pointCount={data.length} />
+            <HoverDimMask id={dimMaskId} />
             <YAxis
               domain={['dataMin', 'dataMax']}
               padding={{ top: 20, bottom: bpi > BP.md ? 20 : 40 }}

--- a/apps/webapp/src/modules/ui/components/ChartTooltip.tsx
+++ b/apps/webapp/src/modules/ui/components/ChartTooltip.tsx
@@ -1,5 +1,86 @@
+import { RefObject, useLayoutEffect, useRef, useState } from 'react';
 import { formatNumber } from '@/utils';
 import { TokenIconStack } from './TokenIconStack';
+
+/** Gap between the hover point and the panel — recharts' own default offset. */
+const CURSOR_OFFSET = 10;
+
+type Box = { left: number; top: number; width: number; height: number };
+type Size = { width: number; height: number };
+
+const sameBox = (a: Box | null, b: Box) =>
+  !!a && a.left === b.left && a.top === b.top && a.width === b.width && a.height === b.height;
+
+const sameSize = (a: Size | null, b: Size) => !!a && a.width === b.width && a.height === b.height;
+
+/**
+ * Places the panel at the hover point in viewport pixels.
+ *
+ * The tooltip renders into a body-level fixed layer rather than inside the
+ * chart card (see `Chart.tsx`), so recharts hands over positioning entirely —
+ * it applies none of its own transform when given a `portal`. Both boxes are
+ * measured in a layout effect rather than read during render, and re-measured
+ * on every hover move, so scrolling and resizing stay tracked.
+ */
+function useTooltipPlacement(
+  coordinate: { x: number; y: number } | undefined,
+  anchorRef: RefObject<HTMLElement | null> | undefined
+) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Only the panel's *size* is tracked, never its position: the panel carries
+  // the placement transform, so storing its left/top would re-enter this hook
+  // on every animated frame and spin forever.
+  const [panelSize, setPanelSize] = useState<Size | null>(null);
+  const [anchor, setAnchor] = useState<Box | null>(null);
+  // Whether a previous render already placed the panel. Until one has, the
+  // glide is off — otherwise the first hover animates the panel in from the
+  // layer's origin, i.e. across the page from the top-left corner.
+  const [placed, setPlaced] = useState(false);
+
+  const positioned = Boolean(coordinate && anchorRef && anchor && panelSize);
+
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    if (panel) {
+      const { width, height } = panel.getBoundingClientRect();
+      setPanelSize(prev => (sameSize(prev, { width, height }) ? prev : { width, height }));
+    }
+    const host = anchorRef?.current;
+    if (host) {
+      const rect = host.getBoundingClientRect();
+      const next = { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+      setAnchor(prev => (sameBox(prev, next) ? prev : next));
+    }
+    if (positioned) setPlaced(true);
+  });
+
+  if (!coordinate || !anchorRef) return { panelRef, style: undefined };
+
+  // First paint after activation has no measurements yet — keep the panel out
+  // of sight for that frame instead of flashing it at the layer's origin.
+  if (!anchor || !panelSize)
+    return { panelRef, style: { position: 'absolute', visibility: 'hidden' } as const };
+
+  // Flip to the other side of the cursor when the panel would leave the plot,
+  // which is what recharts does with the default allowEscapeViewBox.
+  const flipX = coordinate.x + CURSOR_OFFSET + panelSize.width > anchor.width;
+  const flipY = coordinate.y + CURSOR_OFFSET + panelSize.height > anchor.height;
+  const x = anchor.left + coordinate.x + (flipX ? -CURSOR_OFFSET - panelSize.width : CURSOR_OFFSET);
+  const y = anchor.top + coordinate.y + (flipY ? -CURSOR_OFFSET - panelSize.height : CURSOR_OFFSET);
+
+  return {
+    panelRef,
+    style: {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      // Transform, not left/top, so the move is compositor-driven — the same
+      // 400ms glide recharts animates its own wrapper with.
+      transform: `translate(${x}px, ${y}px)`,
+      transition: placed ? 'transform 400ms ease-out' : 'none'
+    } as const
+  };
+}
 
 interface CustomTooltipProps {
   active?: boolean;
@@ -17,6 +98,11 @@ interface CustomTooltipProps {
   /** Token(s) the series represents; renders the trailing token icon(s). Omit
    * for non-token series (e.g. a Rate/% metric) to render no trailing icon. */
   tokenSymbols?: string[];
+  /** Hover point in chart pixel space — recharts passes this to `content`. */
+  coordinate?: { x: number; y: number };
+  /** The chart's plot box, for turning `coordinate` into viewport pixels.
+   *  Omit to render the panel in place (unit tests, previews). */
+  anchorRef?: RefObject<HTMLElement | null>;
 }
 
 export function ChartTooltip({
@@ -28,8 +114,11 @@ export function ChartTooltip({
   labelFormatter,
   prefix,
   tooltipLabel,
-  tokenSymbols
+  tokenSymbols,
+  coordinate,
+  anchorRef
 }: CustomTooltipProps) {
+  const { panelRef, style } = useTooltipPlacement(coordinate, anchorRef);
   const isMin = payload?.some(entry => entry.payload?.isMin === true);
   const isMax = payload?.some(entry => entry.payload?.isMax === true);
 
@@ -51,7 +140,12 @@ export function ChartTooltip({
   // 200 is CSS `blur(100px)` (Figma states background blur at twice the CSS
   // value). It used to be the opaque `bg-container` panel at 12px radius.
   return (
-    <div className="bg-bgTertiary flex min-w-40 flex-col gap-1 rounded-2xl p-3 backdrop-blur-[100px]">
+    <div
+      ref={panelRef}
+      style={style}
+      className="bg-bgTertiary flex min-w-40 flex-col gap-1 rounded-2xl p-3 backdrop-blur-[100px]"
+      data-testid="chart-tooltip"
+    >
       <p className="text-fgPrimary font-circle text-xs leading-3.5 font-medium tracking-[-0.24px]">
         {labelFormatter(label)}
       </p>


### PR DESCRIPTION
Closes the last open items of [APP-443](https://linear.app/ekliptyka/issue/APP-443/redesign-qa-round-july-31): 19.1, 19.4, 20 and 21. (19.2 and 19.3 shipped in #1789; 12 is still a copy question for design.)

### 19.1 — chart tooltip has no blur

The panel already carried the app tooltip's chrome, and its dark-mode fill is pixel-identical to the DS mock. The frost, though, never resolved: the tooltip rendered inside the chart card, whose own `backdrop-blur` makes it a **backdrop root**, and a nested `backdrop-filter` then samples an empty backdrop — so the plot line ran straight through the panel, crisp.

It now renders into a body-level fixed layer, which is where every other app tooltip already lives (Radix portals them). recharts drops all of its own positioning once given a `portal`, so the panel places itself from the hover coordinate and the plot's box — 10px off the point, flipped when it would leave the plot, gliding on the same 400ms transform transition recharts used. Two details worth knowing if you touch it:

- only the panel's **size** is kept in state; storing its position would re-enter the layout effect on every animated frame and spin
- the glide is suppressed until a first real placement, so the panel never animates in from the corner of the page

Side benefit: it is no longer clipped by the card's `overflow-hidden`.

### 19.4 — hover dimming

Was: everything up to the cursor lit, everything after dimmed. Now: the whole series dims and only a 44px window around the hover point stays lit — the width the DS mock's own mask measures (5391:44830).

The ticket describes that window as running to the previous and next data points, and it was built that way first, but the series are far denser than they look:

| Chart | Points | Neighbour spacing |
|---|---|---|
| Morpho rate, 1W | 170 (hourly) | 4.6px |
| Morpho rate, 1M | 722 (hourly) | 1.1px |
| Morpho rate, 1Y | 54 (weekly) | 14.7px |
| Portfolio protocol statistics | 7–8 | 135px |

A point-relative window lights barely more than the hover dot on the first three, and a third of the plot on the last. One flat width keeps every chart reading alike.

### 20 — Earn-with-Sky card stats

Supply first, Risk second, and Risk is the bare meter — the tier word ("Low") isn't in either comp.

### 21 — duplicated "Vault" row

Morpho and sUSDT both render as "Vault", and the dropdown was keyed by module, so the name appeared twice. Products are now grouped: one entry per product owning its module(s), which also becomes the single source for the Product column's label and gives the dropdown a stable order (it previously followed whatever order history arrived in).

Selecting a group has to serve both modules, so `useFilteredPortfolioHistory` takes `products` instead of one `product`. Assembling the result from whichever sources the selection asks for — one Envio family document plus any REST feeds, the REST items held to the family's completeness floor — also collapses the Morpho / Pendle / Trade / default branches it used to switch between into one path.

### Verification

`pnpm typecheck` clean · lint 0 errors · 2236/2237 unit tests — the one failure is the pre-existing `EarnFeaturedCards` maturity date-bomb from #1779, confirmed by stashing.

Browser-verified on a local dev server, **both themes**: 19.1 (the line now disappears behind the panel instead of cutting through it), 19.4, and 20. Checked on the portfolio protocol-statistics chart (default variant) and a Morpho vault detail chart (detail variant, real data, edge-flip near the right edge).

**Item 21 is code-only** — reproducing it needs a wallet with both Morpho and sUSDT history, which the local fork doesn't have. It is covered by unit tests on both sides: one Vault option for the two modules and the filter matching both, plus the hook merging the two vault sources and withholding REST rows below the sUSDT document floor.
