### PR TITLE
APP-428: Add PT-sUSDS icon

### DIFF
--- a/apps/webapp/src/widgets/shared/hooks/useTokenImage.test.tsx
+++ b/apps/webapp/src/widgets/shared/hooks/useTokenImage.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useTokenImage } from './useTokenImage';
+
+const imageFor = (symbol: string) => renderHook(() => useTokenImage(symbol)).result.current;
+
+describe('useTokenImage', () => {
+  it('resolves a plain symbol to its lowercase icon', () => {
+    expect(imageFor('USDS')).toBe('/tokens/usds.svg');
+  });
+
+  it('returns undefined for an empty symbol', () => {
+    expect(imageFor('')).toBeUndefined();
+  });
+
+  it('resolves a dated Pendle PT symbol to the undated market icon', () => {
+    // Morpho's market data returns PT collateral with its maturity attached.
+    expect(imageFor('PT-sUSDS-26NOV2026')).toBe('/tokens/pt-susds.svg');
+    expect(imageFor('PT-sUSDS-4JUN2026')).toBe('/tokens/pt-susds.svg');
+  });
+
+  it('leaves a PT symbol without a maturity suffix alone', () => {
+    expect(imageFor('PT-sUSDS')).toBe('/tokens/pt-susds.svg');
+  });
+
+  it('only strips a suffix that looks like a maturity date', () => {
+    expect(imageFor('PT-sUSDS-FOO')).toBe('/tokens/pt-susds-foo.svg');
+  });
+});

--- a/apps/webapp/src/widgets/shared/hooks/useTokenImage.tsx
+++ b/apps/webapp/src/widgets/shared/hooks/useTokenImage.tsx
@@ -1,11 +1,20 @@
 import { useMemo } from 'react';
 
+/**
+ * Pendle Principal Tokens carry their maturity in the symbol
+ * (`PT-sUSDS-26NOV2026`), and third-party APIs — Morpho's market data, for one —
+ * hand us that dated symbol verbatim. We only ship one icon per PT market, so
+ * drop the `-DDMMMYYYY` suffix and resolve every maturity to the same asset.
+ */
+const PT_MATURITY_SUFFIX = /^(pt-.+)-\d{1,2}[a-z]{3}\d{4}$/;
+
 export const useTokenImage = (symbol: string) => {
   return useMemo(() => {
     if (!symbol) return undefined;
     const symbolLower = symbol.toLowerCase();
+    const assetName = symbolLower.match(PT_MATURITY_SUFFIX)?.[1] ?? symbolLower;
 
     // All tokens use .svg format
-    return `/tokens/${symbolLower}.svg`;
+    return `/tokens/${assetName}.svg`;
   }, [symbol]);
 };


### PR DESCRIPTION
Closes [APP-428](https://linear.app/ekliptyka/issue/APP-428/add-pt-susds-icon-current-app).

## The bug

USDS Flagship details → **Exposure** rendered its PT collateral row with a text-fallback avatar instead of an icon.

`useTokenImage` maps a symbol straight to `/tokens/<lowercase>.svg`. We ship `pt-susds.svg`, but Morpho's market data returns the collateral symbol with the maturity attached — `PT-sUSDS-26NOV2026` — so the lookup asked for `/tokens/pt-susds-26nov2026.svg`, 404'd, and dropped to the uppercase-symbol fallback.

## The fix

Strip a trailing `-DDMMMYYYY` maturity suffix from `PT-` symbols before resolving the icon, so every maturity of a market resolves to the same asset icon. Done in `useTokenImage` rather than at the Morpho call site, so it covers both `TokenIcon` components and any other surface a dated PT symbol reaches.

A PT symbol whose underlying has no icon still falls back to the text avatar, exactly as before.

## Verification

- Browser-checked the USDS Flagship Exposure table against live Morpho data — the `PT-sUSDS-26NOV2026 / USDS` row now shows the PT-sUSDS mark.
- New unit tests for `useTokenImage` covering the dated symbol, the undated symbol, and a non-date suffix.
- `pnpm typecheck`, `pnpm lint` (0 errors), prettier, and the fast unit suite (85 files / 427 tests) all pass.