### PR TITLE
Fix CI: nanoid audit override + repair useAccruingValue tests

### DIFF
--- a/apps/webapp/src/hooks/ui/useAccruingValue.test.tsx
+++ b/apps/webapp/src/hooks/ui/useAccruingValue.test.tsx
@@ -73,26 +73,27 @@ describe('useAccruingValue', () => {
       vi.advanceTimersByTime(60_000);
     });
 
-    // A minute of 3.75% on 100,000 USDS.
+    // A minute of 3.75% on 100,000 USDS. The hook lands on digit turnovers, so
+    // the shown value trails the continuous projection by up to one tick (1e-4).
     const expected = 100_000 * Math.exp(Math.log1p(SSR_3_75) * 60);
-    expect(result.current.value).toBeCloseTo(expected, 6);
     expect(result.current.value).toBeGreaterThan(100_000);
+    expect(result.current.value).toBeLessThanOrEqual(expected);
+    expect(expected - result.current.value).toBeLessThan(2 * 10 ** -4);
   });
 
-  it('renders about once per target tick rather than on a fixed interval', () => {
-    let renders = 0;
-    renderHook(() => {
-      renders += 1;
-      return useAccruingValue({ amount: 100_000, ratePerSecond: SSR_3_75 });
-    });
-    const before = renders;
+  it('wakes about once per target tick rather than on a fixed interval', () => {
+    renderHook(() => useAccruingValue({ amount: 100_000, ratePerSecond: SSR_3_75 }));
 
+    // Count timer wake-ups, not renders: React batches every setState inside
+    // the single act() into one render, so render count can't see the cadence.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
     act(() => {
       vi.advanceTimersByTime(10_000);
     });
 
     // 10s at ~0.86s per tick ≈ 12 wake-ups; anything near 60fps would be ~600.
-    const wakeUps = renders - before;
+    const wakeUps = spy.mock.calls.length;
+    spy.mockRestore();
     expect(wakeUps).toBeGreaterThan(5);
     expect(wakeUps).toBeLessThan(25);
   });
@@ -109,8 +110,9 @@ describe('useAccruingValue', () => {
     const projected = result.current.value;
     expect(projected).toBeGreaterThan(100_000);
 
-    // The chain reports the balance as of a block we've already projected past.
-    rerender({ amount: 100_000.0001 });
+    // The chain reports the balance as of a block we've already projected past —
+    // behind the display, but within the 10-tick (1e-3) drift tolerance.
+    rerender({ amount: projected - 0.0005 });
     expect(result.current.value).toBeGreaterThanOrEqual(projected);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,7 @@ catalogs:
 
 overrides:
   esbuild@<0.28.1: ~0.28.1
+  nanoid@<3.3.17: ~3.3.17
   '@babel/runtime@7.26.7': 7.26.10
   axios@>=1.0.0 <1.18.0: ^1.18.0
   '@json-rpc-tools/provider>axios@^0.21.0': ^1.18.0
@@ -5198,8 +5199,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12651,7 +12652,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -13117,7 +13118,7 @@ snapshots:
 
   postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,6 +119,7 @@ minimumReleaseAge: 10080
 #   @noble/curves instead. Tracked in APP-201.
 overrides:
   esbuild@<0.28.1: ~0.28.1
+  nanoid@<3.3.17: ~3.3.17
   '@babel/runtime@7.26.7': 7.26.10
   axios@>=1.0.0 <1.18.0: ^1.18.0
   '@json-rpc-tools/provider>axios@^0.21.0': ^1.18.0


### PR DESCRIPTION
Fixes two of the three failures currently turning every branch's CI red (including unrelated PRs — verified the same failures on APP-419's and APP-488's runs).

## Audit — nanoid high advisory

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (`nanoid < 3.3.17`, high) landed in the registry and fails `pnpm audit --prod --audit-level high` on every branch. The only vulnerable copy is transitive via `@binance/w3w-wagmi-connector-v2 → … → tailwindcss → postcss → nanoid@3.3.16`.

Added `nanoid@<3.3.17: ~3.3.17` to the workspace overrides, following the file's conventions (range-scoped selector so it self-expires; tilde replacement since nanoid majors can coexist). Audit is back to green at the CI threshold: `21 vulnerabilities found — 6 low | 15 moderate`, no high/critical.

## Test — useAccruingValue "flakes" were deterministic test bugs

The three `useAccruingValue.test.tsx` failures reproduce locally on every run — they've been failing since the hook landed (2026-08-03) and were masked by CI already being red. The hook's behavior is correct; the tests were wrong:

1. **"accrues at the rate"** asserted the continuous projection at exactly t=60s with a 5e-7 tolerance, but the hook deliberately lands on digit turnovers — the displayed value trails the continuous value by up to one tick (1e-4 at this balance/rate). Now asserts the value is within one tick below the projection.
2. **"renders about once per target tick"** counted React renders, but React batches every `setState` fired inside a single `act(advanceTimersByTime(10s))` into one render — the count was always 1. Now counts timer wake-ups via a `setTimeout` spy, which is what the test actually means to measure.
3. **"ignores a read that lands just behind"** fed a read 3.4e-3 behind the display — 3.4× beyond the hook's own `DRIFT_TOLERANCE_TICKS` (10 ticks = 1e-3), so the hook correctly honored it. Now feeds a read genuinely within the tolerance.

Fixed tests pass 5/5 consecutive standalone runs (previously 3 failed on every run).

## Not fixed here: test-shards (6) — stake-mobile e2e

The five `stake-mobile.spec.ts` specs fail consistently (same five, surviving retry, across multiple runs since at least 2026-08-07) — that's a real breakage at the phone tier, not flake, and needs investigation by someone who knows the stake module's mobile comps. Worth its own ticket; this PR doesn't touch it.
