### PR TITLE
3 QA fixes

### DIFF
--- a/apps/webapp/src/hooks/delegates/delegates.test.tsx
+++ b/apps/webapp/src/hooks/delegates/delegates.test.tsx
@@ -113,6 +113,29 @@ describe('useDelegates', async () => {
     checkDefaultQueryParameters(query, 10);
   });
 
+  it('Should OR name-matched addresses into the search condition', async () => {
+    const { result } = renderHook(
+      () =>
+        useDelegates({
+          chainId: TENDERLY_CHAIN_ID,
+          page: 1,
+          pageSize: 10,
+          search: 'cloaky',
+          nameMatches: ['0xaaaa000000000000000000000000000000000001']
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => result.current.isLoading === false);
+    expect(request).toHaveBeenCalled();
+
+    const [[, query]] = (request as Mock).mock.calls;
+    expect(query).toContain(
+      '{ _or: [{ address: { _ilike: "%cloaky%" } }, { address: { _ilike: "0xaaaa000000000000000000000000000000000001" } }] }'
+    );
+    checkDefaultQueryParameters(query, 10);
+  });
+
   it('Should build the correct query with exclude parameter', async () => {
     const { result } = renderHook(
       () =>

--- a/apps/webapp/src/hooks/delegates/useDelegates.ts
+++ b/apps/webapp/src/hooks/delegates/useDelegates.ts
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { DelegateInfo, DelegateRaw } from './delegate';
 import { getRandomItem } from '@/utils';
 import { useMemo } from 'react';
-import { parseDelegatesFn } from './utils';
+import { buildDelegateSearchCondition, parseDelegatesFn } from './utils';
 import { useDelegateMetadataMapping } from './useDelegateMetadataMapping';
 
 async function fetchDelegates(
@@ -18,13 +18,15 @@ async function fetchDelegates(
   orderBy?: string,
   orderDirection?: string,
   search?: string,
-  version?: 1 | 2 | 3
+  version?: 1 | 2 | 3,
+  nameMatches?: `0x${string}`[]
 ): Promise<DelegateInfo[] | undefined> {
   const whereConditions: string[] = [`{ chainId: { _eq: ${chainId} } }`];
   if (version) whereConditions.push(`{ version: { _eq: "${version}" } }`);
   if (exclude?.length)
     whereConditions.push(`{ address: { _nin: [${exclude.map(addr => `"${addr}"`).join(', ')}] } }`);
-  if (search) whereConditions.push(`{ address: { _ilike: "%${search}%" } }`);
+  const searchCondition = buildDelegateSearchCondition(search, nameMatches);
+  if (searchCondition) whereConditions.push(searchCondition);
   const whereClause = `where: { _and: [${whereConditions.join(', ')}] }`;
 
   const paginationClause =
@@ -66,6 +68,7 @@ export function useDelegates({
   random,
   search,
   version,
+  nameMatches,
   enabled = true
 }: {
   chainId: number;
@@ -76,6 +79,8 @@ export function useDelegates({
   random?: boolean;
   search?: string;
   version?: 1 | 2 | 3;
+  /** Addresses whose metadata name matches `search` — see findDelegateNameMatches. */
+  nameMatches?: `0x${string}`[];
   enabled?: boolean;
 }): ReadHook & { data?: DelegateInfo[] } {
   const urlIndexer = indexerUrl ? indexerUrl : getIndexerUrl(chainId) || '';
@@ -108,7 +113,8 @@ export function useDelegates({
       random ? randomOrderBy : undefined,
       random ? randomOrderDirection : undefined,
       search,
-      version
+      version,
+      nameMatches
     ],
     queryFn: () =>
       fetchDelegates(
@@ -120,7 +126,8 @@ export function useDelegates({
         randomOrderBy,
         randomOrderDirection,
         search,
-        version
+        version,
+        nameMatches
       )
   });
 

--- a/apps/webapp/src/hooks/delegates/useUserDelegates.ts
+++ b/apps/webapp/src/hooks/delegates/useUserDelegates.ts
@@ -4,7 +4,7 @@ import { TRUST_LEVELS, TrustLevelEnum, ZERO_ADDRESS } from '../constants';
 import { getIndexerUrl } from '../helpers/getIndexerUrl';
 import { useQuery } from '@tanstack/react-query';
 import { DelegateInfo, DelegateRaw } from './delegate';
-import { parseDelegatesFn } from './utils';
+import { buildDelegateSearchCondition, parseDelegatesFn } from './utils';
 import { useDelegateMetadataMapping } from './useDelegateMetadataMapping';
 
 async function fetchUserDelegates(
@@ -12,16 +12,16 @@ async function fetchUserDelegates(
   chainId: number,
   user: `0x${string}`,
   search?: string,
-  version?: 1 | 2 | 3
+  version?: 1 | 2 | 3,
+  nameMatches?: `0x${string}`[]
 ): Promise<DelegateInfo[] | undefined> {
   const whereConditions = [
     `{ chainId: { _eq: ${chainId} } }`,
     `{ delegations: { delegator: { _eq: "${user.toLowerCase()}" }, amount: { _gt: "0" } } }`
   ];
   if (version) whereConditions.push(`{ version: { _eq: "${version}" } }`);
-  if (search) {
-    whereConditions.push(`{ address: { _ilike: "%${search}%" } }`);
-  }
+  const searchCondition = buildDelegateSearchCondition(search, nameMatches);
+  if (searchCondition) whereConditions.push(searchCondition);
   const whereClause = `where: { _and: [${whereConditions.join(', ')}] }`;
 
   const query = gql`
@@ -77,13 +77,16 @@ export function useUserDelegates({
   chainId,
   user,
   search,
-  version
+  version,
+  nameMatches
 }: {
   indexerUrl?: string;
   chainId: number;
   user: `0x${string}`;
   search?: string;
   version?: 1 | 2 | 3;
+  /** Addresses whose metadata name matches `search` — see findDelegateNameMatches. */
+  nameMatches?: `0x${string}`[];
 }): ReadHook & { data?: DelegateInfo[] } {
   const urlIndexer = indexerUrl ? indexerUrl : getIndexerUrl(chainId) || '';
 
@@ -94,8 +97,8 @@ export function useUserDelegates({
     isLoading
   } = useQuery({
     enabled: Boolean(urlIndexer && user.length > 0 && user !== ZERO_ADDRESS),
-    queryKey: ['user-delegates', urlIndexer, chainId, user, search, version],
-    queryFn: () => fetchUserDelegates(urlIndexer, chainId, user, search, version)
+    queryKey: ['user-delegates', urlIndexer, chainId, user, search, version, nameMatches],
+    queryFn: () => fetchUserDelegates(urlIndexer, chainId, user, search, version, nameMatches)
   });
 
   const { data: metadataMapping } = useDelegateMetadataMapping();

--- a/apps/webapp/src/hooks/delegates/utils.test.ts
+++ b/apps/webapp/src/hooks/delegates/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildDelegateSearchCondition, findDelegateNameMatches } from './utils';
+
+const A = '0xaaaa000000000000000000000000000000000001';
+const B = '0xbbbb000000000000000000000000000000000002';
+
+describe('findDelegateNameMatches', () => {
+  const mapping = {
+    [A]: { name: 'Cloaky' },
+    [B]: { name: 'BLUE' },
+    '0xcccc000000000000000000000000000000000003': { name: undefined }
+  };
+
+  it('matches names case-insensitively on substrings', () => {
+    expect(findDelegateNameMatches(mapping, 'cloak')).toEqual([A]);
+    expect(findDelegateNameMatches(mapping, 'blue')).toEqual([B]);
+  });
+
+  it('returns undefined without a search term, mapping, or any match', () => {
+    expect(findDelegateNameMatches(mapping, undefined)).toBeUndefined();
+    expect(findDelegateNameMatches(mapping, '')).toBeUndefined();
+    expect(findDelegateNameMatches(undefined, 'cloak')).toBeUndefined();
+    expect(findDelegateNameMatches(mapping, 'nobody')).toBeUndefined();
+  });
+});
+
+describe('buildDelegateSearchCondition', () => {
+  it('returns undefined without a search term', () => {
+    expect(buildDelegateSearchCondition(undefined, [A])).toBeUndefined();
+  });
+
+  it('keeps the plain address term when no names matched', () => {
+    expect(buildDelegateSearchCondition('cloak', undefined)).toBe('{ address: { _ilike: "%cloak%" } }');
+    expect(buildDelegateSearchCondition('cloak', [])).toBe('{ address: { _ilike: "%cloak%" } }');
+  });
+
+  it('ORs the address term with one _ilike per name-matched address', () => {
+    expect(buildDelegateSearchCondition('cloak', [A, B])).toBe(
+      `{ _or: [{ address: { _ilike: "%cloak%" } }, { address: { _ilike: "${A}" } }, { address: { _ilike: "${B}" } }] }`
+    );
+  });
+});

--- a/apps/webapp/src/hooks/delegates/utils.ts
+++ b/apps/webapp/src/hooks/delegates/utils.ts
@@ -1,5 +1,41 @@
 import { DelegateInfo, DelegateRaw } from './delegate';
 
+/**
+ * Delegates whose governance-portal name matches the search text. Names exist
+ * only in the vote.sky.money metadata (the indexer's Delegate table has no
+ * name column), so name search resolves to addresses client-side and the
+ * indexer query then filters by address — keeping pagination, ordering and
+ * the user/rest split server-side.
+ */
+export function findDelegateNameMatches(
+  metadataMapping: Record<string, { name?: string }> | undefined,
+  search: string | undefined
+): `0x${string}`[] | undefined {
+  if (!search || !metadataMapping) return undefined;
+  const query = search.toLowerCase();
+  const matches = Object.entries(metadataMapping)
+    .filter(([, metadata]) => metadata.name?.toLowerCase().includes(query))
+    .map(([address]) => address as `0x${string}`);
+  return matches.length ? matches : undefined;
+}
+
+/**
+ * GraphQL condition for the delegate search box: address text match OR one of
+ * the name-matched addresses. Per-address `_ilike` (no wildcards) instead of
+ * `_in` because the metadata keys are lowercased while `_in` compares
+ * case-sensitively against whatever casing the indexer stores.
+ */
+export function buildDelegateSearchCondition(
+  search: string | undefined,
+  nameMatches: `0x${string}`[] | undefined
+): string | undefined {
+  if (!search) return undefined;
+  const addressTerm = `{ address: { _ilike: "%${search}%" } }`;
+  if (!nameMatches?.length) return addressTerm;
+  const nameTerms = nameMatches.map(address => `{ address: { _ilike: "${address}" } }`);
+  return `{ _or: [${[addressTerm, ...nameTerms].join(', ')}] }`;
+}
+
 export function parseDelegatesFn(delegate: DelegateRaw) {
   return {
     ...delegate,

--- a/apps/webapp/src/hooks/stake/useStakeUserDelegates.ts
+++ b/apps/webapp/src/hooks/stake/useStakeUserDelegates.ts
@@ -3,6 +3,8 @@ import { TRUST_LEVELS, TrustLevelEnum, ZERO_ADDRESS } from '../constants';
 import { getIndexerUrl } from '../helpers/getIndexerUrl';
 import { useUserDelegates } from '../delegates/useUserDelegates';
 import { useDelegates } from '../delegates/useDelegates';
+import { useDelegateMetadataMapping } from '../delegates/useDelegateMetadataMapping';
+import { findDelegateNameMatches } from '../delegates/utils';
 import { DelegateInfo } from '../delegates/delegate';
 import { useEffect, useRef, useState, useMemo } from 'react';
 import { formatEther, getAddress } from 'viem';
@@ -62,12 +64,21 @@ export function useStakeUserDelegates({
   const hasInitiallyOrdered = useRef(false);
   const urlIndexer = indexerUrl ? indexerUrl : getIndexerUrl(chainId) || '';
 
+  // Search matches delegate names too: names live only in the governance-portal
+  // metadata, so resolve them to addresses here and let the indexer queries
+  // filter by address (pagination and the user/rest split stay server-side).
+  const { data: metadataMapping } = useDelegateMetadataMapping();
+  const nameMatches = useMemo(
+    () => findDelegateNameMatches(metadataMapping, search),
+    [metadataMapping, search]
+  );
+
   const {
     data: userDelegatesData,
     isLoading: isLoadingUserDelegates,
     error: errorUserDelegates,
     mutate: mutateUserDelegates
-  } = useUserDelegates({ chainId, user: user || ZERO_ADDRESS, search, version: 3 });
+  } = useUserDelegates({ chainId, user: user || ZERO_ADDRESS, search, version: 3, nameMatches });
 
   const totalUserDelegates = userDelegatesData?.length || 0;
   const startIndex = (page - 1) * pageSize;
@@ -89,7 +100,8 @@ export function useStakeUserDelegates({
     pageSize: remainingSlots,
     random,
     search,
-    version: 3
+    version: 3,
+    nameMatches
   });
   const isLoading = isLoadingUserDelegates || isLoadingRestDelegates;
   const isDataReady = user && user !== ZERO_ADDRESS && !isLoading && (userDelegatesData || restDelegates);
@@ -100,10 +112,11 @@ export function useStakeUserDelegates({
   const sortDelegatesFn =
     sortType === 'totalDelegated' ? sortDelegatesByTotalDelegatedFn : sortDelegatesByAlignedFn;
 
-  // Reset hasInitiallyOrdered when search changes
+  // Reset hasInitiallyOrdered when the search (or its resolved name matches,
+  // which can land after the metadata fetch) changes
   useEffect(() => {
     hasInitiallyOrdered.current = false;
-  }, [search]);
+  }, [search, nameMatches]);
 
   // Memoize the delegates transformation to prevent unnecessary re-computations
   const delegatesWithTotals = useMemo(() => {

--- a/apps/webapp/src/modules/stake/components/ManagePositionTakeover.test.tsx
+++ b/apps/webapp/src/modules/stake/components/ManagePositionTakeover.test.tsx
@@ -385,11 +385,11 @@ describe('ManagePositionTakeover', () => {
     expect(screen.getByTestId('stake-manage-max-hint').textContent).toContain('max. 20K USDS');
   });
 
-  it('borrow: the max hint stays visible on a debt-free urn, where no slider carries it', () => {
+  it('borrow: a debt-free urn still shows the slider and the max hint', () => {
     h.existingDebt = 0n;
     renderSheet({ borrowCard: 'borrow' });
 
-    expect(screen.queryByTestId('stake-manage-borrow-slider')).toBeNull();
+    expect(screen.getByTestId('stake-manage-borrow-slider')).toBeTruthy();
     expect(screen.getByTestId('stake-manage-max-hint').textContent).toContain('max. 300K USDS');
   });
 

--- a/apps/webapp/src/modules/stake/components/StakeManageBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeManageBorrowCard.tsx
@@ -229,7 +229,7 @@ export function StakeManageBorrowCard({
 
         <div className="bg-borderPrimary h-px w-full" aria-hidden />
 
-        {shouldShowSlider && !minCollateralNotMet && (
+        {(isRepay ? shouldShowSlider && !minCollateralNotMet : !inputDisabled) && (
           <div className="flex flex-col gap-2">
             <Slider
               variant="range"

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverBorrowCard.tsx
@@ -79,7 +79,7 @@ export function StakeTakeoverBorrowCard({
   collateralData: CollateralRiskParameters | undefined;
   error?: string;
 }) {
-  const { sliderValue, handleSliderChange, shouldShowSlider } = useStakeRiskSlider({
+  const { sliderValue, handleSliderChange } = useStakeRiskSlider({
     vault: simulatedVault,
     vaultNoBorrow,
     usdsToBorrow,
@@ -129,7 +129,7 @@ export function StakeTakeoverBorrowCard({
           <span aria-hidden className="border-borderPrimary border-t" />
         </div>
 
-        {shouldShowSlider && !minCollateralNotMet && (
+        {!inputDisabled && (
           <div className="flex flex-col gap-1.5">
             <Slider
               variant="range"

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
@@ -54,7 +54,7 @@ export function DelegateList({
         <input
           type="text"
           value={search}
-          placeholder={t`Search`}
+          placeholder={t`Search by name or address`}
           onChange={event => setSearch(event.target.value)}
           data-testid={`${dataTestIdPrefix}-search`}
           className="text-text placeholder:text-fgTertiary md:placeholder:text-fgSecondary w-full bg-transparent text-sm leading-[22px] outline-none"

--- a/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeTakeoverDelegateCard.tsx
@@ -54,7 +54,7 @@ export function DelegateList({
         <input
           type="text"
           value={search}
-          placeholder={t`Search by name or address`}
+          placeholder={t`Search`}
           onChange={event => setSearch(event.target.value)}
           data-testid={`${dataTestIdPrefix}-search`}
           className="text-text placeholder:text-fgTertiary md:placeholder:text-fgSecondary w-full bg-transparent text-sm leading-[22px] outline-none"

--- a/apps/webapp/src/modules/ui/components/MinimizedTransactionToast.tsx
+++ b/apps/webapp/src/modules/ui/components/MinimizedTransactionToast.tsx
@@ -12,9 +12,11 @@ const statusIcon: Partial<Record<TxStatus, ReactNode>> = {
 
 /**
  * Content for the toast shown while a transaction modal is minimized (Figma: a
- * status icon, an amount-aware title, and the shortened tx hash). The whole row is
- * a button that re-opens the modal; the close (X) comes from the `toastWithClose`
- * wrapper. The hash is omitted until one exists (batch txs have none while pending).
+ * status icon, an amount-aware title, and the shortened tx hash). The row is a
+ * button whose ::after overlay stretches across the toast card, so the whole
+ * card re-opens the modal; the close (X) comes from the `toastWithClose`
+ * wrapper, which z-indexes above the overlay. The hash is omitted until one
+ * exists (batch txs have none while pending).
  */
 export function MinimizedTransactionToast({
   status,
@@ -31,7 +33,7 @@ export function MinimizedTransactionToast({
     <button
       type="button"
       onClick={onView}
-      className="flex w-full items-center gap-4 pr-6 text-left"
+      className="flex w-full cursor-pointer items-center gap-4 pr-6 text-left after:absolute after:inset-0"
       data-testid="minimized-transaction-toast"
     >
       <span className="shrink-0">{statusIcon[status]}</span>


### PR DESCRIPTION
Three small UX fixes:

**Stake borrow slider** — the risk slider only appeared once a simulated debt existed, so the open-position and manage borrow cards showed no slider until an amount was typed. It now renders whenever the borrow input is usable (hidden only alongside the min-collateral warning or a reached debt ceiling, which disable the input anyway). Repay mode keeps its has-debt gate. Before an amount is entered the slider sits at 0% and dragging it stages a borrow amount directly.

**Minimized transaction toast** — the row button sat inside the sonner card's `p-4 pr-12` padding, leaving a dead click ring around the content. An `after:inset-0` overlay stretches the button's hit area across the whole card; the close button already renders at `z-10` above it and keeps working.

**Delegate search by name** — the search box only matched delegate *addresses* (the indexer has no name column) while the list displays delegates by *name*, so typing a name silently returned nothing. `findDelegateNameMatches` resolves the search text against the already-cached governance-portal metadata map, and both delegate queries OR the resolved addresses into the existing `_ilike` condition — pagination, ordering and the user/rest split stay server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)