### PR TITLE
Keep Active positions count fixed when hovering a position

### DIFF
--- a/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.tsx
+++ b/apps/webapp/src/modules/portfolio/components/StablecoinEarningsCard.tsx
@@ -171,12 +171,7 @@ function SuppliedContent({ view, isLoading }: { view: SuppliedView; isLoading: b
           label={<Trans>Avg. Rate</Trans>}
           value={<StatValue>{formatDecimalPercentage(displayAvgRate)}</StatValue>}
         />
-        {!activePosition && (
-          <Stat
-            label={<Trans>Active positions</Trans>}
-            value={<StatValue>{view.activePositions}</StatValue>}
-          />
-        )}
+        <Stat label={<Trans>Active positions</Trans>} value={<StatValue>{view.activePositions}</StatValue>} />
       </FooterStats>
     </>
   );
@@ -276,8 +271,6 @@ function IdleContent({
             value={<GainValue value={displayProjected} className={LABEL_4} />}
           />
         )}
-        {/* Always the total — unlike Supplied's "Active positions", this stat
-            stays fixed when focusing a single token. */}
         <Stat label={<Trans>Idle stablecoins</Trans>} value={<StatValue>{view.idleCount}</StatValue>} />
       </FooterStats>
     </>


### PR DESCRIPTION
Hovering a position on the Supplied tab (donut or legend) unmounted the "Active positions" footer stat, so the footer lost a column and reflowed on every hover.

This was flagged in review on #1672 — the fix (2b09597) only covered the Idle tab's "Idle stablecoins" stat. This applies the same treatment to the Supplied tab: the count always shows the total.
