### PR TITLE
Track the chart hover chrome together (Figma 1598:76169)

### DIFF
--- a/apps/webapp/src/modules/ui/components/Chart.test.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.test.tsx
@@ -1,7 +1,8 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Chart, HoverDimMask, resolveTooltipLabel } from './Chart';
+import { ActiveDot, Chart, HoverCursor, HoverDimMask, resolveTooltipLabel } from './Chart';
+import { HOVER_EASE, HOVER_TRACK_MS } from './chartMotion';
 
 const h = vi.hoisted(() => ({
   isActive: false,
@@ -53,6 +54,63 @@ describe('resolveTooltipLabel', () => {
   });
 });
 
+// Figma: Sky App: UI 1598:76169 — the comp moves the cursor line, the dot, the
+// lit window and the tooltip panel on the same keyframes. Sharing one duration
+// and easing is what keeps them arriving together, so the pieces are checked
+// against the shared constants rather than against numbers of their own.
+describe('hover tracking', () => {
+  const expectTracks = (el: Element) => {
+    expect(el.getAttribute('style')).toContain(`${HOVER_TRACK_MS}ms`);
+    expect(el.getAttribute('style')).toContain(HOVER_EASE);
+  };
+
+  it('carries the dot on a transform so it can glide in both axes', () => {
+    render(
+      <svg>
+        <ActiveDot cx={120} cy={40} color="red" />
+      </svg>
+    );
+
+    const dot = screen.getByTestId('chart-active-dot');
+    // Position lives on the group; the circles stay at the origin, which is
+    // what lets one transform move the whole dot.
+    expect(dot.style.transform).toBe('translate(120px, 40px)');
+    expect(dot.querySelector('circle')?.getAttribute('cx')).toBeNull();
+    expectTracks(dot);
+  });
+
+  it('draws the cursor as a translated rule rather than moving x1/x2', () => {
+    render(
+      <svg>
+        <HoverCursor
+          points={[
+            { x: 200, y: 0 },
+            { x: 200, y: 240 }
+          ]}
+        />
+      </svg>
+    );
+
+    const cursor = screen.getByTestId('chart-hover-cursor');
+    expect(cursor.getAttribute('x1')).toBe('0');
+    expect(cursor.getAttribute('x2')).toBe('0');
+    expect(cursor.style.transform).toBe('translateX(200px)');
+    expect(cursor.getAttribute('stroke-dasharray')).toBe('3 3');
+    expectTracks(cursor);
+  });
+
+  it('renders nothing until there is a hover point to track', () => {
+    render(
+      <svg>
+        <ActiveDot color="red" />
+        <HoverCursor />
+      </svg>
+    );
+    expect(screen.queryByTestId('chart-active-dot')).toBeNull();
+    expect(screen.queryByTestId('chart-hover-cursor')).toBeNull();
+  });
+});
+
 // APP-443 item 19.4: hovering dims the whole series and relights only the DS
 // mock's 44px window around the hover point.
 describe('HoverDimMask', () => {
@@ -70,20 +128,30 @@ describe('HoverDimMask', () => {
 
     expect(Number(screen.getByTestId('chart-dim-mask-base').getAttribute('opacity'))).toBeLessThan(1);
 
+    // The window holds its geometry and travels on `transform` so the boundary
+    // can be transitioned — an SVG rect's `x` is not reliably animatable.
     const lit = screen.getByTestId('chart-dim-mask-lit');
-    expect(lit.getAttribute('x')).toBe('278');
     expect(lit.getAttribute('width')).toBe('44');
+    expect(lit.style.transform).toBe('translateX(278px)');
     expect(lit.getAttribute('fill')).toBe('white');
   });
 
-  it('clamps the window to the plot at the edges', () => {
+  it('overhangs the edge rather than narrowing, and lets the mask region clip it', () => {
     h.isActive = true;
     h.coordinate = { x: 0, y: 100 };
     renderMask();
 
+    // Half the window now sits at a negative x instead of being clamped to a
+    // 22px sliver. The mask region is the plot box, so what stays *visible* is
+    // the same 22px — but the rect's width never changes, which is what lets
+    // the boundary glide instead of resizing as it nears an edge.
     const lit = screen.getByTestId('chart-dim-mask-lit');
-    expect(lit.getAttribute('x')).toBe('0');
-    expect(lit.getAttribute('width')).toBe('22');
+    expect(lit.getAttribute('width')).toBe('44');
+    expect(lit.style.transform).toBe('translateX(-22px)');
+
+    const mask = lit.closest('mask');
+    expect(mask?.getAttribute('x')).toBe('0');
+    expect(mask?.getAttribute('width')).toBe('800');
   });
 
   it('shows the whole plot at full strength when nothing is hovered', () => {

--- a/apps/webapp/src/modules/ui/components/Chart.tsx
+++ b/apps/webapp/src/modules/ui/components/Chart.tsx
@@ -20,6 +20,7 @@ import {
 import { format } from 'date-fns';
 import { Text } from '@/modules/layout/components/Typography';
 import { ChartTooltip } from './ChartTooltip';
+import { HOVER_EASE, HOVER_TRACK_MS } from './chartMotion';
 import { BP, useBreakpointIndex } from '@/hooks';
 import {
   Select,
@@ -156,27 +157,84 @@ const SERIES_STROKE_WIDTH = 1.5;
 const ACTIVE_DOT_RADIUS = 5.25;
 
 /**
+ * Every hover element tracks on `transform`, never on SVG geometry: `x1`/`x2`
+ * on a line are not CSS properties at all, and `x`/`width` only became
+ * animatable with SVG 2 geometry properties. One mechanism across all of them,
+ * working everywhere the app already runs. Timing is shared with the tooltip —
+ * see `chartMotion.ts` for why the comp's own durations are not used.
+ */
+const trackTransition = (property: string, reduceMotion: boolean | null) =>
+  reduceMotion ? undefined : `${property} ${HOVER_TRACK_MS}ms ${HOVER_EASE}`;
+
+/**
  * The ringed dot under the hover cursor (Figma 5273:12162).
  *
  * Its core is drawn twice: an opaque page-background disc under the
  * `statusBrandBg` tint. The tint alone is 10% alpha, so the series and the
  * dashed hover cursor both read straight through the dot — the comp draws it
  * solid.
+ *
+ * The circles sit at the origin and the group carries the position, so the dot
+ * can track the hover on `transform` — including the vertical travel as it
+ * rides the series (the comp moves it 13px in y over the same keyframes).
  */
-function ActiveDot({ cx, cy, color }: { cx?: number; cy?: number; color?: string }) {
+export function ActiveDot({ cx, cy, color }: { cx?: number; cy?: number; color?: string }) {
+  const reduceMotion = useReducedMotion();
   if (cx == null || cy == null) return null;
   return (
-    <g data-testid="chart-active-dot">
-      <circle cx={cx} cy={cy} r={ACTIVE_DOT_RADIUS} fill="var(--color-pageBackground)" />
+    <g
+      data-testid="chart-active-dot"
+      style={{
+        transform: `translate(${cx}px, ${cy}px)`,
+        transition: trackTransition('transform', reduceMotion)
+      }}
+    >
+      <circle r={ACTIVE_DOT_RADIUS} fill="var(--color-pageBackground)" />
       <circle
-        cx={cx}
-        cy={cy}
         r={ACTIVE_DOT_RADIUS}
         fill="var(--color-statusBrandBg)"
         stroke={color}
         strokeWidth={SERIES_STROKE_WIDTH}
       />
     </g>
+  );
+}
+
+/**
+ * The dashed hover rule (Figma 5273:12162), as a custom cursor so it can track
+ * on `transform`: recharts' default cursor is a `<Curve>` positioned by its
+ * `points`, which land on `x1`/`x2` and cannot be transitioned.
+ */
+export function HoverCursor({
+  points,
+  height,
+  top
+}: {
+  points?: { x: number; y: number }[];
+  height?: number;
+  top?: number;
+}) {
+  const reduceMotion = useReducedMotion();
+  const start = points?.[0];
+  const end = points?.[1];
+  if (!start) return null;
+  return (
+    <line
+      data-testid="chart-hover-cursor"
+      x1={0}
+      x2={0}
+      y1={start.y ?? top ?? 0}
+      y2={end?.y ?? (top ?? 0) + (height ?? 0)}
+      stroke="var(--color-borderQuarternary)"
+      strokeWidth={1}
+      strokeDasharray="3 3"
+      strokeLinecap="round"
+      pointerEvents="none"
+      style={{
+        transform: `translateX(${start.x}px)`,
+        transition: trackTransition('transform', reduceMotion)
+      }}
+    />
   );
 }
 
@@ -241,12 +299,10 @@ export function HoverDimMask({ id }: { id: string }) {
   const coordinate = useActiveTooltipCoordinate();
   const width = useChartWidth();
   const height = useChartHeight();
+  const reduceMotion = useReducedMotion();
   // Pre-layout the chart has no dimensions (and no hover); fall back to a
   // full-coverage white mask so the series never flashes hidden.
   const cursorX = isActive && coordinate && width != null ? coordinate.x : null;
-
-  const litStart = cursorX != null ? Math.max(cursorX - HALF_WINDOW, 0) : 0;
-  const litEnd = cursorX != null && width != null ? Math.min(cursorX + HALF_WINDOW, width) : 0;
 
   return (
     <defs>
@@ -259,15 +315,25 @@ export function HoverDimMask({ id }: { id: string }) {
           height={height ?? '100%'}
           fill="white"
           opacity={cursorX != null ? POST_CURSOR_ALPHA : 1}
+          style={{ transition: trackTransition('opacity', reduceMotion) }}
         />
         {cursorX != null && (
+          /* Full-width window translated into place rather than clamped by
+             recomputing x/width: the mask region is the plot box, so a window
+             that overhangs an edge is clipped to exactly what clamping used to
+             leave visible — and holding the geometry still is what lets the
+             boundary travel with the cursor on `transform`. */
           <rect
             data-testid="chart-dim-mask-lit"
-            x={litStart}
+            x={0}
             y={0}
-            width={Math.max(litEnd - litStart, 0)}
+            width={HALF_WINDOW * 2}
             height={height ?? '100%'}
             fill="white"
+            style={{
+              transform: `translateX(${cursorX - HALF_WINDOW}px)`,
+              transition: trackTransition('transform', reduceMotion)
+            }}
           />
         )}
       </mask>
@@ -743,13 +809,9 @@ function ChartContent({
               // (see useChartTooltipPortal); the tooltip places itself.
               portal={tooltipPortal}
               // DS hover cursor: a faint dashed vertical rule (Figma 5273:12162 —
-              // border-quaternary, 3/3 dashes with round caps).
-              cursor={{
-                stroke: 'var(--color-borderQuarternary)',
-                strokeWidth: 1,
-                strokeDasharray: '3 3',
-                strokeLinecap: 'round'
-              }}
+              // border-quaternary, 3/3 dashes with round caps), drawn by
+              // HoverCursor so it tracks the hover with everything else.
+              cursor={<HoverCursor />}
               content={
                 <ChartTooltip
                   symbol={symbol}

--- a/apps/webapp/src/modules/ui/components/ChartTooltip.tsx
+++ b/apps/webapp/src/modules/ui/components/ChartTooltip.tsx
@@ -1,6 +1,8 @@
 import { RefObject, useLayoutEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { formatNumber } from '@/utils';
 import { TokenIconStack } from './TokenIconStack';
+import { HOVER_EASE, HOVER_FADE_MS, HOVER_TRACK_MS } from './chartMotion';
 
 /** Gap between the hover point and the panel — recharts' own default offset. */
 const CURSOR_OFFSET = 10;
@@ -27,6 +29,7 @@ function useTooltipPlacement(
   anchorRef: RefObject<HTMLElement | null> | undefined
 ) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const reduceMotion = useReducedMotion();
   // Only the panel's *size* is tracked, never its position: the panel carries
   // the placement transform, so storing its left/top would re-enter this hook
   // on every animated frame and spin forever.
@@ -74,12 +77,46 @@ function useTooltipPlacement(
       position: 'absolute',
       left: 0,
       top: 0,
-      // Transform, not left/top, so the move is compositor-driven — the same
-      // 400ms glide recharts animates its own wrapper with.
+      // Transform, not left/top, so the move is compositor-driven. The timing
+      // is shared with the cursor, dot and lit window (Chart.tsx) because the
+      // comp moves all four as one — they leave and land together, on quart.
+      // It replaces a 400ms ease-out inherited from recharts' own wrapper,
+      // which left the panel trailing the rest of the hover chrome.
       transform: `translate(${x}px, ${y}px)`,
-      transition: placed ? 'transform 400ms ease-out' : 'none'
+      transition: placed && !reduceMotion ? `transform ${HOVER_TRACK_MS}ms ${HOVER_EASE}` : 'none'
     } as const
   };
+}
+
+/**
+ * Trades one value for another on a ~100ms crossfade (the comp fades its date
+ * and amount over ~96ms, out on quart and in on easeInOut).
+ *
+ * Both copies are stacked in one grid cell so they overlap while they trade —
+ * a sequential fade would read as a flicker, and floating one copy out of flow
+ * would collapse the panel's width mid-move.
+ */
+function Crossfade({ tokenKey, children }: { tokenKey: string; children: React.ReactNode }) {
+  const reduceMotion = useReducedMotion();
+  if (reduceMotion) return <>{children}</>;
+  return (
+    <span className="grid">
+      <AnimatePresence initial={false} mode="sync">
+        <motion.span
+          key={tokenKey}
+          className="col-start-1 row-start-1"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          // The comp fades the outgoing copy on quart and the incoming one on
+          // easeInOut, so the exit carries its own curve.
+          exit={{ opacity: 0, transition: { duration: HOVER_FADE_MS / 1000, ease: [0.77, 0, 0.175, 1] } }}
+          transition={{ duration: HOVER_FADE_MS / 1000, ease: [0.5, 0, 0.5, 1] }}
+        >
+          {children}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  );
 }
 
 interface CustomTooltipProps {
@@ -147,7 +184,7 @@ export function ChartTooltip({
       data-testid="chart-tooltip"
     >
       <p className="text-fgPrimary font-circle text-xs leading-3.5 font-medium tracking-[-0.24px]">
-        {labelFormatter(label)}
+        <Crossfade tokenKey={labelFormatter(label)}>{labelFormatter(label)}</Crossfade>
       </p>
       {payload.map((entry, i) => (
         <div key={`tooltip-value-item-${i}`} className="flex items-center gap-4">
@@ -167,8 +204,10 @@ export function ChartTooltip({
           )}
           <span className="ml-auto flex items-center gap-1">
             <span className="text-fgPrimary font-circle text-xs leading-3.5 font-medium tracking-[-0.24px]">
-              {prefix || ''}
-              {`${formatNumber(entry.value)}${symbol && !isPercentage && !hasTokenIcon ? ` ${symbol}` : ''}${isPercentage ? '%' : ''}`}
+              <Crossfade tokenKey={String(entry.value)}>
+                {prefix || ''}
+                {`${formatNumber(entry.value)}${symbol && !isPercentage && !hasTokenIcon ? ` ${symbol}` : ''}${isPercentage ? '%' : ''}`}
+              </Crossfade>
             </span>
             {tokenSymbols && tokenSymbols.length > 0 && (
               <TokenIconStack

--- a/apps/webapp/src/modules/ui/components/chartMotion.ts
+++ b/apps/webapp/src/modules/ui/components/chartMotion.ts
@@ -1,0 +1,24 @@
+/**
+ * Hover motion shared by the chart and its tooltip (Figma: Sky App: UI
+ * 1598:76169).
+ *
+ * The comp moves the cursor line, the ringed dot, the lit window and the
+ * tooltip panel as one: they leave and land on the same keyframes, on quart.
+ * One duration and easing across all four is what buys that. They live here
+ * rather than in `Chart.tsx` because `ChartTooltip` needs them too, and
+ * `Chart.tsx` imports the tooltip — reading them from there would be a cycle.
+ *
+ * The comp's own moves run ~500ms, but that figure is the DEMO POINTER's travel
+ * between two far-apart data points, not an interaction spec: a real hover is
+ * already where the user put it, and gliding for half a second behind the mouse
+ * reads as lag rather than motion. The glide is therefore short enough to be
+ * read as tracking — it smooths the jump from one datum to the next without
+ * ever being what the eye waits for. (User call, on the 1598:76169 scope.)
+ */
+export const HOVER_TRACK_MS = 120;
+
+/** Quart, the easing every move in the comp carries. */
+export const HOVER_EASE = 'cubic-bezier(0.77, 0, 0.175, 1)';
+
+/** Tooltip label/value crossfade — ~96ms in the comp. */
+export const HOVER_FADE_MS = 100;


### PR DESCRIPTION
### What does this PR do?

Builds the chart hover motion from [Figma 1598:76169](https://www.figma.com/design/1aCQfCwuGx90hVwGcD2ZLS/Sky-App--UI?node-id=1598-76169&m=dev) — the piece deliberately deferred out of #1803.

The cursor line, the ringed dot, the lit window and the tooltip panel all existed already (APP-443), but each snapped between data points on its own. The comp moves them **as one**: they leave and land on the same keyframes, on quart, and the tooltip trades its date and amount on a ~96ms crossfade instead of swapping them outright.

**The comp's ~500ms moves are not an interaction spec.** They are the demo pointer's own travel between two far-apart data points. A real hover is already where the user put it, so applied literally the chrome would trail the mouse by half a second. Tracking is **120ms quart** — agreed with @inclinedmind before building. What the comp genuinely specifies, and what this implements, is the coordination, the quart easing, the ~100ms content crossfade and the panel's edge clamping.

**Everything rides `transform`, never SVG geometry** — a line's `x1`/`x2` are not CSS properties at all, and `x`/`width` only became animatable with SVG 2 geometry properties:

- **Dot** — circles moved to the origin under a positioned `<g>`, which also carries the comp's vertical travel as the dot rides the series.
- **Cursor** — now a custom `<HoverCursor>`. recharts' default cursor is a `<Curve>` positioned by the `points` it lands on `x1`/`x2`, so it cannot be transitioned in place.
- **Lit window** — keeps a fixed 44px width and **overhangs the plot edge instead of narrowing**. The mask region is the plot box, so it clips to exactly what the old clamping left visible — and holding the geometry still is what lets the boundary glide rather than resize near an edge.
- **Tooltip** — its 400ms ease-out glide (inherited from recharts' own wrapper) retimed to the shared 120ms, so it stops trailing the rest of the chrome.

Timings live in a new `chartMotion.ts` rather than in `Chart.tsx`, because `ChartTooltip` needs them too and `Chart.tsx` imports the tooltip — reading them from there would be an import cycle.

### Testing steps:

Any chart: the product-detail cards, `/stake` Statistics, or the portfolio totals chart.

1. Hover the plot and move between two distant points in one go — cursor, dot, lit window and tooltip should set off and arrive **together**, not in a ragged sequence.
2. Watch the tooltip's date and value as the point changes: they should trade on a short crossfade rather than snapping.
3. Hover near the left and right edges — the lit window should shrink against the edge exactly as before (it now overhangs and is clipped, rather than being clamped).
4. Sweep the mouse quickly across the plot: the chrome should stay with the pointer, not lag behind it.
5. With **Reduce motion** enabled at the OS level, every one of these should snap instantly with no crossfade.

Measured rather than eyeballed, on a jump across the plot:

| | result |
|---|---|
| all four elements | leave and land on the same frames |
| lit window | stays exactly `cursor − 22` |
| glide | value at 25ms into the move matches quart at ~21% of 120ms |
| reduced motion | all four `transitionDuration: 0s`, tooltip text renders bare |
| crossfade under a frantic drag (8px every 4ms) | stays a clean two-way trade — ghost ink beyond the leading copy averages 11%, peaks at 44% (a crossfade midpoint) |

**Not verified locally:** the dot's vertical travel. Local dev has no real series — BA Labs and the indexer are both CORS-blocked — so the plotted line is flat and `cy` never moves. The mechanism is the same transform that drives x, but it is unobserved; worth a look on the preview.

Gates: typecheck clean, lint 0 errors, tests 2260/2261 — the one failure is the known `EarnFeaturedCards` date bomb (a Pendle maturity of `18 Jun 2026`, now in the past), which fails on the base too.
