### PR TITLE
Slide the Earn drill-down vertically, and re-time the chart reveal

### DIFF
--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -927,6 +927,40 @@
   }
 }
 
+/* Drill-down: moving between the Earn marketplace and a product page travels
+   vertically instead of sideways (Figma: Sky App: UI 1598:77307). The router
+   adds a `drill` type alongside `page` for exactly those navigations, so only
+   the keyframes change here — duration, easing and the 100ms overlap are
+   inherited from the rules above, which still match.
+
+   Direction is constant, as in the horizontal case: the outgoing page always
+   leaves upward and the incoming one always arrives from below, whether you
+   are drilling in or going back. The comp's own travel is 40px, small enough
+   that it needs no viewport cap.
+
+   This must stay above the reduced-motion block, which re-declares the
+   `animation` shorthand and so has to win over this animation-name. */
+@media (prefers-reduced-motion: no-preference) {
+  :root:active-view-transition-type(drill)::view-transition-old(page) {
+    animation-name: page-drill-out;
+  }
+  :root:active-view-transition-type(drill)::view-transition-new(page) {
+    animation-name: page-drill-in;
+  }
+}
+@keyframes page-drill-out {
+  to {
+    opacity: 0;
+    transform: translateY(-40px);
+  }
+}
+@keyframes page-drill-in {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+}
+
 /* Reduced motion (WCAG 2.3.3): keep a crossfade — the page change still needs
    to register, and an instant full-page repaint reads as a flash — but drop
    the translate, which is the part that triggers vestibular discomfort. */

--- a/apps/webapp/src/lib/routes.test.ts
+++ b/apps/webapp/src/lib/routes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Intent } from './enums';
 import { IntentMapping } from './constants';
-import { ROUTES, intentToPath, pathToIntent } from './routes';
+import { ROUTES, intentToPath, isEarnDrilldown, pathToIntent } from './routes';
 
 // TRADE/UPGRADE fold into Convert: intentToPath aliases them, so they sit
 // outside the strict inverse and pathToIntent never returns them.
@@ -58,6 +58,47 @@ describe('pathToIntent', () => {
     expect(pathToIntent('/seal-engine')).toBeNull();
     expect(pathToIntent('/batch-transactions-legal-notice')).toBeNull();
     expect(pathToIntent('/bogus')).toBeNull();
+  });
+});
+
+describe('isEarnDrilldown', () => {
+  it('holds drilling from the marketplace into any product page', () => {
+    expect(isEarnDrilldown(ROUTES.EARN, ROUTES.EARN_SAVINGS)).toBe(true);
+    expect(isEarnDrilldown(ROUTES.EARN, ROUTES.EARN_STUSDS)).toBe(true);
+    expect(isEarnDrilldown(ROUTES.EARN, '/earn/vaults/morpho/0xabc')).toBe(true);
+    expect(isEarnDrilldown(ROUTES.EARN, '/earn/rewards/usds-skyfarm')).toBe(true);
+    expect(isEarnDrilldown(ROUTES.EARN, '/earn/fixed/spk-usds')).toBe(true);
+  });
+
+  it('holds going back up, so both directions animate the same way', () => {
+    expect(isEarnDrilldown(ROUTES.EARN_SAVINGS, ROUTES.EARN)).toBe(true);
+    expect(isEarnDrilldown('/earn/vaults/morpho/0xabc', ROUTES.EARN)).toBe(true);
+  });
+
+  it('rejects lateral moves into a product page from outside Earn', () => {
+    expect(isEarnDrilldown(ROUTES.PORTFOLIO, ROUTES.EARN_SAVINGS)).toBe(false);
+    expect(isEarnDrilldown(ROUTES.STAKE, '/earn/vaults/morpho/0xabc')).toBe(false);
+    expect(isEarnDrilldown(ROUTES.EARN_SAVINGS, ROUTES.PORTFOLIO)).toBe(false);
+  });
+
+  it('rejects product-to-product moves and navigations that skip the marketplace', () => {
+    expect(isEarnDrilldown(ROUTES.EARN_SAVINGS, ROUTES.EARN_STUSDS)).toBe(false);
+    expect(isEarnDrilldown('/earn/vaults/morpho/0xabc', '/earn/vaults/spark/0xdef')).toBe(false);
+  });
+
+  it('rejects navigations that never leave the marketplace or a product page', () => {
+    expect(isEarnDrilldown(ROUTES.EARN, ROUTES.EARN)).toBe(false);
+    expect(isEarnDrilldown(ROUTES.EARN_SAVINGS, ROUTES.EARN_SAVINGS)).toBe(false);
+  });
+
+  it('rejects paths that merely start with the Earn segment', () => {
+    expect(isEarnDrilldown(ROUTES.EARN, '/earnings')).toBe(false);
+    expect(isEarnDrilldown('/earnings', ROUTES.EARN)).toBe(false);
+  });
+
+  it('normalizes trailing slashes and case, as pathToIntent does', () => {
+    expect(isEarnDrilldown('/earn/', '/earn/savings/')).toBe(true);
+    expect(isEarnDrilldown('/Earn', '/Earn/Savings')).toBe(true);
   });
 });
 

