### PR TITLE
Motion: modal, drawer, toast and tab comps

### DIFF
--- a/apps/webapp/src/components/product/TakeoverShell.tsx
+++ b/apps/webapp/src/components/product/TakeoverShell.tsx
@@ -1,7 +1,20 @@
 import { ReactNode, useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { motion, useReducedMotion } from 'motion/react';
 import { ChevronLeft, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+
+/**
+ * The takeover opens and closes on the modal comp's motion (Figma: Sky App: UI
+ * 1598:75901): the scrim fades while the card column rises 40px, 300ms,
+ * arriving on quint and leaving on quart. The scrim itself does not travel —
+ * it covers the viewport, so translating it would uncover an edge.
+ *
+ * Callers must render the takeover inside an `AnimatePresence` for the exit
+ * half to run; without one it is unmounted the instant the flow closes.
+ */
+const SCRIM_IN = { duration: 0.3, ease: [0.23, 1, 0.32, 1] } as const;
+const SCRIM_OUT = { duration: 0.3, ease: [0.77, 0, 0.175, 1] } as const;
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -35,6 +48,7 @@ export function TakeoverShell({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
+  const reduceMotion = useReducedMotion();
 
   // Escape-to-close + document scroll lock: syncing with the DOM outside React.
   useEffect(() => {
@@ -95,13 +109,17 @@ export function TakeoverShell({
   // both portalled — and that also keeps it out of reach of any future
   // transform/filter ancestor.
   return createPortal(
-    <div
+    <motion.div
       ref={containerRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}
       tabIndex={-1}
       data-testid={dataTestId}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0, transition: reduceMotion ? { duration: 0 } : SCRIM_OUT }}
+      transition={reduceMotion ? { duration: 0 } : SCRIM_IN}
       // The comps draw the takeover as a full-page MODAL over the live page
       // (APP-432 item 21 — 1036:209505 layers it over `bg-modal`, a render of
       // /earn), not as a second opaque page: same scrim + blur recipe as the
@@ -152,16 +170,22 @@ export function TakeoverShell({
           (1036:209509). The footer is the column's last row rather than a
           sticky bar — the comps scroll it with the content. */}
       <div className="scrollbar-hidden md:scrollbar-thin-always flex-1 overflow-y-auto px-3 md:px-4">
-        <div className="mx-auto flex w-full max-w-[610px] flex-col gap-3 pt-3 pb-[max(16px,env(safe-area-inset-bottom))] md:pt-16 md:pb-16">
+        <motion.div
+          className="mx-auto flex w-full max-w-[610px] flex-col gap-3 pt-3 pb-[max(16px,env(safe-area-inset-bottom))] md:pt-16 md:pb-16"
+          initial={{ y: 40 }}
+          animate={{ y: 0 }}
+          exit={{ y: 40, transition: reduceMotion ? { duration: 0 } : SCRIM_OUT }}
+          transition={reduceMotion ? { duration: 0 } : SCRIM_IN}
+        >
           {children}
           {footer && (
             <div className="flex items-center justify-between gap-4 px-2 py-4 md:gap-6 md:px-6 md:py-6">
               {footer}
             </div>
           )}
-        </div>
+        </motion.div>
       </div>
-    </div>,
+    </motion.div>,
     document.body
   );
 }

--- a/apps/webapp/src/components/ui/dialog.tsx
+++ b/apps/webapp/src/components/ui/dialog.tsx
@@ -25,7 +25,7 @@ const DialogOverlay = React.forwardRef<
       // The scrim fades on the same 300ms curve as the card it sits under: in
       // the comp (Figma: Sky App: UI 1598:75901) the whole modal layer is one
       // fading wrapper, and only the card additionally rises.
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] duration-300',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] data-[state=open]:duration-300 data-[state=closed]:duration-300',
       className
     )}
     {...props}
@@ -53,7 +53,7 @@ const DialogContent = React.forwardRef<
         // The rise composes with the centering offset rather than fighting it,
         // because Tailwind's translate utilities set the `translate` property
         // while the animation drives `transform`.
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-10 data-[state=open]:slide-in-from-bottom-10 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-auto min-w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-[24px] px-5 py-4 shadow-lg outline-hidden duration-300 sm:min-w-[640px] sm:px-10 sm:py-8',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-10 data-[state=open]:slide-in-from-bottom-10 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-auto min-w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-[24px] px-5 py-4 shadow-lg outline-hidden data-[state=open]:duration-300 data-[state=closed]:duration-300 sm:min-w-[640px] sm:px-10 sm:py-8',
         className
       )}
       {...props}

--- a/apps/webapp/src/components/ui/dialog.tsx
+++ b/apps/webapp/src/components/ui/dialog.tsx
@@ -22,7 +22,10 @@ const DialogOverlay = React.forwardRef<
       // the raw effect stores radius 200, which Figma halves in its CSS
       // translation): the scrim fully frosts the page; the modal card is a
       // near-transparent tint over it, so the frosting must come from here.
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px]',
+      // The scrim fades on the same 300ms curve as the card it sits under: in
+      // the comp (Figma: Sky App: UI 1598:75901) the whole modal layer is one
+      // fading wrapper, and only the card additionally rises.
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] duration-300',
       className
     )}
     {...props}
@@ -43,7 +46,14 @@ const DialogContent = React.forwardRef<
         // inside autofocuses, and a non-pointer open (deep link, keyboard)
         // makes that focus :focus-visible — suppress the panel's UA ring, as
         // PopoverContent does; interactive children keep their own rings.
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-auto min-w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-[24px] px-5 py-4 shadow-lg outline-hidden duration-200 sm:min-w-[640px] sm:px-10 sm:py-8',
+        // Motion (Figma: Sky App: UI 1598:75901): the card fades while rising
+        // 40px — `slide-*-bottom-10` is exactly that 2.5rem — over 300ms,
+        // arriving on quint and leaving on quart. It replaces a zoom-95 at
+        // 200ms, which the comp does not do: there is no scale anywhere in it.
+        // The rise composes with the centering offset rather than fighting it,
+        // because Tailwind's translate utilities set the `translate` property
+        // while the animation drives `transform`.
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-10 data-[state=open]:slide-in-from-bottom-10 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-auto min-w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-[24px] px-5 py-4 shadow-lg outline-hidden duration-300 sm:min-w-[640px] sm:px-10 sm:py-8',
         className
       )}
       {...props}

--- a/apps/webapp/src/components/ui/dialog.tsx
+++ b/apps/webapp/src/components/ui/dialog.tsx
@@ -25,7 +25,7 @@ const DialogOverlay = React.forwardRef<
       // The scrim fades on the same 300ms curve as the card it sits under: in
       // the comp (Figma: Sky App: UI 1598:75901) the whole modal layer is one
       // fading wrapper, and only the card additionally rises.
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] data-[state=open]:duration-300 data-[state=closed]:duration-300',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] data-[state=closed]:duration-300 data-[state=open]:duration-300',
       className
     )}
     {...props}
@@ -53,7 +53,7 @@ const DialogContent = React.forwardRef<
         // The rise composes with the centering offset rather than fighting it,
         // because Tailwind's translate utilities set the `translate` property
         // while the animation drives `transform`.
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-10 data-[state=open]:slide-in-from-bottom-10 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-auto min-w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-[24px] px-5 py-4 shadow-lg outline-hidden data-[state=open]:duration-300 data-[state=closed]:duration-300 sm:min-w-[640px] sm:px-10 sm:py-8',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-10 data-[state=open]:slide-in-from-bottom-10 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-auto min-w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-[24px] px-5 py-4 shadow-lg outline-hidden data-[state=closed]:duration-300 data-[state=open]:duration-300 sm:min-w-[640px] sm:px-10 sm:py-8',
         className
       )}
       {...props}

