### PR TITLE
Fix liquidity-constrained Morpho withdrawals in the vault modal (APP-488)

### DIFF
--- a/apps/webapp/src/hooks/vaults/computeVaultLimits.test.ts
+++ b/apps/webapp/src/hooks/vaults/computeVaultLimits.test.ts
@@ -233,3 +233,42 @@ describe('computeVaultLimits — Morpho (stubbed ERC-4626 limits)', () => {
     expect(redeemShares).toBe(0n);
   });
 });
+
+describe('computeVaultLimits — full-position withdrawability', () => {
+  const POSITION = 1_000n * 10n ** 18n;
+
+  it('flags the position fully withdrawable when liquidity covers it', () => {
+    const { isFullPositionWithdrawable, isLiquidityConstrained } = computeVaultLimits({
+      provider: 'morpho',
+      userAssets: POSITION,
+      userShares: POSITION,
+      availableLiquidity: POSITION
+    });
+
+    expect(isFullPositionWithdrawable).toBe(true);
+    expect(isLiquidityConstrained).toBe(false);
+  });
+
+  it('any shortfall is a constraint — the comparison is exact', () => {
+    const { isFullPositionWithdrawable, isLiquidityConstrained } = computeVaultLimits({
+      provider: 'morpho',
+      userAssets: POSITION,
+      userShares: POSITION,
+      availableLiquidity: POSITION - 1n
+    });
+
+    expect(isFullPositionWithdrawable).toBe(false);
+    expect(isLiquidityConstrained).toBe(true);
+  });
+
+  it('an unknown withdraw cap (liquidity read in flight) is never fully withdrawable', () => {
+    const { isFullPositionWithdrawable } = computeVaultLimits({
+      provider: 'morpho',
+      userAssets: POSITION,
+      userShares: POSITION,
+      liquidityKnown: false
+    });
+
+    expect(isFullPositionWithdrawable).toBe(false);
+  });
+});

--- a/apps/webapp/src/hooks/vaults/computeVaultLimits.ts
+++ b/apps/webapp/src/hooks/vaults/computeVaultLimits.ts
@@ -49,6 +49,11 @@ export type VaultLimits = {
   depositCapReached: boolean;
   /** True when the position is larger than what can be withdrawn right now. */
   isLiquidityConstrained: boolean;
+  /**
+   * True when the whole position is withdrawable right now, so a Max
+   * withdrawal may redeem the entire share balance.
+   */
+  isFullPositionWithdrawable: boolean;
   /** True when the provider's liquidity source settled without a figure. */
   isLiquidityDataUnavailable: boolean;
 };
