### PR TITLE
Wire up Est. earnings in the Savings transaction modals

### DIFF
--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.test.tsx
@@ -1,6 +1,6 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 i18n.load('en', {});
@@ -329,10 +329,11 @@ describe('SavingsModalForm — Withdraw from Sky Savings entry body', () => {
         <TooltipProvider>{review?.[1].transactionContent}</TooltipProvider>
       </I18nProvider>
     );
+    // Scoped to this render — the entry body still on screen carries the same test id.
     // 50 USDS left at 3.75%.
-    expect(
-      container.querySelector('[data-testid="savings-modal-row-Est. earnings (1Y)"]')?.textContent
-    ).toContain('1.88');
+    expect(within(container).getByTestId('savings-modal-row-Est. earnings (1Y)').textContent).toContain(
+      '1.88'
+    );
   });
 
   it('disables the confirm and flags an error when the amount exceeds the position', () => {

--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.test.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.test.tsx
@@ -243,6 +243,19 @@ describe('SavingsModalForm — Supply to Sky Savings entry body', () => {
     expect(screen.queryByTestId('savings-modal-amount-error')).not.toBeNull();
   });
 
+  // The projection the "Est. earnings (1Y)" cell draws: the 100-USDS position at
+  // the mocked 3.75% rate, and what it becomes once an amount is entered.
+  it('projects 1Y earnings from the savings rate, before→after', () => {
+    renderForm('supply');
+    const cell = () => screen.getByTestId('savings-modal-row-Est. earnings (1Y)');
+    // 100 USDS × 3.75%
+    expect(cell().textContent).toContain('3.75');
+
+    fireEvent.change(screen.getByTestId('savings-modal-amount-input'), { target: { value: '100' } });
+    // 200 USDS × 3.75% — the delta's `after`.
+    expect(cell().textContent).toContain('7.5');
+  });
+
   it('offers USDS and DAI origin options on mainnet supply', () => {
     renderForm('supply');
     expect(screen.queryByTestId('origin-opt-USDS')).not.toBeNull();
@@ -302,6 +315,24 @@ describe('SavingsModalForm — Withdraw from Sky Savings entry body', () => {
     fireEvent.change(screen.getByTestId('savings-modal-amount-input'), { target: { value: '50' } });
     expect(lastDisabled()).toBe(false);
     expect(screen.queryByTestId('savings-modal-amount-error')).toBeNull();
+  });
+
+  // The review grid is pushed to the modal, not rendered inline — assert the
+  // projection on the position the withdrawal leaves behind.
+  it('pushes the post-withdrawal 1Y projection into the review breakdown', () => {
+    renderForm('withdraw');
+    fireEvent.change(screen.getByTestId('savings-modal-amount-input'), { target: { value: '50' } });
+
+    const review = h.update.mock.calls.filter(([, patch]) => patch?.transactionContent).at(-1);
+    const { container } = render(
+      <I18nProvider i18n={i18n}>
+        <TooltipProvider>{review?.[1].transactionContent}</TooltipProvider>
+      </I18nProvider>
+    );
+    // 50 USDS left at 3.75%.
+    expect(
+      container.querySelector('[data-testid="savings-modal-row-Est. earnings (1Y)"]')?.textContent
+    ).toContain('1.88');
   });
 
   it('disables the confirm and flags an error when the amount exceeds the position', () => {

--- a/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
+++ b/apps/webapp/src/modules/savings/components/SavingsModalForm.tsx
@@ -4,7 +4,7 @@ import { formatUnits } from 'viem';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { formatBigInt, formatNumber } from '@/utils';
+import { formatBigInt, formatNumber, projectAnnualEarnings } from '@/utils';
 import { Text } from '@/modules/layout/components/Typography';
 import { ModalAmountField } from '@/components/product/ModalAmountField';
 import { ModalSummaryGrid } from '@/components/product/ModalSummaryGrid';
@@ -82,6 +82,7 @@ export function SavingsModalForm({
     amountReady,
     position,
     apyDisplay,
+    rate,
     previewShares,
     engineParams,
     transactionScreenContent,
@@ -128,31 +129,46 @@ export function SavingsModalForm({
   // (6-dec) is widened 1:1 (the PSM swaps ≈1:1 — exact figures are stubbed per the
   // PRD Out of Scope). Mainnet is unchanged (amount === amountWad).
   const amountWad = originDecimals === 18 ? amount : amount * 10n ** BigInt(18 - originDecimals);
+
+  // Position after the action, clamped at zero for over-withdrawals (the
+  // insufficient gate blocks submission anyway).
+  const positionAfter = isSupply ? position + amountWad : position > amountWad ? position - amountWad : 0n;
+
+  // 1Y projected earnings, the same simple principal × rate the Savings position
+  // card and every other product modal show. The position is USDS-denominated and
+  // USDS is $1-pegged, so the wad doubles as its USD value. A rate that hasn't
+  // loaded yet keeps the cell on a dash rather than projecting zero.
+  const projectEarnings = (units: bigint) =>
+    rate !== undefined
+      ? formatNumber(projectAnnualEarnings(parseFloat(formatUnits(units, USDS_DECIMALS)), rate), {
+          maxDecimals: 2
+        })
+      : NO_VALUE;
+
   const rows = isSupply
     ? buildSupplyModalRows({
         savingsRate: apyDisplay,
         network: networkName,
         supplyBefore: formatUsds(position),
-        supplyAfter: formatUsds(position + amountWad),
+        supplyAfter: formatUsds(positionAfter),
         hasAmount: !isZero,
         // L2 PSM supply: surface the sUSDS slippage floor once an amount is entered.
         minReceived:
           isL2 && !isZero
             ? formatBigInt(engineParams.minAmountOut ?? 0n, { unit: 18, maxDecimals: 2 })
             : undefined,
-        // 1Y est. earnings has no projection source yet (PRD Out of Scope) — stubbed.
-        earningsBefore: NO_VALUE,
-        earningsAfter: NO_VALUE,
+        earningsBefore: projectEarnings(position),
+        earningsAfter: projectEarnings(positionAfter),
         networkFee: networkFee?.formatted ?? NO_VALUE
       })
     : buildWithdrawModalRows({
         savingsRate: apyDisplay,
         network: networkName,
         supplyBefore: formatUsds(position),
-        supplyAfter: formatUsds(position > amountWad ? position - amountWad : 0n),
+        supplyAfter: formatUsds(positionAfter),
         hasAmount: !isZero,
-        earningsBefore: NO_VALUE,
-        earningsAfter: NO_VALUE,
+        earningsBefore: projectEarnings(position),
+        earningsAfter: projectEarnings(positionAfter),
         networkFee: networkFee?.formatted ?? NO_VALUE
       });
 
@@ -168,11 +184,15 @@ export function SavingsModalForm({
         : NO_VALUE
     : `${formatNumber(parseFloat(formatUnits(amount, originDecimals)), { maxDecimals: 2 })} ${originSymbol}`;
 
+  // The review projects the position the transaction leaves behind. Scalar, so the
+  // memo below stays stable across unrelated renders.
+  const earningsAfterDisplay = projectEarnings(positionAfter);
+
   const transactionContent = useMemo(() => {
     const reviewRows = isSupply
       ? buildSupplyReviewRows({
           youReceive,
-          estEarnings: NO_VALUE,
+          estEarnings: earningsAfterDisplay,
           product: 'Sky Savings',
           rate: apyDisplay,
           withdrawal: i18n._(withdrawalWording('savings', 'supply')),
@@ -182,7 +202,7 @@ export function SavingsModalForm({
       : buildWithdrawReviewRows({
           youReceive,
           receiveToken: originSymbol,
-          estEarnings: NO_VALUE,
+          estEarnings: earningsAfterDisplay,
           product: 'Sky Savings',
           rate: apyDisplay,
           withdrawal: i18n._(withdrawalWording('savings', 'withdraw')),
@@ -201,6 +221,7 @@ export function SavingsModalForm({
   }, [
     isSupply,
     youReceive,
+    earningsAfterDisplay,
     apyDisplay,
     networkName,
     originSymbol,

--- a/apps/webapp/src/modules/savings/components/savingsModalRows.test.ts
+++ b/apps/webapp/src/modules/savings/components/savingsModalRows.test.ts
@@ -14,8 +14,8 @@ const INPUT = {
   supplyBefore: '100',
   supplyAfter: '110',
   hasAmount: true,
-  earningsBefore: '–',
-  earningsAfter: '–',
+  earningsBefore: '6.5',
+  earningsAfter: '7.15',
   networkFee: '–'
 } as const;
 
@@ -25,8 +25,8 @@ const WITHDRAW_INPUT = {
   supplyBefore: '100',
   supplyAfter: '90',
   hasAmount: true,
-  earningsBefore: '–',
-  earningsAfter: '–',
+  earningsBefore: '6.5',
+  earningsAfter: '5.85',
   networkFee: '–'
 } as const;
 
@@ -49,13 +49,13 @@ describe('buildSupplyModalRows — Figma 859:36036 "Supply to Sky Savings" entry
   it('marks Supply and Est. earnings as before→after deltas once an amount is entered', () => {
     const cells = byLabel(buildSupplyModalRows(INPUT));
     expect(cells['Supply']).toMatchObject({ kind: 'delta', before: '100', after: '110' });
-    expect(cells['Est. earnings (1Y)']).toMatchObject({ kind: 'delta', before: '–', after: '–' });
+    expect(cells['Est. earnings (1Y)']).toMatchObject({ kind: 'delta', before: '6.5', after: '7.15' });
   });
 
   it('collapses the delta cells to their current value with no amount (Figma 859:36036 empty state)', () => {
     const cells = byLabel(buildSupplyModalRows({ ...INPUT, hasAmount: false }));
     expect(cells['Supply']).toMatchObject({ kind: 'single', value: '100' });
-    expect(cells['Est. earnings (1Y)']).toMatchObject({ kind: 'single', value: '–' });
+    expect(cells['Est. earnings (1Y)']).toMatchObject({ kind: 'single', value: '6.5' });
   });
 
   it('threads the single-value cells with their presentation hints', () => {
@@ -64,6 +64,7 @@ describe('buildSupplyModalRows — Figma 859:36036 "Supply to Sky Savings" entry
     expect(cells['Network']).toMatchObject({ kind: 'single', value: 'Ethereum', network: true });
     expect(cells['Network fee']).toMatchObject({ kind: 'single', value: '–' });
     expect(cells['Supply']).toMatchObject({ token: 'USDS' });
+    expect(cells['Est. earnings (1Y)']).toMatchObject({ token: 'USDS' });
   });
 
   it('omits the L2 "Receive at least" cell on mainnet (no minReceived)', () => {
@@ -98,14 +99,14 @@ describe('buildWithdrawModalRows — "Withdraw from Sky Savings" entry grid', ()
     const cells = byLabel(buildWithdrawModalRows(WITHDRAW_INPUT));
     expect(cells['Savings rate']).toMatchObject({ kind: 'single', value: '6.50%', rateAccent: 'savings' });
     expect(cells['Supply']).toMatchObject({ kind: 'delta', before: '100', after: '90' });
-    expect(cells['Est. earnings (1Y)']).toMatchObject({ kind: 'delta', before: '–', after: '–' });
+    expect(cells['Est. earnings (1Y)']).toMatchObject({ kind: 'delta', before: '6.5', after: '5.85' });
   });
 });
 
 describe('buildSupplyReviewRows — Figma 859:36154 "Review supply" grid', () => {
   const REVIEW_INPUT = {
     youReceive: '908.93 sUSDS',
-    estEarnings: '–',
+    estEarnings: '59.09',
     product: 'Sky Savings',
     rate: '3.60%',
     withdrawal: 'Anytime',
@@ -128,7 +129,11 @@ describe('buildSupplyReviewRows — Figma 859:36154 "Review supply" grid', () =>
 
     const cells = byLabel(rows);
     expect(cells["You'll receive"]).toMatchObject({ value: '908.93 sUSDS', token: 'sUSDS' });
-    expect(cells['Est. earnings (1Y)']).toMatchObject({ value: '–', trend: true });
+    expect(cells['Est. earnings (1Y)']).toMatchObject({
+      value: '59.09',
+      trend: true,
+      trailingToken: 'USDS'
+    });
     expect(cells['Product']).toMatchObject({ value: 'Sky Savings', token: 'sUSDS', productIcon: 'default' });
     expect(cells['Rate']).toMatchObject({ value: '3.60%', rateAccent: 'savings' });
     expect(cells['Withdrawal']).toMatchObject({ value: 'Anytime' });
@@ -140,7 +145,7 @@ describe('buildWithdrawReviewRows — Figma 859:36322 "Review withdrawal" grid',
   const REVIEW_INPUT = {
     youReceive: '908.93 USDS',
     receiveToken: 'USDS',
-    estEarnings: '–',
+    estEarnings: '3.28',
     product: 'Sky Savings',
     rate: '3.60%',
     withdrawal: 'Instant',
@@ -163,7 +168,11 @@ describe('buildWithdrawReviewRows — Figma 859:36322 "Review withdrawal" grid',
 
     const cells = byLabel(rows);
     expect(cells["You'll receive"]).toMatchObject({ value: '908.93 USDS', token: 'USDS' });
-    expect(cells['Est. earnings (1Y)']).toMatchObject({ value: '–', trend: true });
+    expect(cells['Est. earnings (1Y)']).toMatchObject({
+      value: '3.28',
+      trend: true,
+      trailingToken: 'USDS'
+    });
     expect(cells['Product']).toMatchObject({ value: 'Sky Savings', token: 'sUSDS', productIcon: 'default' });
     expect(cells['Rate']).toMatchObject({ value: '3.60%', rateAccent: 'savings' });
     expect(cells['Withdrawal']).toMatchObject({ value: 'Instant' });

--- a/apps/webapp/src/modules/savings/components/savingsModalRows.ts
+++ b/apps/webapp/src/modules/savings/components/savingsModalRows.ts
@@ -36,11 +36,11 @@ export type SupplyModalRowInput = {
    * so this cell is added "in the spirit of the design" for the L2 swap.
    */
   minReceived?: string;
-  /** 1Y estimated earnings before — stubbed until a projection source exists. */
+  /** 1Y projected earnings on the current position, formatted. */
   earningsBefore: string;
-  /** 1Y estimated earnings after — stubbed until a projection source exists. */
+  /** 1Y projected earnings on the position the supply leaves behind, formatted. */
   earningsAfter: string;
-  /** Network fee, formatted — stubbed until a gas estimate is wired. */
+  /** Network fee, formatted. */
   networkFee: string;
 };
 
@@ -91,11 +91,11 @@ export type WithdrawModalRowInput = {
   supplyAfter: string;
   /** When false the Supply / Est. earnings cells collapse to their `before` value. */
   hasAmount: boolean;
-  /** 1Y estimated earnings before — stubbed until a projection source exists. */
+  /** 1Y projected earnings on the current position, formatted. */
   earningsBefore: string;
-  /** 1Y estimated earnings after — stubbed until a projection source exists. */
+  /** 1Y projected earnings on the position the withdrawal leaves behind, formatted. */
   earningsAfter: string;
-  /** Network fee, formatted — stubbed until a gas estimate is wired. */
+  /** Network fee, formatted. */
   networkFee: string;
 };
 
@@ -133,7 +133,7 @@ export function buildWithdrawModalRows(input: WithdrawModalRowInput): SavingsMod
 export type SupplyReviewRowInput = {
   /** sUSDS you'll receive, formatted (e.g. "9,999.99 sUSDS"). */
   youReceive: string;
-  /** 1Y estimated earnings — stubbed until a projection source exists. */
+  /** 1Y projected earnings on the position the supply leaves behind, formatted. */
   estEarnings: string;
   /** Product name (e.g. "Sky Savings"). */
   product: string;
@@ -143,7 +143,7 @@ export type SupplyReviewRowInput = {
   withdrawal: string;
   /** Network the transaction runs on (e.g. "Ethereum"). */
   network: string;
-  /** Network fee, formatted — stubbed until a gas estimate is wired. */
+  /** Network fee, formatted. */
   networkFee: string;
 };
 
@@ -156,7 +156,15 @@ export function buildSupplyReviewRows(input: SupplyReviewRowInput): SavingsModal
   return [
     [
       { kind: 'single', label: "You'll receive", value: input.youReceive, token: 'sUSDS' },
-      { kind: 'single', label: 'Est. earnings (1Y)', value: input.estEarnings, trend: true }
+      {
+        kind: 'single',
+        label: 'Est. earnings (1Y)',
+        value: input.estEarnings,
+        trend: true,
+        // The projection is USDS-denominated whatever you supplied — name it, as
+        // the vault and stUSDS reviews do.
+        trailingToken: 'USDS'
+      }
     ],
     [
       { kind: 'single', label: 'Product', value: input.product, token: 'sUSDS', productIcon: 'default' },
@@ -176,7 +184,7 @@ export type WithdrawReviewRowInput = {
   youReceive: string;
   /** Destination token symbol for the You'll receive icon. */
   receiveToken: string;
-  /** 1Y estimated earnings after the withdrawal — stubbed until a projection source exists. */
+  /** 1Y projected earnings on the position the withdrawal leaves behind, formatted. */
   estEarnings: string;
   /** Product name (e.g. "Sky Savings"). */
   product: string;
@@ -186,7 +194,7 @@ export type WithdrawReviewRowInput = {
   withdrawal: string;
   /** Network the transaction runs on. */
   network: string;
-  /** Network fee, formatted — stubbed until a gas estimate is wired. */
+  /** Network fee, formatted. */
   networkFee: string;
 };
 
@@ -199,7 +207,13 @@ export function buildWithdrawReviewRows(input: WithdrawReviewRowInput): SavingsM
   return [
     [
       { kind: 'single', label: "You'll receive", value: input.youReceive, token: input.receiveToken },
-      { kind: 'single', label: 'Est. earnings (1Y)', value: input.estEarnings, trend: true }
+      {
+        kind: 'single',
+        label: 'Est. earnings (1Y)',
+        value: input.estEarnings,
+        trend: true,
+        trailingToken: 'USDS'
+      }
     ],
     [
       { kind: 'single', label: 'Product', value: input.product, token: 'sUSDS', productIcon: 'default' },

--- a/apps/webapp/src/modules/savings/hooks/useSavingsTransactionForm.tsx
+++ b/apps/webapp/src/modules/savings/hooks/useSavingsTransactionForm.tsx
@@ -81,6 +81,11 @@ export interface SavingsTransactionForm {
   position: bigint;
   /** Canonical Sky Savings Rate APY, formatted (e.g. "6.50%"). */
   apyDisplay: string;
+  /**
+   * The same rate as a decimal fraction (0.065 = 6.5%), or undefined while it
+   * loads — the projection input behind the modals' "Est. earnings (1Y)".
+   */
+  rate?: number;
   /** Mainnet supply preview: sUSDS shares for the entered amount (when `enablePreview`). */
   previewShares?: bigint;
 
@@ -256,9 +261,8 @@ export function useSavingsTransactionForm({
       : { loading: t`Withdrawing ${label}`, success: t`${label} withdrawn!`, error: t`Withdrawal failed` };
   }, [isSupply, value, originToken.symbol]);
 
-  const apyDisplay = overall?.skySavingsRatecRate
-    ? formatDecimalPercentage(parseFloat(overall.skySavingsRatecRate))
-    : NO_VALUE;
+  const rate = overall?.skySavingsRatecRate ? parseFloat(overall.skySavingsRatecRate) : undefined;
+  const apyDisplay = rate !== undefined ? formatDecimalPercentage(rate) : NO_VALUE;
 
   const onInput = useCallback((raw: string) => {
     // Typing overrides a previous Max selection.
@@ -322,6 +326,7 @@ export function useSavingsTransactionForm({
     amountReady,
     position,
     apyDisplay,
+    rate,
     previewShares,
     engineParams,
     transactionScreenContent,


### PR DESCRIPTION
## The bug

`Est. earnings (1Y)` in the Savings supply/withdraw modals rendered a dash in every state — the entry grid drew `– → –` next to a real `Supply` delta, and the review grid drew a bare `–`.

The row builders were always fed `NO_VALUE`, left over from when the PRD had the projection out of scope:

```ts
// 1Y est. earnings has no projection source yet (PRD Out of Scope) — stubbed.
earningsBefore: NO_VALUE,
earningsAfter: NO_VALUE,
```

Savings was the last family still doing this — Morpho vaults, stUSDS, Rewards and Pendle all project it, and the Savings *position card* has projected it all along. So the modal was contradicting the card it opened from.

## The fix

- `useSavingsTransactionForm` now exposes the Sky Savings Rate as a number (`rate`) alongside the formatted `apyDisplay`, so the modal projects without re-parsing the string.
- `SavingsModalForm` projects with the shared `projectAnnualEarnings` helper — same simple `principal × rate` the position card and every other product modal use. The position is USDS-denominated and USDS is $1-pegged, so the wad doubles as its USD value.
- Both entry grids get the before→after delta; both review grids get the projection on the position the transaction leaves behind.
- A rate that hasn't loaded keeps the cell on a dash rather than projecting zero.
- Extracted the `positionAfter` clamp that supply/withdraw were each computing inline.

One deviation from the current comps: the review cells pick up the trailing USDS icon that the vault and stUSDS reviews already carry. Without it the projection reads as an unlabelled number.

## Verification

Unit: new assertions in `savingsModalRows.test.ts` (real figures instead of dashes, plus the trailing token) and in `SavingsModalForm.test.tsx` (the entry delta at the mocked 3.75% rate, and the post-withdrawal projection pushed into the review breakdown). Full savings suite green — 123 tests. `typecheck`, `lint`, `prettier` clean.

Browser (Tenderly fork, mock wallet, dark mode, 6.5% rate):

| Surface | Result |
| --- | --- |
| Supply entry, 500 USDS from a zero position | `0 → 32.5` |
| Supply review | `↗ 32.5 ◉` |
| Withdraw entry, 200 of a 500 position | `32.5 → 19.5` |
| Withdraw review | `↗ 19.5 ◉` |

The position card reads `32.5` for the same 500 position, so card and modal now agree.