--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ function SheetOverlay({ className, ...props }: React.ComponentProps<typeof Sheet
         // "background blur-full" (Figma 1292:63542, the mobile Modal Overlay —
         // CSS blur(100px), Figma halves the stored radius 200). Near-transparent
         // modal cards (bg-secondary) rely on this frost to be legible.
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] data-[state=open]:duration-300 data-[state=closed]:duration-300',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] data-[state=closed]:duration-300 data-[state=open]:duration-300',
         className
       )}
       {...props}
@@ -74,7 +74,7 @@ function SheetContent({
           // transitions — enter and exit are keyframe animations — and having
           // both meant the transform kept moving after the animation ended,
           // measurably stretching the open past 400ms.
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart data-[state=open]:duration-300 data-[state=closed]:duration-300 fixed z-50 flex flex-col gap-4 shadow-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed z-50 flex flex-col gap-4 shadow-lg data-[state=closed]:duration-300 data-[state=open]:duration-300',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&

--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ function SheetOverlay({ className, ...props }: React.ComponentProps<typeof Sheet
         // "background blur-full" (Figma 1292:63542, the mobile Modal Overlay —
         // CSS blur(100px), Figma halves the stored radius 200). Near-transparent
         // modal cards (bg-secondary) rely on this frost to be legible.
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] duration-300',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] data-[state=open]:duration-300 data-[state=closed]:duration-300',
         className
       )}
       {...props}
@@ -64,7 +64,17 @@ function SheetContent({
           // width in 300ms each way, and the two directions are deliberately
           // different curves — it arrives decisively on quint and leaves evenly
           // on quart. Opening was 500ms on a blanket ease-in-out.
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed z-50 flex flex-col gap-4 shadow-lg transition-[transform,opacity] duration-300',
+          //
+          // The duration is scoped to the state variants, not left bare: a
+          // plain `duration-*` sets the same property `animate-in` does, and
+          // loses to it on source order — measured opening at animate-in's own
+          // 150ms default. The variant outranks it.
+          //
+          // `transition-[transform,opacity]` is gone with it. Nothing here
+          // transitions — enter and exit are keyframe animations — and having
+          // both meant the transform kept moving after the animation ended,
+          // measurably stretching the open past 400ms.
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart data-[state=open]:duration-300 data-[state=closed]:duration-300 fixed z-50 flex flex-col gap-4 shadow-lg',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&

--- a/apps/webapp/src/components/ui/sheet.tsx
+++ b/apps/webapp/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ function SheetOverlay({ className, ...props }: React.ComponentProps<typeof Sheet
         // "background blur-full" (Figma 1292:63542, the mobile Modal Overlay —
         // CSS blur(100px), Figma halves the stored radius 200). Near-transparent
         // modal cards (bg-secondary) rely on this frost to be legible.
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px]',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart bg-modalOverlay fixed inset-0 z-50 backdrop-blur-[100px] duration-300',
         className
       )}
       {...props}
@@ -60,7 +60,11 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition-[transform,opacity] ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          // Motion (Figma: Sky App: UI 1598:75751): the panel travels its full
+          // width in 300ms each way, and the two directions are deliberately
+          // different curves — it arrives decisively on quint and leaves evenly
+          // on quart. Opening was 500ms on a blanket ease-in-out.
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:ease-out-quint data-[state=closed]:ease-in-out-quart fixed z-50 flex flex-col gap-4 shadow-lg transition-[transform,opacity] duration-300',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&

--- a/apps/webapp/src/components/ui/sonner.tsx
+++ b/apps/webapp/src/components/ui/sonner.tsx
@@ -43,7 +43,8 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
     // siblings — never applied. They are Radix Toast's state model; sonner
     // marks toasts with data-mounted/data-removed and has no data-state at
     // all, so those rules had matched nothing since the sonner migration.
-    toast: 'group flex items-start! gap-3! rounded-2xl! bg-bgTertiary! border-none! shadow-none! text-fgPrimary! p-4! pr-12! backdrop-blur-[20px] min-w-[356px] md:min-w-[420px] max-w-[420px] duration-300! ease-in-out-quart! data-[expanded=false]:overflow-hidden',
+    toast:
+      'group flex items-start! gap-3! rounded-2xl! bg-bgTertiary! border-none! shadow-none! text-fgPrimary! p-4! pr-12! backdrop-blur-[20px] min-w-[356px] md:min-w-[420px] max-w-[420px] duration-300! ease-in-out-quart! data-[expanded=false]:overflow-hidden',
     title: 'font-circle text-base leading-[18px]! font-medium tracking-[-0.32px] text-fgPrimary!',
     description: 'font-graphik text-[11px] leading-4! font-normal text-fgSecondary! mt-1',
     icon: 'size-auto! shrink-0',

