### PR TITLE
Give the flagged text its Medium cut, and stop AppLink cutting the leave animation short

### DIFF
--- a/apps/webapp/src/lib/navigation.tsx
+++ b/apps/webapp/src/lib/navigation.tsx
@@ -197,5 +197,20 @@ export type AppLinkProps = Omit<ComponentProps<'a'>, 'href'> & {
 
 export function AppLink({ to, replace, ...anchorProps }: AppLinkProps) {
   const { pathname, search, hash } = splitHref(to);
-  return <Link {...anchorProps} to={pathname as '/'} search={search} hash={hash} replace={replace} />;
+  return (
+    <Link
+      {...anchorProps}
+      to={pathname as '/'}
+      // Merged onto the retained params rather than replacing the search
+      // outright: an href without a query string means "this path", not "drop
+      // the network". Dropping it made useAppOrchestration navigate straight
+      // back to put it in, and that second commit landed in the same frame as
+      // the view transition's pending snapshot — so the outgoing page was
+      // captured already showing the incoming one, and only the enter
+      // animation was visible (APP-432 review).
+      search={prev => ({ ...retainOnNavigate(prev), ...search })}
+      hash={hash}
+      replace={replace}
+    />
+  );
 }

--- a/apps/webapp/src/modules/app/shell/WalletChip.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletChip.tsx
@@ -5,7 +5,6 @@ import { useConnection, useDisconnect, useEnsAvatar, useEnsName } from 'wagmi';
 import { mainnet } from 'viem/chains';
 import { cn } from '@/lib/cn';
 import { Button } from '@/components/ui/button';
-import { Text } from '@/modules/layout/components/Typography';
 import { TermsModal } from '@/modules/ui/components/TermsModal';
 import { CustomAvatar } from '@/modules/ui/components/Avatar';
 import { useConnectModal } from '@/modules/ui/context/ConnectModalContext';
@@ -70,8 +69,11 @@ export function WalletChip() {
             </span>
             {/* DS Mobile / Topbar keeps the name at phone width; the cap stops
                 long ENS names from squeezing the logo out at 360px. Addresses
-                swap to the short trim there instead of ellipsis-truncating. */}
-            <Text className="max-w-24 min-w-0 truncate sm:max-w-none">
+                swap to the short trim there instead of ellipsis-truncating.
+                A bare span, not <Text>: the whole navbar is Label 5 / Circular
+                Medium (Figma 1036:189127) and navbarWallet already sets it —
+                a Text variant would re-declare Graphik at 16px on top. */}
+            <span className="max-w-24 min-w-0 truncate sm:max-w-none">
               {ensName ? (
                 `${isSafeWallet ? 'safe:' : ''}${ensName}`
               ) : (
@@ -80,7 +82,7 @@ export function WalletChip() {
                   <span className="hidden sm:inline">{`${isSafeWallet ? 'safe:' : ''}${formatAddress(address)}`}</span>
                 </>
               )}
-            </Text>
+            </span>
             <ChevronDown className={cn('h-4 w-4 transition-transform', showDrawer && 'rotate-180')} />
           </Button>
           <WalletPreviewDrawer

--- a/apps/webapp/src/modules/app/shell/WalletDrawerAssets.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletDrawerAssets.tsx
@@ -84,7 +84,7 @@ function AssetRow({
             <div className="flex items-center gap-2">
               <Text
                 tag="span"
-                className="font-circle text-text text-base leading-[18px] tracking-tight md:text-lg md:leading-[22px]"
+                className="font-circle text-text text-base leading-[18px] font-medium tracking-tight md:text-lg md:leading-[22px]"
               >
                 {asset.symbol}
               </Text>
@@ -110,7 +110,7 @@ function AssetRow({
         <div className="flex flex-col items-end gap-0.5">
           <Text
             tag="span"
-            className="font-circle text-text text-base leading-[18px] tracking-tight md:text-lg md:leading-[22px]"
+            className="font-circle text-text text-base leading-[18px] font-medium tracking-tight md:text-lg md:leading-[22px]"
           >
             {formatNumber(asset.amount)}
           </Text>

--- a/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
+++ b/apps/webapp/src/modules/app/shell/WalletPreviewHeader.tsx
@@ -79,8 +79,10 @@ export function WalletPreviewHeader({
           <div className="flex flex-col gap-0.5">
             <Text
               tag="span"
+              // Label 4 (Figma 1030:60388) / Label 5 on mobile — both Circular
+              // Medium. font-circle alone falls to Book (450).
               className={cn(
-                'font-circle tracking-tight text-[#f2f3f7]',
+                'font-circle font-medium tracking-tight text-[#f2f3f7]',
                 mobile ? 'text-sm leading-4' : 'text-base leading-[18px]'
               )}
             >
@@ -140,8 +142,10 @@ export function WalletPreviewHeader({
           <Text
             tag="span"
             dataTestId="wallet-drawer-total"
+            // Heading 2 / Heading 3 on mobile — Circular Medium, as every
+            // Headings-family style in the DS is.
             className={cn(
-              'font-circle tracking-[-0.02em] text-[#f2f3f7]',
+              'font-circle font-medium tracking-[-0.02em] text-[#f2f3f7]',
               mobile ? 'text-[32px] leading-[35px]' : 'text-[44px] leading-[48px]'
             )}
           >

--- a/apps/webapp/src/modules/layout/components/Typography.tsx
+++ b/apps/webapp/src/modules/layout/components/Typography.tsx
@@ -13,12 +13,13 @@ interface TypographyProps {
 }
 
 const ELEMENTS: Record<TypographyElement, string> = {
-  //TODO: the header text looks the same regardless of what font weight you give it.
-  //to match the designs the headers should be a little less bolded
-  h1: 'scroll-m-20 font-custom-450 tracking-tight',
-  h2: 'scroll-m-20 font-custom-450 tracking-tight leading-normal transition-colors',
-  h3: 'scroll-m-20 font-custom-450 tracking-tight',
-  h4: 'scroll-m-20 font-custom-450 tracking-tight',
+  // No weight here: every heading is reached through <Heading>, whose variant
+  // classes are merged after these and carry the design system's single
+  // heading weight (Circular Medium — see HEADING_VARIANTS).
+  h1: 'scroll-m-20 tracking-tight',
+  h2: 'scroll-m-20 tracking-tight leading-normal transition-colors',
+  h3: 'scroll-m-20 tracking-tight',
+  h4: 'scroll-m-20 tracking-tight',
   p: 'leading-normal font-normal text-base',
   span: 'leading-normal font-normal text-base'
   // ...add other variants as needed
@@ -45,12 +46,16 @@ interface HeadingProps {
   dataTestId?: string;
 }
 
+// Every Heading style in the design system binds font-weight/label = 500, i.e.
+// Circular Medium (Figma "5. Typography"). Without the weight class these fall
+// to `normal`, which resolves to Circular Book (450) — the face is real, so the
+// difference is a subtly lighter heading rather than an obvious fallback.
 const HEADING_VARIANTS: Record<HeadingVariant, string> = {
-  'x-large': 'text-[32px] text-text font-circle leading-10 font-normal',
-  large: 'text-3xl text-text font-circle',
-  medium: 'text-2xl text-text font-circle',
-  small: 'text-lg text-text font-circle',
-  extraSmall: 'text-base text-text font-circle'
+  'x-large': 'text-[32px] text-text font-circle font-medium leading-10',
+  large: 'text-3xl text-text font-circle font-medium',
+  medium: 'text-2xl text-text font-circle font-medium',
+  small: 'text-lg text-text font-circle font-medium',
+  extraSmall: 'text-base text-text font-circle font-medium'
 };
 
 export function Heading({ variant = 'medium', className, tag = 'h2', ...props }: HeadingProps) {

--- a/apps/webapp/src/modules/ui/components/ChainModal.tsx
+++ b/apps/webapp/src/modules/ui/components/ChainModal.tsx
@@ -111,17 +111,26 @@ export function ChainModal({
               chainId,
               variant === ChainModalVariant.widget ? 'h-5 w-5' : size === 'xs' ? 'h-4 w-4' : 'h-6 w-6'
             )}
-            {showLabel && (
-              <Text
-                className={cn(
-                  'text-text',
-                  size === 'xs' && 'font-circle text-xs leading-[14px] font-medium tracking-[-0.24px]',
-                  labelClassName
-                )}
-              >
-                {client?.chain.name || 'Ethereum'}
-              </Text>
-            )}
+            {showLabel &&
+              (variant === ChainModalVariant.widget ? (
+                <Text className={cn('text-text', labelClassName)}>{client?.chain.name || 'Ethereum'}</Text>
+              ) : (
+                // Label 5 / Circular Medium in every dropdown comp (Figma
+                // 1030:60397, 1030:59254) — which is what dropdownM already
+                // sets, so the label is a bare span and inherits it. A <Text>
+                // here would re-declare Graphik at 16px and win, which is how
+                // the network pill drifted off the comps across all products.
+                // XS steps down to Label 6 (Figma 1030:138802).
+                <span
+                  className={cn(
+                    'text-text',
+                    size === 'xs' && 'text-xs leading-[14px] tracking-[-0.24px]',
+                    labelClassName
+                  )}
+                >
+                  {client?.chain.name || 'Ethereum'}
+                </span>
+              ))}
             {showDropdownIcon &&
               (variant === ChainModalVariant.widget ? (
                 <ChevronDown width={14} height={14} />

--- a/apps/webapp/src/widgets/shared/components/ui/Typography.tsx
+++ b/apps/webapp/src/widgets/shared/components/ui/Typography.tsx
@@ -44,13 +44,13 @@ interface HeadingProps {
   id?: string;
 }
 
+// Circular Medium (font-weight/label = 500) is the only heading weight in the
+// design system; without the class these resolve to Circular Book (450).
 const HEADING_VARIANTS: Record<HeadingVariant, string> = {
-  // TODO: Heading styles should all be Circular Std font
-  // Headings are "book" weight which is 450 but CSS doesn't support that we should choose whichever looks best
-  'x-large': 'text-[32px] text-text font-circle leading-10 font-normal',
-  large: 'text-3xl text-text font-circle',
-  medium: 'text-2xl text-text font-circle',
-  small: 'text-lg text-text font-circle'
+  'x-large': 'text-[32px] text-text font-circle font-medium leading-10',
+  large: 'text-3xl text-text font-circle font-medium',
+  medium: 'text-2xl text-text font-circle font-medium',
+  small: 'text-lg text-text font-circle font-medium'
 };
 
 export function Heading({ variant = 'medium', className, tag = 'h2', ...props }: HeadingProps) {


### PR DESCRIPTION
Two review items. (A third — reserving the scrollbar gutter so navigation can't
shift the page sideways — was tried and dropped; see the note at the bottom.)

## 1. Text on the wrong font weight (and family)

Continues the second bug class from #1786: `font-circle` with no weight class
falls to `normal`, which resolves to Circular **Book 450**. The design system has
no Book — every Headings-family style binds `font-weight/label` = 500 — so those
surfaces render a notch light. Three causes here:

- **A `<Text>` child defeats the button's own recipe.** The `navbarWallet` and
  `dropdownM` size recipes already declare `font-circle text-sm font-medium
  tracking-[-0.28px]`, but the label was wrapped in `<Text>`, whose `large`
  variant re-declares `font-graphik font-normal text-base` on the child element —
  a child's own class always wins, tailwind-merge never sees it. Making the label
  a bare `<span>` fixes the navbar wallet chip and **the network dropdown in every
  product**. ChainModal's `widget` variant keeps its legacy `<Text>`.
- **The shared `Heading` primitive** carried `font-circle` with no weight, so
  every heading in the app rendered Book. Fixed in both `Typography.tsx` copies;
  the now-dead `font-custom-450` and the stale TODO come out of `ELEMENTS`.
- **The wallet drawer** identity, total and asset rows were missing the weight.

Figma (file `1aCQfCwuGx90hVwGcD2ZLS`): navbar 1036:189127 (`get_variable_defs`
reports the whole bar as Label 5 and nothing else), "Earn with Sky" 1036:189282,
wallet drawer 1030:60388 / 60397 / 60408, Stake header 1030:59254.

Family and weight only — no size or tracking changes, per the #1786 rule. One
consequence worth calling out: the navbar wallet label and the product network
dropdown label go 16px → 14px, because that is the size their button recipe
already declared and the comps confirm Label 5 throughout.

Checked by computed style rather than by eye. Every flagged surface reports
`CircleStd / 500` at the comp's px — navbar 14/16, drawer identity 16/18, network
pill 14/16, asset symbol 18/22, page title 44/48 — and `[...document.fonts]`
shows **CircleStd 450 as `unloaded`** on /portfolio and /stake, i.e. nothing
requests Book any more.

## 2. "Back to products" played only the enter animation

The outgoing page vanished instantly and only the incoming one animated.

Root cause: **`AppLink` replaced the whole search string instead of merging.**
`splitHref('/earn')` yields `search: {}`, so the back link navigated with no
params and dropped `network` — then `useAppOrchestration` immediately navigated
again to put it back. That second commit landed in the same frame as the view
transition's pending snapshot, so the outgoing page was captured *already showing
the incoming one*: `::view-transition-old(page)` and `::view-transition-new(page)`
were both /earn, and the product page was never in the transition at all. Fixed
by merging the href's params onto `retainOnNavigate(prev)` — an href with no query
string means "this path", not "drop the network".

Measured by comparing the old snapshot's height against the outgoing DOM's height
at `startViewTransition` time, over six navigations:

| navigation | before | after |
| --- | --- | --- |
| earn → savings (cold chunk) | ✅ | ✅ |
| savings → earn (**back link**) | ❌ 2138px vs 1223px | ✅ |
| earn → savings (warm chunk) | ✅ | ✅ |
| savings → earn (**back link**) | ❌ 2138px vs 1420px | ✅ |
| earn → portfolio | ✅ | ✅ |
| portfolio → earn | ✅ | ✅ |

Also confirmed visually by freezing every view-transition animation at 150ms and
screenshotting: the frame used to show two copies of /earn, and now shows the
product page leaving over /earn arriving. Note this had to be driven with
Playwright — a view transition does not run in a tab that isn't producing frames.

The link keeping `network` is a fix in its own right; the URL used to lose it on
every "Back to products".

## Dropped: reserving the scrollbar gutter

Navigating between a page that overflows and one that doesn't shifts the content
box by the scrollbar width. `scrollbar-gutter: stable` does not fix it — the
property is only honoured on a scroll container, and the root element isn't one,
so Chrome computes `stable` on `<html>` and reserves nothing (re-confirmed in a
bare test page). The only thing that reserves is `overflow-y: scroll`, which
means the track is painted on pages with nothing to scroll. Making the track
transparent hides it, but `.app-background` is `position: fixed` and a fixed box
is clipped to the viewport's content edge, so the image stops short of the gutter
and the reserved column shows flat page background — a visible seam in light
mode. Not worth the trade, so it is out of this PR.

## Gates

Typecheck clean, lint 0 errors, 2257/2258 unit tests. The single failure is the
pre-existing `EarnFeaturedCards` Pendle maturity date bomb (expects
"18 Jun 2026"), untouched by this branch.
