### PR TITLE
Restore the stUSDS max-withdraw resync in the redesigned modal (APP-507)

### DIFF
--- a/apps/webapp/src/modules/stusds/hooks/useStUsdsTransactionForm.test.tsx
+++ b/apps/webapp/src/modules/stusds/hooks/useStUsdsTransactionForm.test.tsx
@@ -1,0 +1,247 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { parseUnits } from 'viem';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const POSITION = parseUnits('1000', 18);
+const NATIVE_MAX = parseUnits('600', 18);
+
+const h = vi.hoisted(() => ({
+  stUsdsData: undefined as Record<string, unknown> | undefined,
+  withdrawBalances: undefined as Record<string, unknown> | undefined,
+  selectedProvider: 'native',
+  selectionQuote: undefined as Record<string, unknown> | undefined,
+  // When set, useDebounce returns this instead of the live value — simulates
+  // the settle window after an amount change.
+  debounceLagged: undefined as bigint | undefined
+}));
+
+vi.mock('wagmi', async importOriginal => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useConnection: () => ({ isConnected: true })
+  };
+});
+
+// The flag-driven max under test reads `available`, which the form derives from
+// these reads — only the data layer is stubbed, the derivation stays real.
+vi.mock('@/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks')>();
+  return {
+    ...actual,
+    useDebounce: <T,>(value: T) => (h.debounceLagged !== undefined ? h.debounceLagged : value),
+    useStUsdsData: () => ({ data: h.stUsdsData }),
+    useStUsdsCapacityData: () => ({ data: { remainingCapacityBuffered: parseUnits('100000', 18) } }),
+    useStUsdsWithdrawBalances: () => h.withdrawBalances,
+    useStUsdsProviderSelection: () => ({
+      selectedProvider: h.selectedProvider,
+      selectionReason: 'native_default',
+      selectedQuote: h.selectionQuote,
+      nativeProvider: undefined,
+      curveProvider: undefined,
+      allProvidersBlocked: false,
+      rateDifferencePercent: 0,
+      isSelectionLoading: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn()
+    })
+  };
+});
+
+vi.mock('@/modules/config/hooks/useConfigContext', () => ({
+  useConfigContext: () => ({
+    expertRiskDisclaimerShown: true,
+    userConfig: {},
+    updateUserConfig: vi.fn()
+  })
+}));
+
+import { useStUsdsTransactionForm } from './useStUsdsTransactionForm';
+
+const setState = ({
+  nativeMax = NATIVE_MAX,
+  curveMaxWithdraw,
+  withdrawProvider = 'native',
+  withdrawBalancesLoading = false
+}: {
+  nativeMax?: bigint;
+  curveMaxWithdraw?: bigint;
+  withdrawProvider?: 'native' | 'curve';
+  withdrawBalancesLoading?: boolean;
+} = {}) => {
+  h.stUsdsData = {
+    userUsdsBalance: parseUnits('2000', 18),
+    userStUsdsBalance: parseUnits('950', 18),
+    userSuppliedUsds: POSITION,
+    userMaxWithdrawBuffered: nativeMax,
+    moduleRate: 0n
+  };
+  h.withdrawBalances = {
+    effectiveBalance: curveMaxWithdraw ?? POSITION,
+    curveMaxWithdraw,
+    nativeBalance: POSITION,
+    userStUsdsBalance: parseUnits('950', 18),
+    selectedProvider: withdrawProvider,
+    isLoading: withdrawBalancesLoading,
+    error: null
+  };
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nProvider i18n={i18n}>{children}</I18nProvider>
+);
+
+const renderForm = (flow: 'supply' | 'withdraw' = 'withdraw') =>
+  renderHook(() => useStUsdsTransactionForm({ flow }), { wrapper });
+
+describe('useStUsdsTransactionForm flag-driven max withdraw (APP-507)', () => {
+  beforeEach(() => {
+    setState();
+    h.selectedProvider = 'native';
+    h.selectionQuote = undefined;
+    h.debounceLagged = undefined;
+  });
+  afterEach(() => cleanup());
+
+  it('Max derives the display from the current native max and follows it when it drifts', () => {
+    const { result, rerender } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.value).toBe('600');
+    expect(result.current.engineParams.max).toBe(true);
+
+    setState({ nativeMax: parseUnits('650', 18) });
+    rerender();
+    expect(result.current.value).toBe('650');
+    expect(result.current.amount).toBe(parseUnits('650', 18));
+  });
+
+  it('follows the Curve max when Curve backs the withdrawal', () => {
+    setState({ curveMaxWithdraw: parseUnits('1005', 18), withdrawProvider: 'curve' });
+    const { result, rerender } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.value).toBe('1005');
+
+    setState({ curveMaxWithdraw: parseUnits('1010', 18), withdrawProvider: 'curve' });
+    rerender();
+    expect(result.current.value).toBe('1010');
+  });
+
+  it('keeps following unconditionally — no freeze condition to strand after an error', () => {
+    // The old resync froze on txStatus !== IDLE, which outlived a failed tx
+    // (Back leaves ERROR standing) and reintroduced the drift. The derived
+    // display has no guard to get stuck.
+    const { result, rerender } = renderForm();
+    act(() => result.current.setMaxAmount());
+
+    setState({ nativeMax: parseUnits('650', 18) });
+    rerender();
+    setState({ nativeMax: parseUnits('700', 18) });
+    rerender();
+    expect(result.current.value).toBe('700');
+  });
+
+  it('typing clears Max and returns to the typed value', () => {
+    const { result, rerender } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    act(() => result.current.onInput('250'));
+
+    setState({ nativeMax: parseUnits('650', 18) });
+    rerender();
+    expect(result.current.value).toBe('250');
+    expect(result.current.engineParams.max).toBe(false);
+  });
+
+  it('max is exempt from the insufficient/debounce gating (no confirm flicker on drift)', () => {
+    const { result, rerender } = renderForm();
+    act(() => result.current.setMaxAmount());
+
+    // Simulate the debounce still settling on the pre-drift amount.
+    setState({ nativeMax: parseUnits('650', 18) });
+    h.debounceLagged = NATIVE_MAX;
+    rerender();
+
+    expect(result.current.debouncePending).toBe(true);
+    expect(result.current.amountReady).toBe(true);
+
+    // The same lag on a typed amount still gates confirm.
+    h.debounceLagged = undefined;
+    act(() => result.current.onInput('250'));
+    h.debounceLagged = parseUnits('100', 18);
+    rerender();
+    expect(result.current.amountReady).toBe(false);
+  });
+
+  it('holds confirm while the Curve max quote is loading instead of trusting the native fallback', () => {
+    setState({ withdrawProvider: 'curve', curveMaxWithdraw: undefined, withdrawBalancesLoading: true });
+    const { result, rerender } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.amountReady).toBe(false);
+
+    setState({ withdrawProvider: 'curve', curveMaxWithdraw: parseUnits('1005', 18) });
+    rerender();
+    expect(result.current.value).toBe('1005');
+    expect(result.current.amountReady).toBe(true);
+  });
+
+  it('a drained max shows 0 and disables confirm', () => {
+    const { result, rerender } = renderForm();
+    act(() => result.current.setMaxAmount());
+
+    setState({ nativeMax: 0n });
+    rerender();
+    expect(result.current.value).toBe('0');
+    expect(result.current.amountReady).toBe(false);
+  });
+
+  it('price-impact acknowledgement lapses when the acknowledged amount drifts', () => {
+    setState({ curveMaxWithdraw: parseUnits('1005', 18), withdrawProvider: 'curve' });
+    h.selectedProvider = 'curve';
+    h.selectionQuote = { rateInfo: { priceImpactBps: 250 }, outputAmount: 0n, inputAmount: 0n };
+    const { result, rerender } = renderForm();
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.needsImpactAcknowledgement).toBe(true);
+    act(() => result.current.setImpactAccepted(true));
+    expect(result.current.impactAccepted).toBe(true);
+
+    setState({ curveMaxWithdraw: parseUnits('1010', 18), withdrawProvider: 'curve' });
+    rerender();
+    expect(result.current.impactAccepted).toBe(false);
+  });
+
+  it('supply Max fills the wallet balance once and never follows (max is withdraw-only)', () => {
+    const { result, rerender } = renderForm('supply');
+
+    act(() => result.current.setMaxAmount());
+    expect(result.current.value).toBe('2000');
+    expect(result.current.engineParams.max).toBe(false);
+
+    setState();
+    h.stUsdsData = { ...h.stUsdsData!, userUsdsBalance: parseUnits('2500', 18) };
+    rerender();
+    expect(result.current.value).toBe('2000');
+  });
+
+  it('the 100% chip behaves like Max', () => {
+    const { result, rerender } = renderForm();
+
+    act(() => result.current.setPercentAmount(100));
+    expect(result.current.value).toBe('600');
+    expect(result.current.engineParams.max).toBe(true);
+
+    setState({ nativeMax: parseUnits('700', 18) });
+    rerender();
+    expect(result.current.value).toBe('700');
+  });
+});

