### PR TITLE
Tint mobile browser chrome with the active theme

### DIFF
--- a/apps/webapp/src/index.html
+++ b/apps/webapp/src/index.html
@@ -5,7 +5,9 @@
     <!-- Set theme before first paint to avoid a flash (FOUC). Mirrors the
          resolution in src/lib/theme.ts: stored choice, else OS pref, else dark.
          Also preloads the theme's page background image so the shell doesn't
-         paint on a bare backdrop while the CSS background downloads. -->
+         paint on a bare backdrop while the CSS background downloads, and sets
+         theme-color (the browser-chrome tint) from the same choice — the values
+         mirror THEME_COLORS in src/lib/theme.ts, which owns it after mount. -->
     <script>
       (function () {
         try {
@@ -19,14 +21,16 @@
         } catch (e) {
           document.documentElement.dataset.theme = 'dark';
         }
+        var isLight = document.documentElement.dataset.theme === 'light';
         var link = document.createElement('link');
         link.rel = 'preload';
         link.as = 'image';
-        link.href =
-          document.documentElement.dataset.theme === 'light'
-            ? '/images/background-light.webp'
-            : '/images/background-dark.webp';
+        link.href = isLight ? '/images/background-light.webp' : '/images/background-dark.webp';
         document.head.appendChild(link);
+        var themeColor = document.createElement('meta');
+        themeColor.name = 'theme-color';
+        themeColor.content = isLight ? '#ecf0ff' : '#090420';
+        document.head.appendChild(themeColor);
       })();
     </script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/apps/webapp/src/lib/theme.ts
+++ b/apps/webapp/src/lib/theme.ts
@@ -9,8 +9,31 @@ export const getSystemTheme = (): Theme => {
   return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : DEFAULT_THEME;
 };
 
+/**
+ * Page background per theme, mirroring `--color-pageBackground` in globals.css.
+ * Drives `<meta name="theme-color">`, which is what tints the browser chrome
+ * around the viewport (Safari's status bar and toolbar on iOS, the address bar
+ * on Android Chrome). Kept in sync with the pre-paint script in index.html.
+ */
+export const THEME_COLORS: Record<Theme, string> = {
+  dark: '#090420',
+  light: '#ecf0ff'
+};
+
+/** Point `<meta name="theme-color">` at the theme's page background, creating it if absent. */
+const applyThemeColorMeta = (theme: Theme): void => {
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = 'theme-color';
+    document.head.appendChild(meta);
+  }
+  meta.content = THEME_COLORS[theme];
+};
+
 /** Apply a theme to the document by setting the `data-theme` attribute on <html>. */
 export const applyTheme = (theme: Theme): void => {
   if (typeof document === 'undefined') return;
   document.documentElement.dataset.theme = theme;
+  applyThemeColorMeta(theme);
 };


### PR DESCRIPTION
## Problem

On mobile, Safari's status bar and toolbar strips stayed light even with the app in dark mode:

The app never shipped a `<meta name="theme-color">`, which is what Safari (iOS 15+) and Android Chrome use to tint the browser chrome around the viewport. With no value, Safari falls back to its own default.

## Change

- **`index.html`** — the existing pre-paint script now creates the meta alongside the background preload, so the strips are correct on first paint instead of flashing light until React mounts.
- **`lib/theme.ts`** — new `THEME_COLORS` map (`dark: #090420`, `light: #ecf0ff`, mirroring `--color-pageBackground`), and `applyTheme` updates the meta whenever it sets `data-theme`. That's the single choke point `ConfigProvider` and the design-system page already go through, so the toggle picks it up with no extra wiring.

## Verification

Local dev, dark first:

- meta present at load with `#090420`, matching computed `--color-pageBackground`
- flips to `#ecf0ff` on toggling Dark mode off, back to `#090420` on re-toggle
- stays a single element across toggles (no duplicates)
- `pnpm typecheck` passes

Not yet checked on a physical iOS device — worth a look on the preview build.

## Note

The tint is necessarily a flat color while the real page top is the sky image. `#090420` is the base the dark background image is pre-baked over, so it matches closely; if the top of the image reads lighter than the strip on a real device, the value can be nudged in `THEME_COLORS` (and its twin in `index.html`) without touching the CSS token.
