### PR TITLE
Accrue the savings position on screen

### DIFF
--- a/apps/webapp/src/components/product/PositionHero.test.tsx
+++ b/apps/webapp/src/components/product/PositionHero.test.tsx
@@ -1,0 +1,47 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+vi.mock('@/modules/ui/components/TokenIcon', () => ({ TokenIcon: () => null }));
+
+import { PositionHero } from './PositionHero';
+
+/** Per-second growth of the 3.75% SSR. */
+const SSR_3_75 = Math.expm1(Math.log1p(0.0375) / (365 * 24 * 60 * 60));
+
+const renderHero = (props: Parameters<typeof PositionHero>[0]) =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <PositionHero {...props} />
+    </I18nProvider>
+  );
+
+afterEach(cleanup);
+
+describe('PositionHero', () => {
+  it('renders a still figure without a rate, trimmed to 5 decimals', () => {
+    renderHero({ balanceSymbol: 'USDS', amount: 100000.0002 });
+    expect(screen.getByText('100,000')).not.toBeNull();
+    expect(screen.getByText('.0002')).not.toBeNull();
+  });
+
+  it('renders a pre-formatted string figure whole', () => {
+    renderHero({ balanceSymbol: 'SKY', amount: '12,345.67' });
+    expect(screen.getByText('12,345.67')).not.toBeNull();
+  });
+
+  it('switches the fraction to the accruing counter when given a rate', () => {
+    renderHero({ balanceSymbol: 'USDS', amount: 100_000, ratePerSecond: SSR_3_75 });
+
+    // 100,000 USDS at 3.75% turns its 4th decimal over about once a second.
+    expect(screen.getByText('0000')).not.toBeNull();
+    // Each digit gets its own clip window to roll inside — and only the
+    // fraction does, so the 44px whole part stays out of them.
+    expect(screen.getAllByTestId('rolling-digit')).toHaveLength(4);
+    expect(screen.getByText('100,000')).not.toBeNull();
+  });
+});