--- a/apps/webapp/src/components/ui/sonner.tsx
+++ b/apps/webapp/src/components/ui/sonner.tsx
@@ -25,8 +25,25 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
   const bottomOffset =
     bannerHeight > 0 ? BANNER_BOTTOM_MARGIN + bannerHeight + BANNER_TOAST_GAP : SONNER_DEFAULT_OFFSET;
   const defaultClassNames: ToastClassnames = {
-    toast:
-      'group flex items-start! gap-3! rounded-2xl! bg-bgTertiary! border-none! shadow-none! text-fgPrimary! p-4! pr-12! backdrop-blur-[20px] min-w-[356px] md:min-w-[420px] max-w-[420px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-bottom-full data-[expanded=false]:overflow-hidden',
+    // Motion (Figma: Sky App: UI 1598:76070): the toast slides its own height
+    // up from the bottom edge and leaves the same way, ~300ms each way on
+    // easeInOutQuart.
+    //
+    // That direction is what sonner already does natively — it drives a `--y`
+    // custom property between translateY(100%) and translateY(0), flipping the
+    // sign on removal — so this only retimes it off sonner's 400ms default.
+    // The `!` is required: sonner's own [data-sonner-toast] rule ships in a
+    // stylesheet it injects at runtime, which lands after ours.
+    //
+    // The comp animates y alone, but sonner's opacity fade is kept
+    // deliberately: the toaster is not a clipping container, so a toast that
+    // only translated would still be visible sitting below its resting place.
+    //
+    // NOTE: the classes removed here — data-[state=open]:animate-in and its
+    // siblings — never applied. They are Radix Toast's state model; sonner
+    // marks toasts with data-mounted/data-removed and has no data-state at
+    // all, so those rules had matched nothing since the sonner migration.
+    toast: 'group flex items-start! gap-3! rounded-2xl! bg-bgTertiary! border-none! shadow-none! text-fgPrimary! p-4! pr-12! backdrop-blur-[20px] min-w-[356px] md:min-w-[420px] max-w-[420px] duration-300! ease-in-out-quart! data-[expanded=false]:overflow-hidden',
     title: 'font-circle text-base leading-[18px]! font-medium tracking-[-0.32px] text-fgPrimary!',
     description: 'font-graphik text-[11px] leading-4! font-normal text-fgSecondary! mt-1',
     icon: 'size-auto! shrink-0',

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -304,8 +304,12 @@
   --ease-out-expo: cubic-bezier(0.16, 1, 0.03, 1);
   --ease-in-out-expo: cubic-bezier(0.87, 0, 0.13, 1);
   --ease-bezier-mouse: cubic-bezier(0.4, 0, 0.2, 1);
-  /* The curve the motion comps use for page transitions (easeInOutQuart). */
+  /* The two curves the motion comps are drawn on. Across every comp the
+     pairing is consistent: a surface ARRIVES on quint (decisive, front-loaded)
+     and LEAVES on quart (even), while anything that merely crossfades or
+     travels in both directions uses quart alone. */
   --ease-in-out-quart: cubic-bezier(0.77, 0, 0.175, 1);
+  --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
 
   --transition-duration-250: 250ms;
   --transition-duration-350: 350ms;

--- a/apps/webapp/src/modules/stake/components/LiquidationPostMortemModal.tsx
+++ b/apps/webapp/src/modules/stake/components/LiquidationPostMortemModal.tsx
@@ -129,7 +129,16 @@ function LiquidationRecoveryConfirmSummary({
  * NOT indexed against the bark yet, so those stats render the same NO_VALUE
  * gap as every other undesigned/ungated stat on the sibling details modal.
  */
-export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: number; onClose: () => void }) {
+export function LiquidationPostMortemModal({
+  urnIndex,
+  open = true,
+  onClose
+}: {
+  urnIndex: number;
+  /** Controlled for the same reason as PositionDetailsModal's — see there. */
+  open?: boolean;
+  onClose: () => void;
+}) {
   const chainId = useChainId();
   const queryClient = useQueryClient();
 
@@ -210,7 +219,7 @@ export function LiquidationPostMortemModal({ urnIndex, onClose }: { urnIndex: nu
   const ctaDisabled = !recovery.prepared || recovery.isLoading || !hasRecovery;
 
   return (
-    <Dialog open onOpenChange={open => !open && onClose()}>
+    <Dialog open={open} onOpenChange={next => !next && onClose()}>
       <DialogContent
         aria-describedby={undefined}
         data-testid="stake-postmortem-modal"

--- a/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionDetailsModal.tsx
@@ -380,12 +380,19 @@ function ManageCtas({
  */
 export function PositionDetailsModal({
   urnIndex,
+  open = true,
   onClose,
   onAction,
   onClaim,
   onReopen
 }: {
   urnIndex: number;
+  /**
+   * Controlled so the modal can be told to close and still be here to animate
+   * it: the flow that owns this used to unmount it on close, which skipped the
+   * dismissal entirely. Defaults to open for callers that mount it on demand.
+   */
+  open?: boolean;
   onClose: () => void;
   onAction: (action: StakeManageAction) => void;
   /** Opens the claim-rewards modal (F6) — row enabled while something is claimable. */
@@ -481,7 +488,7 @@ export function PositionDetailsModal({
 
   return (
     <>
-      <Dialog open onOpenChange={open => !open && onClose()}>
+      <Dialog open={open} onOpenChange={next => !next && onClose()}>
         <DialogContent
           aria-describedby={undefined}
           data-testid="stake-position-details"

--- a/apps/webapp/src/modules/stake/components/PositionManageFlow.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionManageFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence } from 'motion/react';
 import { QueryParams } from '@/lib/constants';
 import { useAppSearchParams } from '@/lib/navigation';
@@ -106,17 +106,34 @@ export function PositionManageFlow({
   const { data: positions } = useStakeUserPositions();
   const position = urnIndex !== null ? positions?.find(p => p.index === urnIndex) : undefined;
 
-  // The views are resolved into one element and handed to a single
-  // AnimatePresence below, rather than returned early from here.
+  // Closing deletes the params, but StakeProductPage holds this flow mounted
+  // for the exit — so keep drawing whatever was on screen, and let each view
+  // dismiss itself the way it knows how.
   //
-  // Closing deletes the urn_index param, which makes this component return
-  // nothing while it is still mounted — so an AnimatePresence around it in the
-  // parent is no help: it preserves this element, this element re-renders
-  // against the new params, and the takeover is gone before it can animate.
-  // The boundary has to sit here, where the child element itself is what gets
-  // preserved, with its props frozen at the moment it left.
+  // The two families need opposite treatment. The Radix modals must stay
+  // MOUNTED and be told `open={false}`, since that is what makes Radix render a
+  // closing state at all; unmounting them (what used to happen) skips the
+  // dismissal entirely. The motion takeovers are the reverse: their exit runs
+  // by being REMOVED from the AnimatePresence below, so they must go to null.
+  const isOpen = urnIndex !== null;
+  const lastOpen = useRef<{ urnIndex: number; view: ManageView; isPostMortem: boolean } | null>(null);
+  if (urnIndex !== null) {
+    lastOpen.current = {
+      urnIndex,
+      view,
+      isPostMortem: !!position && isLiquidatedStakePosition(position)
+    };
+  }
+  const current = lastOpen.current;
+
+  // The views are resolved into one element and handed to a single
+  // AnimatePresence, rather than returned early. One boundary only: nesting a
+  // second one in the parent breaks this one, because closing empties this
+  // presence in the same tick and the outer boundary then unmounts the subtree
+  // before the exit it just started can run.
   const resolveView = () => {
-    if (urnIndex === null) return null;
+    if (!current) return null;
+    const { urnIndex: index, view: currentView, isPostMortem } = current;
 
     // Liquidated urns always land on the post-mortem, BEFORE the view dispatch:
     // a `stake_tab` deep link or a caller-staged `initialSheetInit` mounts the
@@ -125,28 +142,31 @@ export function PositionManageFlow({
     // timestamp overtakes the bark and `isLiquidatedStakePosition` flips to
     // false on its own — this then falls through to the ordinary views without
     // any extra transition here.
-    if (position && isLiquidatedStakePosition(position)) {
-      return <LiquidationPostMortemModal key="postmortem" urnIndex={urnIndex} onClose={close} />;
+    if (isPostMortem) {
+      return <LiquidationPostMortemModal key="postmortem" urnIndex={index} open={isOpen} onClose={close} />;
     }
 
-    if (view.name === 'claim') {
-      return <StakeClaimModal key="claim" urnIndex={urnIndex} onClose={onBack} />;
+    if (currentView.name === 'claim') {
+      // Portalled into the transaction modal's entry slot, so it leaves with
+      // that modal rather than on its own.
+      return isOpen ? <StakeClaimModal key="claim" urnIndex={index} onClose={onBack} /> : null;
     }
 
-    if (view.name === 'reopen') {
-      return (
+    if (currentView.name === 'reopen') {
+      return isOpen ? (
         <OpenPositionTakeover
           key="reopen"
-          reopen={{ urnIndex, borrowExpanded: view.borrowExpanded, onBack, onClose: close }}
+          reopen={{ urnIndex: index, borrowExpanded: currentView.borrowExpanded, onBack, onClose: close }}
         />
-      );
+      ) : null;
     }
 
-    if (view.name === 'details') {
+    if (currentView.name === 'details') {
       return (
         <PositionDetailsModal
           key="details"
-          urnIndex={urnIndex}
+          urnIndex={index}
+          open={isOpen}
           onClose={close}
           onAction={onAction}
           onClaim={onClaim}
@@ -155,15 +175,15 @@ export function PositionManageFlow({
       );
     }
 
-    return (
+    return isOpen ? (
       <ManagePositionTakeover
         key="manage"
-        urnIndex={urnIndex}
-        init={view.init}
+        urnIndex={index}
+        init={currentView.init}
         onBack={onBack}
         onClose={close}
       />
-    );
+    ) : null;
   };
 
   return <AnimatePresence>{resolveView()}</AnimatePresence>;

--- a/apps/webapp/src/modules/stake/components/PositionManageFlow.tsx
+++ b/apps/webapp/src/modules/stake/components/PositionManageFlow.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { AnimatePresence } from 'motion/react';
 import { QueryParams } from '@/lib/constants';
 import { useAppSearchParams } from '@/lib/navigation';
 import { StakeManageFlowInit } from '../hooks/useStakeManageFlowState';
@@ -105,42 +106,65 @@ export function PositionManageFlow({
   const { data: positions } = useStakeUserPositions();
   const position = urnIndex !== null ? positions?.find(p => p.index === urnIndex) : undefined;
 
-  if (urnIndex === null) return null;
+  // The views are resolved into one element and handed to a single
+  // AnimatePresence below, rather than returned early from here.
+  //
+  // Closing deletes the urn_index param, which makes this component return
+  // nothing while it is still mounted — so an AnimatePresence around it in the
+  // parent is no help: it preserves this element, this element re-renders
+  // against the new params, and the takeover is gone before it can animate.
+  // The boundary has to sit here, where the child element itself is what gets
+  // preserved, with its props frozen at the moment it left.
+  const resolveView = () => {
+    if (urnIndex === null) return null;
 
-  // Liquidated urns always land on the post-mortem, BEFORE the view dispatch:
-  // a `stake_tab` deep link or a caller-staged `initialSheetInit` mounts the
-  // flow directly in 'sheet', which must not open a manage sheet on a barked
-  // urn. A successful recovery frees the SKY, so the position's next mutation
-  // timestamp overtakes the bark and `isLiquidatedStakePosition` flips to
-  // false on its own — this then falls through to the ordinary views without
-  // any extra transition here.
-  if (position && isLiquidatedStakePosition(position)) {
-    return <LiquidationPostMortemModal urnIndex={urnIndex} onClose={close} />;
-  }
+    // Liquidated urns always land on the post-mortem, BEFORE the view dispatch:
+    // a `stake_tab` deep link or a caller-staged `initialSheetInit` mounts the
+    // flow directly in 'sheet', which must not open a manage sheet on a barked
+    // urn. A successful recovery frees the SKY, so the position's next mutation
+    // timestamp overtakes the bark and `isLiquidatedStakePosition` flips to
+    // false on its own — this then falls through to the ordinary views without
+    // any extra transition here.
+    if (position && isLiquidatedStakePosition(position)) {
+      return <LiquidationPostMortemModal key="postmortem" urnIndex={urnIndex} onClose={close} />;
+    }
 
-  if (view.name === 'claim') {
-    return <StakeClaimModal urnIndex={urnIndex} onClose={onBack} />;
-  }
+    if (view.name === 'claim') {
+      return <StakeClaimModal key="claim" urnIndex={urnIndex} onClose={onBack} />;
+    }
 
-  if (view.name === 'reopen') {
+    if (view.name === 'reopen') {
+      return (
+        <OpenPositionTakeover
+          key="reopen"
+          reopen={{ urnIndex, borrowExpanded: view.borrowExpanded, onBack, onClose: close }}
+        />
+      );
+    }
+
+    if (view.name === 'details') {
+      return (
+        <PositionDetailsModal
+          key="details"
+          urnIndex={urnIndex}
+          onClose={close}
+          onAction={onAction}
+          onClaim={onClaim}
+          onReopen={onReopen}
+        />
+      );
+    }
+
     return (
-      <OpenPositionTakeover
-        reopen={{ urnIndex, borrowExpanded: view.borrowExpanded, onBack, onClose: close }}
-      />
-    );
-  }
-
-  if (view.name === 'details') {
-    return (
-      <PositionDetailsModal
+      <ManagePositionTakeover
+        key="manage"
         urnIndex={urnIndex}
+        init={view.init}
+        onBack={onBack}
         onClose={close}
-        onAction={onAction}
-        onClaim={onClaim}
-        onReopen={onReopen}
       />
     );
-  }
+  };
 
-  return <ManagePositionTakeover urnIndex={urnIndex} init={view.init} onBack={onBack} onClose={close} />;
+  return <AnimatePresence>{resolveView()}</AnimatePresence>;
 }

--- a/apps/webapp/src/modules/stake/components/StakeProductPage.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeProductPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence } from 'motion/react';
 import { useChains, useConnection } from 'wagmi';
 import { Trans } from '@lingui/react/macro';
@@ -18,6 +18,32 @@ import { StakeStatisticsTab } from './StakeStatisticsTab';
 import { StakeAboutTab } from './StakeAboutTab';
 import { OpenPositionTakeover } from './OpenPositionTakeover';
 import { PositionManageFlow, manageActionInit } from './PositionManageFlow';
+
+/** Matches the takeover dismissal in `components/product/TakeoverShell.tsx`. */
+const TAKEOVER_EXIT_MS = 300;
+
+/**
+ * Keeps a route-driven overlay mounted for the length of its exit animation
+ * after its flag clears, so the overlay's own AnimatePresence has something to
+ * animate. Without it the flag and the overlay's data (the urn index) clear in
+ * the same tick and the whole subtree is gone before any exit can run.
+ */
+function useExitHold(active: boolean, ms: number) {
+  const [held, setHeld] = useState(active);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Opening is immediate; only the release is deferred.
+  if (active && !held) setHeld(true);
+
+  useEffect(() => {
+    if (active || !held) return;
+    timer.current = setTimeout(() => setHeld(false), ms);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [active, held, ms]);
+
+  return held;
+}
 
 // URL tab contract for the Stake destination page: `?tab=` selects the visible
 // tab and always wins; without it (or with an unknown value) the default is
@@ -62,6 +88,7 @@ export function StakeProductPage() {
   // `flow=manage&urn_index=N`; closing returns to a clean URL.
   const isOpenFlow = searchParams.get(QueryParams.Flow) === 'open';
   const isManageFlow = searchParams.get(QueryParams.Flow) === 'manage';
+  const holdManageFlow = useExitHold(isManageFlow, TAKEOVER_EXIT_MS);
 
   // Radix only fires onValueChange for a *different* tab, so clicking the
   // already-active trigger writes nothing — and the statistics default could
@@ -182,14 +209,18 @@ export function StakeProductPage() {
           unmount them outright — without an AnimatePresence above the
           condition, closing one skips its exit entirely. */}
       <AnimatePresence>{isOpenFlow && <OpenPositionTakeover />}</AnimatePresence>
-      <AnimatePresence>
-        {isManageFlow && (
-          <PositionManageFlow
-            initialSheetInit={pendingSheetInit ?? undefined}
-            onInitialSheetInitConsumed={onInitialSheetInitConsumed}
-          />
-        )}
-      </AnimatePresence>
+      {/* Held rather than wrapped in an AnimatePresence of its own: the flow
+          owns one internally (its views swap behind it), and nesting the two
+          breaks the exit. Closing empties the inner presence in the same tick,
+          so an outer boundary sees nothing left to wait for, calls its exit
+          done, and unmounts the subtree out from under the animation that had
+          just started. Holding the mount lets the inner one finish. */}
+      {holdManageFlow && (
+        <PositionManageFlow
+          initialSheetInit={pendingSheetInit ?? undefined}
+          onInitialSheetInitConsumed={onInitialSheetInitConsumed}
+        />
+      )}
     </div>
   );
 }

--- a/apps/webapp/src/modules/stake/components/StakeProductPage.tsx
+++ b/apps/webapp/src/modules/stake/components/StakeProductPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { AnimatePresence } from 'motion/react';
 import { useChains, useConnection } from 'wagmi';
 import { Trans } from '@lingui/react/macro';
 import { Intent } from '@/lib/enums';
@@ -177,13 +178,18 @@ export function StakeProductPage() {
         </TabsContent>
       </Tabs>
 
-      {isOpenFlow && <OpenPositionTakeover />}
-      {isManageFlow && (
-        <PositionManageFlow
-          initialSheetInit={pendingSheetInit ?? undefined}
-          onInitialSheetInitConsumed={onInitialSheetInitConsumed}
-        />
-      )}
+      {/* The takeovers animate themselves (TakeoverShell), but the flow flags
+          unmount them outright — without an AnimatePresence above the
+          condition, closing one skips its exit entirely. */}
+      <AnimatePresence>{isOpenFlow && <OpenPositionTakeover />}</AnimatePresence>
+      <AnimatePresence>
+        {isManageFlow && (
+          <PositionManageFlow
+            initialSheetInit={pendingSheetInit ?? undefined}
+            onInitialSheetInitConsumed={onInitialSheetInitConsumed}
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/webapp/src/modules/stake/hooks/useStakeRewardsRate.test.tsx
+++ b/apps/webapp/src/modules/stake/hooks/useStakeRewardsRate.test.tsx
@@ -1,19 +1,28 @@
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RewardsChartInfoParsed } from '@/hooks';
 
 // Two stake farms; the chart-info arrays are swapped per test via this knob.
-let mockChartInfo: (Partial<RewardsChartInfoParsed>[] | undefined)[] = [];
+let mockChartInfo: (Partial<RewardsChartInfoParsed>[] | undefined)[] | undefined = [];
+// Both queries re-report loading whenever their key changes, so the tests can
+// drive those flags independently of the data.
+let mockContracts: { contractAddress: string }[] | undefined = [
+  { contractAddress: '0xfarmA' },
+  { contractAddress: '0xfarmB' }
+];
+let mockContractsLoading = false;
+let mockChartsLoading = false;
 
 vi.mock('@/hooks', async importOriginal => {
   const actual = await importOriginal<typeof import('@/hooks')>();
   return {
     ...actual,
-    useStakeRewardContracts: () => ({
-      data: [{ contractAddress: '0xfarmA' }, { contractAddress: '0xfarmB' }],
-      isLoading: false
-    }),
-    useMultipleRewardsChartInfo: () => ({ data: mockChartInfo, isLoading: false, error: null })
+    useStakeRewardContracts: () => ({ data: mockContracts, isLoading: mockContractsLoading }),
+    useMultipleRewardsChartInfo: () => ({
+      data: mockChartInfo,
+      isLoading: mockChartsLoading,
+      error: null
+    })
   };
 });
 
@@ -22,6 +31,12 @@ import { useStakeRewardsRate } from './useStakeRewardsRate';
 const point = (blockTimestamp: number, rate: string) => ({ blockTimestamp, rate });
 
 describe('useStakeRewardsRate', () => {
+  beforeEach(() => {
+    mockContracts = [{ contractAddress: '0xfarmA' }, { contractAddress: '0xfarmB' }];
+    mockContractsLoading = false;
+    mockChartsLoading = false;
+  });
+
   it('crowns the farm with the highest most-recent rate and returns its full series', () => {
     // Farm A peaked at 0.20 in the past but its LATEST point (0.05) is what
     // competes; farm B's latest 0.08 wins.
@@ -70,5 +85,54 @@ describe('useStakeRewardsRate', () => {
     const { result } = renderHook(() => useStakeRewardsRate());
 
     expect(result.current.currentRate).toBeNull();
+  });
+
+  it('reports loading on the cold start, before anything has resolved', () => {
+    mockChartInfo = undefined;
+    mockContracts = undefined;
+    mockContractsLoading = true;
+
+    const { result } = renderHook(() => useStakeRewardsRate());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.series).toEqual([]);
+  });
+
+  it('holds the resolved series instead of re-reporting loading when a query key changes', () => {
+    // The contract list arrives as a hardcoded placeholder and the indexer's
+    // real one replaces it, which rewrites the farm URLs the chart query is
+    // keyed on: both queries hand back undefined and say "loading" a second
+    // time. Passing that through returns the chart to its skeleton, and the
+    // remount is what replays its entrance wipe.
+    const farm = [point(100, '0.01'), point(200, '0.08')];
+    mockChartInfo = [farm];
+
+    const { result, rerender } = renderHook(() => useStakeRewardsRate());
+    expect(result.current.series).toBe(farm);
+    expect(result.current.isLoading).toBe(false);
+
+    mockChartInfo = undefined;
+    mockContracts = undefined;
+    mockContractsLoading = true;
+    mockChartsLoading = true;
+    rerender();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.series).toBe(farm);
+    expect(result.current.currentRate).toBeCloseTo(0.08, 10);
+  });
+
+  it('swaps to the new series once the refetch lands', () => {
+    const first = [point(200, '0.08')];
+    mockChartInfo = [first];
+    const { result, rerender } = renderHook(() => useStakeRewardsRate());
+    expect(result.current.series).toBe(first);
+
+    const second = [point(300, '0.12')];
+    mockChartInfo = [second];
+    rerender();
+
+    expect(result.current.series).toBe(second);
+    expect(result.current.currentRate).toBeCloseTo(0.12, 10);
   });
 });

--- a/apps/webapp/src/modules/stake/hooks/useStakeRewardsRate.ts
+++ b/apps/webapp/src/modules/stake/hooks/useStakeRewardsRate.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useStakeRewardContracts, useMultipleRewardsChartInfo, type RewardsChartInfoParsed } from '@/hooks';
 
 // Full farm history: the Statistics chart's `All` range and the trailing
@@ -50,10 +50,32 @@ export function useStakeRewardsRate(): StakeRewardsRate {
 
   const parsedRate = winner ? parseFloat(winner.latest.rate) : NaN;
 
+  /**
+   * Both underlying queries hand back `undefined` and re-report loading when
+   * their key changes, not just on the first fetch — the contract list arrives
+   * as a hardcoded placeholder before the indexer's real one replaces it, which
+   * rewrites the farm URLs the chart query is keyed on, and an indexer failure
+   * swaps the whole hook onto its on-chain fallback. Passed straight through,
+   * each of those flips takes the chart back to its skeleton, and the chart
+   * unmounting is what makes its entrance wipe play a second time.
+   *
+   * So the last series that actually resolved is held on to and kept on screen
+   * while the next one loads. Only the true cold start, with nothing resolved
+   * yet, still reports loading.
+   */
+  const lastResolved = useRef<{ series: RewardsChartInfoParsed[]; currentRate: number | null } | null>(null);
+  if (winner) {
+    lastResolved.current = {
+      series: winner.series,
+      currentRate: Number.isFinite(parsedRate) ? parsedRate : null
+    };
+  }
+  const resolved = lastResolved.current;
+
   return {
-    series: winner?.series ?? [],
-    currentRate: Number.isFinite(parsedRate) ? parsedRate : null,
-    isLoading: contractsLoading || chartsLoading,
+    series: resolved?.series ?? [],
+    currentRate: resolved?.currentRate ?? null,
+    isLoading: (contractsLoading || chartsLoading) && !resolved,
     error: error ?? null
   };
 }

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ChartSkeleton } from '@/components/ui/chart-skeleton';
-import { AnimatePresence, motion } from 'motion/react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { easeOutExpo } from '../animation/timingFunctions';
 import { positionAnimations } from '../animation/presets';
 import { AnimationLabels } from '../animation/constants';
@@ -179,7 +179,19 @@ const POST_CURSOR_ALPHA = 0.4;
  * lands after any page transition has finished.
  */
 const REVEAL_DURATION_MS = 900;
+/**
+ * The same wipe, replayed when the series is swapped for another one — the
+ * Rate|TVL switch in the tabs comp (Figma: Sky App: UI 1598:76322), where the
+ * outgoing series fades over ~230ms and the incoming one draws itself in over
+ * ~600ms. recharts carries a single animationDuration for both the first
+ * reveal and every replay, so the component steps it down once the opening
+ * wipe has finished.
+ */
+const RE_REVEAL_DURATION_MS = 600;
 const REVEAL_EASING = 'cubic-bezier(0.77,0,0.175,1)';
+
+/** The active pill's slide between segments (tabs comp): 151ms, easeInOut. */
+const PILL_SLIDE = { duration: 0.15, ease: [0.42, 0, 0.58, 1] } as const;
 
 /**
  * DS Line hover (Figma 5273:12162): the plotted series keeps full strength up
@@ -288,19 +300,48 @@ function SegmentedPills<T extends string>({
   /** Extra classes on each pill (e.g. `flex-1` to split the width evenly). */
   itemClassName?: string;
 }) {
+  // One shared layout element per group, so switching segments slides the
+  // active fill across instead of repainting it in place. The id scopes the
+  // shared element to this group — a page renders several of these (metric and
+  // timeframe, plus their mobile counterparts) and a duplicated layoutId would
+  // make pills fly between groups.
+  const pillId = useId();
+  const reduceMotion = useReducedMotion();
+
   return (
     <div className={cn(tabsListVariants({ variant: 'segmented' }), className)} data-testid={dataTestId}>
-      {options.map(option => (
-        <button
-          key={option.value}
-          type="button"
-          onClick={() => onChange(option.value)}
-          data-state={value === option.value ? 'active' : 'inactive'}
-          className={cn(tabsTriggerVariants({ variant: 'segmented' }), itemClassName)}
-        >
-          {option.label}
-        </button>
-      ))}
+      {options.map(option => {
+        const isActive = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            data-state={isActive ? 'active' : 'inactive'}
+            className={cn(
+              tabsTriggerVariants({ variant: 'segmented' }),
+              // The recipe paints the active fill and border on the trigger
+              // itself; the travelling element below owns them here. Suppressed
+              // locally rather than in the recipe, which other non-Radix groups
+              // still rely on.
+              'relative data-[state=active]:border-transparent data-[state=active]:bg-none',
+              itemClassName
+            )}
+          >
+            {isActive && (
+              <motion.span
+                layoutId={`${pillId}-active-pill`}
+                aria-hidden
+                // -z-10 keeps the fill under the label; the button's own
+                // background is transparent, so nothing else needs stacking.
+                className="border-borderBrandDim from-brand2-start to-brand2-end absolute inset-0 -z-10 rounded-full border bg-linear-to-b bg-origin-border"
+                transition={reduceMotion ? { duration: 0 } : PILL_SLIDE}
+              />
+            )}
+            {option.label}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -543,6 +584,11 @@ function ChartContent({
   const { bpi } = useBreakpointIndex();
   const gradientId = useId();
   const dimMaskId = useId();
+  // The opening wipe is the slower one; every replay after it — a metric or
+  // timeframe switch, which recharts treats as a fresh entrance — runs at the
+  // tabs comp's shorter figure. Stepped down when the first wipe reports done,
+  // since recharts reads one duration for both.
+  const [revealDuration, setRevealDuration] = useState(REVEAL_DURATION_MS);
 
   // components/charts/bg-chart2 unless the caller themes the series (e.g. the
   // Stake destination chart's bg-chart1 indigo).
@@ -627,8 +673,9 @@ function ChartContent({
             // at its 'auto' default is deliberate: it resolves to off under
             // prefers-reduced-motion (and under SSR), so the reveal needs no
             // reduced-motion handling of its own.
-            animationDuration={REVEAL_DURATION_MS}
+            animationDuration={revealDuration}
             animationEasing={REVEAL_EASING}
+            onAnimationEnd={() => setRevealDuration(RE_REVEAL_DURATION_MS)}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -332,13 +332,16 @@ function SegmentedPills<T extends string>({
               <motion.span
                 layoutId={`${pillId}-active-pill`}
                 aria-hidden
-                // -z-10 keeps the fill under the label; the button's own
-                // background is transparent, so nothing else needs stacking.
-                className="border-borderBrandDim from-brand2-start to-brand2-end absolute inset-0 -z-10 rounded-full border bg-linear-to-b bg-origin-border"
+                // No negative z-index: the group paints its own well
+                // (bg-pageBackground), and a -z-10 fill sits behind THAT and
+                // disappears entirely. Stacking is by DOM order instead — the
+                // fill is positioned and comes first, the label is positioned
+                // and comes after, so the label wins.
+                className="border-borderBrandDim from-brand2-start to-brand2-end absolute inset-0 rounded-full border bg-linear-to-b bg-origin-border"
                 transition={reduceMotion ? { duration: 0 } : PILL_SLIDE}
               />
             )}
-            {option.label}
+            <span className="relative">{option.label}</span>
           </button>
         );
       })}

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -4,7 +4,7 @@ import { tabsListVariants, tabsTriggerVariants } from '@/components/ui/tabs';
 import { cn } from '@/lib/cn';
 import { HStack } from '@/modules/layout/components/HStack';
 import { formatNumber } from '@/utils';
-import { useMemo, useState, useRef, useEffect, useId } from 'react';
+import { useMemo, useState, useRef, useEffect, useId, useCallback } from 'react';
 import {
   Area,
   AreaChart,
@@ -671,6 +671,13 @@ function ChartContent({
   // tabs comp's shorter figure. Stepped down when the first wipe reports done,
   // since recharts reads one duration for both.
   const [revealDuration, setRevealDuration] = useState(REVEAL_DURATION_MS);
+  // Stable identity is load-bearing, not tidiness: recharts rebuilds the
+  // running animation from zero whenever this handler's identity changes
+  // (JavascriptAnimate lists onAnimationEnd in the deps of the effect that
+  // constructs it). Inline, the wipe restarted on every re-render that landed
+  // mid-reveal — on a cold load the series stuttered through two or three
+  // false starts before the real one.
+  const handleRevealEnd = useCallback(() => setRevealDuration(RE_REVEAL_DURATION_MS), []);
   const tooltipPortal = useChartTooltipPortal();
   // The plot box, so the portalled tooltip can turn recharts' chart-space
   // coordinate into viewport pixels.
@@ -778,7 +785,7 @@ function ChartContent({
               // reduced-motion handling of its own.
               animationDuration={revealDuration}
               animationEasing={REVEAL_EASING}
-              onAnimationEnd={() => setRevealDuration(RE_REVEAL_DURATION_MS)}
+              onAnimationEnd={handleRevealEnd}
             />
           </AreaChart>
         </ResponsiveContainer>

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -567,6 +567,7 @@ function ChartContent({
   tokenSymbols,
   chartHeight,
   color,
+  seriesKey,
   isDetail = false
 }: {
   data: Data[];
@@ -581,6 +582,14 @@ function ChartContent({
   tokenSymbols?: string[];
   chartHeight?: number;
   color?: string;
+  /**
+   * Identifies which series is plotted (metric + timeframe). Changing it
+   * remounts the Area so the new series wipes in from the left, rather than
+   * recharts interpolating the old curve into the new one — handed a new
+   * dataset for the same Area, it morphs the path, which is not what the tabs
+   * comp draws.
+   */
+  seriesKey?: string;
   /** detail variant: no date axis under the plot, so it runs to the card floor. */
   isDetail?: boolean;
 }) {
@@ -658,6 +667,7 @@ function ChartContent({
           />
 
           <Area
+            key={seriesKey}
             dataKey="value"
             stroke={seriesColor}
             strokeWidth={SERIES_STROKE_WIDTH}
@@ -880,6 +890,7 @@ export function Chart({
             tooltipLabel={resolveTooltipLabel(tooltipLabel, metrics, activeMetric)}
             tokenSymbols={tokenSymbols}
             color={color}
+            seriesKey={`${activeMetric ?? ''}-${activeTimeframe}`}
           />
         </div>
         {isMobileDetail && (

--- a/apps/webapp/src/modules/ui/context/ConnectModalContext.tsx
+++ b/apps/webapp/src/modules/ui/context/ConnectModalContext.tsx
@@ -1,4 +1,13 @@
-import { createContext, useContext, useState, ReactNode, Suspense } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  ReactNode,
+  Suspense
+} from 'react';
 import { ConnectModal } from '../components/ConnectModal';
 
 interface ConnectModalContextType {
@@ -9,16 +18,37 @@ interface ConnectModalContextType {
 
 export const ConnectModalContext = createContext<ConnectModalContextType | undefined>(undefined);
 
+/** Matches the dismissal in `components/ui/dialog.tsx`. */
+const MODAL_EXIT_MS = 300;
+
 export function ConnectModalProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
+  // `isOpen` gates the modal so its lazy chunk stays off the initial load, but
+  // that also unmounted it in the same tick it was told to close, cutting the
+  // exit animation. Mounting is held for the length of that animation and then
+  // released, so the modal still gets a fresh mount on the next open.
+  const [mounted, setMounted] = useState(false);
+  const unmountTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const openConnectModal = () => setIsOpen(true);
-  const closeConnectModal = () => setIsOpen(false);
+  const setOpen = useCallback((next: boolean) => {
+    setIsOpen(next);
+    if (unmountTimer.current) clearTimeout(unmountTimer.current);
+    if (next) {
+      setMounted(true);
+    } else {
+      unmountTimer.current = setTimeout(() => setMounted(false), MODAL_EXIT_MS);
+    }
+  }, []);
+
+  useEffect(() => () => (unmountTimer.current ? clearTimeout(unmountTimer.current) : undefined), []);
+
+  const openConnectModal = useCallback(() => setOpen(true), [setOpen]);
+  const closeConnectModal = useCallback(() => setOpen(false), [setOpen]);
 
   return (
     <ConnectModalContext.Provider value={{ isOpen, openConnectModal, closeConnectModal }}>
       {children}
-      <Suspense fallback={null}>{isOpen && <ConnectModal open={isOpen} onOpenChange={setIsOpen} />}</Suspense>
+      <Suspense fallback={null}>{mounted && <ConnectModal open={isOpen} onOpenChange={setOpen} />}</Suspense>
     </ConnectModalContext.Provider>
   );
 }

--- a/apps/webapp/src/modules/ui/context/TransactionContext.tsx
+++ b/apps/webapp/src/modules/ui/context/TransactionContext.tsx
@@ -552,9 +552,13 @@ export function TransactionProvider({ children }: { children: ReactNode }) {
             OUTSIDE the Radix dialog, so minimizing (which unmounts the dialog body)
             never tears down a running transaction. It portals its visible inputs into
             the modal's entry slot when present. See `backgroundContent` in the contract. */}
-        {activeConfig?.backgroundContent && (
+        {/* Held through the exit alongside the modal itself: this is where the
+            widget that portals its inputs into the modal's entry slot lives, so
+            unmounting it on close emptied the modal's body a beat before the
+            modal had finished animating away. */}
+        {modalView?.config.backgroundContent && (
           <div hidden key={`bg-${launchCount}`}>
-            {activeConfig.backgroundContent}
+            {modalView.config.backgroundContent}
           </div>
         )}
         {/* Live state while the modal is up; the retained snapshot while it is

--- a/apps/webapp/src/modules/ui/context/TransactionContext.tsx
+++ b/apps/webapp/src/modules/ui/context/TransactionContext.tsx
@@ -68,6 +68,21 @@ export function useEntrySlot() {
   return useContext(EntrySlotContext);
 }
 
+/** The modal's render inputs, retained across its exit animation. */
+type TransactionModalView = {
+  config: TransactionConfig;
+  txStatus: TxStatus;
+  externalLink: string | undefined;
+  currentStep: number;
+};
+
+/**
+ * How long the modal is kept mounted after being told to close, so its exit
+ * animation can play. Matches the dismissal in `components/ui/dialog.tsx`
+ * (and the bottom sheet's, which is the same 300ms).
+ */
+const MODAL_EXIT_MS = 300;
+
 export function TransactionProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
   // Minimized = modal hidden but the transaction keeps running. Distinct from
@@ -86,6 +101,17 @@ export function TransactionProvider({ children }: { children: ReactNode }) {
   // Config is state so updateModalContent re-renders the modal; ref mirrors it for callback reads.
   const [activeConfig, setActiveConfig] = useState<TransactionConfig | null>(null);
   const configRef = useRef<TransactionConfig | null>(null);
+  // Everything the modal draws arrives as props, so this snapshot of them is
+  // enough to keep it on screen, unchanged, while it animates away.
+  //
+  // It exists because `activeConfig` gates the whole modal subtree and
+  // handleClose clears it synchronously: the modal was being unmounted in the
+  // same tick it was told to close, so its exit animation never ran and it
+  // simply vanished. Holding the last rendered props for the length of that
+  // animation lets Radix play the exit. The teardown itself is untouched —
+  // this deliberately does not defer any of it.
+  const [exitingView, setExitingView] = useState<TransactionModalView | null>(null);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeSessionRef = useRef<string | null>(null);
   // Session generation: advanced by launch() and handleClose(), so engine
   // callbacks are bound to the session that rendered them (state) and can spot
@@ -248,6 +274,20 @@ export function TransactionProvider({ children }: { children: ReactNode }) {
       notifyRequestAbandoned();
     }
 
+    // Snapshot what is on screen before tearing it down, so the modal can
+    // finish leaving (see exitingView). Dropped once the animation is over, or
+    // immediately superseded if a new transaction launches inside that window.
+    if (configRef.current) {
+      setExitingView({
+        config: configRef.current,
+        txStatus: txStatusRef.current,
+        externalLink,
+        currentStep
+      });
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = setTimeout(() => setExitingView(null), MODAL_EXIT_MS);
+    }
+
     // End the session generation FIRST: an engine the wallet already answered
     // may fire callbacks right after this teardown, and they must see
     // themselves as stale (see sessionGen above).
@@ -262,7 +302,11 @@ export function TransactionProvider({ children }: { children: ReactNode }) {
     setActiveConfig(null);
     configRef.current = null;
     activeSessionRef.current = null;
-  }, [txStatus, chainId, trackTransactionCompleted, startNewFlow]);
+  }, [txStatus, chainId, trackTransactionCompleted, startNewFlow, externalLink, currentStep]);
+
+  // The exit hold is the only timer here; a provider unmounting mid-dismissal
+  // has nothing left to animate.
+  useEffect(() => () => (exitTimerRef.current ? clearTimeout(exitTimerRef.current) : undefined), []);
 
   // Hide the modal without ending the transaction. Unlike handleClose this keeps
   // activeConfig + txStatus intact (and fires no 'cancelled' analytics), so the
@@ -485,6 +529,10 @@ export function TransactionProvider({ children }: { children: ReactNode }) {
     )
   };
 
+  const modalView: TransactionModalView | null = activeConfig
+    ? { config: activeConfig, txStatus, externalLink, currentStep }
+    : exitingView;
+
   return (
     <TransactionContext.Provider
       value={{
@@ -509,34 +557,38 @@ export function TransactionProvider({ children }: { children: ReactNode }) {
             {activeConfig.backgroundContent}
           </div>
         )}
-        {activeConfig && (
+        {/* Live state while the modal is up; the retained snapshot while it is
+            animating away, which is the only time activeConfig is null here. */}
+        {modalView && (
           <TransactionModal
             key={launchCount}
-            open={open && !minimized}
+            // Already false by the time the snapshot is rendering — that is
+            // what tells Radix to play the exit rather than the enter.
+            open={open && !minimized && !!activeConfig}
             registerEntrySlot={setEntrySlotEl}
             onClose={handleClose}
             onMinimize={minimize}
-            title={activeConfig.title}
-            transactionTitle={activeConfig.transactionTitle}
-            reviewTitle={activeConfig.reviewTitle}
-            subtitles={activeConfig.subtitles}
-            transactionContent={activeConfig.transactionContent}
-            transactionScreenContent={activeConfig.transactionScreenContent}
-            entry={activeConfig.entry}
-            rightHeaderComponent={activeConfig.rightHeaderComponent}
-            titleBadge={activeConfig.titleBadge}
-            onConfirm={activeConfig.onConfirm}
-            onSecondaryConfirm={activeConfig.onSecondaryConfirm}
+            title={modalView.config.title}
+            transactionTitle={modalView.config.transactionTitle}
+            reviewTitle={modalView.config.reviewTitle}
+            subtitles={modalView.config.subtitles}
+            transactionContent={modalView.config.transactionContent}
+            transactionScreenContent={modalView.config.transactionScreenContent}
+            entry={modalView.config.entry}
+            rightHeaderComponent={modalView.config.rightHeaderComponent}
+            titleBadge={modalView.config.titleBadge}
+            onConfirm={modalView.config.onConfirm}
+            onSecondaryConfirm={modalView.config.onSecondaryConfirm}
             onRetry={handleRetry}
             onBack={resetTransactionProgress}
-            txStatus={txStatus}
-            externalLink={externalLink}
-            confirmLabel={activeConfig.confirmLabel}
-            confirmDisabled={activeConfig.confirmDisabled}
-            successLabel={activeConfig.successLabel}
-            errorLabel={activeConfig.errorLabel}
-            steps={activeConfig.steps}
-            currentStep={currentStep}
+            txStatus={modalView.txStatus}
+            externalLink={modalView.externalLink}
+            confirmLabel={modalView.config.confirmLabel}
+            confirmDisabled={modalView.config.confirmDisabled}
+            successLabel={modalView.config.successLabel}
+            errorLabel={modalView.config.errorLabel}
+            steps={modalView.config.steps}
+            currentStep={modalView.currentStep}
           />
         )}
       </EntrySlotContext.Provider>


### PR DESCRIPTION
Stacked on #1800 — base is `redesign/earn-drill-transition`, so review that one first.

Implements four of the six component motion comps. Charts is deliberately out (see below), and table filtering is deferred with a finding.

## What the comps specify, and what shipped

### Modal — [1598:75901](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-75901)

The card fades while rising 40px; the scrim fades on the same beat, because the comp treats the whole modal layer as one fading wrapper. **No scale anywhere** — this replaces a `zoom-95` at 200ms.

| | duration | easing |
|---|---|---|
| open | 300ms | easeOutQuint |
| close | 300ms | easeInOutQuart |

### Drawer — [1598:75751](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-75751)

Full-width travel, 300ms each way, asymmetric curves (quint in, quart out). Opening was 500ms on a blanket `ease-in-out`.

### Toast — [1598:76070](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-76070)

Slides its own height up from the bottom edge and leaves the same way, ~300ms on easeInOutQuart. That direction is what sonner already does natively, so this is a retime off its 400ms default.

### Tabs — [1598:76322](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-76322)

The active fill **slides** between segments (151ms) instead of repainting in place, and the chart re-wipes its series on the switch.

Two review findings from the first pass are fixed in follow-up commits:

- **The series morphed instead of wiping.** Handed a new dataset for the same Area, recharts interpolates the old curve into the new one, so the line visibly reshaped rather than drawing in from the left. Only a mount counts as an entrance, and swapping the metric was not one — keying the Area on metric+timeframe makes each series its own mount. Measured after: 0 → 779px over ~600ms, where before there was no reveal clip at all.
- **The modal never animated out.** `handleClose` clears `activeConfig` synchronously and the provider renders the modal behind `activeConfig && …`, so the whole Radix subtree unmounted in the same tick it was told to close. This predates the PR — the previous zoom-out never played either. Since everything the modal draws arrives as props, the fix snapshots them for the length of the exit; the teardown is untouched, and every piece of state still ends synchronously. Measured after: the dialog survives 375ms declaring `exit / 300ms / easeInOutQuart`, against being gone on the next frame.

## Three findings worth reviewing

**1. The toast's animation classes were dead code.** `sonner.tsx` carried `data-[state=open]:animate-in`, `data-[state=closed]:slide-out-to-right-full` and friends. That is Radix Toast's state model — sonner marks toasts with `data-mounted`/`data-removed` and sets no `data-state` at all, so those rules had matched nothing since the sonner migration. Removed. The exit direction they *described* (to the right) was also wrong versus the comp; sonner's native downward exit is correct.

**2. A bare `duration-*` does not retime `animate-in`.** Both the modal and drawer initially picked up the new easing but kept animating at **animate-in's own 150ms default** — the plain utility sets the same property and loses on source order. Scoping it to the `data-state` variants fixes it, which is how the sheet's original 500/300 pair was written. Caught by measuring rather than reading.

**3. This settles the open question from #1800.** The tabs comp re-wipes the series on a metric switch, so replaying the entrance reveal is intended, not a wart. The comp wants ~600ms there against the ~900ms opening wipe and recharts carries one `animationDuration` for both, so the component steps the value down once the opening wipe reports done.

## Second QA round

Three more from review, all fixed and measured:

- **Connect modal never animated out** — the same unmount-on-close shape as the transaction modal: `{isOpen && <ConnectModal/>}`, gated that way to keep its lazy chunk off the initial load. Mounting is now held for the exit and released after, so it still gets a fresh mount on the next open. Survives 368ms with its opacity animating, against being gone on the next frame.
- **The transaction modal emptied a beat before it left** — `backgroundContent` (the widget that portals its inputs into the modal's entry slot) was still rendered from `activeConfig`, so it unmounted on close and the card blanked mid-dismissal. Rendered from the retained view too; content now holds at 145 characters and 1 input for every frame it is on screen.
- **The position details modal** — the one behind the position rows — is a Radix dialog, not a takeover, so it needed the opposite treatment and none of the takeover work touched it. It rendered `<Dialog open>` with the prop hardcoded, so closing could only mean unmounting and Radix never rendered a closing state. It now takes a controlled `open`, and the flow keeps drawing it while it dismisses. That splits the flow's views in two, which the code now states plainly: Radix modals stay **mounted** and are told `open={false}`; motion takeovers are **removed** from the AnimatePresence, since removal is what starts their exit. `LiquidationPostMortemModal` had the same shape and gets the same prop; the claim modal needs nothing (it portals into the transaction modal and leaves with it). Measured: 201ms declaring `exit / 300ms`, against vanishing on the next frame.
- **The manage takeover needed a third pass.** Two independent causes, and fixing one hid the other. Closing deletes the `urn_index` param, so `PositionManageFlow` renders nothing while still mounted — an `AnimatePresence` in the parent preserves the flow element, but the element then drops the takeover on its own next render, so the boundary has to sit inside the flow around its view dispatch. And nesting two boundaries breaks the inner one outright: closing empties the inner presence in the same tick, the outer sees no motion children left to wait for, declares its exit finished, and unmounts the subtree out from under the animation that just started. The parent now holds the mount for the exit duration rather than wrapping it. Measured: 287ms with opacity animating, against ~40ms flat.
- **The stake takeovers had no motion at all** — they appeared and vanished outright while every other modal surface animated. `TakeoverShell` now runs the modal comp's recipe (scrim fades, card column rises 40px, quint in / quart out), with `AnimatePresence` at both call sites since the flow flags unmount them. The scrim deliberately does not travel: translating a full-viewport overlay would uncover an edge. Holds 376ms after Escape.

## Deferred

**Charts hover ([1598:76169](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-76169))** — held back to a later PR at your request, since #1799 is open and unreviewed over the same chart internals. Worth recording what the analysis found: recharts' `Tooltip` already self-animates its position (400ms), while our `activeDot` and `HoverDimMask` rects jump instantly, so they visibly desync today.

**Table filtering ([1598:77060](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-77060))** — built, measured, and reverted. The comp collapses a row's height 88 → 0 over 300ms. Driving that height from the row **stalls at 38px**: a `td`'s `height` is a *minimum*, so the cell content's own height holds the row open, and it then pops the remaining 38px. Measured: `88 → 82 → 62 → 38 → 38 → 38 → 38 → removed`, i.e. roughly a third of the animation stalled.

Collapsing fully needs every cell's content wrapped in a clipping, fixed-height box so it stops contributing height — a real change to cell padding and alignment semantics on a table that was just restyled in the H8 batch. That is its own PR with its own QA, not a rider on this one.

## Verification

Playwright against a dev build, dark mode, sampling computed style and geometry per frame.

| surface | declared | measured travel |
|---|---|---|
| modal open | `enter` / 0.3s / `cubic-bezier(.23,1,.32,1)` | y 0→40px, opacity 0→1 |
| modal close | `exit` / 0.3s / `cubic-bezier(.77,0,.175,1)` | y 40→0 |
| drawer open | `enter` / 0.3s / `cubic-bezier(.23,1,.32,1)` | x 0→384px |
| drawer close | `exit` / 0.3s / `cubic-bezier(.77,0,.175,1)` | x 384→0 |
| toast | transition 0.3s / `cubic-bezier(.77,0,.175,1)` | y 0→72px (its own height) |
| tabs pill | — | one element, 50px, ~124ms |
| chart series (switch) | 600ms | clip 0→779px, ~600ms |
| transaction modal exit | `exit` / 0.3s / `cubic-bezier(.77,0,.175,1)` | present 375ms after Escape |

The pill also needed a look, not just a measurement: it first shipped with a negative z-index that put the fill **behind the group's own `bg-pageBackground`**, so the active segment rendered with no fill at all while measuring perfectly. Fixed and screenshot-confirmed in both states.

## Gates

- typecheck clean
- lint 0 errors
- tests 2240/2241 — the failure is `EarnFeaturedCards.test.tsx`, the known date-bomb that fails on base too
