### PR TITLE
Stop the claim Confirm waiting on the wallet capability probe

### DIFF
--- a/apps/webapp/src/hooks/shared/useIsBatchSupported.ts
+++ b/apps/webapp/src/hooks/shared/useIsBatchSupported.ts
@@ -8,7 +8,29 @@ export function useIsBatchSupported(): ReadHook & {
 } {
   const chainId = useChainId();
 
-  const { data: capabilities, isLoading, error, refetch } = useCapabilities();
+  const {
+    data: capabilities,
+    isLoading,
+    error,
+    refetch
+  } = useCapabilities({
+    query: {
+      // A wallet that doesn't implement EIP-5792 rejects `wallet_getCapabilities`
+      // outright. That's a definitive answer, not a transient failure — but
+      // react-query's default is three retries with 1s/2s/4s backoff, so the probe
+      // stays `isLoading` for the better part of ten seconds before settling on the
+      // "no" it already had. Ask once.
+      retry: false,
+      // Batching support doesn't change under a live session, and the query key
+      // already carries the connector and account — a wallet or account switch gets
+      // a fresh key. Keeping the answer means the probe is a wallet round trip once
+      // per connection instead of on every flow that mounts cold, and any later
+      // background revalidation resolves against retained data, so `isLoading` never
+      // goes true a second time.
+      staleTime: 5 * 60 * 1000,
+      gcTime: Infinity
+    }
+  });
 
   const atomicCapabilityStatus = capabilities?.[chainId]?.atomic?.status;
   // Safe wallets use `atomicBatch` capabilities

--- a/apps/webapp/src/hooks/shared/useTransactionFlow.test.tsx
+++ b/apps/webapp/src/hooks/shared/useTransactionFlow.test.tsx
@@ -1,0 +1,128 @@
+import { renderHook, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { erc20Abi, type Call } from 'viem';
+
+const capabilities = vi.hoisted(() => ({
+  data: undefined as boolean | undefined,
+  isLoading: true
+}));
+
+vi.mock('./useIsBatchSupported', () => ({
+  useIsBatchSupported: () => capabilities
+}));
+
+const sequentialSpy = vi.hoisted(() => vi.fn());
+const batchSpy = vi.hoisted(() => vi.fn());
+
+const stubFlow = {
+  execute: () => {},
+  isLoading: false,
+  prepared: false,
+  currentCallIndex: 0,
+  reset: () => {}
+};
+
+vi.mock('./useSequentialTransactionFlow', () => ({
+  useSequentialTransactionFlow: (parameters: { enabled: boolean }) => {
+    sequentialSpy(parameters);
+    return stubFlow;
+  }
+}));
+
+vi.mock('./useSendBatchTransactionFlow', () => ({
+  useSendBatchTransactionFlow: (parameters: { enabled: boolean }) => {
+    batchSpy(parameters);
+    return stubFlow;
+  }
+}));
+
+import { useTransactionFlow } from './useTransactionFlow';
+
+const call: Call = {
+  to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  abi: erc20Abi,
+  functionName: 'approve',
+  args: ['0xA188EEC8F81263234dA3622A406892F3D630f98c', 1n]
+} as unknown as Call;
+
+/** `enabled` most recently handed to the sequential flow. */
+const sequentialEnabled = () => sequentialSpy.mock.lastCall?.[0].enabled;
+const batchEnabled = () => batchSpy.mock.lastCall?.[0].enabled;
+
+beforeEach(() => {
+  sequentialSpy.mockClear();
+  batchSpy.mockClear();
+  capabilities.data = undefined;
+  capabilities.isLoading = true;
+});
+
+afterEach(cleanup);
+
+describe('useTransactionFlow', () => {
+  describe('while the wallet capability probe is still in flight', () => {
+    // The regression this file exists for: `wallet_getCapabilities` is a wallet round
+    // trip, and a single call can only ever go sequentially — so simulating it must not
+    // queue behind the probe. It used to, which left every claim modal's Confirm
+    // disabled for as long as the wallet took to answer.
+    it('simulates a single call immediately', () => {
+      renderHook(() => useTransactionFlow({ calls: [call] }));
+
+      expect(sequentialEnabled()).toBe(true);
+      expect(batchEnabled()).toBe(false);
+    });
+
+    it('simulates immediately when the caller has opted out of bundling', () => {
+      renderHook(() => useTransactionFlow({ calls: [call, call], shouldUseBatch: false }));
+
+      expect(sequentialEnabled()).toBe(true);
+    });
+
+    it('waits for the answer when bundling could still apply', () => {
+      // Here the probe genuinely decides the route, so neither path may start: a
+      // sequential simulation would be thrown away the moment the wallet says it bundles.
+      renderHook(() => useTransactionFlow({ calls: [call, call] }));
+
+      expect(sequentialEnabled()).toBe(false);
+      expect(batchEnabled()).toBe(false);
+    });
+
+    it('honours an explicitly disabled flow', () => {
+      renderHook(() => useTransactionFlow({ calls: [call], enabled: false }));
+
+      expect(sequentialEnabled()).toBe(false);
+    });
+  });
+
+  describe('once the probe has answered', () => {
+    it('routes multiple calls to the batch flow on a wallet that bundles', () => {
+      capabilities.data = true;
+      capabilities.isLoading = false;
+
+      const { result } = renderHook(() => useTransactionFlow({ calls: [call, call] }));
+
+      expect(batchEnabled()).toBe(true);
+      expect(sequentialEnabled()).toBe(false);
+      expect(result.current.isBatch).toBe(true);
+    });
+
+    it('keeps a single call sequential even on a wallet that bundles', () => {
+      capabilities.data = true;
+      capabilities.isLoading = false;
+
+      const { result } = renderHook(() => useTransactionFlow({ calls: [call] }));
+
+      expect(sequentialEnabled()).toBe(true);
+      expect(result.current.isBatch).toBe(false);
+    });
+
+    it('falls back to sequential when the wallet cannot bundle', () => {
+      capabilities.data = false;
+      capabilities.isLoading = false;
+
+      renderHook(() => useTransactionFlow({ calls: [call, call] }));
+
+      expect(sequentialEnabled()).toBe(true);
+      expect(batchEnabled()).toBe(false);
+    });
+  });
+});

--- a/apps/webapp/src/hooks/shared/useTransactionFlow.ts
+++ b/apps/webapp/src/hooks/shared/useTransactionFlow.ts
@@ -26,8 +26,24 @@ export function useTransactionFlow(parameters: UseTransactionFlowParameters): Ba
   // Check if wallet supports batch transactions
   const { data: batchSupported, isLoading: isLoadingCapabilities } = useIsBatchSupported();
 
-  // Determine if we should actually use batch based on user preference, wallet support, and number of calls
-  const useBatch = shouldUseBatch && batchSupported && calls.length > 1;
+  // Bundling is only ever on the table for more than one call, and only when the caller
+  // asked for it. `batchSupported` is undefined while the probe is in flight, so this is
+  // false until the wallet answers.
+  const batchPossible = shouldUseBatch && calls.length > 1;
+  const useBatch = batchPossible && !!batchSupported;
+
+  // `wallet_getCapabilities` is a round trip to the WALLET, not to an RPC — instant over
+  // an injected provider, seconds over a WalletConnect relay or a wallet that rejects the
+  // method. It only decides anything when bundling is possible: with a single call the
+  // sequential path is the answer whatever the wallet replies. Gating the simulation on
+  // the probe regardless made every one-call flow wait the probe out BEFORE its `eth_call`
+  // was even sent — two round trips in series where one would do. That is what left the
+  // claim modal's Confirm disabled for seconds: every claim is a single call (Merkl claims
+  // every selected token in one `claim`, an ecosystem row is one `getReward`), and the
+  // portfolio page mounts no other flow to warm the probe first, so the wait landed in
+  // full on the first claim opened. Claiming something else first "fixed" it only because
+  // that modal had already paid for the probe.
+  const routeUndecided = batchPossible && isLoadingCapabilities;
 
   const commonTransactionParameters = {
     calls,
@@ -41,14 +57,15 @@ export function useTransactionFlow(parameters: UseTransactionFlowParameters): Ba
   // Use sequential flow
   const sequentialResults = useSequentialTransactionFlow({
     ...commonTransactionParameters,
-    enabled: enabled && !useBatch && !isLoadingCapabilities,
+    enabled: enabled && !useBatch && !routeUndecided,
     gcTime
   });
 
-  // Use batch flow
+  // Use batch flow. `useBatch` already implies the probe has answered, so it carries the
+  // loading gate the sequential path spells out.
   const batchResults = useSendBatchTransactionFlow({
     ...commonTransactionParameters,
-    enabled: enabled && useBatch && !isLoadingCapabilities
+    enabled: enabled && useBatch
   });
 
   // Return the appropriate results based on useBatch, carrying the calls and the routing

--- a/apps/webapp/src/modules/ui/context/TransactionContext.tsx
+++ b/apps/webapp/src/modules/ui/context/TransactionContext.tsx
@@ -6,7 +6,7 @@ import { Trans } from '@lingui/react/macro';
 import { toast, toastWithClose } from '@/components/ui/use-toast';
 import { MinimizedTransactionToast } from '@/modules/ui/components/MinimizedTransactionToast';
 import { TransactionNoticeToast } from '@/modules/ui/components/TransactionNoticeToast';
-import { useIsSafeWallet } from '@/hooks';
+import { useIsSafeWallet, useIsBatchSupported } from '@/hooks';
 import { useChainId, useConnection } from 'wagmi';
 import { TransactionModal } from '@/modules/ui/components/TransactionModal';
 import { useAppAnalytics } from '@/modules/analytics/hooks/useAppAnalytics';
@@ -84,6 +84,14 @@ type TransactionModalView = {
 const MODAL_EXIT_MS = 300;
 
 export function TransactionProvider({ children }: { children: ReactNode }) {
+  // Warm the EIP-5792 capability probe from the provider, which is mounted for the whole
+  // session, so it runs on connect rather than the first time a flow needs the answer.
+  // A multi-call flow genuinely has to know whether the wallet can bundle before it can
+  // pick a route, and paying for that wallet round trip at modal-open time is what makes
+  // a Confirm button sit disabled while nothing visible is happening. Result is shared —
+  // this is the same react-query key every `useIsBatchSupported` caller reads.
+  useIsBatchSupported();
+
   const [open, setOpen] = useState(false);
   // Minimized = modal hidden but the transaction keeps running. Distinct from
   // closed (which tears the transaction down); see minimize()/restore() below.


### PR DESCRIPTION
## Problem

Opening any claim modal from the portfolio page left its **Claim** button disabled for seconds before it could be pressed.

The wait was not the RPC simulating the claim — it was `wallet_getCapabilities`, a round trip to the **wallet**, blocking the simulation from starting. `useTransactionFlow` disabled *both* engines while the EIP-5792 probe was in flight:

```ts
enabled: enabled && !useBatch && !isLoadingCapabilities
```

So the sequence was: open modal → ask the wallet whether it can bundle → *then* send the `eth_call` that produces `simulationData.request` → `flow.prepared` flips → Confirm enables. Two round trips in series where the claim only ever needed one.

That accounts for the three things that looked odd about it:

1. **Why claims specifically.** Every claim is a *single* call — Merkl claims all selected tokens in one `claim(users, tokens, amounts, proofs)`, an ecosystem row is one `getReward()`. With one call, `useBatch` (`shouldUseBatch && batchSupported && calls.length > 1`) is always false, so the probe's answer cannot change anything — yet the flow waited for it regardless. Pure dead time.
2. **Why worse than other transactions.** Everywhere else the flow mounts behind a form you type an amount into, so the probe overlaps with typing and is warm by the time you click. The portfolio page mounts no transaction flow until the modal opens, and the amount is already known — so the wait is naked and lands entirely on the first claim opened.
3. **Why claiming a GROVE reward "unblocked" a Merkl claim.** It didn't unblock it, it pre-paid it. Both modals mount the same `ClaimRewardsPanel` and run the same probe under the same react-query key; once cached, the second modal finds the answer already there.

**Aggravating factor:** `useCapabilities` had no `retry` override, so a wallet that *rejects* the method got react-query's default 4 attempts at 1s/2s/4s backoff — ~7s during which the query has no data, so `isLoading` stays `true`. viem's own transport retry does not apply here (`shouldRetry` excludes `MethodNotSupportedRpcError`), so react-query's was the only layer, and it was enough on its own.

## Changes

- **`useTransactionFlow.ts`** — gate the sequential engine on the probe only when bundling is genuinely possible (`shouldUseBatch && calls.length > 1`). Single-call flows now simulate immediately, in parallel with the probe. The batch engine's redundant `!isLoadingCapabilities` goes away — `useBatch` already implies the probe answered.
- **`useIsBatchSupported.ts`** — `retry: false` (a rejected method is a definitive answer, not a transient failure), plus `staleTime: 5min` / `gcTime: Infinity` so it's one wallet round trip per connection. Later revalidation resolves against retained data, so `isLoading` never flips true a second time.
- **`TransactionContext.tsx`** — warm the probe from `TransactionProvider` on connect, so multi-call flows (Claim all over SPK + GROVE = 2 calls, where the route genuinely does depend on the answer) have it decided before a modal opens rather than at click time.

## Testing

- New `useTransactionFlow.test.tsx` — 7 tests covering routing both while the probe is in flight and after it answers. Fails against the old code, so it is a real guard.
  - Note it sits under `src/hooks/`, which the fast suite excludes; it runs under `pnpm test:hooks`. Verified locally by temporarily lifting that exclude, then restoring `vite.config.ts`.
- `pnpm typecheck` clean; `pnpm lint` clean (0 errors).
- Fast suite: 2257 passed, 1 failed — `EarnFeaturedCards.test.tsx` asserts a hardcoded `'18 Jun 2026'` Pendle maturity that is now in the past. Pre-existing date bomb, unrelated to this change.

## How to verify in the browser

Open DevTools → Network and open a claim modal. The `eth_call` should fire on the first frame after open, rather than only after the wallet request settles.

## Caveat

Diagnosed from the code path rather than reproduced against a funded wallet with live reward state. If Confirm is still slow after this, the next thing to measure is the `eth_call` itself — a Merkl claim carries large merkle proofs, so its request body is much bigger than a typical simulation.