@@ -117,12 +122,15 @@ export function computeVaultLimits({
 
   const redeemShares = usesMarketLiquidity ? shares : min(shares, maxRedeem ?? shares);
 
+  const isFullPositionWithdrawable = maxWithdrawInput !== undefined && maxWithdrawInput === position;
+
   return {
     maxDepositInput,
     maxWithdrawInput,
     redeemShares,
     depositCapReached,
-    isLiquidityConstrained: position > 0n && maxWithdrawInput !== undefined && maxWithdrawInput < position,
+    isLiquidityConstrained: position > 0n && maxWithdrawInput !== undefined && !isFullPositionWithdrawable,
+    isFullPositionWithdrawable,
     isLiquidityDataUnavailable: usesMarketLiquidity && liquidityKnown && availableLiquidity === undefined
   };
 }

--- a/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
@@ -147,14 +147,12 @@ export function VaultModalForm({
       ? { description: t`The amount of ${assetToken.symbol} currently available for instant withdrawal.` }
       : undefined;
 
-  // All withdrawable liquidity is gone: the notice below carries the whole story
-  // (in error red — it blocks the action), so the inline over-limit error is
-  // suppressed rather than repeating the identical sentence under the input.
+  // With zero liquidity the notice alone carries the message — the inline error
+  // would repeat it word for word.
   const zeroLiquidity = !isSupply && isLiquidityConstrained && available === 0n;
 
-  // Withdraw-only liquidity notice, one of three states (wording mirrors the old
-  // widget's SupplyWithdraw): all liquidity gone / liquidity figure unknown /
-  // position partially covered. Error red only for the hard-blocked state.
+  // Withdraw-only notice, one of three states; wording mirrors the widget's
+  // SupplyWithdraw. Error red only for the blocking state.
   const liquidityNotice = !isSupply
     ? zeroLiquidity
       ? {
@@ -261,9 +259,7 @@ export function VaultModalForm({
           onInput={onInput}
           disabled={!isConnected}
           balance={
-            // "Balance" would lie when liquidity caps the withdrawable amount below
-            // the position (e.g. shows 500 while the user holds 1,000) — call the
-            // figure "Available" in exactly that case, "Balance" everywhere else.
+            // "Available", not "Balance", when liquidity caps the figure below the position.
             <>
               {!isSupply && isLiquidityConstrained ? <Trans>Available</Trans> : <Trans>Balance</Trans>}:{' '}
               {isConnected ? formatAsset(available) : NO_VALUE}
@@ -281,8 +277,11 @@ export function VaultModalForm({
                 {isSupply ? (
                   <Trans>Insufficient balance</Trans>
                 ) : isLiquidityConstrained ? (
+                  // Full precision: a rounded-up cap would name a maximum that itself
+                  // fails the gate.
                   <Trans>
-                    Insufficient liquidity. Maximum available is {formatAsset(available)} {assetToken.symbol}.
+                    Insufficient liquidity. Maximum available is {formatUnits(available, decimals)}{' '}
+                    {assetToken.symbol}.
                   </Trans>
                 ) : (
                   <Trans>Amount exceeds your position</Trans>

--- a/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
@@ -147,13 +147,18 @@ export function VaultModalForm({
       ? { description: t`The amount of ${assetToken.symbol} currently available for instant withdrawal.` }
       : undefined;
 
+  // All withdrawable liquidity is gone: the notice below carries the whole story
+  // (in error red — it blocks the action), so the inline over-limit error is
+  // suppressed rather than repeating the identical sentence under the input.
+  const zeroLiquidity = !isSupply && isLiquidityConstrained && available === 0n;
+
   // Withdraw-only liquidity notice, one of three states (wording mirrors the old
   // widget's SupplyWithdraw): all liquidity gone / liquidity figure unknown /
-  // position partially covered. Amber only for the hard-blocked state.
+  // position partially covered. Error red only for the hard-blocked state.
   const liquidityNotice = !isSupply
-    ? isLiquidityConstrained && available === 0n
+    ? zeroLiquidity
       ? {
-          tone: 'text-amber-400',
+          tone: 'text-error',
           testId: 'vault-modal-liquidity-zero-notice',
           text: <Trans>Withdrawals are temporarily unavailable due to liquidity constraints.</Trans>
         }
@@ -271,19 +276,14 @@ export function VaultModalForm({
             <TokenSelectorPill tokens={[assetToken]} selected={assetToken} testId="vault-modal-asset" />
           }
           error={
-            insufficient ? (
+            insufficient && !zeroLiquidity ? (
               <Text className="text-error text-sm" data-testid="vault-modal-amount-error">
                 {isSupply ? (
                   <Trans>Insufficient balance</Trans>
                 ) : isLiquidityConstrained ? (
-                  available > 0n ? (
-                    <Trans>
-                      Insufficient liquidity. Maximum available is {formatAsset(available)}{' '}
-                      {assetToken.symbol}.
-                    </Trans>
-                  ) : (
-                    <Trans>Withdrawals are temporarily unavailable due to liquidity constraints.</Trans>
-                  )
+                  <Trans>
+                    Insufficient liquidity. Maximum available is {formatAsset(available)} {assetToken.symbol}.
+                  </Trans>
                 ) : (
                   <Trans>Amount exceeds your position</Trans>
                 )}

--- a/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
@@ -256,8 +256,12 @@ export function VaultModalForm({
           onInput={onInput}
           disabled={!isConnected}
           balance={
+            // "Balance" would lie when liquidity caps the withdrawable amount below
+            // the position (e.g. shows 500 while the user holds 1,000) — call the
+            // figure "Available" in exactly that case, "Balance" everywhere else.
             <>
-              <Trans>Balance</Trans>: {isConnected ? formatAsset(available) : NO_VALUE}
+              {!isSupply && isLiquidityConstrained ? <Trans>Available</Trans> : <Trans>Balance</Trans>}:{' '}
+              {isConnected ? formatAsset(available) : NO_VALUE}
             </>
           }
           onPercent={setPercentAmount}

--- a/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
+++ b/apps/webapp/src/modules/morpho/components/VaultModalForm.tsx
@@ -16,6 +16,7 @@ import { toGridCells } from '@/components/product/ModalGridCells';
 import { TokenSelectorPill } from '@/components/product/TokenSelectorPill';
 import { useModalEntryBody } from '@/modules/ui/hooks/useModalEntryBody';
 import { useNetworkFee } from '@/hooks';
+import { PopoverRateInfo } from '@/widgets/shared/components/ui/PopoverRateInfo';
 import { useVaultLaunch, type VaultLaunchFlow } from '../hooks/useVaultLaunch';
 import { useVaultTransactionForm, type VaultModalPreset } from '../hooks/useVaultTransactionForm';
 import { buildVaultEntryRows, buildVaultReviewRows } from './vaultModalRows';
@@ -81,6 +82,8 @@ export function VaultModalForm({
     insufficient,
     amountReady,
     position,
+    isLiquidityConstrained,
+    isLiquidityDataUnavailable,
     engineParams,
     toast,
     transactionScreenContent,
@@ -136,6 +139,42 @@ export function VaultModalForm({
   // Position after the action, clamped at zero for over-withdrawals (the
   // insufficient gate blocks submission anyway).
   const positionAfter = isSupply ? position + amount : position > amount ? position - amount : 0n;
+
+  // Liquidity copy is provider-specific: Spark/Tether vaults expose instant-withdrawal
+  // liquidity, not a Morpho market (same override the widget's SupplyWithdraw applies).
+  const liquidityTooltipOverride =
+    provider === 'sky'
+      ? { description: t`The amount of ${assetToken.symbol} currently available for instant withdrawal.` }
+      : undefined;
+
+  // Withdraw-only liquidity notice, one of three states (wording mirrors the old
+  // widget's SupplyWithdraw): all liquidity gone / liquidity figure unknown /
+  // position partially covered. Amber only for the hard-blocked state.
+  const liquidityNotice = !isSupply
+    ? isLiquidityConstrained && available === 0n
+      ? {
+          tone: 'text-amber-400',
+          testId: 'vault-modal-liquidity-zero-notice',
+          text: <Trans>Withdrawals are temporarily unavailable due to liquidity constraints.</Trans>
+        }
+      : isLiquidityDataUnavailable
+        ? {
+            tone: 'text-text',
+            testId: 'vault-modal-liquidity-unknown-notice',
+            text: (
+              <Trans>
+                Liquidity data is temporarily unavailable. Withdrawals may be limited by available liquidity.
+              </Trans>
+            )
+          }
+        : isLiquidityConstrained
+          ? {
+              tone: 'text-text',
+              testId: 'vault-modal-liquidity-partial-notice',
+              text: <Trans>You cannot withdraw your full balance due to current liquidity limits.</Trans>
+            }
+          : undefined
+    : undefined;
 
   const rows = buildVaultEntryRows({
     rate,
@@ -209,34 +248,64 @@ export function VaultModalForm({
 
   const body = (
     <div className="flex flex-col gap-8 sm:gap-12" data-testid={`vault-modal-${flow}-form`}>
-      <ModalAmountField
-        label={<Trans>Amount</Trans>}
-        tokenSymbol={assetToken.symbol}
-        value={value}
-        onInput={onInput}
-        disabled={!isConnected}
-        balance={
-          <>
-            <Trans>Balance</Trans>: {isConnected ? formatAsset(available) : NO_VALUE}
-          </>
-        }
-        onPercent={setPercentAmount}
-        selector={
-          // Figma 859:38126 draws the DS dropdown pill, but a vault has exactly
-          // one underlying asset — the pill collapses to its static chip.
-          <TokenSelectorPill tokens={[assetToken]} selected={assetToken} testId="vault-modal-asset" />
-        }
-        error={
-          insufficient ? (
-            <Text className="text-error text-sm" data-testid="vault-modal-amount-error">
-              {isSupply ? <Trans>Insufficient balance</Trans> : <Trans>Amount exceeds your position</Trans>}
+      <div className="flex flex-col gap-2">
+        <ModalAmountField
+          label={<Trans>Amount</Trans>}
+          tokenSymbol={assetToken.symbol}
+          value={value}
+          onInput={onInput}
+          disabled={!isConnected}
+          balance={
+            <>
+              <Trans>Balance</Trans>: {isConnected ? formatAsset(available) : NO_VALUE}
+            </>
+          }
+          onPercent={setPercentAmount}
+          selector={
+            // Figma 859:38126 draws the DS dropdown pill, but a vault has exactly
+            // one underlying asset — the pill collapses to its static chip.
+            <TokenSelectorPill tokens={[assetToken]} selected={assetToken} testId="vault-modal-asset" />
+          }
+          error={
+            insufficient ? (
+              <Text className="text-error text-sm" data-testid="vault-modal-amount-error">
+                {isSupply ? (
+                  <Trans>Insufficient balance</Trans>
+                ) : isLiquidityConstrained ? (
+                  available > 0n ? (
+                    <Trans>
+                      Insufficient liquidity. Maximum available is {formatAsset(available)}{' '}
+                      {assetToken.symbol}.
+                    </Trans>
+                  ) : (
+                    <Trans>Withdrawals are temporarily unavailable due to liquidity constraints.</Trans>
+                  )
+                ) : (
+                  <Trans>Amount exceeds your position</Trans>
+                )}
+              </Text>
+            ) : undefined
+          }
+          inputAriaLabel={isSupply ? t`Supply amount` : t`Withdraw amount`}
+          inputTestId="vault-modal-amount-input"
+          maxTestId="vault-modal-amount-max"
+        />
+        {liquidityNotice && (
+          <div
+            className={`ml-3 flex items-start ${liquidityNotice.tone}`}
+            data-testid={liquidityNotice.testId}
+          >
+            <PopoverRateInfo
+              type="morphoLiquidity"
+              tooltipOverride={liquidityTooltipOverride}
+              iconClassName={`mt-1 shrink-0 ${liquidityNotice.tone}`}
+            />
+            <Text variant="small" className="ml-2">
+              {liquidityNotice.text}
             </Text>
-          ) : undefined
-        }
-        inputAriaLabel={isSupply ? t`Supply amount` : t`Withdraw amount`}
-        inputTestId="vault-modal-amount-input"
-        maxTestId="vault-modal-amount-max"
-      />
+          </div>
+        )}
+      </div>
 
       <ModalSummaryGrid rows={toGridCells(rows, 'vault-modal-row', feeCell)} dividerClassName="h-8" />
 

--- a/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.test.tsx
+++ b/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.test.tsx
@@ -1,0 +1,185 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { parseUnits } from 'viem';
+import type { Token } from '@/hooks';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const TEST_ADDRESS = '0x1234567890123456789012345678901234567890' as const;
+const VAULT = '0xvault' as `0x${string}`;
+const POSITION = parseUnits('1000', 18);
+const SHARES = parseUnits('950', 18);
+
+const h = vi.hoisted(() => ({
+  vaultData: undefined as Record<string, unknown> | undefined,
+  marketData: undefined as Record<string, unknown> | undefined,
+  marketLoading: false
+}));
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useChainId: () => 1,
+    useConnection: () => ({ address: TEST_ADDRESS, isConnected: true, isConnecting: false })
+  };
+});
+
+// The limits mapping (computeVaultLimits) stays real — Max routing across the
+// liquidity states is exactly the seam under test. Only the data reads are stubbed.
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    getTokenDecimals: () => 18,
+    useTokenBalance: () => ({ data: { value: 0n } }),
+    useErc4626VaultData: () => ({ data: h.vaultData }),
+    useVaultMarketData: () => ({ data: h.marketData, isLoading: h.marketLoading })
+  };
+});
+
+import { useVaultTransactionForm } from './useVaultTransactionForm';
+
+const ASSET = { symbol: 'USDS', address: { 1: '0xusds' } } as unknown as Token;
+
+// Morpho vault data: the on-chain max* reads are stubs that read 0 for everyone
+// (APP-456 #7) — liquidity comes from the market API instead.
+const morphoVaultData = {
+  totalAssets: parseUnits('5000000', 18),
+  totalSupply: parseUnits('4750000', 18),
+  assetPerShare: parseUnits('1.0526', 18),
+  userShares: SHARES,
+  userAssets: POSITION,
+  maxDeposit: 0n,
+  maxWithdraw: 0n,
+  maxRedeem: 0n,
+  asset: '0xusds',
+  decimals: 18
+};
+
+const setVaultState = ({
+  liquidity,
+  marketLoading = false
+}: {
+  liquidity?: bigint;
+  marketLoading?: boolean;
+}) => {
+  h.vaultData = morphoVaultData;
+  h.marketData = liquidity === undefined ? {} : { liquidity };
+  h.marketLoading = marketLoading;
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nProvider i18n={i18n}>{children}</I18nProvider>
+);
+
+const renderForm = (flow: 'supply' | 'withdraw' = 'withdraw') =>
+  renderHook(
+    () => useVaultTransactionForm({ flow, vaultAddress: VAULT, assetToken: ASSET, provider: 'morpho' }),
+    { wrapper }
+  );
+
+describe('useVaultTransactionForm Max routing (APP-488)', () => {
+  afterEach(() => cleanup());
+
+  it('liquidity-constrained Max fills the cap and routes to a plain withdraw (max=false)', () => {
+    setVaultState({ liquidity: parseUnits('500', 18) });
+    const { result } = renderForm();
+
+    expect(result.current.isLiquidityConstrained).toBe(true);
+    act(() => result.current.setMaxAmount());
+
+    expect(result.current.value).toBe('500');
+    expect(result.current.engineParams.amount).toBe(parseUnits('500', 18));
+    // Redeem-all against 500 of liquidity would revert in simulation and
+    // dead-end the confirm button — the engine must withdraw(cap) instead.
+    expect(result.current.engineParams.max).toBe(false);
+  });
+
+  it('unconstrained Max still routes through redeem-all (max=true, no dust)', () => {
+    setVaultState({ liquidity: parseUnits('5000', 18) });
+    const { result } = renderForm();
+
+    expect(result.current.isLiquidityConstrained).toBe(false);
+    act(() => result.current.setMaxAmount());
+
+    expect(result.current.value).toBe('1000');
+    expect(result.current.engineParams.max).toBe(true);
+    expect(result.current.engineParams.shares).toBe(SHARES);
+  });
+
+  it('liquidity exactly covering the position counts as unconstrained (redeem-all)', () => {
+    setVaultState({ liquidity: POSITION });
+    const { result } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.engineParams.max).toBe(true);
+  });
+
+  it('the 100% chip routes exactly like Max in the constrained case', () => {
+    setVaultState({ liquidity: parseUnits('500', 18) });
+    const { result } = renderForm();
+
+    act(() => result.current.setPercentAmount(100));
+
+    expect(result.current.value).toBe('500');
+    expect(result.current.engineParams.max).toBe(false);
+  });
+
+  it('zero liquidity: Max fills 0 and never flags redeem-all', () => {
+    setVaultState({ liquidity: 0n });
+    const { result } = renderForm();
+
+    expect(result.current.isLiquidityConstrained).toBe(true);
+    expect(result.current.available).toBe(0n);
+    act(() => result.current.setMaxAmount());
+
+    expect(result.current.engineParams.max).toBe(false);
+    expect(result.current.amountReady).toBe(false);
+  });
+
+  it('liquidity figure unknown after settling: flags data-unavailable, Max stays a plain withdraw', () => {
+    setVaultState({ liquidity: undefined });
+    const { result } = renderForm();
+
+    expect(result.current.isLiquidityDataUnavailable).toBe(true);
+    // Settled-but-empty liquidity falls back to the full position for the cap…
+    act(() => result.current.setMaxAmount());
+    expect(result.current.value).toBe('1000');
+    // …and the full position is withdrawable as far as we know, so no-dust applies.
+    expect(result.current.engineParams.max).toBe(true);
+  });
+
+  it('while the liquidity read is in flight the cap is held back and Max is not redeem-all', () => {
+    setVaultState({ liquidity: undefined, marketLoading: true });
+    const { result } = renderForm();
+
+    expect(result.current.available).toBe(0n);
+    act(() => result.current.setMaxAmount());
+    expect(result.current.engineParams.max).toBe(false);
+  });
+
+  it('typing after Max clears the redeem-all flag', () => {
+    setVaultState({ liquidity: parseUnits('5000', 18) });
+    const { result } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.engineParams.max).toBe(true);
+
+    act(() => result.current.onInput('250'));
+    expect(result.current.engineParams.max).toBe(false);
+    expect(result.current.engineParams.amount).toBe(parseUnits('250', 18));
+  });
+
+  it('supply Max never sets the redeem-all flag', () => {
+    setVaultState({ liquidity: parseUnits('500', 18) });
+    const { result } = renderForm('supply');
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.engineParams.max).toBe(false);
+  });
+});

--- a/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.test.tsx
+++ b/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.test.tsx
@@ -142,23 +142,34 @@ describe('useVaultTransactionForm Max routing (APP-488)', () => {
     expect(result.current.amountReady).toBe(false);
   });
 
-  it('liquidity figure unknown after settling: flags data-unavailable, Max stays a plain withdraw', () => {
+  it('liquidity figure unknown after settling: input stays open and Max still redeems all', () => {
     setVaultState({ liquidity: undefined });
     const { result } = renderForm();
 
     expect(result.current.isLiquidityDataUnavailable).toBe(true);
-    // Settled-but-empty liquidity falls back to the full position for the cap…
     act(() => result.current.setMaxAmount());
     expect(result.current.value).toBe('1000');
-    // …and the full position is withdrawable as far as we know, so no-dust applies.
+    // Deliberate: withdrawals aren't blocked on missing data — the contract
+    // enforces the real liquidity on submit.
     expect(result.current.engineParams.max).toBe(true);
   });
 
-  it('while the liquidity read is in flight the cap is held back and Max is not redeem-all', () => {
+  it('while the liquidity read is in flight the position backs the input and Max is a plain withdraw', () => {
     setVaultState({ liquidity: undefined, marketLoading: true });
     const { result } = renderForm();
 
-    expect(result.current.available).toBe(0n);
+    // The position stands in until the read lands — not a flashed 0.
+    expect(result.current.available).toBe(POSITION);
+    act(() => result.current.setMaxAmount());
+    expect(result.current.value).toBe('1000');
+    expect(result.current.engineParams.max).toBe(false);
+  });
+
+  it('any liquidity shortfall counts as constrained — the full-cover comparison is exact', () => {
+    setVaultState({ liquidity: POSITION - 1n });
+    const { result } = renderForm();
+
+    expect(result.current.isLiquidityConstrained).toBe(true);
     act(() => result.current.setMaxAmount());
     expect(result.current.engineParams.max).toBe(false);
   });

--- a/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.tsx
+++ b/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.tsx
@@ -42,6 +42,10 @@ export interface VaultTransactionForm {
   amountReady: boolean;
   /** Supplied position in asset units (ERC-4626 `userAssets`) — feeds the entry deltas. */
   position: bigint;
+  /** Withdraw-relevant: vault liquidity currently caps the input below the position. */
+  isLiquidityConstrained: boolean;
+  /** Withdraw-relevant: the provider's liquidity source settled without a figure. */
+  isLiquidityDataUnavailable: boolean;
   engineParams: VaultEngineParams;
   toast: VaultToastTitles;
   transactionScreenContent: ReactNode;
@@ -98,7 +102,13 @@ export function useVaultTransactionForm({
     vaultAddress
   });
 
-  const { maxDepositInput, maxWithdrawInput, redeemShares } = computeVaultLimits({
+  const {
+    maxDepositInput,
+    maxWithdrawInput,
+    redeemShares,
+    isLiquidityConstrained,
+    isLiquidityDataUnavailable
+  } = computeVaultLimits({
     provider,
     assetBalance: walletBalance?.value,
     maxDeposit: vaultData?.maxDeposit,
@@ -110,6 +120,7 @@ export function useVaultTransactionForm({
     liquidityKnown: !isMarketDataLoading
   });
 
+  const position = vaultData?.userAssets ?? 0n;
   const available = isSupply ? maxDepositInput : (maxWithdrawInput ?? 0n);
   const isZero = amount === 0n;
   const insufficient = amount > available;
@@ -121,8 +132,11 @@ export function useVaultTransactionForm({
   };
   const setMaxAmount = () => {
     setValue(formatUnits(available, decimals));
-    // On withdraw, Max redeems the whole share balance; supply just fills the amount.
-    setMax(!isSupply);
+    // On withdraw, Max redeems the whole share balance (no dust) — but only when the
+    // full position is withdrawable. Under a liquidity constraint the input is capped
+    // below the position, and a redeem-all would revert against the missing liquidity
+    // (APP-488); the engine must run a plain withdraw of the capped amount instead.
+    setMax(!isSupply && maxWithdrawInput !== undefined && maxWithdrawInput === position);
   };
   const setPercentAmount = (pct: number) => {
     if (pct >= 100) return setMaxAmount();
@@ -186,7 +200,9 @@ export function useVaultTransactionForm({
     isZero,
     insufficient,
     amountReady,
-    position: vaultData?.userAssets ?? 0n,
+    position,
+    isLiquidityConstrained,
+    isLiquidityDataUnavailable,
     engineParams,
     toast,
     transactionScreenContent,

--- a/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.tsx
+++ b/apps/webapp/src/modules/morpho/hooks/useVaultTransactionForm.tsx
@@ -107,6 +107,7 @@ export function useVaultTransactionForm({
     maxWithdrawInput,
     redeemShares,
     isLiquidityConstrained,
+    isFullPositionWithdrawable,
     isLiquidityDataUnavailable
   } = computeVaultLimits({
     provider,
@@ -121,7 +122,9 @@ export function useVaultTransactionForm({
   });
 
   const position = vaultData?.userAssets ?? 0n;
-  const available = isSupply ? maxDepositInput : (maxWithdrawInput ?? 0n);
+  // While the liquidity read is in flight the position backs the input (no
+  // "Balance: 0" flash); if liquidity settles lower the insufficient gate re-clamps.
+  const available = isSupply ? maxDepositInput : (maxWithdrawInput ?? position);
   const isZero = amount === 0n;
   const insufficient = amount > available;
   const amountReady = isConnected && !isZero && !insufficient;
@@ -132,11 +135,10 @@ export function useVaultTransactionForm({
   };
   const setMaxAmount = () => {
     setValue(formatUnits(available, decimals));
-    // On withdraw, Max redeems the whole share balance (no dust) — but only when the
-    // full position is withdrawable. Under a liquidity constraint the input is capped
-    // below the position, and a redeem-all would revert against the missing liquidity
-    // (APP-488); the engine must run a plain withdraw of the capped amount instead.
-    setMax(!isSupply && maxWithdrawInput !== undefined && maxWithdrawInput === position);
+    // Max redeems the whole share balance (no dust) only when the full position
+    // is withdrawable; under a liquidity constraint the engine runs a plain
+    // withdraw of the cap instead — a redeem-all would revert (APP-488).
+    setMax(!isSupply && isFullPositionWithdrawable);
   };
   const setPercentAmount = (pct: number) => {
     if (pct >= 100) return setMaxAmount();


### PR DESCRIPTION
Fixes [APP-488](https://linear.app/ekliptyka/issue/APP-488/fix-liquidity-constrained-morpho-withdrawals-in-the-vault-modal).

## Problem

For Morpho vaults whose available liquidity is lower than the user's position (e.g. 1,000 deposited, 500 withdrawable), the redesigned withdraw modal:

1. **Dead-ended on Max.** `setMaxAmount` filled the liquidity-capped amount but also set `max=true`, routing the engine to redeem-all (for Morpho, `redeemShares` is always the whole share balance). Redeeming 1,000-worth against 500 of liquidity reverts in simulation → `prepared=false` → the confirm button stays disabled with no error shown anywhere.
2. **Lost the liquidity messaging** the old `VaultWidget` had — `computeVaultLimits` returns `isLiquidityConstrained` / `isLiquidityDataUnavailable`, but the modal read neither flag.
3. **Showed wrong error copy.** Typing an amount over the liquidity cap (but within the position) said "Amount exceeds your position" — false; it exceeds vault liquidity.

## Fix

- `useVaultTransactionForm`: Max (and the 100% chip) only sets the redeem-all flag when the full position is withdrawable (`maxWithdrawInput === position`); under a liquidity constraint the engine runs a plain `withdraw(cap)` instead. The hook now exposes `isLiquidityConstrained` / `isLiquidityDataUnavailable`.
- `VaultModalForm`: three distinct notices (partial constraint / zero liquidity / liquidity data unavailable) with the same wording as the widget's `SupplyWithdraw`, and the over-limit withdraw error now distinguishes "Insufficient liquidity. Maximum available is X" from "Amount exceeds your position". The zero-liquidity notice renders in error red (it blocks the action) and suppresses the inline error, which would otherwise duplicate it word for word.
- The corner figure is labeled **"Available"** instead of "Balance" exactly when liquidity caps it below the position ("Balance: 500" next to a 1,000 position read as a lie); it stays "Balance" for supply and unconstrained withdrawals.
- `computeVaultLimits` gains `isFullPositionWithdrawable` (exact full-cover check) so Max routing and `isLiquidityConstrained` agree by construction. A dust tolerance was considered and deliberately dropped in favor of the exact comparison — `min()` already makes it exact whenever liquidity clears the position.
- While the liquidity read is in flight, the position backs the withdraw input instead of collapsing to 0 — no "Balance: 0" flash, and Max no longer fills a 0 that never repopulates. The insufficient-liquidity error prints the cap at full precision so it never names a maximum that itself fails the gate.

Out of scope (per ticket): the old `VaultWidget` has the same inherited Max redeem-all routing bug; it is superseded by the redesign.

## Before → after

Reproduced with hook-level mocks (position 1,000 USDS, market-API liquidity 500 USDS, Morpho `max*` stubs at 0) on the USDS Flagship vault with the mock wallet.

**Max / 100% chip**

| Before | After |
| --- | --- |
| ![Before: Max fills 500, Review disabled, no explanation](https://raw.githubusercontent.com/jetstreamgg/tarmac/e065128d9b3ce4c8143fa994e91510a396864566/app488-before-max-dead-end.png) | ![After: Max fills 500 with a liquidity notice, routed as plain withdraw](https://raw.githubusercontent.com/jetstreamgg/tarmac/e065128d9b3ce4c8143fa994e91510a396864566/app488-after-max-notice.png) |

Before: 500 filled, Review permanently disabled (redeem-all reverts in simulation), no notice — "Balance: 500" next to "Supply: 1,000" with no explanation. After: the constraint notice renders and Max routes to `withdraw(500)`.

**Typing 1,000 (over liquidity, within position)**

| Before | After |
| --- | --- |
| ![Before: wrong error "Amount exceeds your position"](https://raw.githubusercontent.com/jetstreamgg/tarmac/e065128d9b3ce4c8143fa994e91510a396864566/app488-before-wrong-error.png) | ![After: "Insufficient liquidity. Maximum available is 500 USDS."](https://raw.githubusercontent.com/jetstreamgg/tarmac/e065128d9b3ce4c8143fa994e91510a396864566/app488-after-error-copy.png) |

**Zero liquidity (position 1,000, liquidity 0), typing 100**

| Before | After |
| --- | --- |
| ![Before: "Balance: 0" with the wrong "Amount exceeds your position" error and no notice](https://raw.githubusercontent.com/jetstreamgg/tarmac/e065128d9b3ce4c8143fa994e91510a396864566/app488-before-zero-liquidity.png) | ![After: "Available: 0" with a single red withdrawals-temporarily-unavailable notice](https://raw.githubusercontent.com/jetstreamgg/tarmac/e065128d9b3ce4c8143fa994e91510a396864566/app488-after-zero-liquidity.png) |

Before: "Balance: 0" with the false "Amount exceeds your position" error and no explanation. After: "Available: 0" and a single red "Withdrawals are temporarily unavailable due to liquidity constraints." notice — the inline over-limit error is suppressed in exactly this state so the same sentence isn't stacked twice (the `insufficient` gate still disables Review).

## Testing

- 10 new hook tests (`useVaultTransactionForm.test.tsx`) cover Max/100% routing: constrained, unconstrained, exact-cover, wei-short shortfall, zero liquidity, liquidity-data-unavailable, in-flight liquidity read, typing-clears-Max, and supply flow. `computeVaultLimits` stays real in the tests — only the data reads are stubbed. 3 new `computeVaultLimits` tests pin the full-cover boundary.
- Full morpho module suite (49 tests, 12 files) and `computeVaultLimits` suite (20 tests) pass; typecheck and lint clean.
- Verified in the browser against the mocked scenario (screenshots above). Note: in that mock environment the confirm button still can't enable because simulation runs against a chain where the account holds nothing — the routing change is asserted by the unit tests; a real-fork e2e pass of "Max → confirm executes withdraw(cap)" is worth a follow-up check.
