### PR TITLE
Explain the protocol lineage behind the Earn hero years badge

### DIFF
--- a/apps/webapp/src/modules/earn/components/EarnPage.tsx
+++ b/apps/webapp/src/modules/earn/components/EarnPage.tsx
@@ -27,14 +27,10 @@ import { filterEarnRows, sortEarnRows } from '../helpers/earnTableState';
 import { partitionByGeoAvailability } from '../helpers/geoAvailability';
 import { formatMaturity } from '../helpers/formatMaturity';
 import { formatUsdCompact } from '../helpers/formatUsdCompact';
-import {
-  formatCirculation,
-  formatCirculationCoarse,
-  protocolStartYear,
-  yearsOperating
-} from '../helpers/protocolStats';
+import { formatCirculation, formatCirculationCoarse, protocolStartYear } from '../helpers/protocolStats';
 import { useEarnTableState } from '../hooks/useEarnTableState';
 import { EarnFeaturedCards } from './EarnFeaturedCards';
+import { ProtocolLineageBadge } from './ProtocolLineageBadge';
 
 const NO_VALUE = '–';
 
@@ -138,7 +134,6 @@ export function EarnPage() {
   // than a positional "{0}".
   const amount = circulation !== undefined ? formatCirculation(circulation) : undefined;
   const coarseAmount = circulation !== undefined ? formatCirculationCoarse(circulation) : undefined;
-  const years = useMemo(() => String(yearsOperating()), []);
 
   // Slug ↔ chain mapping for the network filter (same normalized names the
   // `network` query param uses).
@@ -266,9 +261,9 @@ export function EarnPage() {
                 <Trans>{amount} in circulation</Trans>
               </HeaderBadge>
             ) : null}
-            <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>
-              <Trans>Operating for {years} years</Trans>
-            </HeaderBadge>
+            {/* Owns its own year count — the badge and the lineage tooltip it
+                carries read the same PROTOCOL_START the subtitle does. */}
+            <ProtocolLineageBadge />
           </>
         }
         title={<Trans>Only the best ways to put your stablecoins to work</Trans>}