--- a/apps/webapp/src/lib/routes.ts
+++ b/apps/webapp/src/lib/routes.ts
@@ -51,13 +51,33 @@ const INTENT_ROUTES = (Object.entries(PATH_BY_INTENT) as [Intent, RoutePath][])
   .filter(([intent]) => !ALIAS_INTENTS.has(intent))
   .sort(([, a], [, b]) => b.length - a.length);
 
+const normalizePath = (pathname: string) => pathname.toLowerCase().replace(/\/+$/, '');
+
 // Classifies a pathname into the Intent its screen consumes (validation,
 // analytics, network mapping). Returns null for intent-less routes; route
 // existence/404 stays the router's concern.
 export function pathToIntent(pathname: string): Intent | null {
-  const path = pathname.toLowerCase().replace(/\/+$/, '');
+  const path = normalizePath(pathname);
   for (const [intent, base] of INTENT_ROUTES) {
     if (path === base || path.startsWith(`${base}/`)) return intent;
   }
   return null;
+}
+
+/**
+ * True when a navigation moves between the Earn marketplace and one of its
+ * product pages, in either direction — the drill-down that the motion comp
+ * (Figma: Sky App: UI 1598:77307) slides vertically rather than sideways.
+ *
+ * Deliberately narrow: arriving at a product page from anywhere else (the
+ * Portfolio, a deep link, the nav) is a lateral move and keeps the horizontal
+ * slide. There is no product-to-product case to weigh, because every bare
+ * sub-path (/earn/vaults, /earn/rewards, /earn/fixed) redirects to /earn — the
+ * only Earn screens that exist are the marketplace and the product leaves.
+ */
+export function isEarnDrilldown(fromPathname: string, toPathname: string): boolean {
+  const from = normalizePath(fromPathname);
+  const to = normalizePath(toPathname);
+  const isProduct = (path: string) => path.startsWith(`${ROUTES.EARN}/`);
+  return (from === ROUTES.EARN && isProduct(to)) || (to === ROUTES.EARN && isProduct(from));
 }

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -170,6 +170,25 @@ const CustomizedDot = ({
 const POST_CURSOR_ALPHA = 0.4;
 
 /**
+ * The series' entrance reveal (Figma: Sky App: UI 1598:77307, where the plot
+ * grows from 1px to its full 760px width). recharts draws exactly that by
+ * default — `AreaRevealShape` wipes the curve in left-to-right behind an
+ * animated clip-path — so this only re-times it from recharts' 1500ms/`ease`
+ * to the comp's figures.
+ *
+ * The easing has to be spelled out rather than read from `--ease-in-out-quart`:
+ * recharts parses the string itself to build an easing function, so it never
+ * reaches CSS where a custom property would resolve.
+ *
+ * No delay is paired with this. The reveal is gated by data, not by the clock —
+ * `LoadingErrorWrapper` holds the skeleton until a series exists, so the Area
+ * mounts (and wipes in) only once there is something to draw, which in practice
+ * lands after any page transition has finished.
+ */
+const REVEAL_DURATION_MS = 900;
+const REVEAL_EASING = 'cubic-bezier(0.77,0,0.175,1)';
+
+/**
  * DS Line hover (Figma 5273:12162): the plotted series keeps full strength up
  * to the hover cursor and dims past it. Implemented as a luminance mask on the
  * Area — white keeps the series, gray fades stroke+fill together — so the
@@ -584,6 +603,12 @@ function ChartContent({
             dot={<CustomizedDot data={data} stroke={seriesColor} />}
             // Ringed hover dot at the cursor point (Figma 5273:12162).
             activeDot={{ r: 5, fill: seriesColor, stroke: 'var(--color-container)', strokeWidth: 3 }}
+            // Entrance wipe — see REVEAL_DURATION_MS. Leaving isAnimationActive
+            // at its 'auto' default is deliberate: it resolves to off under
+            // prefers-reduced-motion (and under SSR), so the reveal needs no
+            // reduced-motion handling of its own.
+            animationDuration={REVEAL_DURATION_MS}
+            animationEasing={REVEAL_EASING}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/apps/webapp/src/pages/router.tsx
+++ b/apps/webapp/src/pages/router.tsx
@@ -4,6 +4,7 @@ import { routeTree } from '../routeTree.gen';
 import ErrorPage from './ErrorPage';
 import { NotFound } from '../modules/layout/components/NotFound';
 import { queryClient as appQueryClient } from '@/lib/queryClient';
+import { isEarnDrilldown } from '@/lib/routes';
 import type { AppSearchParams } from '../routes/__root';
 
 export type { AppSearchParams } from '../routes/__root';
@@ -53,7 +54,7 @@ export const createAppRouter = (history?: RouterHistory, queryClient: QueryClien
     // `pathChanged` then excludes navigations that only rewrite search params
     // (network switch, stake urn index, balance filters): same page, no slide.
     defaultViewTransition: {
-      types: ({ pathChanged, fromLocation }) => {
+      types: ({ pathChanged, fromLocation, toLocation }) => {
         if (!fromLocation || !pathChanged) return false;
         // Runs synchronously immediately before startViewTransition, which is
         // the only moment the pre-navigation scroll position is still readable.
@@ -61,7 +62,12 @@ export const createAppRouter = (history?: RouterHistory, queryClient: QueryClien
         // needs this to show the part that was on screen — see the
         // ::view-transition-group(page) block in globals.css.
         document.documentElement.style.setProperty('--vt-scroll', `${window.scrollY}px`);
-        return ['page'];
+        // Drilling between the Earn marketplace and a product page travels
+        // vertically instead (Figma: Sky App: UI 1598:77307). The second type
+        // is additive — it only swaps which keyframes run, so the timing,
+        // easing, overlap and snapshot handling stay shared with every other
+        // navigation.
+        return isEarnDrilldown(fromLocation.pathname, toLocation.pathname) ? ['page', 'drill'] : ['page'];
       }
     },
     // Full-width routes scroll on the document (no inner-scroll box), so the


### PR DESCRIPTION
Stacked on #1788 — base is `redesign/page-transitions`, so review that one first.

Implements the Earn drill-down motion comp (Figma: Sky App: UI [1598:77307](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-77307)).

## What the comp specifies

A 4s loop drilling from the Earn marketplace into the Sky Savings product page and back. Three layers animate; the top navbar and the background never move.

| | outgoing | incoming |
|---|---|---|
| opacity | 1 → 0 | 0 → 1 |
| travel | `y` 0 → −40px | `y` +40 → 0 |
| duration | ~300ms | ~300ms |
| easing | `cubic-bezier(.77,0,.175,1)` | same |

Plus the rate chart's plot growing from 1px to its full 760px width, starting as the page settles.

## 1. Vertical drill-down

The router already tags real path changes with a `page` view-transition type. Earn drill-downs now get a second, additive `drill` type, so the CSS swaps only the animation names — duration, easing, the 100ms overlap, snapshot placement and the `pointer-events` handling all stay shared with the horizontal transition, and reduced motion still collapses both to the same 150ms crossfade.

Two decisions worth calling out:

- **Direction stays constant.** Out-upward / in-from-below in both directions; going back up is not a reversal. Same rule the horizontal slide already follows.
- **Scope is narrow, per design.** Only `/earn` ↔ a product page. Reaching a product page from the Portfolio, a deep link or the nav is a lateral move and keeps the horizontal slide. There is no product-to-product case to weigh: every bare sub-path (`/earn/vaults`, `/earn/rewards`, `/earn/fixed`) redirects to `/earn`, so the only Earn screens that exist are the marketplace and the leaves.

The comp's forward and backward halves disagree on the overlap (105ms vs 197ms). Read as hand-tuning noise and unified on the 100ms the existing transition already uses.

## 2. Chart entrance reveal

The interesting find: **recharts was already doing this.** `AreaRevealShape` wipes the Area in behind an animated clip-path on entrance and is on by default, so the reveal has been shipping at recharts' 1500ms/`ease`. This re-times it to the comp's ~900ms on the same easeInOutQuart curve — two props on the one shared `<Area>`.

No delay is paired with it. The chart sits behind `LoadingErrorWrapper`, so the Area mounts only once there is a series to draw, which puts the wipe after the page transition without scheduling anything.

Every line chart in the app renders through `modules/ui/components/Chart.tsx`, so savings, stUSDS, vaults, Pendle, rewards, stake rate, portfolio totals and the USDS/SKY totals chart all pick it up. `PortfolioDonutChart` is a separate Pie tree and is untouched.

**Pre-existing behaviour worth a look:** the reveal also re-fires on a timeframe or metric switch, not just on page entry, which the comp does not cover. That was already true at 1500ms; this PR makes it shorter, not new. Happy to suppress it on toggles if design would rather it only played on entry.

## Verification

Driven with Playwright — Chrome aborts view transitions in a background tab, so it cannot observe them. Read off the running animations rather than screenshots, which capture the live DOM under the snapshots rather than the transition itself.

| navigation | types | animations |
|---|---|---|
| `/earn` → vault product | `['page','drill']` | `page-drill-out` / `page-drill-in`, `translateY(±40px)` |
| vault product → `/earn` | `['page','drill']` | same, direction unchanged |
| `/earn` → `/stake` | `['page']` | `page-slide-out` / `page-slide-in`, `translateX(±120px)` |
| drill, reduced motion | `['page','drill']` | `page-fade-out` / `page-fade-in`, no translate |

Chart reveal, sampled every 25ms on the vault page: the clip rect grows 0 → 778px between 1017ms and 1901ms (~885ms), with a clear ease-in-out profile. Under `prefers-reduced-motion` the reveal clip never appears at all — `isAnimationActive: 'auto'` self-disables.

## Gates

- typecheck clean
- lint: 3 errors, all pre-existing in `ProductCard.test.tsx` (`testing-library/no-container`), identical on base
- tests 2221/2222 — the one failure is `EarnFeaturedCards.test.tsx`, the known date-bomb that fails on base too
- 7 new unit tests covering the drill predicate, including the lateral and product-to-product cases
