### PR TITLE
Single-source withdrawal availability wording across risk details and transaction modals

### DIFF
--- a/apps/webapp/src/components/product/RiskTierDetails.tsx
+++ b/apps/webapp/src/components/product/RiskTierDetails.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/responsive-modal';
 import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
 import { RiskTierMeter } from './RiskMeter';
+import { WITHDRAWAL_AVAILABILITY } from './withdrawalAvailability';
 
 // TODO(BL-07): like the tier assignment in hooks/earn/earnProducts.ts, this
 // per-tier copy is a static front-end config pending the risk-rating source
@@ -61,7 +62,7 @@ const RISK_TIER_DETAILS: Record<
  */
 const RISK_PROFILE_DETAILS: Record<
   EarnRiskProfileId,
-  { description: ReactNode; exposureTokens: string[]; liquidationRisk: ReactNode; withdrawals: ReactNode }
+  { description: ReactNode; exposureTokens: string[]; liquidationRisk: ReactNode }
 > = {
   savings: {
     description: (
@@ -71,16 +72,14 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   rewards: {
     description: (
       <Trans>Supply directly to Sky Protocol and earn rewards. Reward rates vary with emissions.</Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'rewards-sky': {
     description: (
@@ -90,8 +89,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'rewards-spk': {
     description: (
@@ -101,8 +99,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'rewards-grove': {
     description: (
@@ -112,8 +109,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'rewards-cle': {
     description: (
@@ -123,8 +119,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'vault-flagship': {
     description: (
@@ -134,8 +129,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['cbBTC', 'wstETH', 'WETH', 'PT-sUSDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Liquidity based</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'vault-usdt-savings': {
     description: (
@@ -145,8 +139,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['sUSDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Liquidity based</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'vault-tether-savings': {
     // PLACEHOLDER — this vault has no row in the APP-396 risk sheet.
@@ -157,8 +150,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['sUSDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Instant</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   'vault-risk-capital': {
     description: (
@@ -168,8 +160,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['stUSDS', 'SKY'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Liquidity based</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   fixed: {
     description: (
@@ -179,8 +170,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['USDS'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>At maturity or via market sell</Trans>
+    liquidationRisk: <Trans>None</Trans>
   },
   stusds: {
     description: (
@@ -190,8 +180,7 @@ const RISK_PROFILE_DETAILS: Record<
       </Trans>
     ),
     exposureTokens: ['SKY'],
-    liquidationRisk: <Trans>None</Trans>,
-    withdrawals: <Trans>Liquidity based</Trans>
+    liquidationRisk: <Trans>None</Trans>
   }
 };
 
@@ -253,6 +242,7 @@ function FactRow({ label, value }: { label: ReactNode; value: ReactNode }) {
 
 /** Scale + description + divider + fact rows — shared by the tooltip card and the bottom sheet. */
 function RiskTierDetailsBody({ tier, profile }: { tier: EarnRiskTier; profile: EarnRiskProfileId }) {
+  const { i18n } = useLingui();
   const severity = RISK_TIER_DETAILS[tier];
   const details = RISK_PROFILE_DETAILS[profile];
 
@@ -278,7 +268,7 @@ function RiskTierDetailsBody({ tier, profile }: { tier: EarnRiskTier; profile: E
           value={<ExposureFactValue symbols={details.exposureTokens} />}
         />
         <FactRow label={<Trans>Liquidation risk</Trans>} value={details.liquidationRisk} />
-        <FactRow label={<Trans>Withdrawals</Trans>} value={details.withdrawals} />
+        <FactRow label={<Trans>Withdrawals</Trans>} value={i18n._(WITHDRAWAL_AVAILABILITY[profile])} />
       </div>
     </>
   );

--- a/apps/webapp/src/components/product/RiskTierDetails.tsx
+++ b/apps/webapp/src/components/product/RiskTierDetails.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/components/ui/responsive-modal';
 import { TokenIconStack } from '@/modules/ui/components/TokenIconStack';
 import { RiskTierMeter } from './RiskMeter';
-import { WITHDRAWAL_AVAILABILITY } from './withdrawalAvailability';
+import { withdrawalWording } from './withdrawalAvailability';
 
 // TODO(BL-07): like the tier assignment in hooks/earn/earnProducts.ts, this
 // per-tier copy is a static front-end config pending the risk-rating source
@@ -268,7 +268,7 @@ function RiskTierDetailsBody({ tier, profile }: { tier: EarnRiskTier; profile: E
           value={<ExposureFactValue symbols={details.exposureTokens} />}
         />
         <FactRow label={<Trans>Liquidation risk</Trans>} value={details.liquidationRisk} />
-        <FactRow label={<Trans>Withdrawals</Trans>} value={i18n._(WITHDRAWAL_AVAILABILITY[profile])} />
+        <FactRow label={<Trans>Withdrawals</Trans>} value={i18n._(withdrawalWording(profile))} />
       </div>
     </>
   );

--- a/apps/webapp/src/components/product/withdrawalAvailability.ts
+++ b/apps/webapp/src/components/product/withdrawalAvailability.ts
@@ -11,8 +11,9 @@ type WithdrawalFlow = 'supply' | 'withdraw';
  *
  * `sheet` is the canonical product attribute. A flow override exists only where
  * the answer genuinely differs by flow (Pendle: the PT is locked until maturity,
- * but the withdraw review's market sell executes now) or where the comps spec
- * friendlier supply wording for the same fact (savings/rewards: "Anytime").
+ * but the withdraw review's market sell executes now) or on instant-exit
+ * products, whose supply review uses the comps' friendlier future-looking
+ * "Anytime" for the same fact.
  * 'vault-tether-savings' is PLACEHOLDER copy pending a product assessment,
  * like its RiskTierDetails entry.
  */
@@ -28,7 +29,7 @@ const WITHDRAWAL_AVAILABILITY: Record<
   'rewards-cle': { sheet: msg`Instant`, supply: msg`Anytime` },
   'vault-flagship': { sheet: msg`Liquidity based` },
   'vault-usdt-savings': { sheet: msg`Liquidity based` },
-  'vault-tether-savings': { sheet: msg`Instant` },
+  'vault-tether-savings': { sheet: msg`Instant`, supply: msg`Anytime` },
   'vault-risk-capital': { sheet: msg`Liquidity based` },
   fixed: { sheet: msg`At maturity or via market sell`, withdraw: msg`Instant` },
   stusds: { sheet: msg`Liquidity based` }

--- a/apps/webapp/src/components/product/withdrawalAvailability.ts
+++ b/apps/webapp/src/components/product/withdrawalAvailability.ts
@@ -1,0 +1,25 @@
+import { msg } from '@lingui/core/macro';
+import type { MessageDescriptor } from '@lingui/core';
+import type { EarnRiskProfileId } from '@/hooks';
+
+/**
+ * Withdrawal-availability wording per risk profile, from the APP-396 risk
+ * sheet. Single source for the risk-details fact row (RiskTierDetails) and the
+ * transaction modals' Withdrawal cell, so the two surfaces cannot drift.
+ * 'vault-tether-savings' is PLACEHOLDER copy pending a product assessment,
+ * like its RiskTierDetails entry.
+ */
+export const WITHDRAWAL_AVAILABILITY: Record<EarnRiskProfileId, MessageDescriptor> = {
+  savings: msg`Instant`,
+  rewards: msg`Instant`,
+  'rewards-sky': msg`Instant`,
+  'rewards-spk': msg`Instant`,
+  'rewards-grove': msg`Instant`,
+  'rewards-cle': msg`Instant`,
+  'vault-flagship': msg`Liquidity based`,
+  'vault-usdt-savings': msg`Liquidity based`,
+  'vault-tether-savings': msg`Instant`,
+  'vault-risk-capital': msg`Liquidity based`,
+  fixed: msg`At maturity or via market sell`,
+  stusds: msg`Liquidity based`
+};

--- a/apps/webapp/src/components/product/withdrawalAvailability.ts
+++ b/apps/webapp/src/components/product/withdrawalAvailability.ts
@@ -2,24 +2,43 @@ import { msg } from '@lingui/core/macro';
 import type { MessageDescriptor } from '@lingui/core';
 import type { EarnRiskProfileId } from '@/hooks';
 
+type WithdrawalFlow = 'supply' | 'withdraw';
+
 /**
  * Withdrawal-availability wording per risk profile, from the APP-396 risk
  * sheet. Single source for the risk-details fact row (RiskTierDetails) and the
- * transaction modals' Withdrawal cell, so the two surfaces cannot drift.
+ * transaction modals' Withdrawal cell, so the surfaces cannot drift.
+ *
+ * `sheet` is the canonical product attribute. A flow override exists only where
+ * the answer genuinely differs by flow (Pendle: the PT is locked until maturity,
+ * but the withdraw review's market sell executes now) or where the comps spec
+ * friendlier supply wording for the same fact (savings/rewards: "Anytime").
  * 'vault-tether-savings' is PLACEHOLDER copy pending a product assessment,
  * like its RiskTierDetails entry.
  */
-export const WITHDRAWAL_AVAILABILITY: Record<EarnRiskProfileId, MessageDescriptor> = {
-  savings: msg`Instant`,
-  rewards: msg`Instant`,
-  'rewards-sky': msg`Instant`,
-  'rewards-spk': msg`Instant`,
-  'rewards-grove': msg`Instant`,
-  'rewards-cle': msg`Instant`,
-  'vault-flagship': msg`Liquidity based`,
-  'vault-usdt-savings': msg`Liquidity based`,
-  'vault-tether-savings': msg`Instant`,
-  'vault-risk-capital': msg`Liquidity based`,
-  fixed: msg`At maturity or via market sell`,
-  stusds: msg`Liquidity based`
+const WITHDRAWAL_AVAILABILITY: Record<
+  EarnRiskProfileId,
+  { sheet: MessageDescriptor } & Partial<Record<WithdrawalFlow, MessageDescriptor>>
+> = {
+  savings: { sheet: msg`Instant`, supply: msg`Anytime` },
+  rewards: { sheet: msg`Instant`, supply: msg`Anytime` },
+  'rewards-sky': { sheet: msg`Instant`, supply: msg`Anytime` },
+  'rewards-spk': { sheet: msg`Instant`, supply: msg`Anytime` },
+  'rewards-grove': { sheet: msg`Instant`, supply: msg`Anytime` },
+  'rewards-cle': { sheet: msg`Instant`, supply: msg`Anytime` },
+  'vault-flagship': { sheet: msg`Liquidity based` },
+  'vault-usdt-savings': { sheet: msg`Liquidity based` },
+  'vault-tether-savings': { sheet: msg`Instant` },
+  'vault-risk-capital': { sheet: msg`Liquidity based` },
+  fixed: { sheet: msg`At maturity or via market sell`, withdraw: msg`Instant` },
+  stusds: { sheet: msg`Liquidity based` }
 };
+
+/**
+ * The Withdrawal wording for a surface: pass the modal's `flow` for the review
+ * grid cell, omit it for the risk-details fact row.
+ */
+export function withdrawalWording(profile: EarnRiskProfileId, flow?: WithdrawalFlow): MessageDescriptor {
+  const entry = WITHDRAWAL_AVAILABILITY[profile];
+  return (flow && entry[flow]) || entry.sheet;
+}

--- a/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
@@ -3,7 +3,9 @@ import { useChainId, useChains } from 'wagmi';
 import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
-import { type Token, type VaultProvider, useVaultMarketData } from '@/hooks';
+import { useLingui } from '@lingui/react';
+import { getVaultByAddress, type Token, type VaultProvider, useVaultMarketData } from '@/hooks';
+import { WITHDRAWAL_AVAILABILITY } from '@/components/product/withdrawalAvailability';
 import { BundleSavingsPromo } from '@/modules/ui/components/BundleSavingsPromo';
 import { useBundleFeeState } from '@/modules/ui/components/NetworkFeeValue';
 import { formatDecimalPercentage, formatNumber, projectAnnualEarnings } from '@/utils';
@@ -60,6 +62,12 @@ export function VaultModalForm({
 }) {
   const chainId = useChainId();
   const chains = useChains();
+  const { i18n } = useLingui();
+  // Openable vaults come from the registry, so the lookup only misses on an
+  // unsupported chain; the fallback keeps the provider's wording in that case.
+  const riskProfile =
+    getVaultByAddress(vaultAddress, chainId)?.riskProfile ??
+    (provider === 'morpho' ? 'vault-flagship' : 'vault-tether-savings');
 
   const form = useVaultTransactionForm({ flow, vaultAddress, assetToken, provider, preset });
   const {
@@ -160,7 +168,7 @@ export function VaultModalForm({
               product: vaultName,
               rate,
               boostedRate,
-              withdrawal: flow === 'supply' ? t`Anytime` : t`Instant`,
+              withdrawal: i18n._(WITHDRAWAL_AVAILABILITY[riskProfile]),
               network: networkName,
               networkFee: networkFee?.formatted ?? NO_VALUE
             }),

--- a/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
@@ -5,7 +5,7 @@ import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { getVaultByAddress, type Token, type VaultProvider, useVaultMarketData } from '@/hooks';
-import { WITHDRAWAL_AVAILABILITY } from '@/components/product/withdrawalAvailability';
+import { withdrawalWording } from '@/components/product/withdrawalAvailability';
 import { BundleSavingsPromo } from '@/modules/ui/components/BundleSavingsPromo';
 import { useBundleFeeState } from '@/modules/ui/components/NetworkFeeValue';
 import { formatDecimalPercentage, formatNumber, projectAnnualEarnings } from '@/utils';
@@ -168,7 +168,7 @@ export function VaultModalForm({
               product: vaultName,
               rate,
               boostedRate,
-              withdrawal: i18n._(WITHDRAWAL_AVAILABILITY[riskProfile]),
+              withdrawal: i18n._(withdrawalWording(riskProfile, flow)),
               network: networkName,
               networkFee: networkFee?.formatted ?? NO_VALUE
             }),

--- a/apps/webapp/src/modules/morpho/components/vaultModalRows.ts
+++ b/apps/webapp/src/modules/morpho/components/vaultModalRows.ts
@@ -87,7 +87,7 @@ export type VaultReviewRowInput = {
   rate: string;
   /** Append the morpho stars glyph to the rate. */
   boostedRate: boolean;
-  /** Withdrawal availability — Figma: "Anytime" on supply, "Instant" on withdraw. */
+  /** Withdrawal availability — "Liquidity based" per the risk sheet (RiskTierDetails); diverges from the comp's "Anytime"/"Instant". */
   withdrawal: string;
   /** Network the transaction runs on. */
   network: string;

--- a/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
@@ -44,7 +44,7 @@ import { useNetworkFee } from '@/hooks';
 import { WidgetAnalyticsEventType, type WidgetAnalyticsEvent } from '@/widgets/shared/types/analyticsEvents';
 import { useWidgetAnalytics } from '@/modules/analytics/hooks/useWidgetAnalytics';
 import { SlippageMenu } from '@/components/ui/SlippageMenu';
-import { WITHDRAWAL_AVAILABILITY } from '@/components/product/withdrawalAvailability';
+import { withdrawalWording } from '@/components/product/withdrawalAvailability';
 import { Text } from '@/modules/layout/components/Typography';
 import { ModalAmountField, type PercentPreset } from '@/components/product/ModalAmountField';
 import { ModalSummaryGrid } from '@/components/product/ModalSummaryGrid';
@@ -444,7 +444,7 @@ export function PendleModalForm({
               // convention, not the market's marketing name ("Fixed Yield").
               product: `Pendle ${market.underlyingSymbol} (PT-${market.underlyingSymbol})`,
               productSymbol: market.underlyingSymbol,
-              withdrawal: flow === 'supply' ? i18n._(WITHDRAWAL_AVAILABILITY.fixed) : t`Instant`,
+              withdrawal: i18n._(withdrawalWording('fixed', flow)),
               slippage: slippageDisplay,
               slippageMode,
               priceImpact: priceImpactDisplay,

--- a/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
+++ b/apps/webapp/src/modules/pendle/components/PendleModalForm.tsx
@@ -5,6 +5,7 @@ import { formatUnits, parseUnits } from 'viem';
 import { format } from 'date-fns';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
 import {
   getTokenDecimals,
   PENDLE_ROUTER_V4_ADDRESS,
@@ -43,6 +44,7 @@ import { useNetworkFee } from '@/hooks';
 import { WidgetAnalyticsEventType, type WidgetAnalyticsEvent } from '@/widgets/shared/types/analyticsEvents';
 import { useWidgetAnalytics } from '@/modules/analytics/hooks/useWidgetAnalytics';
 import { SlippageMenu } from '@/components/ui/SlippageMenu';
+import { WITHDRAWAL_AVAILABILITY } from '@/components/product/withdrawalAvailability';
 import { Text } from '@/modules/layout/components/Typography';
 import { ModalAmountField, type PercentPreset } from '@/components/product/ModalAmountField';
 import { ModalSummaryGrid } from '@/components/product/ModalSummaryGrid';
@@ -100,6 +102,7 @@ export function PendleModalForm({
 }) {
   const chainId = useChainId();
   const chains = useChains();
+  const { i18n } = useLingui();
   const { isConnected, address } = useConnection();
   const isSupply = flow === 'supply';
   const side = isSupply ? PendleConvertSide.BUY : PendleConvertSide.WITHDRAW;
@@ -441,7 +444,7 @@ export function PendleModalForm({
               // convention, not the market's marketing name ("Fixed Yield").
               product: `Pendle ${market.underlyingSymbol} (PT-${market.underlyingSymbol})`,
               productSymbol: market.underlyingSymbol,
-              withdrawal: flow === 'supply' ? t`Anytime` : t`Instant`,
+              withdrawal: flow === 'supply' ? i18n._(WITHDRAWAL_AVAILABILITY.fixed) : t`Instant`,
               slippage: slippageDisplay,
               slippageMode,
               priceImpact: priceImpactDisplay,

--- a/apps/webapp/src/modules/pendle/components/pendleModalRows.ts
+++ b/apps/webapp/src/modules/pendle/components/pendleModalRows.ts
@@ -120,7 +120,7 @@ export type PendleReviewRowInput = {
   product: string;
   /** Underlying symbol for the Product cell's ringed icon. */
   productSymbol: string;
-  /** Withdrawal availability — Figma: "Anytime" on supply, "Instant" on withdraw. */
+  /** Withdrawal availability — supply: "At maturity or via market sell" per the risk sheet (RiskTierDetails, diverging from the comp's "Anytime"); withdraw: "Instant" (the market sell executes now). */
   withdrawal: string;
   /** Current slippage, formatted (e.g. "0.50%"). */
   slippage: string;

--- a/apps/webapp/src/modules/rewards/components/RewardsModalForm.tsx
+++ b/apps/webapp/src/modules/rewards/components/RewardsModalForm.tsx
@@ -3,12 +3,14 @@ import { useChainId, useChains } from 'wagmi';
 import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
 import { type Token, useNetworkFee } from '@/hooks';
 import { formatDecimalPercentage, formatNumber, projectAnnualEarnings } from '@/utils';
 import { Text } from '@/modules/layout/components/Typography';
 import { ModalAmountField } from '@/components/product/ModalAmountField';
 import { ModalSummaryGrid } from '@/components/product/ModalSummaryGrid';
 import { toGridCells } from '@/components/product/ModalGridCells';
+import { withdrawalWording } from '@/components/product/withdrawalAvailability';
 import { TokenSelectorPill } from '@/components/product/TokenSelectorPill';
 import { BundleSavingsPromo } from '@/modules/ui/components/BundleSavingsPromo';
 import { useBundleFeeState } from '@/modules/ui/components/NetworkFeeValue';
@@ -68,6 +70,7 @@ export function RewardsModalForm({
 }) {
   const chainId = useChainId();
   const chains = useChains();
+  const { i18n } = useLingui();
 
   const form = useRewardsTransactionForm({ flow, contractAddress, supplyToken, preset });
   const {
@@ -161,13 +164,13 @@ export function RewardsModalForm({
       ? buildRewardsSupplyReviewRows({
           ...reviewInput,
           rewardsIn: rewardTokenSymbol,
-          withdrawal: t`Anytime`
+          withdrawal: i18n._(withdrawalWording('rewards', 'supply'))
         })
       : buildRewardsWithdrawReviewRows({
           ...reviewInput,
           youReceive: `${formatNumber(amountUsd, { maxDecimals: 2 })} ${supplyToken.symbol}`,
           receiveToken: supplyToken.symbol,
-          withdrawal: t`Instant`
+          withdrawal: i18n._(withdrawalWording('rewards', 'withdraw'))
         });
     return (
       <div className="flex flex-col gap-8 sm:gap-12" data-testid={`rewards-modal-${flow}-review`}>
@@ -191,7 +194,8 @@ export function RewardsModalForm({
     flow,
     transactionScreenContent,
     feeCell,
-    networkFee
+    networkFee,
+    i18n
   ]);
 
   // Stable confirm over a live `execute` ref + the `updateModalContent` push that

--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
@@ -3,11 +3,13 @@ import { useChainId, useChains } from 'wagmi';
 import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
 import { formatBigInt, formatNumber } from '@/utils';
 import { Text } from '@/modules/layout/components/Typography';
 import { ModalAmountField } from '@/components/product/ModalAmountField';
 import { ModalSummaryGrid } from '@/components/product/ModalSummaryGrid';
 import { toGridCells } from '@/components/product/ModalGridCells';
+import { withdrawalWording } from '@/components/product/withdrawalAvailability';
 import { useModalEntryBody } from '@/modules/ui/hooks/useModalEntryBody';
 import { useNetworkFee } from '@/hooks';
 import { BundleSavingsPromo } from '@/modules/ui/components/BundleSavingsPromo';
@@ -60,6 +62,7 @@ export function SavingsModalForm({
 }) {
   const chainId = useChainId();
   const chains = useChains();
+  const { i18n } = useLingui();
 
   // The mainnet supply preview feeds the review's "You'll receive" (ERC-4626
   // convertToShares); L2 covers it with the PSM min-out bound.
@@ -172,7 +175,7 @@ export function SavingsModalForm({
           estEarnings: NO_VALUE,
           product: 'Sky Savings',
           rate: apyDisplay,
-          withdrawal: t`Anytime`,
+          withdrawal: i18n._(withdrawalWording('savings', 'supply')),
           network: networkName,
           networkFee: networkFee?.formatted ?? NO_VALUE
         })
@@ -182,7 +185,7 @@ export function SavingsModalForm({
           estEarnings: NO_VALUE,
           product: 'Sky Savings',
           rate: apyDisplay,
-          withdrawal: t`Instant`,
+          withdrawal: i18n._(withdrawalWording('savings', 'withdraw')),
           network: networkName,
           networkFee: networkFee?.formatted ?? NO_VALUE
         });
@@ -204,7 +207,8 @@ export function SavingsModalForm({
     flow,
     transactionScreenContent,
     feeCell,
-    networkFee
+    networkFee,
+    i18n
   ]);
 
   // Stable confirm over a live `execute` ref + the `updateModalContent` push that

--- a/apps/webapp/src/modules/stusds/components/StUsdsModalForm.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUsdsModalForm.tsx
@@ -5,7 +5,7 @@ import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { StUsdsProviderType, TOKENS } from '@/hooks';
-import { WITHDRAWAL_AVAILABILITY } from '@/components/product/withdrawalAvailability';
+import { withdrawalWording } from '@/components/product/withdrawalAvailability';
 import { BundleSavingsPromo } from '@/modules/ui/components/BundleSavingsPromo';
 import { useBundleFeeState } from '@/modules/ui/components/NetworkFeeValue';
 import { useNetworkFee } from '@/hooks';
@@ -178,7 +178,7 @@ export function StUsdsModalForm({
               rate: rateDisplay,
               route: isCurveRoute ? t`Curve` : t`Native`,
               routeDetail: isCurveRoute ? t`Curve pool` : t`stUSDS module`,
-              withdrawal: i18n._(WITHDRAWAL_AVAILABILITY.stusds),
+              withdrawal: i18n._(withdrawalWording('stusds', flow)),
               network: networkName,
               networkFee: networkFee?.formatted ?? NO_VALUE
             }),

--- a/apps/webapp/src/modules/stusds/components/StUsdsModalForm.tsx
+++ b/apps/webapp/src/modules/stusds/components/StUsdsModalForm.tsx
@@ -3,7 +3,9 @@ import { useChainId, useChains } from 'wagmi';
 import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
 import { StUsdsProviderType, TOKENS } from '@/hooks';
+import { WITHDRAWAL_AVAILABILITY } from '@/components/product/withdrawalAvailability';
 import { BundleSavingsPromo } from '@/modules/ui/components/BundleSavingsPromo';
 import { useBundleFeeState } from '@/modules/ui/components/NetworkFeeValue';
 import { useNetworkFee } from '@/hooks';
@@ -59,6 +61,7 @@ export function StUsdsModalForm({
 }) {
   const chainId = useChainId();
   const chains = useChains();
+  const { i18n } = useLingui();
 
   const form = useStUsdsTransactionForm({ flow, preset });
   const {
@@ -175,7 +178,7 @@ export function StUsdsModalForm({
               rate: rateDisplay,
               route: isCurveRoute ? t`Curve` : t`Native`,
               routeDetail: isCurveRoute ? t`Curve pool` : t`stUSDS module`,
-              withdrawal: flow === 'supply' ? t`Anytime` : t`Instant`,
+              withdrawal: i18n._(WITHDRAWAL_AVAILABILITY.stusds),
               network: networkName,
               networkFee: networkFee?.formatted ?? NO_VALUE
             }),

--- a/apps/webapp/src/modules/stusds/components/stUsdsModalRows.ts
+++ b/apps/webapp/src/modules/stusds/components/stUsdsModalRows.ts
@@ -79,7 +79,7 @@ export type StUsdsReviewRowInput = {
   route: string;
   /** What executes the route, shown as the cell value (e.g. "stUSDS module" / "Curve pool"). */
   routeDetail: string;
-  /** Withdrawal availability — vault-family standard: "Anytime" on supply, "Instant" on withdraw. */
+  /** Withdrawal availability — "Liquidity based" per the risk sheet (RiskTierDetails); diverges from the vault-family comp's "Anytime"/"Instant". */
   withdrawal: string;
   /** Network the transaction runs on. */
   network: string;


### PR DESCRIPTION
The review modals hardcoded **Anytime**/**Instant** for every product while the risk-profile details one click away said **Liquidity based** (Morpho vaults, stUSDS) or **At maturity or via market sell** (Pendle) for the same products.

- New `components/product/withdrawalAvailability.ts`: a `riskProfile`-keyed map of Lingui `msg` descriptors (canonical `sheet` wording + per-flow overrides, resolved via `withdrawalWording(profile, flow)`), consumed by `RiskTierDetails` and every modal form — the surfaces can no longer drift.
- The vault form resolves its profile via `getVaultByAddress`, so the Spark sUSDT vault keeps its distinct instant-exit wording (**Anytime** on supply, **Instant** on withdraw) while all Morpho vaults read **Liquidity based**.
- Pendle supply review now reads **At maturity or via market sell**; Pendle withdraw keeps **Instant** (the market sell executes immediately).
- Savings/Rewards modals keep their comp'd **Anytime**/**Instant** pair, now resolved through the same map — it carries the canonical risk-sheet wording plus per-flow overrides (`withdrawalWording(profile, flow)`), so no modal hardcodes withdrawal copy anymore.

All strings already exist in the catalog (the sheet wording matches `RiskTierDetails`; "Anytime" is the comps' supply-review wording on instant-exit products), so no new catalog entries. Note: the modal copy for Morpho vaults/stUSDS/Pendle now intentionally diverges from the Figma comps' "Anytime" — the comps oversold those products' exit terms.

| | Before | After |
|---|---|---|
| Vault supply review | ![before-vault](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/withdrawal-availability/before-vault.png) | ![after-vault](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/withdrawal-availability/after-vault.png) |
| Pendle supply review | ![before-pendle](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/withdrawal-availability/before-pendle.png) | ![after-pendle](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/withdrawal-availability/after-pendle.png) |
| stUSDS supply review | ![before-stusds](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/withdrawal-availability/before-stusds.png) | ![after-stusds](https://raw.githubusercontent.com/jetstreamgg/tarmac/screenshots/withdrawal-availability/after-stusds.png) |

(The stUSDS shots were captured with a local dev-only stub faking a healthy native route — the module contracts aren't live on the shared dev vnet; only the Withdrawal cell differs between branches.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