--- a/apps/webapp/src/modules/earn/components/ProtocolLineageBadge.test.tsx
+++ b/apps/webapp/src/modules/earn/components/ProtocolLineageBadge.test.tsx
@@ -1,0 +1,76 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { yearsOperating } from '../helpers/protocolStats';
+import { ProtocolLineageBadge } from './ProtocolLineageBadge';
+
+// Pin the pointer/touch split per test — happy-dom reports no touch support,
+// so the tooltip branch is the default.
+const device = vi.hoisted(() => ({ isTouch: false }));
+vi.mock('@/hooks/ui/useIsTouchDevice', () => ({ useIsTouchDevice: () => device.isTouch }));
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const renderBadge = () =>
+  render(
+    <I18nProvider i18n={i18n}>
+      <ProtocolLineageBadge />
+    </I18nProvider>
+  );
+
+const LINEAGE =
+  /Sky Protocol is MakerDAO's continuation — running decentralized stablecoin infrastructure since 2017\./;
+
+describe('ProtocolLineageBadge — the Earn hero years badge and its lineage tooltip', () => {
+  afterEach(() => {
+    device.isTouch = false;
+    cleanup();
+  });
+
+  it('labels the badge with the completed years since the protocol start', () => {
+    renderBadge();
+
+    expect(screen.getByText(`Operating for ${yearsOperating()} years`)).toBeTruthy();
+  });
+
+  it('keeps the lineage copy out of the resting hero', () => {
+    renderBadge();
+
+    expect(screen.queryByText(LINEAGE)).toBeNull();
+  });
+
+  it('reveals the lineage copy from the badge on focus', () => {
+    renderBadge();
+
+    // Radix opens the tooltip on keyboard-visible focus.
+    fireEvent.keyDown(document.body, { key: 'Tab' });
+    fireEvent.focus(screen.getByRole('button'));
+
+    expect(screen.getAllByText(LINEAGE).length).toBeGreaterThan(0);
+  });
+
+  it('opens the same copy on tap where there is no hover', () => {
+    device.isTouch = true;
+    renderBadge();
+
+    expect(screen.queryByText(LINEAGE)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getAllByText(LINEAGE).length).toBeGreaterThan(0);
+  });
+
+  it('takes the tooltip year from the same constant as the badge count, so the two cannot drift', () => {
+    renderBadge();
+
+    fireEvent.keyDown(document.body, { key: 'Tab' });
+    fireEvent.focus(screen.getByRole('button'));
+
+    // 2017 + the badge's completed years is the current year (or the year
+    // before, until the December anniversary passes).
+    const currentYear = new Date().getUTCFullYear();
+    expect(2017 + yearsOperating()).toBeGreaterThanOrEqual(currentYear - 1);
+    expect(screen.getAllByText(/since 2017\./).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/webapp/src/modules/earn/components/ProtocolLineageBadge.tsx
+++ b/apps/webapp/src/modules/earn/components/ProtocolLineageBadge.tsx
@@ -32,7 +32,19 @@ const LINEAGE_COPY = (
  * has no hover value in either theme.
  */
 const TRIGGER_CLASSES =
-  'hover:ring-glassBorder focus-visible:ring-ring inline-flex cursor-help rounded-full transition-shadow hover:ring-1 hover:ring-inset focus-visible:ring-1 focus-visible:outline-hidden';
+  'hover:ring-glassBorder focus-visible:ring-ring inline-flex cursor-default rounded-full transition-shadow hover:ring-1 hover:ring-inset focus-visible:ring-1 focus-visible:outline-hidden';
+
+/**
+ * Opens *above* the badge, against the hero's empty top padding — every other
+ * app tooltip opens below its trigger, but this one would then sit on the 44px
+ * hero heading, and the DS surface is glass: 40% white over blur(20px) in
+ * light, 10% lavender in dark. Blurring display type doesn't hide it, it
+ * averages it, so the card picked up a grey cast in light and washed out in
+ * dark — visibly unlike every other tooltip in the app. Deepening the blur
+ * can't fix a luminance difference (100px and 300px were both still grey); a
+ * clean backdrop can, and above the badge there is one.
+ */
+const SIDE = 'top';
 
 /**
  * The Earn hero's years badge (5031:52321), carrying the Maker/DAI lineage on
@@ -60,7 +72,7 @@ export function ProtocolLineageBadge() {
         {/* Touch fallback mirrors the DS tooltip chrome (Figma 5043:57748). */}
         <PopoverContent
           align="center"
-          side="bottom"
+          side={SIDE}
           className="bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[20px]"
         >
           <p>{LINEAGE_COPY}</p>
@@ -81,7 +93,7 @@ export function ProtocolLineageBadge() {
           </button>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent side="bottom">
+          <TooltipContent side={SIDE}>
             <p>{LINEAGE_COPY}</p>
           </TooltipContent>
         </TooltipPortal>

--- a/apps/webapp/src/modules/earn/components/ProtocolLineageBadge.tsx
+++ b/apps/webapp/src/modules/earn/components/ProtocolLineageBadge.tsx
@@ -1,0 +1,91 @@
+import { Trans } from '@lingui/react/macro';
+import { useIsTouchDevice } from '@/hooks';
+import { HeaderBadge } from '@/components/ui/page-header';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
+import { IllustrationStaked } from '@/modules/icons';
+import { protocolStartYear, yearsOperating } from '../helpers/protocolStats';
+
+/**
+ * The lineage the "Operating for N years" claim rests on (APP-432 item 3
+ * thread). Copy is the legal-reviewed line: it deliberately avoids counting
+ * years a second time, so only the badge label has to move each anniversary.
+ * The year interpolates from `PROTOCOL_START` for the same reason the subtitle
+ * does — badge, subtitle and tooltip can then never disagree.
+ */
+const LINEAGE_COPY = (
+  <Trans>
+    Sky Protocol is MakerDAO&apos;s continuation — running decentralized stablecoin infrastructure since{' '}
+    {protocolStartYear}.
+  </Trans>
+);
+
+/**
+ * Hover affordance on a badge the DS draws borderless: a ring in the glass
+ * border token rather than a fill change, since the pill's `glassBadge` fill
+ * has no hover value in either theme.
+ */
+const TRIGGER_CLASSES =
+  'hover:ring-glassBorder focus-visible:ring-ring inline-flex cursor-help rounded-full transition-shadow hover:ring-1 hover:ring-inset focus-visible:ring-1 focus-visible:outline-hidden';
+
+/**
+ * The Earn hero's years badge (5031:52321), carrying the Maker/DAI lineage on
+ * hover. Tooltip from a pointer, tap-open popover on touch (Radix force-closes
+ * tooltips there) — the same split `InfoTooltip` makes.
+ */
+export function ProtocolLineageBadge() {
+  const isTouchDevice = useIsTouchDevice();
+  // Whole years only tick over on an anniversary, so one read per mount is
+  // plenty — and it keeps the label stable across re-renders.
+  const years = String(yearsOperating());
+
+  // Accessible name comes from the badge's own text, so the trigger carries no
+  // aria-label that would shadow it.
+  const trigger = (
+    <HeaderBadge icon={<IllustrationStaked boxSize={16} />}>
+      <Trans>Operating for {years} years</Trans>
+    </HeaderBadge>
+  );
+
+  if (isTouchDevice) {
+    return (
+      <Popover>
+        <PopoverTrigger className={TRIGGER_CLASSES}>{trigger}</PopoverTrigger>
+        {/* Touch fallback mirrors the DS tooltip chrome (Figma 5043:57748). */}
+        <PopoverContent
+          align="center"
+          side="bottom"
+          className="bg-bgTertiary text-fgPrimary font-graphik w-auto max-w-[260px] rounded-2xl text-[11px] leading-4 font-normal backdrop-blur-[20px]"
+        >
+          <p>{LINEAGE_COPY}</p>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    // Own provider (same 300ms delay as the app root's, which nests harmlessly
+    // under it) so the badge is self-contained on any surface — page, tests —
+    // with no host setup. Same precedent as RiskTierDetailsTrigger.
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" className={TRIGGER_CLASSES}>
+            {trigger}
+          </button>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent side="bottom">
+            <p>{LINEAGE_COPY}</p>
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
### What does this PR do?

Closes the tooltip thread on [APP-432](https://linear.app/ekliptyka/issue/APP-432/redesign-qa-round-july-28#comment-84b72328) (item 3). The hero's years badge asserted "Operating for 8 years" with nothing behind it; Kacper asked for the Maker/DAI legacy on hover, and it now carries the line legal review settled on:

> Sky Protocol is MakerDAO's continuation — running decentralized stablecoin infrastructure since 2017.

That copy deliberately doesn't count years a second time, so only the badge label has to move each anniversary. Its `2017` interpolates from `PROTOCOL_START`, the same constant the subtitle reads — badge count, subtitle and tooltip can't drift apart.

**Where it anchors.** The years badge, hover-only — no info icon. The alternative was the subtitle's "since 2017", but a mid-sentence trigger has nowhere sensible to go on touch.

**The affordance.** A `ring-glassBorder` inset ring rather than a fill change: the DS badge is borderless and `glassBadge` has no hover value in either theme. `glassSurface` is the neighbouring token, but it's *lighter* than `glassBadge` in dark, so hovering would read backwards.

Pointer gets the DS tooltip, touch gets a popover with the same chrome — Radix force-closes tooltips on touch devices. Same split `InfoTooltip` already makes. The trigger carries no `aria-label`, since the badge's own text is its accessible name.

`EarnPage` no longer computes `years`; the new `ProtocolLineageBadge` owns the badge and its tooltip together.

### Testing steps:

`/earn` — hover the "Operating for 8 years" badge; the pill picks up a ring and the tooltip opens below it.

Verified in the browser on a fork at 1244px, dark then light. The touch popover branch is covered by unit tests only.

Note the full suite has one red test on this branch, `EarnFeaturedCards.test.tsx` — it asserts a Pendle maturity of `18 Jun 2026`, now in the past. It fails on a clean `app-redesign` too and is unrelated to this change.

<img width="500" height="175" alt="image" src="https://github.com/user-attachments/assets/32e72ba7-d1c9-4fb7-ae38-be94f7a4e9bf" />