--- a/apps/webapp/src/modules/stusds/hooks/useStUsdsTransactionForm.tsx
+++ b/apps/webapp/src/modules/stusds/hooks/useStUsdsTransactionForm.tsx
@@ -102,34 +102,15 @@ export function useStUsdsTransactionForm({
   // balance (no dust) and the Curve quote runs in max mode.
   const [max, setMax] = useState(false);
 
-  const amount = parseAmount(value);
-  const debouncedAmount = useDebounce(amount);
-  const debouncePending = debouncedAmount !== amount;
-
   const { data: stUsdsData } = useStUsdsData();
   const { data: capacityData } = useStUsdsCapacityData();
-
-  const providerSelection = useStUsdsProviderSelection({
-    amount: debouncedAmount,
-    referenceAmount: REFERENCE_AMOUNT,
-    direction: isSupply ? StUsdsDirection.SUPPLY : StUsdsDirection.WITHDRAW,
-    userStUsdsBalance: stUsdsData?.userStUsdsBalance,
-    isMax: max
-  });
-  const isCurveSelected = providerSelection.selectedProvider === StUsdsProviderType.CURVE;
 
   const {
     effectiveBalance: withdrawBalanceLimit,
     curveMaxWithdraw,
-    selectedProvider: withdrawSelectedProvider
+    selectedProvider: withdrawSelectedProvider,
+    isLoading: withdrawBalancesLoading
   } = useStUsdsWithdrawBalances();
-
-  // If Curve can absorb the supply there's no protocol limit on the input;
-  // otherwise the native module capacity caps it (widget behavior).
-  const isCurveAvailableForSupply = providerSelection.curveProvider?.state?.canDeposit ?? false;
-  const moduleMaxSupplyAmount = isCurveAvailableForSupply
-    ? undefined
-    : (providerSelection.nativeProvider?.state?.maxDeposit ?? capacityData?.remainingCapacityBuffered ?? 0n);
 
   // Native max withdraw is buffered against liquidity drift; the Curve max is
   // the pool quote for the full share balance.
@@ -140,8 +121,39 @@ export function useStUsdsTransactionForm({
       : nativeMaxWithdraw;
 
   const available = isSupply ? (stUsdsData?.userUsdsBalance ?? 0n) : maxWithdrawAmount;
+
+  // Withdraw Max is flag-driven (savings-form pattern): the engine redeems the
+  // whole share balance / swaps the live quote, never the typed number, so the
+  // displayed amount derives from the live max instead of a click-time
+  // snapshot — the Curve quotes behind `available` refetch every 15s, and a
+  // pure derivation keeps tracking them with no state rewrite to freeze,
+  // invalidate, or misfire (the retired widget resynced with an effect).
+  const displayValue = max && !isSupply ? formatUnits(available, DECIMALS) : value;
+  const amount = parseAmount(displayValue);
+  const debouncedAmount = useDebounce(amount);
+  const debouncePending = debouncedAmount !== amount;
+
+  const providerSelection = useStUsdsProviderSelection({
+    amount: debouncedAmount,
+    referenceAmount: REFERENCE_AMOUNT,
+    direction: isSupply ? StUsdsDirection.SUPPLY : StUsdsDirection.WITHDRAW,
+    userStUsdsBalance: stUsdsData?.userStUsdsBalance,
+    isMax: max
+  });
+  const isCurveSelected = providerSelection.selectedProvider === StUsdsProviderType.CURVE;
+
+  // If Curve can absorb the supply there's no protocol limit on the input;
+  // otherwise the native module capacity caps it (widget behavior).
+  const isCurveAvailableForSupply = providerSelection.curveProvider?.state?.canDeposit ?? false;
+  const moduleMaxSupplyAmount = isCurveAvailableForSupply
+    ? undefined
+    : (providerSelection.nativeProvider?.state?.maxDeposit ?? capacityData?.remainingCapacityBuffered ?? 0n);
+
   const isZero = amount === 0n;
+  // A max withdraw bypasses the amount checks: the derived display can drift or
+  // lag the debounce, but the flag — not the number — drives the redemption.
   const insufficient =
+    !max &&
     amount > 0n &&
     (isSupply ? amount > available : amount > available || amount > (withdrawBalanceLimit ?? available));
 
@@ -154,8 +166,13 @@ export function useStUsdsTransactionForm({
       (isSupply && moduleMaxSupplyAmount !== undefined && debouncedAmount > moduleMaxSupplyAmount));
 
   // Curve price-impact gate (≥2% requires the explicit "proceed anyway" check).
+  // The acknowledgement is keyed to the amount it was given for: if the derived
+  // max drifts under a checked box, the check lapses and confirm re-gates on
+  // the impact the user would actually take.
   const priceImpactBps = providerSelection.selectedQuote?.rateInfo.priceImpactBps;
-  const [impactAccepted, setImpactAccepted] = useState(false);
+  const [impactAcceptedAmount, setImpactAcceptedAmount] = useState<bigint | null>(null);
+  const impactAccepted = impactAcceptedAmount !== null && impactAcceptedAmount === debouncedAmount;
+  const setImpactAccepted = (checked: boolean) => setImpactAcceptedAmount(checked ? debouncedAmount : null);
   const needsImpactAcknowledgement =
     isCurveSelected &&
     priceImpactBps !== undefined &&
@@ -179,7 +196,13 @@ export function useStUsdsTransactionForm({
     }
   };
 
-  const amountReady = isConnected && !isZero && !insufficient && !blocked && !debouncePending;
+  // Max readiness needs a real max: zero (nothing to withdraw) or a still-loading
+  // Curve max quote (whose transient fallback is the smaller native max) hold
+  // the confirm rather than gating on the derived number.
+  const amountReady =
+    isConnected &&
+    !blocked &&
+    (max ? available > 0n && !withdrawBalancesLoading : !isZero && !insufficient && !debouncePending);
 
   const rate = stUsdsData ? calculateApyFromStr(stUsdsData.moduleRate) / 100 : undefined;
 
@@ -251,7 +274,7 @@ export function useStUsdsTransactionForm({
     isConnected,
     isSupply,
     decimals: DECIMALS,
-    value,
+    value: displayValue,
     amount: debouncedAmount,
     available,
     isZero,


### PR DESCRIPTION
Restores a behavior lost in the widget→modal port, per APP-507.

The retired widget kept a Max-filled withdraw amount synced to the live max while idle; the modal froze it at click time even though the Curve quotes behind it refetch every 15s. This adopts the savings-form pattern instead of the widget's resync effect: the `max` flag (not the typed number) drives the redemption and is exempt from the amount gating, and the displayed value *derives* from the live max at render time — no resync state to freeze after an error, flicker the confirm on quote refetches, or rewrite the input during a transient quote reload (confirm is held while the Curve max quote is loading). The ≥2% price-impact acknowledgement is now keyed to the amount it was given for, so a drifting max lapses the checkbox and re-gates confirm.

Unit tests cover the derived display (native + Curve drift), gating exemption, loading hold, acknowledgement lapse, and the typed-value/supply paths (10 cases). Typecheck, eslint, prettier clean; stusds suite (35) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)