--- a/apps/webapp/src/components/product/PositionHero.test.tsx
+++ b/apps/webapp/src/components/product/PositionHero.test.tsx
@@ -38,7 +38,7 @@ describe('PositionHero', () => {
     renderHero({ balanceSymbol: 'USDS', amount: 100_000, ratePerSecond: SSR_3_75 });
 
     // 100,000 USDS at 3.75% turns its 4th decimal over about once a second.
-    expect(screen.getByText('0000')).not.toBeNull();
+    expect(screen.getByTestId('rolling-digits').textContent).toBe('0000');
     // Each digit gets its own clip window to roll inside — and only the
     // fraction does, so the 44px whole part stays out of them.
     expect(screen.getAllByTestId('rolling-digit')).toHaveLength(4);

--- a/apps/webapp/src/components/product/PositionHero.tsx
+++ b/apps/webapp/src/components/product/PositionHero.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from 'react';
 import { Trans } from '@lingui/react/macro';
 import { splitAmount } from '@/utils';
+import { useAccruingValue } from '@/hooks/ui';
+import { RollingDigits } from '@/components/ui/rolling-digits';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { ProductBadge } from './ProductCard';
 
@@ -19,6 +21,7 @@ export function PositionHero({
   pillLabel,
   balanceSymbol,
   amount,
+  ratePerSecond,
   subline
 }: {
   /** Token tagged on the pill (the product's share/reward token). */
@@ -34,11 +37,29 @@ export function PositionHero({
    * pre-formatted string to render the figure whole (the /stake comp does).
    */
   amount: number | string;
+  /**
+   * Fractional growth per second of a continuously-compounding position. Pass it
+   * and the figure accrues on screen between chain reads, its decimals rolling
+   * over one at a time (Figma 1598:76444). Products that don't appreciate by the
+   * second leave it off and render a still figure.
+   */
+  ratePerSecond?: number;
   /** Optional line under the figure, indented past the token mark (e.g. "~$120,788.90"). */
   subline?: ReactNode;
 }) {
+  const { value, fractionDigits } = useAccruingValue({
+    amount: typeof amount === 'number' ? amount : undefined,
+    ratePerSecond
+  });
+  // The counter picks its own precision from the balance and the rate, so a live
+  // figure formats off that rather than the flat 5 decimals a still one uses.
+  const isAccruing = fractionDigits !== undefined;
   const { whole, fraction } =
-    typeof amount === 'number' ? splitAmount(amount) : { whole: amount, fraction: undefined };
+    typeof amount === 'number'
+      ? isAccruing
+        ? splitAmount(value, fractionDigits, { trimTrailingZeros: false, round: false })
+        : splitAmount(amount)
+      : { whole: amount, fraction: undefined };
 
   return (
     <div className="flex flex-col gap-10 rounded-2xl bg-[linear-gradient(180deg,_rgba(182,179,252,0)_50.24%,_rgba(117,111,236,0.1)_100%)] p-4 md:gap-16 md:p-6">
@@ -67,7 +88,10 @@ export function PositionHero({
             </span>
             {fraction && (
               <span className="text-fgSecondary font-circle text-lg leading-5 font-medium tracking-[-0.36px] md:text-xl md:leading-[22px] md:tracking-[-0.4px]">
-                .{fraction}
+                {/* Only the fraction rolls. The whole part turns over once every
+                    few hours at any realistic rate, so a still carry there costs
+                    nothing and keeps the 44px figure out of the clip windows. */}
+                .{isAccruing ? <RollingDigits value={fraction} /> : fraction}
               </span>
             )}
           </span>

--- a/apps/webapp/src/components/ui/rolling-digits.test.tsx
+++ b/apps/webapp/src/components/ui/rolling-digits.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { RollingDigits } from './rolling-digits';
+
+afterEach(cleanup);
+
+describe('RollingDigits', () => {
+  it('reads as one figure to assistive tech, not a string of digits', () => {
+    render(<RollingDigits value="00026" />);
+    expect(screen.getByText('00026')).not.toBeNull();
+    // Every visible glyph is hidden from the accessibility tree.
+    const hidden = screen
+      .getAllByTestId('rolling-digit')
+      .every(digit => digit.getAttribute('aria-hidden') === 'true');
+    expect(hidden).toBe(true);
+  });
+
+  it('rolls only the digit that changed', () => {
+    const { rerender } = render(<RollingDigits value="00026" />);
+    expect(screen.queryAllByTestId('rolling-digit-out')).toHaveLength(0);
+
+    rerender(<RollingDigits value="00027" />);
+    const outgoing = screen.getAllByTestId('rolling-digit-out');
+    expect(outgoing).toHaveLength(1);
+    expect(outgoing[0].textContent).toBe('6');
+    expect(screen.getAllByTestId('rolling-digit-in')).toHaveLength(1);
+  });
+
+  it('rolls every digit a carry touches', () => {
+    const { rerender } = render(<RollingDigits value="00099" />);
+    rerender(<RollingDigits value="00100" />);
+    expect(screen.getAllByTestId('rolling-digit-out')).toHaveLength(3);
+  });
+
+  it('keeps a digit in its own window across a carry that widens the figure', () => {
+    const { rerender } = render(<RollingDigits value="999" />);
+    rerender(<RollingDigits value="1,000" />);
+    // The three 9s roll to 0s in place; the new leading "1," arrives fresh.
+    expect(screen.getAllByTestId('rolling-digit-out')).toHaveLength(3);
+  });
+
+  it('leaves separators out of the clip windows', () => {
+    render(<RollingDigits value="1,000" />);
+    // Four digit windows; the comma is a bare span.
+    expect(screen.getAllByTestId('rolling-digit')).toHaveLength(4);
+  });
+});

--- a/apps/webapp/src/components/ui/rolling-digits.test.tsx
+++ b/apps/webapp/src/components/ui/rolling-digits.test.tsx
@@ -6,14 +6,19 @@ import { RollingDigits } from './rolling-digits';
 afterEach(cleanup);
 
 describe('RollingDigits', () => {
-  it('reads as one figure to assistive tech, not a string of digits', () => {
+  it('holds exactly one copy of the figure, so it reads and copies whole', () => {
     render(<RollingDigits value="00026" />);
-    expect(screen.getByText('00026')).not.toBeNull();
-    // Every visible glyph is hidden from the accessibility tree.
-    const hidden = screen
-      .getAllByTestId('rolling-digit')
-      .every(digit => digit.getAttribute('aria-hidden') === 'true');
-    expect(hidden).toBe(true);
+    expect(screen.getByTestId('rolling-digits').textContent).toBe('00026');
+  });
+
+  it('hides the outgoing glyph, so a roll in flight cannot intrude on the figure', () => {
+    const { rerender } = render(<RollingDigits value="00026" />);
+    rerender(<RollingDigits value="00027" />);
+
+    // The old glyph is in the DOM for the 200ms it takes to leave, but out of
+    // the accessibility tree the whole time.
+    expect(screen.getByTestId('rolling-digit-out').getAttribute('aria-hidden')).toBe('true');
+    expect(screen.getByTestId('rolling-digit-in').getAttribute('aria-hidden')).toBeNull();
   });
 
   it('rolls only the digit that changed', () => {

--- a/apps/webapp/src/components/ui/rolling-digits.tsx
+++ b/apps/webapp/src/components/ui/rolling-digits.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { useReducedMotion } from 'motion/react';
+import { cn } from '@/lib/cn';
+
+/**
+ * Odometer digits (Figma 1598:76444). Each character sits in its own one-line
+ * clip window; when a digit changes, the old glyph slides up and out of the
+ * window while its replacement rises into it from below.
+ *
+ * The window clips with `clip-path` rather than `overflow: hidden` on purpose:
+ * an inline-block with a non-visible overflow takes its baseline from its bottom
+ * margin edge, which would drop the figure off the baseline it shares with the
+ * rest of the number. `clip-path` clips the paint and leaves the baseline alone.
+ */
+export function RollingDigits({ value, className }: { value: string; className?: string }) {
+  const characters = [...value];
+
+  return (
+    // Inline, not inline-flex: flex would drop the letter-spacing the hero
+    // figure is tracked with. `tabular-nums` keeps the box widths equal so the
+    // number doesn't shuffle sideways as digits turn over.
+    <span className={cn('tabular-nums', className)}>
+      {/* One reading of the whole figure for assistive tech — the per-digit
+          boxes below would otherwise be announced a character at a time. No
+          live region: this changes about once a second. */}
+      <span className="sr-only">{value}</span>
+      {characters.map((character, index) => (
+        // Keyed from the right, so a carry (999 → 1,000) leaves every existing
+        // digit in the box it already occupies instead of shifting them along.
+        <RollingCharacter key={characters.length - index} character={character} />
+      ))}
+    </span>
+  );
+}
+
+function RollingCharacter({ character }: { character: string }) {
+  const prefersReducedMotion = useReducedMotion();
+  const [state, setState] = useState({ current: character, previous: null as string | null, gen: 0 });
+
+  if (state.current !== character) {
+    // Derived during render: the roll has to start on the commit that paints the
+    // new digit, which an effect would be a frame too late for.
+    setState({
+      current: character,
+      // Nothing to roll out when motion is reduced — the outgoing glyph is only
+      // ever visible while it animates away, so rendering it would leave it
+      // stacked on top of its replacement.
+      previous: prefersReducedMotion ? null : state.current,
+      gen: state.gen + 1
+    });
+  }
+
+  // Separators sit between the windows rather than inside one.
+  if (!/\d/.test(state.current)) {
+    return <span aria-hidden>{state.current}</span>;
+  }
+
+  return (
+    <span aria-hidden data-testid="rolling-digit" className="relative inline-block [clip-path:inset(0)]">
+      {state.previous !== null && (
+        <span
+          key={`out-${state.gen}`}
+          data-testid="rolling-digit-out"
+          className="motion-safe:animate-digit-roll-out absolute inset-x-0 top-0"
+          onAnimationEnd={() => setState(current => ({ ...current, previous: null }))}
+        >
+          {state.previous}
+        </span>
+      )}
+      {/* In flow, so it sizes the window and sets its baseline; the roll is a
+          transform, which costs no layout. */}
+      <span
+        key={`in-${state.gen}`}
+        data-testid={state.gen > 0 ? 'rolling-digit-in' : undefined}
+        className={cn('block', state.gen > 0 && 'motion-safe:animate-digit-roll-in')}
+      >
+        {state.current}
+      </span>
+    </span>
+  );
+}

--- a/apps/webapp/src/components/ui/rolling-digits.tsx
+++ b/apps/webapp/src/components/ui/rolling-digits.tsx
@@ -19,11 +19,11 @@ export function RollingDigits({ value, className }: { value: string; className?:
     // Inline, not inline-flex: flex would drop the letter-spacing the hero
     // figure is tracked with. `tabular-nums` keeps the box widths equal so the
     // number doesn't shuffle sideways as digits turn over.
-    <span className={cn('tabular-nums', className)}>
-      {/* One reading of the whole figure for assistive tech — the per-digit
-          boxes below would otherwise be announced a character at a time. No
-          live region: this changes about once a second. */}
-      <span className="sr-only">{value}</span>
+    <span data-testid="rolling-digits" className={cn('tabular-nums', className)}>
+      {/* The digits are the only copy of the figure in the DOM — adjacent inline
+          spans form one text run, so this still reads and copies as a single
+          number. Only the glyph on its way out is hidden, so a roll in flight
+          can't wedge a stale digit into the middle of it. */}
       {characters.map((character, index) => (
         // Keyed from the right, so a carry (999 → 1,000) leaves every existing
         // digit in the box it already occupies instead of shifting them along.
@@ -52,27 +52,33 @@ function RollingCharacter({ character }: { character: string }) {
 
   // Separators sit between the windows rather than inside one.
   if (!/\d/.test(state.current)) {
-    return <span aria-hidden>{state.current}</span>;
+    return <span>{state.current}</span>;
   }
 
   return (
-    <span aria-hidden data-testid="rolling-digit" className="relative inline-block [clip-path:inset(0)]">
+    <span data-testid="rolling-digit" className="relative inline-block [clip-path:inset(0)]">
       {state.previous !== null && (
         <span
           key={`out-${state.gen}`}
+          aria-hidden
           data-testid="rolling-digit-out"
-          className="motion-safe:animate-digit-roll-out absolute inset-x-0 top-0"
+          // Out of the accessibility tree and out of the selection, so neither a
+          // screen reader nor a copy taken mid-roll picks up the stale digit.
+          className="motion-safe:animate-digit-roll-out absolute inset-x-0 top-0 select-none"
           onAnimationEnd={() => setState(current => ({ ...current, previous: null }))}
         >
           {state.previous}
         </span>
       )}
       {/* In flow, so it sizes the window and sets its baseline; the roll is a
-          transform, which costs no layout. */}
+          transform, which costs no layout. It has to be a box for the transform
+          to apply at all, and specifically an inline-block one: Chrome's
+          selection serialiser puts a newline after every block-level box, which
+          would copy the figure out one digit per line. */}
       <span
         key={`in-${state.gen}`}
         data-testid={state.gen > 0 ? 'rolling-digit-in' : undefined}
-        className={cn('block', state.gen > 0 && 'motion-safe:animate-digit-roll-in')}
+        className={cn('inline-block', state.gen > 0 && 'motion-safe:animate-digit-roll-in')}
       >
         {state.current}
       </span>

--- a/apps/webapp/src/globals.css
+++ b/apps/webapp/src/globals.css
@@ -286,6 +286,13 @@
   --animate-slide-down-fade: slide-down-fade 0.2s ease-out;
   --animate-slide-up-fade: slide-up-fade 0.2s ease-out;
 
+  /* Odometer roll for a live-accruing figure (Figma 1598:76444): one line-height
+     of travel over 200ms on the comp's easeOut. The outgoing glyph holds its end
+     state until the component drops it, so it can't flash back into the window
+     for a frame. */
+  --animate-digit-roll-in: digit-roll-in 200ms cubic-bezier(0, 0, 0.58, 1);
+  --animate-digit-roll-out: digit-roll-out 200ms cubic-bezier(0, 0, 0.58, 1) forwards;
+
   --max-height-screen-70: calc(100vh - 70px);
 
   --breakpoint-sm: 640px;
@@ -343,6 +350,22 @@
     }
     to {
       height: 0;
+    }
+  }
+  @keyframes digit-roll-in {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+  @keyframes digit-roll-out {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(-100%);
     }
   }
   @keyframes slide-down-fade {

--- a/apps/webapp/src/hooks/ui/index.ts
+++ b/apps/webapp/src/hooks/ui/index.ts
@@ -1,3 +1,4 @@
+export * from './useAccruingValue';
 export * from './useBreakpoint';
 export * from './useDebounce';
 export * from './useDeltaTimestamps';

--- a/apps/webapp/src/hooks/ui/useAccruingValue.test.tsx
+++ b/apps/webapp/src/hooks/ui/useAccruingValue.test.tsx
@@ -1,0 +1,142 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { pickFractionDigits, useAccruingValue } from './useAccruingValue';
+
+/** Per-second growth of the 3.75% SSR: (1.0375)^(1/31536000) - 1. */
+const SSR_3_75 = Math.expm1(Math.log1p(0.0375) / (365 * 24 * 60 * 60));
+
+afterEach(cleanup);
+
+describe('pickFractionDigits', () => {
+  // The whole point of the adaptive precision: one cadence across five orders of
+  // magnitude, which a fixed decimal count can't give.
+  it.each([
+    [10_000_000, 2],
+    [100_000, 4],
+    [1_000, 6],
+    [1, 9]
+  ])('shows %i USDS to %i decimals', (amount, expected) => {
+    expect(pickFractionDigits(amount, SSR_3_75)).toBe(expected);
+  });
+
+  it('keeps every balance down to 1 USDS on the target cadence', () => {
+    for (const amount of [1, 10, 250, 1_000, 99_999, 100_000, 4_000_000]) {
+      const digits = pickFractionDigits(amount, SSR_3_75);
+      const tickSeconds = 10 ** -digits / (amount * SSR_3_75);
+      expect(tickSeconds).toBeGreaterThan(0.25);
+      expect(tickSeconds).toBeLessThan(2.6);
+    }
+  });
+
+  it('caps sub-unit dust at the precision 1 USDS gets, and lets it tick slower', () => {
+    const cap = pickFractionDigits(1, SSR_3_75);
+    expect(pickFractionDigits(0.1, SSR_3_75)).toBe(cap);
+    expect(pickFractionDigits(0.001, SSR_3_75)).toBe(cap);
+  });
+
+  it('never goes below cents, however large the position', () => {
+    expect(pickFractionDigits(10 ** 12, SSR_3_75)).toBe(2);
+  });
+
+  it('re-derives the cap from the rate', () => {
+    // A 10x rate earns a decimal place back at every balance.
+    expect(pickFractionDigits(1, SSR_3_75 * 10)).toBe(pickFractionDigits(1, SSR_3_75) - 1);
+  });
+});
+
+describe('useAccruingValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('holds the amount still without a rate', () => {
+    const { result } = renderHook(() => useAccruingValue({ amount: 100_000 }));
+    expect(result.current.value).toBe(100_000);
+    expect(result.current.fractionDigits).toBeUndefined();
+  });
+
+  it('holds a zero position still', () => {
+    const { result } = renderHook(() => useAccruingValue({ amount: 0, ratePerSecond: SSR_3_75 }));
+    expect(result.current.fractionDigits).toBeUndefined();
+  });
+
+  it('accrues at the rate and wakes once per digit turnover', () => {
+    const { result } = renderHook(() => useAccruingValue({ amount: 100_000, ratePerSecond: SSR_3_75 }));
+    expect(result.current.value).toBe(100_000);
+    expect(result.current.fractionDigits).toBe(4);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    // A minute of 3.75% on 100,000 USDS.
+    const expected = 100_000 * Math.exp(Math.log1p(SSR_3_75) * 60);
+    expect(result.current.value).toBeCloseTo(expected, 6);
+    expect(result.current.value).toBeGreaterThan(100_000);
+  });
+
+  it('renders about once per target tick rather than on a fixed interval', () => {
+    let renders = 0;
+    renderHook(() => {
+      renders += 1;
+      return useAccruingValue({ amount: 100_000, ratePerSecond: SSR_3_75 });
+    });
+    const before = renders;
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    // 10s at ~0.86s per tick ≈ 12 wake-ups; anything near 60fps would be ~600.
+    const wakeUps = renders - before;
+    expect(wakeUps).toBeGreaterThan(5);
+    expect(wakeUps).toBeLessThan(25);
+  });
+
+  it('ignores a read that lands just behind the projection', () => {
+    const { result, rerender } = renderHook(
+      ({ amount }) => useAccruingValue({ amount, ratePerSecond: SSR_3_75 }),
+      { initialProps: { amount: 100_000 } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    const projected = result.current.value;
+    expect(projected).toBeGreaterThan(100_000);
+
+    // The chain reports the balance as of a block we've already projected past.
+    rerender({ amount: 100_000.0001 });
+    expect(result.current.value).toBeGreaterThanOrEqual(projected);
+  });
+
+  it('accepts a withdrawal, which clears the drift tolerance', () => {
+    const { result, rerender } = renderHook(
+      ({ amount }) => useAccruingValue({ amount, ratePerSecond: SSR_3_75 }),
+      { initialProps: { amount: 100_000 } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    rerender({ amount: 40_000 });
+    expect(result.current.value).toBeCloseTo(40_000, 4);
+  });
+
+  it('re-baselines on a supply', () => {
+    const { result, rerender } = renderHook(
+      ({ amount }) => useAccruingValue({ amount, ratePerSecond: SSR_3_75 }),
+      { initialProps: { amount: 1_000 } }
+    );
+    expect(result.current.fractionDigits).toBe(6);
+
+    rerender({ amount: 100_000 });
+    expect(result.current.value).toBeCloseTo(100_000, 4);
+    // The bigger position earns faster, so a coarser digit carries the cadence.
+    expect(result.current.fractionDigits).toBe(4);
+  });
+});

--- a/apps/webapp/src/hooks/ui/useAccruingValue.ts
+++ b/apps/webapp/src/hooks/ui/useAccruingValue.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Projects a continuously-compounding balance forward between chain reads, so a
+ * position figure visibly earns while you watch it (Figma 1598:76444 — the
+ * savings hero's rolling counter).
+ *
+ * Two things have to be decided here, and they are coupled:
+ *
+ *  1. **How fast to tick.** The comp rolls three digits over a 2.202s loop, so a
+ *     digit dwells ~734ms. That cadence is a design constant; the accrual rate
+ *     is not.
+ *  2. **Which digit ticks.** A fixed precision can't serve every balance: at the
+ *     comp's own 5 decimals, 100,000 USDS at 3.75% would tick ~12x a second
+ *     (a blur) while 1,000 USDS would tick once every 8.5s (frozen).
+ *
+ * So the precision is chosen per position to land the cadence on the comp's,
+ * which keeps the *motion* constant and lets the *precision* absorb the spread
+ * in balances. See `pickFractionDigits` for the cap.
+ */
+
+/** The comp's per-digit dwell (2.202s / 3 digits ≈ 734ms), rounded. */
+const TARGET_TICK_MS = 800;
+
+/** A hero figure never drops below cents, however large the position. */
+const MIN_FRACTION_DIGITS = 2;
+
+/**
+ * How far a fresh read may sit *behind* the projection before we believe it.
+ * Between blocks the projection legitimately runs ahead of what the chain
+ * reports; a withdrawal moves the balance by far more than a few ticks.
+ */
+const DRIFT_TOLERANCE_TICKS = 10;
+
+export type AccruingValue = {
+  /** The projected amount. Equals the input amount when accrual isn't live. */
+  value: number;
+  /**
+   * Decimals to render, fixed-width. `undefined` when the value isn't accruing
+   * (no rate, no position, still loading) — callers fall back to their static
+   * formatting.
+   */
+  fractionDigits?: number;
+};
+
+/**
+ * The decimal place whose last digit ticks about every `TARGET_TICK_MS`.
+ *
+ * A balance accrues `amount * ratePerSecond` per second, so the digit worth
+ * `10^-d` turns over every `10^-d / (amount * ratePerSecond)` seconds. Solving
+ * for the target cadence gives `d = -log10(amount * ratePerSecond * target)`.
+ *
+ * The cap is that same expression at **one whole unit** — the smallest position
+ * we promise to animate visibly. Because `d` falls as the balance rises, any
+ * amount at or above 1 already lands below the cap, so it only ever binds on
+ * sub-unit dust (which then simply ticks slower than the target). At a 3.75%
+ * SSR the cap works out to 9 decimals, and it re-derives itself if the rate
+ * moves.
+ */
+export function pickFractionDigits(amount: number, ratePerSecond: number): number {
+  const targetSeconds = TARGET_TICK_MS / 1000;
+  const ideal = Math.round(-Math.log10(amount * ratePerSecond * targetSeconds));
+  const cap = Math.round(-Math.log10(ratePerSecond * targetSeconds));
+  return Math.max(MIN_FRACTION_DIGITS, Math.min(ideal, cap));
+}
+
+export function useAccruingValue({
+  amount,
+  ratePerSecond
+}: {
+  /** Last balance read from the chain, in whole token units. */
+  amount?: number;
+  /** Fractional growth per second (an SSR ray of 1.0000000011… → 1.1e-9). */
+  ratePerSecond?: number;
+}): AccruingValue {
+  const isLive = amount !== undefined && amount > 0 && ratePerSecond !== undefined && ratePerSecond > 0;
+  const fractionDigits = isLive ? pickFractionDigits(amount, ratePerSecond) : undefined;
+
+  const [baseline, setBaseline] = useState<{ amount: number; at: number }>();
+  const [projected, setProjected] = useState(amount ?? 0);
+  // What the user is currently looking at, readable from the re-baseline effect
+  // below without making it depend on (and so restart on) every tick.
+  const displayed = useRef(amount ?? 0);
+
+  // Re-baseline on a fresh read.
+  useEffect(() => {
+    if (amount === undefined) return;
+    const tickSize = fractionDigits === undefined ? 0 : 10 ** -fractionDigits;
+    const behind = displayed.current - amount;
+    // Ignore a read that lands just short of what we've already shown: that's
+    // the projection running ahead of the chain, and honouring it would count
+    // the figure backwards. A real withdrawal clears the tolerance and lands.
+    if (behind > 0 && behind < tickSize * DRIFT_TOLERANCE_TICKS) return;
+    displayed.current = amount;
+    setProjected(amount);
+    setBaseline({ amount, at: Date.now() });
+  }, [amount, fractionDigits]);
+
+  // Tick.
+  useEffect(() => {
+    if (!isLive || !baseline || fractionDigits === undefined) return;
+
+    // log1p/expm1 rather than the naive (1 + r)^t: r is ~1e-9, where the naive
+    // form loses most of its significant digits to the leading 1.
+    const logGrowth = Math.log1p(ratePerSecond);
+    const scale = 10 ** fractionDigits;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const tick = () => {
+      const elapsed = (Date.now() - baseline.at) / 1000;
+      const next = baseline.amount * Math.exp(logGrowth * elapsed);
+      displayed.current = next;
+      setProjected(next);
+
+      // Wake exactly when the last rendered digit turns over, so this renders
+      // once per visible change instead of on some arbitrary interval.
+      const nextDigitValue = (Math.floor(next * scale) + 1) / scale;
+      const nextElapsed = Math.log1p((nextDigitValue - baseline.amount) / baseline.amount) / logGrowth;
+      const delay = baseline.at + nextElapsed * 1000 - Date.now();
+      timer = setTimeout(tick, Math.max(delay, 16));
+    };
+
+    tick();
+    return () => clearTimeout(timer);
+  }, [isLive, baseline, ratePerSecond, fractionDigits]);
+
+  return { value: isLive ? projected : (amount ?? 0), fractionDigits };
+}

--- a/apps/webapp/src/modules/savings/components/SavingsPositionCard.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsPositionCard.test.tsx
@@ -105,7 +105,7 @@ describe('SavingsPositionCard — position routing', () => {
 
     // 100 USDS at 3.75% earns its 7th decimal about once a second, so that's
     // the digit the counter rolls — padded, not trimmed, so it can't reflow.
-    expect(screen.getByText('0000000')).not.toBeNull();
+    expect(screen.getByTestId('rolling-digits').textContent).toBe('0000000');
   });
 
   it('opens the "Supply to Sky Savings" editable modal (entry descriptor) on Supply', () => {

--- a/apps/webapp/src/modules/savings/components/SavingsPositionCard.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsPositionCard.test.tsx
@@ -36,6 +36,12 @@ vi.mock('@/hooks', async importOriginal => {
   };
 });
 
+// The live-accrual rate would otherwise reach for the chain (sUSDS `ssr`).
+// 3.75% expressed per second.
+vi.mock('../hooks/useSavingsAccrualRate', () => ({
+  useSavingsAccrualRate: () => Math.expm1(Math.log1p(0.0375) / (365 * 24 * 60 * 60))
+}));
+
 // Stub the leaf cards/bodies — routing is the unit under test, not their internals.
 vi.mock('./SavingsSupplyCard', () => ({
   SavingsSupplyCard: () => <div data-testid="savings-supply-card" />
@@ -91,6 +97,15 @@ describe('SavingsPositionCard — position routing', () => {
     expect(screen.queryByTestId('savings-supply-card')).toBeNull();
     expect(screen.queryByTestId('savings-position-supply')).not.toBeNull();
     expect(screen.queryByTestId('savings-position-withdraw')).not.toBeNull();
+  });
+
+  it('hands the hero the SSR, so the position accrues on screen', () => {
+    h.savingsBalance = 100n * 10n ** 18n;
+    renderCard();
+
+    // 100 USDS at 3.75% earns its 7th decimal about once a second, so that's
+    // the digit the counter rolls — padded, not trimmed, so it can't reflow.
+    expect(screen.getByText('0000000')).not.toBeNull();
   });
 
   it('opens the "Supply to Sky Savings" editable modal (entry descriptor) on Supply', () => {

--- a/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsPositionCard.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/product/ProductCard';
 import { TokenIcon } from '@/modules/ui/components/TokenIcon';
 import { useSavingsModal } from '../hooks/useSavingsModal';
+import { useSavingsAccrualRate } from '../hooks/useSavingsAccrualRate';
 import { SavingsSupplyCard } from './SavingsSupplyCard';
 
 const formatToken = (value?: bigint) =>
@@ -46,6 +47,8 @@ export function SavingsPositionCard() {
     token: TOKENS.susds.address[chainId]
   });
   const { data: overall } = useOverallSkyData();
+  // sUSDS appreciates every second; the hero figure shows it happening.
+  const ratePerSecond = useSavingsAccrualRate();
   // Refresh position card + sUSDS balance after a successful supply/withdraw.
   // A no-position supply also flips this card to "My position" once the savings
   // balance refetches above zero.
@@ -76,7 +79,14 @@ export function SavingsPositionCard() {
   return (
     <ProductPositionCard
       data-testid="savings-position-card"
-      hero={<PositionHero pillSymbol="sUSDS" balanceSymbol="USDS" amount={positionValue} />}
+      hero={
+        <PositionHero
+          pillSymbol="sUSDS"
+          balanceSymbol="USDS"
+          amount={positionValue}
+          ratePerSecond={ratePerSecond}
+        />
+      }
       stats={
         <>
           <ProductStatPair grow>

--- a/apps/webapp/src/modules/savings/hooks/useSavingsAccrualRate.ts
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsAccrualRate.ts
@@ -1,0 +1,44 @@
+import { useChainId } from 'wagmi';
+import { sUsdsAddress, useOverallSkyData, useReadSavingsUsds, useReadSsrAuthOracleGetSsr } from '@/hooks';
+import { isL2ChainId } from '@/utils';
+
+const RAY = 10n ** 27n;
+const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
+
+/**
+ * The Sky Savings Rate as a plain per-second growth fraction, for projecting a
+ * position forward between chain reads (`useAccruingValue`).
+ *
+ * SSR is stored as a per-second compounding ray — 1.0000000011… — so the
+ * fraction is `(ssr - RAY) / RAY`. Subtracting in bigint first matters: the
+ * difference is ~1e-9, and going through a float ray would spend most of its
+ * significant digits on the leading 1.
+ *
+ * Mainnet reads it off sUSDS directly; the L2s read the value the SSR auth
+ * oracle relays (`useSavingsSupplyMinAmountOut` uses the sibling reads for its
+ * chi projection). Where neither is deployed — a fork chain the oracle doesn't
+ * know about — it falls back to inverting the APY the page already displays, so
+ * the counter still runs rather than freezing.
+ */
+export function useSavingsAccrualRate(): number | undefined {
+  const chainId = useChainId();
+  const isL2 = isL2ChainId(chainId);
+
+  const { data: mainnetSsr } = useReadSavingsUsds({
+    functionName: 'ssr',
+    chainId: (isL2 ? 1 : chainId) as keyof typeof sUsdsAddress,
+    query: { enabled: !isL2 }
+  });
+  const { data: l2Ssr } = useReadSsrAuthOracleGetSsr({ query: { enabled: isL2 } });
+  const { data: overall } = useOverallSkyData();
+
+  const ssr = isL2 ? l2Ssr : mainnetSsr;
+  if (ssr !== undefined && ssr > RAY) {
+    return Number(ssr - RAY) / 1e27;
+  }
+
+  const apy = overall?.skySavingsRatecRate ? parseFloat(overall.skySavingsRatecRate) : undefined;
+  if (apy === undefined || !(apy > 0)) return undefined;
+  // APY is the ray compounded over a year, so invert it the same way.
+  return Math.expm1(Math.log1p(apy) / SECONDS_PER_YEAR);
+}

--- a/apps/webapp/src/utils/formatValue.test.ts
+++ b/apps/webapp/src/utils/formatValue.test.ts
@@ -97,4 +97,25 @@ describe('splitAmount', () => {
     expect(splitAmount(0.999996)).toEqual({ whole: '1', fraction: '' });
     expect(splitAmount(1.999996)).toEqual({ whole: '2', fraction: '' });
   });
+
+  // A live counter needs a fraction that neither changes width as it ticks nor
+  // shows a digit the position hasn't earned yet.
+  it('keeps the fraction padded when trimming is off', () => {
+    expect(splitAmount(12.5, 4, { trimTrailingZeros: false })).toEqual({
+      whole: '12',
+      fraction: '5000'
+    });
+    expect(splitAmount(42, 4, { trimTrailingZeros: false })).toEqual({
+      whole: '42',
+      fraction: '0000'
+    });
+  });
+
+  it('truncates instead of rounding when rounding is off', () => {
+    expect(splitAmount(0.999996, 5, { round: false })).toEqual({ whole: '0', fraction: '99999' });
+    expect(splitAmount(100000.000269, 4, { trimTrailingZeros: false, round: false })).toEqual({
+      whole: '100,000',
+      fraction: '0002'
+    });
+  });
 });

--- a/apps/webapp/src/utils/formatValue.ts
+++ b/apps/webapp/src/utils/formatValue.ts
@@ -88,16 +88,36 @@ export function formatNumber(amount: number, options?: FormatOptions): string {
  * value can render the whole part large and the decimals small/dimmed
  * (e.g. `100,000` + `.00026`). Returns an empty `fraction` when there is none.
  */
-export function splitAmount(value: number, fractionDigits = 5): { whole: string; fraction: string } {
+export function splitAmount(
+  value: number,
+  fractionDigits = 5,
+  options?: {
+    /** Off for a live counter, whose fraction must not change width as it ticks. */
+    trimTrailingZeros?: boolean;
+    /**
+     * Off for a live counter: rounding would show a digit the position hasn't
+     * earned yet, and would tick half a place out of step with the schedule the
+     * counter wakes on.
+     */
+    round?: boolean;
+  }
+): { whole: string; fraction: string } {
+  const { trimTrailingZeros = true, round = true } = options ?? {};
   const scale = 10 ** fractionDigits;
   // Round once at the scaled-integer level so a fraction that rounds up to a full
   // unit (e.g. 0.999996 → 1) carries into the whole part instead of producing
   // whole "0" / fraction "1".
-  const scaled = Math.round(value * scale);
+  const scaled = round ? Math.round(value * scale) : Math.floor(value * scale);
   const whole = Math.trunc(scaled / scale);
   const fractionRaw = scaled - whole * scale;
-  const fraction =
-    fractionRaw > 0 ? String(fractionRaw).padStart(fractionDigits, '0').replace(/0+$/, '') : '';
+  const padded = String(fractionRaw).padStart(fractionDigits, '0');
+  const fraction = trimTrailingZeros
+    ? fractionRaw > 0
+      ? padded.replace(/0+$/, '')
+      : ''
+    : fractionDigits > 0
+      ? padded
+      : '';
   return { whole: formatNumber(whole, { maxDecimals: 0 }), fraction };
 }
 


### PR DESCRIPTION
### What does this PR do?

Makes the Sky Savings position figure accrue on screen, per the motion comp ([Figma 1598:76444](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-76444&m=dev)). sUSDS appreciates every second; the hero showed a still number. It now projects the balance forward from the SSR between chain reads and rolls its decimals over one at a time.

Stacked on #1800 — review that first.

**The rate is read from the chain**, not from the displayed APY: `sUSDS.ssr()` on mainnet and `SsrAuthOracle.getSsr()` on L2 (the sibling reads `useSavingsSupplyMinAmountOut` already uses), falling back to inverting the BA Labs APY so a fork chain the oracle doesn't know still animates. Since `assets(t) = assets(t₀) · ssr^(t − t₀)`, the balance is its own baseline and no share math is needed.

**The precision is picked per position.** The comp's fixed 5 decimals can't carry the motion at every balance — at 3.75% they'd tick ~12×/second on 100,000 USDS and once every 8.5s on 1,000. So the decimal count is chosen to land the comp's cadence:

`d = -log10(amount · ratePerSecond · 0.8s)`, clamped to `[2, cap]`

where `cap` is that same expression evaluated at **1 USDS**. Because `d` falls as the balance rises, the cap never binds at or above one whole unit — every such position ticks at the target cadence — and sub-unit dust holds that precision and simply ticks slower. At today's 3.75% SSR the cap works out to 9 decimals, and it re-derives itself if the rate moves.

| Balance @ 3.75% | Decimals | Tick interval |
|---|---|---|
| 10,000,000 | 2 (floor) | ~0.9s |
| 100,000 | 4 | ~0.86s |
| 1,000 | 6 | ~0.86s |
| 1 | 9 (cap) | ~0.86s |
| 0.10 | 9 | ~8.6s |

**Worth a designer's eye:** this replaces the comp's fixed 5 decimals, so at 100,000 the figure reads `100,000.0002`, not `.00026`. Rendered width stays ~10 significant digits at any balance, so it never grows past the comp — but the decimal count now differs between users.

Other notes:
- **Savings only, built generically.** `PositionHero` takes an optional `ratePerSecond`; stUSDS, the Morpho vaults and Pendle opt in later with no rework.
- **Only the fraction rolls.** The whole part turns over once every few hours at any realistic rate, so a still carry there costs nothing and keeps the 44px figure out of the clip windows.
- The counter wakes on the exact digit boundary, so it renders about once per visible change rather than on an interval or at 60fps.
- A read landing slightly *behind* the projection is ignored — that's the projection running ahead of the chain between blocks, and honouring it would count the figure backwards. A withdrawal moves far more than a few ticks and re-baselines.
- Reduced motion drops the travel (the roll sits behind `motion-safe:`) and the digit simply swaps.

Three DOM details the implementation depends on, all found in browser QA:
1. `overflow: hidden` on an inline-block takes its baseline from the bottom margin edge, which drops the fraction off the baseline it shares with the whole part. The clip is `clip-path: inset(0)` instead — it clips the paint and leaves the baseline alone.
2. The digits are the only copy of the figure in the DOM. An `sr-only` duplicate doubles the number on copy (`110,628.76587658`); adjacent inline spans already form one text run, so it wasn't needed.
3. The rolling glyph boxes are `inline-block`. A block-level box makes Chrome's selection serialiser copy the figure out one digit per line.

### Testing steps:

Automated: `pnpm lint` (0 errors), `pnpm typecheck`, `pnpm -F webapp test`. 2252/2253 pass — the one failure, `EarnFeaturedCards` > Pendle maturity stat, is a pre-existing date bomb that fails identically on the base branch.

Manual, on a Tenderly fork (dark mode):
1. `pnpm vnet:fork`, then `VITE_SKIP_AUTH_CHECK=true pnpm -F webapp dev:mock`.
2. Fund the mock wallet with sUSDS: `tenderly_setErc20Balance` on `0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD` for `0x0944AB0c507A12052A5D766e43bf3a541e45A7Fc`.
3. Connect the mock wallet, go to **Earn → Sky Savings**.
4. The **My position** figure should tick about once a second, the changed digit sliding up out of its window as the new one rises in.
5. Set the balance to ~0.9e18 and reload: the figure should show 9 decimals and still tick about once a second.
6. Select and copy the figure — it should come out as one clean number, not one digit per line.

Verified on the fork at both magnitudes: roll animations run at 200ms / `cubic-bezier(0, 0, 0.58, 1)` with 22px of travel, matching the comp; the fraction's box geometry is identical to the static hero's.
