### PR TITLE
fix(stusds): derive Curve withdraw minOut from the routed quote

### DIFF
--- a/apps/webapp/src/modules/stusds/hooks/useStUsdsLaunch.test.tsx
+++ b/apps/webapp/src/modules/stusds/hooks/useStUsdsLaunch.test.tsx
@@ -334,6 +334,55 @@ describe('useStUsdsLaunch — Curve withdraw calldata parity', () => {
   });
 });
 
+describe('useStUsdsLaunch — Curve withdraw slippage baseline', () => {
+  beforeEach(() => {
+    h.capturedCalls = [];
+    h.nativeAllowance = HAS_ALLOWANCE;
+    h.curveHasAllowance = { USDS: false, stUSDS: true }; // elide the approve, leaving just the exchange
+  });
+  afterEach(() => cleanup());
+
+  // The parity tests above pass the same value for `amount` and `expectedOutput`, so
+  // they cannot tell which one min_dy came from. On a Max withdraw the two are seeded
+  // by separate provider selections and can disagree: min_dy has to track the quote
+  // whose stUSDS input is actually being swapped, or the floor sits below the real output.
+  it('derives min_dy from the routed quote output, not the UI amount', () => {
+    const UI_AMOUNT = parseUnits('995', 18);
+    const QUOTE_OUT = parseUnits('1000', 18);
+
+    const orch = captureOrchestratorCalls({
+      flow: 'withdraw',
+      amount: UI_AMOUNT,
+      selectedProvider: StUsdsProviderType.CURVE,
+      expectedOutput: QUOTE_OUT,
+      stUsdsAmount: WITHDRAW_STUSDS_IN
+    });
+
+    const minOutput = calculateMinOutputWithSlippage(QUOTE_OUT, STUSDS_PROVIDER_CONFIG.maxSlippageBps);
+    expect(orch.find(c => c.functionName === 'exchange')?.args).toEqual([
+      1n,
+      0n,
+      WITHDRAW_STUSDS_IN,
+      minOutput,
+      TEST_ADDRESS
+    ]);
+  });
+
+  // calculateMinOutputWithSlippage has no zero guard, so an absent quote would encode
+  // min_dy = 0 and accept any output at all.
+  it('routes no swap when the quote output is unavailable', () => {
+    const orch = captureOrchestratorCalls({
+      flow: 'withdraw',
+      amount: parseUnits('995', 18),
+      selectedProvider: StUsdsProviderType.CURVE,
+      expectedOutput: 0n,
+      stUsdsAmount: WITHDRAW_STUSDS_IN
+    });
+
+    expect(orch).toEqual([]);
+  });
+});
+
 describe('useStUsdsLaunch — native withdraw params parity (useWriteContractFlow seam)', () => {
   beforeEach(() => {
     h.capturedCalls = [];

--- a/apps/webapp/src/modules/stusds/hooks/useStUsdsLaunch.ts
+++ b/apps/webapp/src/modules/stusds/hooks/useStUsdsLaunch.ts
@@ -121,12 +121,15 @@ export function useStUsdsLaunch({
     enabled: isSupply && isCurve,
     ...txCallbacks
   });
+  // minOut must derive from the same quote that produced stUsdsAmount: on a max withdraw the UI
+  // amount and the routed quote are seeded by separate provider selections and can diverge.
+  // The zero check matters because calculateMinOutputWithSlippage has no guard of its own.
   const curveWithdraw = useBatchCurveSwap({
     direction: StUsdsDirection.WITHDRAW,
     inputAmount: stUsdsAmount ?? 0n,
-    expectedOutput: amount,
+    expectedOutput,
     shouldUseBatch,
-    enabled: !isSupply && isCurve && (stUsdsAmount ?? 0n) > 0n,
+    enabled: !isSupply && isCurve && (stUsdsAmount ?? 0n) > 0n && expectedOutput > 0n,
     ...txCallbacks
   });
 


### PR DESCRIPTION
APP-472 — `app-redesign` counterpart of #1816.

Same defect in `useStUsdsLaunch.ts`: the Curve withdraw path passed the UI `amount` as `expectedOutput`, which is what `minOut` is derived from. It should be the routed quote's USDS output.

On a max withdraw the two are seeded by **separate** provider selections — `useStUsdsWithdrawBalances` builds its own with no `isMax`, so it quotes via `get_dx` while the executing path quotes via `get_dy`. When they disagree on the route, `minOut` can land below the real swap output.

Also gates on `expectedOutput > 0n`: `calculateMinOutputWithSlippage` has no zero guard, so a missing quote would produce `minOut = 0`. The old code was accidentally safe because `amount` was always non-zero.

No-op on non-max withdraws. No visual change.

### Tests

`useStUsdsLaunch.test.tsx` already covered this path, but its Curve withdraw case passed the same value for `amount` and `expectedOutput` — so it passed whichever of the two the code read, and could not catch this regression.

Added two cases that discriminate: one where the values diverge, asserting `min_dy` derives from the quote output; one asserting no swap is routed when the quote output is missing. Both verified to fail with the fix reverted.

### CI

The two red checks (`Test (24, 11.5.0, 19)`, `test-shards (6)`) are pre-existing on `app-redesign` — every open PR into that branch fails the same two. Both causes are unrelated to this change: timing assertions in `useAccruingValue.test.tsx`, and a terms-modal timeout in `psm-conversion.ts`.
