### PR TITLE
fix: reject non-decimal deep-link amounts before parseUnits

### DIFF
--- a/apps/webapp/src/modules/utils/validateSearchParams.test.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.test.ts
@@ -177,3 +177,18 @@ describe('validateSearchParams geo overrides (non-production)', () => {
     expect(params.has('geo_module_savings')).toBe(false);
   });
 });
+
+describe('validateSearchParams input_amount', () => {
+  it.each(['100', '0.5', '.5', '5.'])('keeps plain decimal amount %s', value => {
+    const params = validateParams(`input_amount=${value}`);
+    expect(params.get('input_amount')).toBe(value);
+  });
+
+  it.each(['0x10', '1e999', 'Infinity', ' 16 ', '1,5', '0', '-1', 'abc'])(
+    'strips non-decimal or non-positive amount %s',
+    value => {
+      const params = validateParams(`input_amount=${encodeURIComponent(value)}`);
+      expect(params.has('input_amount')).toBe(false);
+    }
+  );
+});

--- a/apps/webapp/src/modules/utils/validateSearchParams.ts
+++ b/apps/webapp/src/modules/utils/validateSearchParams.ts
@@ -326,8 +326,8 @@ export const validateSearchParams = (
 
     // validate input amount
     if (key === QueryParams.InputAmount) {
-      // check if input amount is not a valid number or is negative
-      if (isNaN(Number(value)) || Number(value) <= 0) {
+      // only plain decimal strings: Number() also admits hex/exponential notation, which parseUnits rejects
+      if (!/^(\d+(\.\d*)?|\.\d+)$/.test(value) || Number(value) <= 0) {
         searchParams.delete(key);
       }
     }

--- a/apps/webapp/src/widgets/lib/utils.test.ts
+++ b/apps/webapp/src/widgets/lib/utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getValidatedState } from './utils';
+
+describe('getValidatedState amount validation', () => {
+  it.each(['100', '0.5', '.5', '5.', '0', ''])('accepts plain decimal amount %j', amount => {
+    expect(getValidatedState({ amount })).toEqual({ amount });
+  });
+
+  it.each(['0x10', '1e999', 'Infinity', ' 16 ', '1,5', '-1', 'abc'])(
+    'rejects non-decimal amount %j',
+    amount => {
+      expect(getValidatedState({ amount })).toBeUndefined();
+    }
+  );
+
+  it.each(['0x10', '1e999'])('rejects non-decimal targetAmount %j', targetAmount => {
+    expect(getValidatedState({ targetAmount })).toBeUndefined();
+  });
+});

--- a/apps/webapp/src/widgets/lib/utils.ts
+++ b/apps/webapp/src/widgets/lib/utils.ts
@@ -49,10 +49,11 @@ const amountValidationRule = z
       if (value === undefined) {
         return true;
       }
-      return !isNaN(Number(value)) && Number(value) >= 0;
+      // only plain decimal strings: Number() also admits hex/exponential notation, which parseUnits rejects
+      return value === '' || /^(\d+(\.\d*)?|\.\d+)$/.test(value);
     },
     {
-      error: 'amount must be a number-like string greater than 0'
+      error: 'amount must be a plain decimal string'
     }
   );
 


### PR DESCRIPTION
Fixes WEBAPP-B6 (`InvalidDecimalNumberError: Number 0x10 is not a valid decimal number`, 13 events).

Both amount validators used `Number()`-based checks, which accept hex (`Number('0x10')` → 16) and exponential (`Number('1e999')` → Infinity) strings. A deep link like `/?widget=convert&convert_module=upgrade&source_token=DAI&input_amount=0x10` passed validation and crashed the widget into its error boundary when viem's `parseUnits` threw during render.

- `validateSearchParams`: `input_amount` must now be a plain positive decimal string, matching what `parseUnits` accepts.
- `getValidatedState` (`amountValidationRule`, covers `amount`/`targetAmount` in all widgets): same restriction; empty string stays accepted since call sites guard it with `|| '0'` (see 5bfd4d830).

Not an issue on `app-redesign`, which retired amount-by-URL entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
