### PR TITLE
fix(stusds): derive Curve withdraw minOut from the routed quote

### DIFF
--- a/apps/webapp/src/widgets/StUSDSWidget/hooks/useStUsdsTransactions.test.tsx
+++ b/apps/webapp/src/widgets/StUSDSWidget/hooks/useStUsdsTransactions.test.tsx
@@ -2,11 +2,15 @@
 
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { StUsdsProviderType } from '@/hooks';
+import { StUsdsProviderType, StUsdsDirection } from '@/hooks';
 
 const captured = {
-  batchStUsdsDeposit: undefined as Record<string, unknown> | undefined
+  batchStUsdsDeposit: undefined as Record<string, unknown> | undefined,
+  curveSwaps: [] as Record<string, unknown>[]
 };
+
+const curveWithdrawParams = () =>
+  captured.curveSwaps.find(params => params.direction === StUsdsDirection.WITHDRAW);
 
 vi.mock('@/hooks', async importOriginal => {
   const actual = await importOriginal<typeof import('@/hooks')>();
@@ -17,7 +21,10 @@ vi.mock('@/hooks', async importOriginal => {
       return {};
     },
     useStUsdsWithdraw: () => ({}),
-    useBatchCurveSwap: () => ({})
+    useBatchCurveSwap: (params: Record<string, unknown>) => {
+      captured.curveSwaps.push(params);
+      return {};
+    }
   };
 });
 
@@ -57,5 +64,44 @@ describe('useStUsdsTransactions referralCode contract-arg', () => {
   it('forwards undefined when referralCode is undefined', () => {
     renderHook(() => useStUsdsTransactions({ ...baseParams, referralCode: undefined }));
     expect(captured.batchStUsdsDeposit?.referral).toBeUndefined();
+  });
+});
+
+describe('useStUsdsTransactions Curve withdraw slippage baseline', () => {
+  const curveWithdrawParamsBase = {
+    ...baseParams,
+    selectedProvider: StUsdsProviderType.CURVE,
+    referralCode: undefined,
+    stUsdsAmount: 900n * 10n ** 18n
+  };
+
+  beforeEach(() => {
+    captured.curveSwaps = [];
+  });
+
+  // The UI amount and the routed quote are seeded by separate provider selections and can
+  // disagree on a max withdraw. minOut must track the quote whose stUsdsAmount is being swapped.
+  it('uses the routed quote output as the slippage baseline, not the UI amount', () => {
+    renderHook(() =>
+      useStUsdsTransactions({
+        ...curveWithdrawParamsBase,
+        amount: 995n * 10n ** 18n,
+        expectedOutput: 1000n * 10n ** 18n
+      })
+    );
+
+    expect(curveWithdrawParams()?.expectedOutput).toBe(1000n * 10n ** 18n);
+  });
+
+  it('stays disabled when the routed quote output is unavailable', () => {
+    renderHook(() =>
+      useStUsdsTransactions({
+        ...curveWithdrawParamsBase,
+        amount: 995n * 10n ** 18n,
+        expectedOutput: 0n
+      })
+    );
+
+    expect(curveWithdrawParams()?.enabled).toBe(false);
   });
 });

--- a/apps/webapp/src/widgets/StUSDSWidget/hooks/useStUsdsTransactions.tsx
+++ b/apps/webapp/src/widgets/StUSDSWidget/hooks/useStUsdsTransactions.tsx
@@ -104,13 +104,19 @@ export const useStUsdsTransactions = ({
   // Curve swap for withdraw (stUSDS -> USDS)
   // Input: stUSDS (stUsdsAmount from quote), Output: USDS
   // Note: For normal withdrawals, stUsdsAmount is calculated via get_dx from desired USDS.
-  // For max withdrawals, stUsdsAmount is the user's full stUSDS balance and amount is calculated via get_dy.
+  // For max withdrawals, stUsdsAmount is the user's full stUSDS balance, quoted via get_dy.
+  // minOut must derive from the same quote that produced stUsdsAmount, not from the UI
+  // amount: on max the two are seeded by separate provider selections and can diverge.
   const curveWithdrawSwap = useBatchCurveSwap({
     direction: StUsdsDirection.WITHDRAW,
     inputAmount: stUsdsAmount ?? 0n, // stUSDS to swap (from quote)
-    expectedOutput: amount, // Quoted USDS output (slippage applied internally by hook)
+    expectedOutput,
     shouldUseBatch,
-    enabled: isCurve && widgetState.action === StUSDSAction.WITHDRAW && (stUsdsAmount ?? 0n) > 0n,
+    enabled:
+      isCurve &&
+      widgetState.action === StUSDSAction.WITHDRAW &&
+      (stUsdsAmount ?? 0n) > 0n &&
+      expectedOutput > 0n,
     ...withdrawTransactionCallbacks
   });
 


### PR DESCRIPTION
APP-472

The Curve withdraw path passed the UI `amount` as `expectedOutput`, which is what `minOut` is derived from. It should be the routed quote's USDS output.

On a max withdraw the two are seeded by **separate** provider selections — `useStUsdsWithdrawBalances` builds its own with no `isMax`, so it quotes via `get_dx` while the executing path quotes via `get_dy`. When they disagree on the route, `minOut` can land below the real swap output and the slack above the 0.5% tolerance is extractable.

Also gates the swap on `expectedOutput > 0n`: `calculateMinOutputWithSlippage` has no zero guard, so a missing quote would produce `minOut = 0`. The old code was accidentally safe here because `amount` was always non-zero.

No-op on non-max withdraws, where `outputAmount === amount` by construction.

Two regression tests added — verified they fail if `expectedOutput` reverts to `amount`. No visual change.

The parallel fix for `app-redesign` (`useStUsdsLaunch.ts`) is #1817.
